### PR TITLE
catalog: add Oversmack — full-surface overtake build of Smack

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1093,12 +1093,23 @@
     {
       "id": "smack-in",
       "name": "Smack In",
-      "description": "Standalone mic/line-in build of Smack: quantized loop capture with seeded per-slice glitch FX in one slot, no linein needed",
+      "description": "Standalone input build of Smack (mic/line/USB-C): quantized loop capture with seeded per-slice glitch FX in one slot, no linein needed",
       "author": "timncox",
       "component_type": "sound_generator",
       "github_repo": "timncox/schwung-smack-in",
       "default_branch": "main",
       "asset_name": "smack-in-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "oversmack",
+      "name": "Oversmack",
+      "description": "Full-surface Smack: input loop glitcher (mic/line/USB-C) with the whole pad grid as a step-FX editor - family-grouped 22-effect palette, pressure-bent punches, dual mono, BPM detect",
+      "author": "timncox",
+      "component_type": "overtake",
+      "github_repo": "timncox/schwung-oversmack",
+      "default_branch": "main",
+      "asset_name": "oversmack-module.tar.gz",
       "min_host_version": "0.3.0"
     }
   ]


### PR DESCRIPTION
Adds **Oversmack** — the overtake build of [Smack](https://github.com/timncox/schwung-smack) (merged in #156) — and freshens the smack-in description to mention USB-C input.

**What it is:** Smack's loop-glitcher engine with the whole Move surface as the interface. Reads Move's selected input (mic/line/USB-C), captures clock-quantized loops, and turns the grid into a step-FX editor:

- Steps show the sliced pattern (family-colored) with playhead chase; press to select, jog/arrows page through bars for long loops
- Three pad rows are the effect palette, grouped by family (stutter/tape/reverse/pitch/shape/filter/space/destruction); tap = set a slice's effect, hold = pin it (pins survive Re-Roll), hold with no selection = momentary whole-loop punch with **per-pad pressure bending the effect parameter**
- Bottom row: Capture / Arm / A-B (hold = momentary punch) / Re-Roll (hold = clear pins) / Clear / Monitor / Stereo-DualMono / lane select
- Dual mono (L/R as independent lanes with per-lane patterns + pans), Shift knob page 2, BPM detection (Shift+Re-Roll) driving the free-run grid, speaker-feedback guard, on-device help.json, full screen-reader support
- `suspend_keeps_js`: Back hides the UI while the audio keeps running; Play passes through so Move's transport/clock stay live

**Repo:** https://github.com/timncox/schwung-oversmack (thin distribution repo; source lives in timncox/schwung-smack, MIT)
**Release:** v0.3.8 with tarball + release.json
Extensively hardware-tested on Move through eleven release iterations today (capture, USB-C input, feedback guard, dual mono, punches). Heavily written by coding agents, with human supervision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
