### PR TITLE
Add PALETTE — 4-slot serial multi-effect (audio_fx)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1045,6 +1045,17 @@
       "default_branch": "main",
       "asset_name": "movy-module.tar.gz",
       "min_host_version": "0.9.13"
+    },
+    {
+      "id": "palette",
+      "name": "PALETTE",
+      "description": "4-slot serial multi-effect — 24 reorderable effects, per-slot drift, feedback + tempo sync (Chroma Console reimagined)",
+      "author": "Filliformes",
+      "component_type": "audio_fx",
+      "github_repo": "filliformes/palette-move",
+      "default_branch": "master",
+      "asset_name": "palette-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **PALETTE** to the module catalog.

**PALETTE** is a 4-slot serial multi-effect for the Signal Chain — a shared palette of 24 reorderable effects (drive, fuzz, wavefolder, delays, tape echo, Clouds reverbs, DJ filter, granular, spectral-free harmonic resonator, and more), each with Amount / Macro / Drift. Effect uniqueness (each ≤ 1 slot), 50 factory presets, 6 randomizers, a global feedback send, and MIDI-clock / internal tempo sync. Inspired by the Hologram Electronics Chroma Console.

- **Repo:** https://github.com/filliformes/palette-move
- **Release:** https://github.com/filliformes/palette-move/releases/tag/v0.1.0
- **Author:** Filliformes · **License:** MIT

Checklist:
- [x] `api_version: 2`, `component_type: audio_fx` at root of `module.json` **and** `src/module.json`
- [x] `release.json` on default branch (`master`) with matching `download_url`
- [x] Asset `palette-module.tar.gz` (matches catalog `asset_name`)
- [x] Built on `ubuntu-22.04` — glibc ≤ 2.27, no `libmvec` (loads on Move)
- [x] `src/module.json` reachable (desktop installer discovery)
- [x] `help.json` included; scripts executable; `-Wall -Wextra` clean

Entry appended (no existing lines modified).