### PR TITLE
catalog: refresh Forge description for v0.2.0

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -916,7 +916,7 @@
     {
       "id": "forge",
       "name": "Forge",
-      "description": "8-voice FM/subtractive hybrid drum synthesiser with Kit A↔B morph across 16 pads, 5 voice algorithms, per-voice resonator, dual filter with Comb modes, three concurrent FX buses & 64 factory kits",
+      "description": "8-voice FM/subtractive hybrid drum synthesiser for Ableton Move — Kit A↔B morph across 16 pads, 5 voice algorithms, a self-oscillating ladder filter, dedicated noise oscillator, enveloped FM, per-voice resonator, Ctrl-All performance macros, three concurrent FX buses & 137 factory kits",
       "author": "filliformes",
       "component_type": "sound_generator",
       "github_repo": "filliformes/forge-move",


### PR DESCRIPTION
Updates the Forge catalog description to reflect the v0.2.0 release.

New since the current text: self-oscillating **ladder filter**, a **dedicated noise oscillator**, **enveloped FM**, **Ctrl-All performance macros**, and **137 factory kits** (was 64). One-line change to `module-catalog.json`; version/download are unchanged (resolved from the repo's release.json).

Repo: https://github.com/filliformes/forge-move · Release: https://github.com/filliformes/forge-move/releases/tag/v0.2.0