### PR TITLE
Allow chainable modules to handle Back button for internal navigation

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -12084,6 +12084,15 @@ function handleSelect() {
 }
 
 function handleBack() {
+    /* Pre-emption: in component-edit, let a module with a custom chain_ui
+     * handle Back for its own internal navigation. Truthy = consumed;
+     * falsy/absent falls through to the host unload logic below. */
+    if (view === VIEWS.COMPONENT_EDIT && loadedModuleUi &&
+        typeof loadedModuleUi.handleBack === "function" &&
+        loadedModuleUi.handleBack()) {
+        needsRedraw = true;
+        return;
+    }
     hideOverlay();
     switch (view) {
         case VIEWS.SLOTS:


### PR DESCRIPTION
When a chain module with a custom UI (chain_ui pattern) is loaded in component-edit mode, the shadow UI now calls the module's handleBack() method first before unloading the module. This allows modules to drive their own internal navigation via the Back button instead of always exiting the module.

The hook is pre-emptive and only fires when:
- The current view is COMPONENT_EDIT
- A module UI is loaded (loadedModuleUi exists)
- The loaded module exposes a handleBack function
- The module's handleBack returns truthy (consumed the press)

If the module's handleBack returns falsy or doesn't exist, the host's existing behavior (unload + return to chain editor) runs unchanged.

This is a no-op for modules using standard globals (init/tick/onMidiMessageInternal), which don't expose handleBack and thus continue to behave exactly as before.

Fixes: chainable modules with custom UIs had dead-code handleBack methods.