### PR TITLE
catalog: fix Mark/Oversmack host gate and refresh Smack copy

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1110,7 +1110,7 @@
       "github_repo": "timncox/schwung-oversmack",
       "default_branch": "main",
       "asset_name": "oversmack-module.tar.gz",
-      "min_host_version": "0.12.0"
+      "min_host_version": "0.11.4"
     },
     {
       "id": "mark",
@@ -1121,7 +1121,7 @@
       "github_repo": "timncox/schwung-mark",
       "default_branch": "main",
       "asset_name": "mark-module.tar.gz",
-      "min_host_version": "0.12.0"
+      "min_host_version": "0.11.4"
     },
     {
       "id": "belt",

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1082,7 +1082,7 @@
     {
       "id": "smack",
       "name": "Smack",
-      "description": "Quantized live-loop capture with seeded per-slice glitch FX and slice reordering - 22 effects, A/B punch, step-button pattern editing",
+      "description": "Quantized live-loop capture with seeded per-slice glitch FX and slice reordering - 26 effects, A/B punch, step-button editing, Pad Play",
       "author": "timncox",
       "component_type": "audio_fx",
       "github_repo": "timncox/schwung-smack",
@@ -1093,7 +1093,7 @@
     {
       "id": "smack-in",
       "name": "Smack In",
-      "description": "Standalone mic/line-in build of Smack: quantized loop capture with seeded per-slice glitch FX in one slot, no linein needed",
+      "description": "Standalone mic/line/USB-C input build of Smack: quantized loop capture with the same 26-effect seeded slice engine and Pad Play",
       "author": "timncox",
       "component_type": "sound_generator",
       "github_repo": "timncox/schwung-smack-in",


### PR DESCRIPTION
## What changed

- lower Mark and Oversmack's catalog requirement from the unreleased Schwung 0.12.0 to the released 0.11.4 host
- refresh Smack's catalog copy from 22 to 26 effects and mention Pad Play
- update Smack In's input description to include USB-C

## Root cause

The live catalog currently advertises Schwung **0.11.4** as the latest host while Mark and Oversmack require **0.12.0**. That makes both modules impossible to install from the store, even on a fully updated Move.

The 0.12.0 gate was added conservatively after feedback-gate failures during hardware testing, but neither module actually depends on a post-0.11.4 module API.

## Compatibility evidence

- Mark, Oversmack, Smack, and Belt vendor byte-identical native API headers to Schwung v0.11.4.
- Mark and Oversmack only call `host_module_get_param`, `host_module_set_param`, `host_speaker_active`, and `host_line_in_connected`; all four are registered in v0.11.4.
- Schwung v0.11.4 already provides the overtake DSP loader and raw hardware `audio_in_offset` path used by both modules.
- Mark and Oversmack contain their own continuous speaker-feedback guards and Monitor overrides.
- Smack, Smack In, Belt, and Belt In already use a lower `min_host_version: "0.3.0"`; this change does not alter those gates.

This change claims compatibility with **0.11.4**, the version audited here. It does not claim support for older, unverified hosts.

## Validation

- `jq empty module-catalog.json`
- catalog version remains v2 and module IDs remain unique
- catalog host latest version and both corrected gates assert as 0.11.4
- `tests/store/test_release_json_fallback_to_catalog_asset.sh`
- static ABI hash and JS host-binding audit against tag `v0.11.4`