### PR TITLE
catalog: add Movy (knob UI + 4-track sequencer tool)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1034,6 +1034,17 @@
       "default_branch": "main",
       "asset_name": "war_bells-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "movy",
+      "name": "Movy",
+      "description": "Elektron-style knob UI + 4-track sequencer with per-step parameters, parameter automation, and live recording",
+      "author": "megadake",
+      "component_type": "tool",
+      "github_repo": "DimaDake/schwung-movy",
+      "default_branch": "main",
+      "asset_name": "movy-module.tar.gz",
+      "min_host_version": "0.9.13"
     }
   ]
 }


### PR DESCRIPTION
Adds **Movy** to the module catalog.

Movy is an Elektron-style knob UI + 4-track sequencer for Schwung on Ableton Move. It auto-generates parameter pages for any module (arc/enum knobs, scrollable enum overlay, ADSR envelope graphics, full chain navigation + master FX), and adds a 4-track sequencer (Rust engine) with clips, Session view, live recording, loop/bar editing, parameter automation, and per-step parameters (velocity, length, probability, A:B conditions).

- **Repo:** https://github.com/DimaDake/schwung-movy (public)
- **Release:** [v0.21.0](https://github.com/DimaDake/schwung-movy/releases/tag/v0.21.0) with `movy-module.tar.gz` attached
- **`release.json`** present at repo root
- `component_type: tool`, `min_host_version: 0.9.13`

Catalog entry verified: the raw `release.json` and the tarball `download_url` both resolve publicly, and the tarball extracts to a single top-level `movy/` folder (`module.json` + `ui.js` + `dsp.so`).