### PR TITLE
Add Fizzik — polyphonic simplex physical-modeling synth

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1045,6 +1045,17 @@
       "default_branch": "main",
       "asset_name": "movy-module.tar.gz",
       "min_host_version": "0.9.13"
+    },
+    {
+      "id": "fizzik",
+      "name": "Fizzik",
+      "description": "Polyphonic simplex physical-modeling synth: two coupled resonators (string/beam/plate/membrane), tension modulation, 12-voicing analog filter, poly aftertouch, dual LFOs, full FX chain",
+      "author": "Filliformes",
+      "component_type": "sound_generator",
+      "github_repo": "filliformes/fizzik-move",
+      "default_branch": "master",
+      "asset_name": "fizzik-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Fizzik** (`sound_generator`) to the catalog.

Two coupled physical resonators per voice (String waveguide / Beam / Plate / Membrane) with tension-modulation nonlinearity, a 12-voicing analog-modeled global filter, polyphonic aftertouch expression (10 AT presets), dual LFOs, musically-bounded randomizers, a full FX chain (reverb, ping-pong delay, chorus, EQ, glue comp), and a lookahead brickwall limiter with a hearing-safe default ceiling. 30 level-calibrated presets. Inspired by MechanOdd (odoare); DSP reimplemented clean-room in C. MIT.

- Repo: https://github.com/filliformes/fizzik-move
- Release: https://github.com/filliformes/fizzik-move/releases/tag/v0.1.0 (CI-built, tarball version verified)
- `release.json` present on default branch `master`
- `api_version: 2`, `component_type` at root level, Shadow UI `ui_hierarchy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)