### PR TITLE
chore: generalize module-specific examples in co-run/MIDI comments

### DIFF
--- a/docs/CORUN.md
+++ b/docs/CORUN.md
@@ -243,7 +243,7 @@ Surfaces the tool does not own pass through — Move's LEDs reach the buttons /
 pads / knob rings directly.
 
 **Lights vs input split.** LED ownership is its own mask, letting a tool **paint** a
-surface while still **ceding its presses** — e.g. dAVEBOx draws the track-button
+surface while still **ceding its presses** — e.g. a tool draws the track-button
 clip indicator (owns TRACK LEDs) but lets Move/Schwung handle the press (cedes
 TRACK input). Cede-model tools set it with `shadow_corun_set_led_cede_mask`
 (cede these LEDs, paint the rest); legacy tools use `shadow_corun_set_led_keep_mask`

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -178,13 +178,13 @@ typedef struct shadow_control_t {
         /* LED ownership; 0 = follow keep_mask (the common "own both" case) UNLESS
          * CORUN_F_LED_DISTINCT is set, in which case this mask is authoritative
          * even when 0. Lets a tool paint a surface while ceding its presses (e.g.
-         * dAVEBOx draws the track-button clip indicator but cedes the press). */
+         * a tool draws the track-button clip indicator but cedes the press). */
         uint32_t led_keep_mask;
     } corun;
     volatile uint8_t shadow_display_owner; /* display_owner_t: who currently owns the OLED. Independent of shadow_display_mode (which only says "shadow session active"). */
     /* 1=also strip Move's cable-0 sysex (RGB pad/clip/grid LEDs) during FULL
      * overtake, so a tool that forces Move's sequencer to keep running (e.g.
-     * dAVEBOx Clock Follow) gets true full LED control instead of fighting
+     * a clock-follow sequencer) gets true full LED control instead of fighting
      * Move's repaints. Opt-in per tool (shadow_set_overtake_suppress_sysex);
      * default 0 leaves the existing sysex passthrough unchanged. This byte
      * reuses the former reserved[1] slot, but the struct still grew 72->76

--- a/src/host/shadow_led_queue.c
+++ b/src/host/shadow_led_queue.c
@@ -454,7 +454,7 @@ void shadow_clear_move_leds_if_overtake(void) {
              * F0 00 21 1D ... LED command). The note/CC strips above don't
              * touch sysex, so by default Move's RGB repaints pass through —
              * fine when its sequencer is stopped, but they fight the tool's
-             * LEDs once a tool (dAVEBOx Clock Follow) keeps Move running.
+             * LEDs once a tool (e.g. a clock-follow sequencer) keeps Move running.
              * Opt-in: strip every cable-0 sysex packet (start/continue/end,
              * CIN 0x04-0x07) so the tool owns RGB too. Safe because such a
              * tool paints its own pads via note-palette / CC, injected into

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -85,7 +85,7 @@ int shadow_external_dispatch_was_recent(uint8_t status, uint8_t d1, uint8_t d2)
  * shifts down as Move consumes slot 0.  A retriggered note (new XMOS event)
  * has a fresh timestamp, so its key differs and it dispatches normally.
  *
- * Injected packets (chain MIDI FX, davebox ROUTE_MOVE) carry a zero timestamp
+ * Injected packets (chain MIDI FX, an overtake tool routing to Move) carry a zero timestamp
  * — they collide if they share USB-MIDI bytes within the staleness window,
  * but they don't reach this dispatcher in normal operation (Move's firmware
  * routes them out of MIDI_IN cable-2 quickly via the cable-0 inject path). */


### PR DESCRIPTION
Comment + documentation cleanup only — **no behavior change**.

A few co-run LED-ownership and MIDI-inject comments (and one line in `docs/CORUN.md`) used a specific module as the illustrative example. Reworded to neutral framework language ("a tool" / "a clock-follow sequencer" / "an overtake tool routing to Move") so the host code reads generically.

Files: `src/host/shadow_constants.h`, `src/host/shadow_led_queue.c`, `src/host/shadow_midi.c`, `docs/CORUN.md` (+5/−5, comments/doc).
