### PR TITLE
catalog: add Mark (RC-505-style 5-track loop station) + Oversmack

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1100,6 +1100,28 @@
       "default_branch": "main",
       "asset_name": "smack-in-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "oversmack",
+      "name": "Oversmack",
+      "description": "Full-surface Smack: input loop glitcher (mic/line/USB-C) with the whole pad grid as a step-FX editor - palette pinning, global punch FX with pad pressure, dual-mono lanes, browser editor",
+      "author": "timncox",
+      "component_type": "overtake",
+      "github_repo": "timncox/schwung-oversmack",
+      "default_branch": "main",
+      "asset_name": "oversmack-module.tar.gz",
+      "min_host_version": "0.12.0"
+    },
+    {
+      "id": "mark",
+      "name": "Mark",
+      "description": "RC-505-style 5-track live loop station: per-track record/play/overdub + insert FX, measure-quantized sync, undo/redo, 16 on-device save sessions, single/section mode, browser mixer",
+      "author": "timncox",
+      "component_type": "overtake",
+      "github_repo": "timncox/schwung-mark",
+      "default_branch": "main",
+      "asset_name": "mark-module.tar.gz",
+      "min_host_version": "0.12.0"
     }
   ]
 }


### PR DESCRIPTION
Adds two full-surface overtake modules from timncox.

## Mark

An RC-505-style five-track live loop station with:

- per-track record, play, overdub, stop, clear, level, pan, reverse, and one-shot controls
- measure-quantized sync from Move MIDI clock or the first recorded loop
- per-track insert FX, undo/redo, and single/section play mode
- 16 on-device sessions that store loop audio and settings
- a browser mixer in the Remote UI Tool tab

Current release: **v0.3.2**  
Docs: https://timncox.github.io/schwung-mark/  
Repository: https://github.com/timncox/schwung-mark

## Oversmack

The full-surface build of Smack, whose chain and standalone-input variants were merged in #156:

- whole-grid step-FX editing with palette pinning
- pressure-controlled global punch effects
- retro and armed capture, A/B switching, and seeded rerolls
- dual-mono lanes and a browser palette editor
- the current 26-effect Smack engine and Pad Play sequencing

Current release: **v0.10.0**  
Docs and source: https://timncox.github.io/schwung-smack/  
Distribution repository: https://github.com/timncox/schwung-oversmack

## Host compatibility

Both modules declare overtake audio input. They retain `min_host_version: "0.12.0"` so released hosts with the older feedback-gate crash cannot install them.

The catalog entries point at each repository and asset name rather than pinning a release version, so they will continue resolving future published releases.