### PR TITLE
catalog: add Smack + Smack In + Oversmack — loop capture with per-slice glitch FX

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1078,6 +1078,17 @@
       "default_branch": "master",
       "asset_name": "palette-module.tar.gz",
       "min_host_version": "0.7.11"
+    },
+    {
+      "id": "smack",
+      "name": "Smack",
+      "description": "Quantized live-loop capture with seeded per-slice glitch FX and slice reordering - 18 effects, A/B punch, step-button pattern editing",
+      "author": "timncox",
+      "component_type": "audio_fx",
+      "github_repo": "timncox/schwung-smack",
+      "default_branch": "main",
+      "asset_name": "smack-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1082,7 +1082,7 @@
     {
       "id": "smack",
       "name": "Smack",
-      "description": "Quantized live-loop capture with seeded per-slice glitch FX and slice reordering - 18 effects, A/B punch, step-button pattern editing",
+      "description": "Quantized live-loop capture with seeded per-slice glitch FX and slice reordering - 22 effects, A/B punch, step-button pattern editing",
       "author": "timncox",
       "component_type": "audio_fx",
       "github_repo": "timncox/schwung-smack",

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1089,6 +1089,17 @@
       "default_branch": "main",
       "asset_name": "smack-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "smack-in",
+      "name": "Smack In",
+      "description": "Standalone mic/line-in build of Smack: quantized loop capture with seeded per-slice glitch FX in one slot, no linein needed",
+      "author": "timncox",
+      "component_type": "sound_generator",
+      "github_repo": "timncox/schwung-smack-in",
+      "default_branch": "main",
+      "asset_name": "smack-in-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Smack** (audio_fx), **Smack In** (sound_generator), and **Oversmack** (overtake) to the module catalog — three builds of one loop-glitcher core.

**What it is:** quantized live-loop capture (retroactive grab via the Capture button, or arm/record; 1 step–16 bars, MIDI-clock synced with project-tempo free-run fallback) → grid slicing (½-step to 4-step) → a **seeded pattern** of per-slice effects and slice reordering at independent densities. Patterns repeat identically each pass until re-rolled; the Seed knob browses patterns by number. A/B punches between the clean loop and the pattern, quantized to slice/loop boundaries.

- 22 per-slice effects: retrig, reverse, varispeed pitch (±24 st), half/double speed, gate, buzz, crush, repeat-after-split, reverse-after-split, tape stop/start, scratch, envelope shapes, pan, LP/HP sweeps, morphing vowel filter, tonal delay, granular freeze, tempo-synced delay (incl. ping-pong), distortion, phaser, gated reverb bursts
- **Dual mono**: L/R inputs as independent lanes, each with its own pattern, panned into the field
- **BPM detection**: Shift+Capture analyses the last 8 s of input and sets the free-run grid (clock always wins)
- **Smack** works in Signal Chain and Master FX slots; **Smack In** is the standalone input build (declares `audio_in`, host feedback gate applies, plus its own monitor guard); **Oversmack** takes the whole surface — steps select slices, three pad rows are the effect palette, pins survive re-roll, arrows/jog page through bars, `suspend_keeps_js` keeps audio running under Move
- On-device help (`help.json`) and full screen-reader support in all three; module presets via the `state` contract; transport follow
- Exports `move_audio_fx_on_midi` for clock (audio_fx build); struct `on_midi` for the generator/overtake path; non-allocating render; api_version 2

**Repos:** https://github.com/timncox/schwung-smack (source, MIT; vendored API headers attributed), plus thin distribution repos https://github.com/timncox/schwung-smack-in and https://github.com/timncox/schwung-oversmack (each catalog id resolves its own `release.json`)
**Releases:** smack/smack-in v0.6.2, oversmack v0.3.3
Tested on Move hardware through several release iterations (Master FX placement, Oversmack full-surface UI, USB-C input, feedback guard, dual mono). Native host-simulation suite covers the engine. Heavily written by coding agents, with human supervision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
