### PR TITLE
catalog: add Belt (live vocal processor) + Belt In

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1100,6 +1100,28 @@
       "default_branch": "main",
       "asset_name": "smack-in-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "belt",
+      "name": "Belt",
+      "description": "Live vocal processor: autotune pitch correction, diatonic backing-vocal harmonies, doubler, and formant shift - chain and Master FX build",
+      "author": "timncox",
+      "component_type": "audio_fx",
+      "github_repo": "timncox/schwung-belt",
+      "default_branch": "main",
+      "asset_name": "belt-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "belt-in",
+      "name": "Belt In",
+      "description": "Standalone live-input (mic/line/USB-C) build of Belt: sing into the Move and get tuned, harmonized vocals in one slot",
+      "author": "timncox",
+      "component_type": "sound_generator",
+      "github_repo": "timncox/schwung-belt-in",
+      "default_branch": "main",
+      "asset_name": "belt-in-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds two catalog entries for **Belt**, a live vocal processor for Ableton Move.

## Belt

The `audio_fx` build for Signal Chain slots and Master FX:

- autotune-style pitch correction from transparent correction to Hard Tune
- four scale-aware backing-vocal harmony voices
- stereo doubler, formant shift, Flex, and Humanize controls
- step-button tuner and direct key selection
- corrected stereo pan behavior and output limiting for stable headroom

Repository: https://github.com/timncox/schwung-belt

## Belt In

The `sound_generator` live-input build for Move microphone, line-in, or USB-C input. It uses the same DSP and chain UI with the host-compatible feedback guard.

Distribution repository: https://github.com/timncox/schwung-belt-in

Current release for both modules: **v0.1.1**  
Operation manual: https://timncox.github.io/schwung-belt/

Both release repositories expose validated aarch64 archives and installer metadata. The catalog entries point at the repositories and asset names rather than pinning a release version, so future published releases will resolve automatically.