### PR TITLE
Add Magneto to module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1045,6 +1045,17 @@
       "default_branch": "main",
       "asset_name": "movy-module.tar.gz",
       "min_host_version": "0.9.13"
+    },
+    {
+      "id": "magneto",
+      "name": "Magneto",
+      "description": "Stereo cassette/tape looper + recorder: two 30 s tape sides, overdub, 9 tape models, varspeed/reverse/scrub/scan/stutter, tempo-synced loops, WAV load/export",
+      "author": "Filliformes",
+      "component_type": "audio_fx",
+      "github_repo": "filliformes/magneto-move",
+      "default_branch": "main",
+      "asset_name": "magneto-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1055,7 +1055,7 @@
       "github_repo": "filliformes/magneto-move",
       "default_branch": "main",
       "asset_name": "magneto-module.tar.gz",
-      "min_host_version": "0.3.0"
+      "min_host_version": "0.7.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Magneto** — a stereo cassette/tape looper + recorder audio FX, inspired by the Library of Congress C-1 cassette player and the Tascam Portastudio.

- Two 30 s tape sides (A/B) with record, overdub (classic sound-on-sound) and per-Set loop persistence
- 9 tape models (baked EQ voices, wow/flutter, coloured hiss), Tascam-style channel strip
- Performance surface: varspeed (±2 oct), reverse, fast-wind, scrub jog, jump, scan, stutter, dropouts, tape-stop
- Tempo-synced loop lengths (tick-locked to MIDI clock, manual BPM fallback)
- WAV load/export via the stock filepath browser (`UserLibrary/Magneto Recs`)

Repo: https://github.com/filliformes/magneto-move · Current release: [v0.1.1](https://github.com/filliformes/magneto-move/releases/tag/v0.1.1) · `release.json` present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)