### PR TITLE
Background mode: self-managed suspend for overtake tools

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1693,8 +1693,23 @@ typedef struct host_api_v1 {
 
     /* Clock status for sync-aware plugins */
     int (*get_clock_status)(void);
+
+    /* Transport beat position for phase-locked sync. Beats elapsed since the
+     * active transport's start, derived from 24-PPQN MIDI clock and
+     * interpolated per audio block, tracking whichever transport is playing —
+     * Move's native sequencer (cable-0 clock) or an internal overtake
+     * sequencer that emits clock (e.g. movy). Returns < 0 when no transport is
+     * running (callers should fall back, e.g. free-run an LFO). Use this
+     * instead of accumulating phase from get_bpm() to stay drift-free and
+     * bar-aligned. May be NULL on older hosts — always guard. Appended 2026-07. */
+    double (*get_beat_position)(void);
 } host_api_v1_t;
 ```
+
+**Tempo while stopped:** `get_bpm()` retains the last-playing transport's tempo
+after it stops (so a synced LFO that switches from phase-lock to free-run keeps
+the same rate). It updates from emitted clock, so changing an internal
+sequencer's tempo while it is *stopped* is not reflected until it plays again.
 
 ## Audio Specifications
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -235,7 +235,7 @@ if needs_rebuild build/schwung-shim.so \
     src/schwung_shim.c \
     src/lib/schwung_spi_lib.c src/lib/schwung_spi_lib.h \
     src/lib/schwung_jack_bridge.c src/lib/schwung_jack_bridge.h src/lib/schwung_jack_shm.h \
-    src/host/shadow_sampler.c src/host/shadow_set_pages.c src/host/shadow_dbus.c \
+    src/host/shadow_sampler.c src/host/shadow_transport.c src/host/shadow_set_pages.c src/host/shadow_dbus.c \
     src/host/shadow_chain_mgmt.c src/host/shadow_link_audio.c src/host/shadow_process.c \
     src/host/shadow_resample.c src/host/shadow_overlay.c src/host/shadow_pin_scanner.c \
     src/host/shadow_led_queue.c src/host/shadow_state.c \
@@ -243,7 +243,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_shm_util.c src/host/schwung_trace.c src/host/shadow_test_stream.c src/host/shadow_test_stream.h \
     $SHIM_TTS_SRC \
     src/host/shadow_constants.h src/host/shadow_midi_inject_writer.h src/host/shadow_midi.h src/host/shadow_sampler.h \
-    src/host/shim_worker.h \
+    src/host/shim_worker.h src/host/shadow_transport.h \
     src/host/shadow_set_pages.h src/host/shadow_dbus.h src/host/shadow_chain_mgmt.h \
     src/host/shadow_chain_types.h src/host/shadow_link_audio.h src/host/shadow_process.h \
     src/host/shadow_resample.h src/host/shadow_overlay.h src/host/shadow_pin_scanner.h \
@@ -258,6 +258,7 @@ if needs_rebuild build/schwung-shim.so \
         src/lib/schwung_spi_lib.c \
         src/lib/schwung_jack_bridge.c \
         src/host/shadow_sampler.c \
+        src/host/shadow_transport.c \
         src/host/shadow_set_pages.c \
         src/host/shadow_dbus.c \
         src/host/shadow_chain_mgmt.c \

--- a/src/host/lfo_common.h
+++ b/src/host/lfo_common.h
@@ -206,6 +206,15 @@ static inline float lfo_sync_rate_hz(float bpm, int rate_div) {
     return (bpm / 60.0f) / beats;
 }
 
+/* Phase-locked LFO phase from a transport beat position (see
+ * host_api_v1.get_beat_position). Drift-free by construction: phase is a
+ * pure function of song position, so it stays bar-aligned forever. */
+static inline double lfo_synced_phase(double beat_position, int rate_div) {
+    if (rate_div < 0) rate_div = 0;
+    if (rate_div >= LFO_NUM_DIVISIONS) rate_div = LFO_NUM_DIVISIONS - 1;
+    return fmod(beat_position / (double)lfo_divisions[rate_div].beats, 1.0);
+}
+
 /* Advance LFO phase by one block, return new phase (wraps at 1.0) */
 static inline double lfo_advance_phase(double phase, float rate_hz, int frames, float sample_rate) {
     phase += (double)rate_hz * (double)frames / (double)sample_rate;

--- a/src/host/plugin_api_v1.h
+++ b/src/host/plugin_api_v1.h
@@ -110,6 +110,13 @@ typedef struct host_api_v1 {
      * e.g. minijv part 6). NULL if the host doesn't expose slot context. */
     int (*slot_recv_channel)(void *instance);
 
+    /* Beats since transport start of the active clock source (Move's native
+     * sequencer, or an internal module's emitted clock), derived from
+     * 24-PPQN realtime ticks and interpolated per block. Returns < 0 when
+     * no transport is running — callers must fall back (e.g. LFO free-run).
+     * Appended in 2026-07; may be NULL on older hosts, always guard. */
+    double (*get_beat_position)(void);
+
 } host_api_v1_t;
 
 /*

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -992,6 +992,7 @@ int shadow_inprocess_load_chain(void) {
     shadow_host_api.audio_in_offset = MOVE_AUDIO_IN_OFFSET;
     shadow_host_api.log = shadow_log;
     shadow_host_api.get_bpm = host.get_bpm;  /* Tempo query for LFO sync */
+    shadow_host_api.get_beat_position = host.get_beat_position;  /* transport phase for LFO sync */
     shadow_host_api.midi_inject_to_move = shadow_chain_midi_inject;
     shadow_host_api.slot_recv_channel = shadow_chain_slot_recv_channel;
 

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -2170,17 +2170,25 @@ void shadow_master_fx_lfo_tick(int frames) {
             continue;
         }
 
-        /* Phase accumulation */
-        float rate_hz;
-        if (lfo->sync) {
-            float bpm = 120.0f;
-            if (host.get_bpm) bpm = host.get_bpm();
-            rate_hz = lfo_sync_rate_hz(bpm, lfo->rate_div);
+        /* Phase: when a transport is running, lock to song position (writing
+         * lfo->phase keeps continuity — on stop, free-run resumes from the
+         * locked phase instead of jumping). Otherwise free-run as before. */
+        double bp = -1.0;
+        if (lfo->sync && host.get_beat_position)
+            bp = host.get_beat_position();
+        if (lfo->sync && bp >= 0.0) {
+            lfo->phase = lfo_synced_phase(bp, lfo->rate_div);
         } else {
-            rate_hz = lfo->rate_hz;
+            float rate_hz;
+            if (lfo->sync) {
+                float bpm = 120.0f;
+                if (host.get_bpm) bpm = host.get_bpm();
+                rate_hz = lfo_sync_rate_hz(bpm, lfo->rate_div);
+            } else {
+                rate_hz = lfo->rate_hz;
+            }
+            lfo->phase = lfo_advance_phase(lfo->phase, rate_hz, frames, sample_rate);
         }
-
-        lfo->phase = lfo_advance_phase(lfo->phase, rate_hz, frames, sample_rate);
 
         /* Compute waveform with phase offset */
         double effective_phase = fmod(lfo->phase + (double)lfo->phase_offset, 1.0);

--- a/src/host/shadow_chain_mgmt.h
+++ b/src/host/shadow_chain_mgmt.h
@@ -80,6 +80,10 @@ typedef struct {
     /* Tempo query — returns current BPM via sampler_get_bpm() fallback chain. */
     float (*get_bpm)(void);
 
+    /* Transport beat position for LFO phase-lock (see host_api_v1). < 0 when
+     * no transport is running; may be NULL. */
+    double (*get_beat_position)(void);
+
     /* Web UI notification: called after any param set completes successfully.
      * Pushes the changed value to the web param notify ring for real-time
      * browser updates. May be NULL if web ring is not available. */

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -413,6 +413,23 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
     }
 }
 
+/* Broadcast a 1-byte system-realtime message to every active chain slot.
+ * Realtime must NOT go through shadow_chain_dispatch_midi_to_slots: the
+ * per-slot channel remap rewrites the status low nibble (0xF8 -> 0xF0|ch)
+ * for slots with a forward channel. Mirrors the shim's cable-0 realtime
+ * broadcast, for internally generated transport (e.g. movy's sequencer). */
+void shadow_chain_broadcast_realtime(uint8_t status)
+{
+    const plugin_api_v2_t *pv2 = *host_plugin_v2;
+    if (!pv2 || !pv2->on_midi) return;
+    uint8_t msg[1] = { status };
+    for (int i = 0; i < SHADOW_CHAIN_INSTANCES; i++) {
+        if (host_chain_slots[i].active && host_chain_slots[i].instance)
+            pv2->on_midi(host_chain_slots[i].instance, msg, 1,
+                         MOVE_MIDI_SOURCE_EXTERNAL);
+    }
+}
+
 /* ============================================================================
  * External MIDI CC forwarding
  * ============================================================================ */

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -112,6 +112,11 @@ uint8_t shadow_chain_remap_channel(int slot, uint8_t status);
  * (they receive MIDI via the direct MIDI_IN path instead). */
 void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *midi_log_count, int skip_direct);
 
+/* Broadcast a 1-byte system-realtime message (0xF8/0xFA/0xFB/0xFC) to every
+ * active chain slot, bypassing per-slot channel remap (which would corrupt the
+ * status byte). For internally generated transport clock. */
+void shadow_chain_broadcast_realtime(uint8_t status);
+
 /* Dispatch external MIDI from MIDI_IN cable 2 directly to slots configured
  * for passthrough (receive=All, forward=THRU).  Bypasses Move's MIDI_OUT
  * channel remapping so that MPE per-note expression data stays on the

--- a/src/host/shadow_sampler.c
+++ b/src/host/shadow_sampler.c
@@ -9,6 +9,7 @@
 
 #define _GNU_SOURCE
 #include "shadow_sampler.h"
+#include "shadow_transport.h"
 #include "shim_worker.h"
 #include <semaphore.h>
 
@@ -330,6 +331,17 @@ static int sampler_read_settings_tempo(void) {
 
 /* Get best available BPM using fallback chain */
 float sampler_get_bpm(tempo_source_t *source) {
+    /* 0. Internal transport (an overtake sequencer driving the clock).
+     * Cable-0 (Move) clock is already covered by the measured-clock check
+     * below, so only the internal source needs delegation. */
+    if (shadow_transport_source() == TRANSPORT_SRC_INTERNAL) {
+        float tbpm = shadow_transport_bpm();
+        if (tbpm >= 20.0f) {
+            if (source) *source = TEMPO_SOURCE_CLOCK;
+            return tbpm;
+        }
+    }
+
     /* 1. Active MIDI clock */
     if (sampler_clock_active && sampler_measured_bpm >= 20.0f) {
         if (source) *source = TEMPO_SOURCE_CLOCK;

--- a/src/host/shadow_sampler.c
+++ b/src/host/shadow_sampler.c
@@ -348,6 +348,18 @@ float sampler_get_bpm(tempo_source_t *source) {
         return sampler_measured_bpm;
     }
 
+    /* 1b. Internal transport's last tempo (movy sequencer stopped). Keep synced
+     * params at movy's tempo instead of snapping back to the Set/default tempo,
+     * so a synced LFO free-runs at the rate it was locked to. Ranks below an
+     * actively-running clock (above) but above the Set tempo. */
+    if (shadow_transport_last_source() == TRANSPORT_SRC_INTERNAL) {
+        float lbpm = shadow_transport_last_bpm();
+        if (lbpm >= 20.0f) {
+            if (source) *source = TEMPO_SOURCE_LAST_CLOCK;
+            return lbpm;
+        }
+    }
+
     /* 2. Current Set's tempo */
     float set_tempo = s_set_tempo_ptr ? *s_set_tempo_ptr : 0.0f;
     if (set_tempo >= 20.0f) {

--- a/src/host/shadow_transport.c
+++ b/src/host/shadow_transport.c
@@ -23,6 +23,11 @@ static transport_source_state_t g_src[3];
 static unsigned long long g_now;
 static uint32_t g_sample_rate = 44100;
 static unsigned long long g_stale_samples;
+/* Last actively-measured tempo + its source, retained after stop. */
+static float g_last_bpm;
+static int g_last_bpm_source;
+
+static transport_source_state_t *transport_active(int *which);
 
 void shadow_transport_init(uint32_t sample_rate) {
     for (int i = 0; i < 3; i++) {
@@ -35,6 +40,8 @@ void shadow_transport_init(uint32_t sample_rate) {
     g_now = 0;
     g_sample_rate = sample_rate ? sample_rate : 44100;
     g_stale_samples = (unsigned long long)(TRANSPORT_STALE_SEC * g_sample_rate);
+    g_last_bpm = 0.0f;
+    g_last_bpm_source = TRANSPORT_SRC_NONE;
 }
 
 void shadow_transport_advance_block(int frames) {
@@ -46,6 +53,14 @@ void shadow_transport_advance_block(int frames) {
             g_now - g_src[i].last_tick_at > g_stale_samples) {
             g_src[i].running = 0;
         }
+    }
+    /* Capture the active transport's tempo each block; it survives stop so a
+     * free-running LFO keeps the rate it was locked to. */
+    int which = TRANSPORT_SRC_NONE;
+    transport_source_state_t *a = transport_active(&which);
+    if (a && a->tick_interval > 0.0) {
+        g_last_bpm = (float)((60.0 * g_sample_rate) / (a->tick_interval * TRANSPORT_PPQN));
+        g_last_bpm_source = which;
     }
 }
 
@@ -131,4 +146,12 @@ int shadow_transport_source(void) {
     int which = TRANSPORT_SRC_NONE;
     (void)transport_active(&which);
     return which;
+}
+
+float shadow_transport_last_bpm(void) {
+    return g_last_bpm;
+}
+
+int shadow_transport_last_source(void) {
+    return g_last_bpm_source;
 }

--- a/src/host/shadow_transport.c
+++ b/src/host/shadow_transport.c
@@ -1,0 +1,134 @@
+/* Single authority for transport state: which clock source is running, its
+ * tempo, and an interpolated beat position. Fed system-realtime bytes from
+ * the shim's cable-0 tap (Move native) and from overtake-DSP internal sends.
+ * Every function runs on the shim's audio thread: fixed-size state, no
+ * locks, no I/O, no allocation. */
+#include "shadow_transport.h"
+
+#define TRANSPORT_PPQN 24
+#define TRANSPORT_STALE_SEC 0.5
+/* EMA weight: converges in ~10 ticks while absorbing the ±1-block (~2.9 ms)
+ * jitter of block-quantized clock senders. */
+#define TRANSPORT_EMA_ALPHA 0.25
+
+typedef struct {
+    int running;
+    int awaiting_first_tick;  /* set by 0xFA; the next 0xF8 is tick 0 */
+    unsigned long long tick_count;
+    unsigned long long last_tick_at;  /* sample time of last 0xF8 */
+    double tick_interval;             /* EMA, samples per tick; 0 = unknown */
+} transport_source_state_t;
+
+static transport_source_state_t g_src[3];
+static unsigned long long g_now;
+static uint32_t g_sample_rate = 44100;
+static unsigned long long g_stale_samples;
+
+void shadow_transport_init(uint32_t sample_rate) {
+    for (int i = 0; i < 3; i++) {
+        g_src[i].running = 0;
+        g_src[i].awaiting_first_tick = 0;
+        g_src[i].tick_count = 0;
+        g_src[i].last_tick_at = 0;
+        g_src[i].tick_interval = 0.0;
+    }
+    g_now = 0;
+    g_sample_rate = sample_rate ? sample_rate : 44100;
+    g_stale_samples = (unsigned long long)(TRANSPORT_STALE_SEC * g_sample_rate);
+}
+
+void shadow_transport_advance_block(int frames) {
+    if (frames > 0) g_now += (unsigned long long)frames;
+    /* Staleness safety net: Move normally sends 0xFC on stop, but a wedged
+     * sender must not leave LFOs frozen on a dead beat position. */
+    for (int i = 1; i < 3; i++) {
+        if (g_src[i].running && g_src[i].last_tick_at &&
+            g_now - g_src[i].last_tick_at > g_stale_samples) {
+            g_src[i].running = 0;
+        }
+    }
+}
+
+void shadow_transport_on_realtime(transport_src_t src, uint8_t status) {
+    if (src != TRANSPORT_SRC_MOVE && src != TRANSPORT_SRC_INTERNAL) return;
+    transport_source_state_t *s = &g_src[src];
+    switch (status) {
+    case 0xFA:
+        s->running = 1;
+        s->awaiting_first_tick = 1;
+        s->tick_count = 0;
+        s->last_tick_at = g_now;
+        break;
+    case 0xFB:
+        s->running = 1;
+        break;
+    case 0xFC:
+        s->running = 0;
+        break;
+    case 0xF8:
+        if (!s->running) {
+            /* Clock without Start (we attached mid-song): run unanchored so
+             * the tempo is right; bar alignment arrives with the next 0xFA. */
+            s->running = 1;
+            s->awaiting_first_tick = 1;
+        }
+        if (s->awaiting_first_tick) {
+            s->awaiting_first_tick = 0;
+            s->tick_count = 0;
+        } else {
+            s->tick_count++;
+            double delta = (double)(g_now - s->last_tick_at);
+            /* Accept only intervals inside 20-999 BPM at 24 PPQN. */
+            double min_d = (60.0 * g_sample_rate) / (999.0 * TRANSPORT_PPQN);
+            double max_d = (60.0 * g_sample_rate) / (20.0 * TRANSPORT_PPQN);
+            if (delta >= min_d && delta <= max_d) {
+                s->tick_interval = (s->tick_interval <= 0.0)
+                    ? delta
+                    : s->tick_interval + TRANSPORT_EMA_ALPHA * (delta - s->tick_interval);
+            }
+        }
+        s->last_tick_at = g_now;
+        break;
+    default:
+        break;
+    }
+}
+
+static transport_source_state_t *transport_active(int *which) {
+    if (g_src[TRANSPORT_SRC_MOVE].running) {
+        if (which) *which = TRANSPORT_SRC_MOVE;
+        return &g_src[TRANSPORT_SRC_MOVE];
+    }
+    if (g_src[TRANSPORT_SRC_INTERNAL].running) {
+        if (which) *which = TRANSPORT_SRC_INTERNAL;
+        return &g_src[TRANSPORT_SRC_INTERNAL];
+    }
+    if (which) *which = TRANSPORT_SRC_NONE;
+    return 0;
+}
+
+double shadow_transport_beat_position(void) {
+    transport_source_state_t *s = transport_active(0);
+    if (!s) return -1.0;
+    double frac = 0.0;
+    if (s->tick_interval > 0.0) {
+        frac = (double)(g_now - s->last_tick_at) / s->tick_interval;
+        /* Never run past the next expected tick: a late tick freezes phase
+         * instead of overshooting and snapping back. */
+        if (frac > 1.0) frac = 1.0;
+        if (frac < 0.0) frac = 0.0;
+    }
+    return ((double)s->tick_count + frac) / (double)TRANSPORT_PPQN;
+}
+
+float shadow_transport_bpm(void) {
+    transport_source_state_t *s = transport_active(0);
+    if (!s || s->tick_interval <= 0.0) return 0.0f;
+    return (float)((60.0 * g_sample_rate) / (s->tick_interval * TRANSPORT_PPQN));
+}
+
+int shadow_transport_source(void) {
+    int which = TRANSPORT_SRC_NONE;
+    (void)transport_active(&which);
+    return which;
+}

--- a/src/host/shadow_transport.c
+++ b/src/host/shadow_transport.c
@@ -1,8 +1,12 @@
 /* Single authority for transport state: which clock source is running, its
  * tempo, and an interpolated beat position. Fed system-realtime bytes from
  * the shim's cable-0 tap (Move native) and from overtake-DSP internal sends.
- * Every function runs on the shim's audio thread: fixed-size state, no
- * locks, no I/O, no allocation. */
+ * The writers (shadow_transport_on_realtime, shadow_transport_advance_block)
+ * run on the shim's audio thread: fixed-size state, no locks, no I/O, no
+ * allocation. The BPM/source readers (shadow_transport_bpm/source/last_*) may
+ * also be called off the audio thread via sampler_get_bpm; like the existing
+ * unlocked sampler BPM reads, a torn double read on 32-bit ARM yields at worst
+ * a transient wrong BPM, never a crash, and no reader mutates state. */
 #include "shadow_transport.h"
 
 #define TRANSPORT_PPQN 24
@@ -76,6 +80,12 @@ void shadow_transport_on_realtime(transport_src_t src, uint8_t status) {
         break;
     case 0xFB:
         s->running = 1;
+        /* Continue resumes mid-bar (tick_count is kept, unlike 0xFA). Refresh
+         * last_tick_at so advance_block's staleness net can't flip us back off
+         * before the first post-Continue 0xF8 — that would re-anchor the next
+         * tick to beat 0 instead of resuming. (Movy emits only FA/F8/FC, so
+         * this hardens the Move-native source, which can send Continue.) */
+        s->last_tick_at = g_now;
         break;
     case 0xFC:
         s->running = 0;

--- a/src/host/shadow_transport.h
+++ b/src/host/shadow_transport.h
@@ -24,4 +24,11 @@ double shadow_transport_beat_position(void);         /* beats; < 0 = no transpor
 float  shadow_transport_bpm(void);                   /* 0 = unknown */
 int    shadow_transport_source(void);                /* active transport_src_t */
 
+/* Last transport that measured a tempo, and that tempo — retained after the
+ * transport stops (until a different source runs or re-init). Lets synced
+ * params (e.g. a free-running LFO) hold the stopped transport's tempo instead
+ * of snapping back to the Set/default tempo. bpm 0 / source NONE = never run. */
+float  shadow_transport_last_bpm(void);
+int    shadow_transport_last_source(void);
+
 #endif /* SHADOW_TRANSPORT_H */

--- a/src/host/shadow_transport.h
+++ b/src/host/shadow_transport.h
@@ -1,0 +1,27 @@
+/* shadow_transport.h - Single authority for transport (clock) state.
+ *
+ * Answers "which clock source is running, at what tempo, at what beat
+ * position." Fed system-realtime bytes from the shim's cable-0 tap (Move's
+ * native sequencer) and from overtake-DSP internal sends (e.g. movy). Every
+ * function runs on the shim's audio thread: fixed-size state, no locks, no
+ * I/O, no allocation, no logging. */
+
+#ifndef SHADOW_TRANSPORT_H
+#define SHADOW_TRANSPORT_H
+
+#include <stdint.h>
+
+typedef enum {
+    TRANSPORT_SRC_NONE = 0,
+    TRANSPORT_SRC_MOVE = 1,      /* Move's native sequencer (cable-0 realtime) */
+    TRANSPORT_SRC_INTERNAL = 2,  /* overtake DSP (movy) via midi_send_internal */
+} transport_src_t;
+
+void   shadow_transport_init(uint32_t sample_rate);
+void   shadow_transport_on_realtime(transport_src_t src, uint8_t status);
+void   shadow_transport_advance_block(int frames);   /* once per audio block */
+double shadow_transport_beat_position(void);         /* beats; < 0 = no transport */
+float  shadow_transport_bpm(void);                   /* 0 = unknown */
+int    shadow_transport_source(void);                /* active transport_src_t */
+
+#endif /* SHADOW_TRANSPORT_H */

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1890,19 +1890,25 @@ static void lfo_tick(chain_instance_t *inst, int frames) {
         lfo_state_t *lfo = &inst->lfos[i];
         if (!lfo->enabled || !lfo->active) continue;
 
-        /* Phase accumulation */
-        float rate_hz;
-        if (lfo->sync) {
-            float bpm = 120.0f;
-            if (inst->host && inst->host->get_bpm) {
-                bpm = inst->host->get_bpm();
-            }
-            rate_hz = lfo_sync_rate_hz(bpm, lfo->rate_div);
+        /* Phase: when a transport is running, lock to song position (writing
+         * lfo->phase keeps continuity — on stop, free-run resumes from the
+         * locked phase instead of jumping). Otherwise free-run as before. */
+        double bp = -1.0;
+        if (lfo->sync && inst->host && inst->host->get_beat_position)
+            bp = inst->host->get_beat_position();
+        if (lfo->sync && bp >= 0.0) {
+            lfo->phase = lfo_synced_phase(bp, lfo->rate_div);
         } else {
-            rate_hz = lfo->rate_hz;
+            float rate_hz;
+            if (lfo->sync) {
+                float bpm = 120.0f;
+                if (inst->host && inst->host->get_bpm) bpm = inst->host->get_bpm();
+                rate_hz = lfo_sync_rate_hz(bpm, lfo->rate_div);
+            } else {
+                rate_hz = lfo->rate_hz;
+            }
+            lfo->phase = lfo_advance_phase(lfo->phase, rate_hz, frames, sample_rate);
         }
-
-        lfo->phase = lfo_advance_phase(lfo->phase, rate_hz, frames, sample_rate);
 
         /* Compute waveform with phase offset */
         double effective_phase = fmod(lfo->phase + (double)lfo->phase_offset, 1.0);

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1466,6 +1466,7 @@ static void shadow_overtake_dsp_load(const char *path) {
     overtake_host_api.midi_send_internal = overtake_midi_send_internal;
     overtake_host_api.midi_send_external = overtake_midi_send_external;
     overtake_host_api.get_bpm = shim_get_bpm;
+    overtake_host_api.get_beat_position = shadow_transport_beat_position;
     overtake_host_api.midi_inject_to_move = shadow_chain_midi_inject;
 
     /* Extract module directory from dsp path */
@@ -3878,6 +3879,7 @@ static void shim_init_subsystems(void)
             .startup_modwheel_reset_frames = STARTUP_MODWHEEL_RESET_FRAMES,
             .handle_param_special = shim_handle_param_special,
             .get_bpm = shim_get_bpm,
+            .get_beat_position = shadow_transport_beat_position,
             .on_param_changed = web_param_notify_push,
         };
         chain_mgmt_init(&cm_host);

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -47,6 +47,7 @@
 #include "host/tts_engine.h"
 #include "host/link_audio.h"
 #include "host/shadow_sampler.h"
+#include "host/shadow_transport.h"
 #include "host/shadow_set_pages.h"
 #include "host/shim_worker.h"
 #include "host/shadow_dbus.h"
@@ -1199,6 +1200,7 @@ static void shadow_inprocess_process_midi(void) {
             /* Sampler sees clock from cable 0 only (Move internal) to avoid double-counting */
             if (cable == 0) {
                 sampler_on_clock(status_usb);
+                shadow_transport_on_realtime(TRANSPORT_SRC_MOVE, status_usb);
             }
 
             /* Deliver realtime to overtake DSP from cable 0 (Move's internal
@@ -1324,6 +1326,14 @@ static void shadow_inprocess_process_midi(void) {
 /* MIDI send callback for overtake DSP → chain slots */
 static int overtake_midi_send_internal(const uint8_t *msg, int len) {
     if (!msg || len < 4) return 0;
+    /* System realtime is transport, not note data: feed the transport service
+     * and broadcast on the same 1-byte path as the cable-0 tap. Must NOT go
+     * through dispatch_to_slots, whose channel remap corrupts the status byte. */
+    if (msg[1] >= 0xF8) {
+        shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, msg[1]);
+        shadow_chain_broadcast_realtime(msg[1]);
+        return len;
+    }
     /* Build USB-MIDI packet: [CIN, status, d1, d2] */
     uint8_t cin = (msg[1] >> 4) & 0x0F;
     uint8_t pkt[4] = { cin, msg[1], msg[2], msg[3] };
@@ -1581,6 +1591,10 @@ static uint32_t spi_slot_probe_burst_max;
  */
 static void shadow_inprocess_render_to_buffer(void) {
     if (!shadow_inprocess_ready || !global_mmap_addr) return;
+
+    /* Advance the transport clock before slot/master LFOs render below, so
+     * they read a beat position interpolated to this block. */
+    shadow_transport_advance_block(MOVE_FRAMES_PER_BLOCK);
 
     /* Clear the deferred buffer (used for overtake DSP) */
     memset(shadow_deferred_dsp_buffer, 0, sizeof(shadow_deferred_dsp_buffer));
@@ -3868,6 +3882,8 @@ static void shim_init_subsystems(void)
         };
         chain_mgmt_init(&cm_host);
     }
+    /* Move's audio path is fixed 44.1 kHz (see shadow_master_fx_lfo_tick). */
+    shadow_transport_init(44100);
     /* Sampler announce wrapper: defined inline above so this scope can
      * reference it. (Hoisted via the prototype near the top of the file.) */
     /* Initialize sampler subsystem with callbacks to shim functions.

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1325,11 +1325,16 @@ static void shadow_inprocess_process_midi(void) {
 
 /* MIDI send callback for overtake DSP → chain slots */
 static int overtake_midi_send_internal(const uint8_t *msg, int len) {
+    /* Realtime must be padded to >= 4 bytes to clear this guard: the emit path
+     * packs status as [status,0,0,0], so a 1-byte realtime send is dropped. */
     if (!msg || len < 4) return 0;
     /* System realtime is transport, not note data: feed the transport service
      * and broadcast on the same 1-byte path as the cable-0 tap. Must NOT go
-     * through dispatch_to_slots, whose channel remap corrupts the status byte. */
-    if (msg[1] >= 0xF8) {
+     * through dispatch_to_slots, whose channel remap corrupts the status byte.
+     * Match only the four transport bytes — Start/Continue/Stop/Clock — not the
+     * whole 0xF8..0xFF range, which also spans undefined (F9/FD), active
+     * sensing (FE) and reset (FF); those must not fan out to every slot. */
+    if (msg[1] == 0xF8 || msg[1] == 0xFA || msg[1] == 0xFB || msg[1] == 0xFC) {
         shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, msg[1]);
         shadow_chain_broadcast_realtime(msg[1]);
         return len;

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -14041,6 +14041,10 @@ globalThis.tick = function() {
     {
         const parkedIds = Object.keys(suspendedOvertakes);
         if (parkedIds.length > 0) {
+            /* Signal to each parked module's tick() that it is running blind in
+             * the background (draw calls below are no-ops). Modules read
+             * globalThis.overtakeParked to skip display/LED work while parked. */
+            globalThis.overtakeParked = true;
             const _noop = function() {};
             const _saved = {
                 clear_screen: globalThis.clear_screen,
@@ -14082,6 +14086,7 @@ globalThis.tick = function() {
                     }
                 }
             } finally {
+                globalThis.overtakeParked = false;
                 for (const k in _saved) globalThis[k] = _saved[k];
                 if (_savedShimGet === undefined) delete globalThis.host_module_get_param;
                 else globalThis.host_module_get_param = _savedShimGet;
@@ -15266,11 +15271,17 @@ globalThis.onMidiMessageInternal = function(data) {
                 debugLog("HOST: Shift+Back → full exit (suspend_keeps_js module)");
                 if (toolOvertakeActive) exitToolOvertake();
                 else exitOvertakeMode();
-            } else {
+                return;
+            }
+            if (!overtakeSuspendSelfManaged) {
                 debugLog("HOST: Back → suspend (module parks in background)");
                 suspendOvertakeMode();
+                return;
             }
-            return;
+            /* suspend_self_managed: the module owns plain Back for its own
+             * navigation and calls host_suspend_overtake() when it decides to
+             * park. Fall through to its onMidiMessageInternal (Shift+Back above
+             * is still the host's universal full-exit). */
         }
 
         /* CO-RUN: intercept chain-editor navigation CCs (jog turn, jog click,

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -570,6 +570,7 @@ let overtakeModuleId = "";         // ID of loaded overtake module (for per-modu
 let previousView = VIEWS.SLOTS;   // View to return to after overtake
 let overtakeModuleCallbacks = null; // {init, tick, onMidiMessageInternal} for loaded module
 let overtakeSuspendKeepsJs = false; // Current module opted in to JS-alive suspend
+let overtakeSuspendSelfManaged = false; // Module owns Back; suspends via host_suspend_overtake()
 let overtakePassthroughCCs = [];    // CCs declared in capabilities.button_passthrough — shim lets these
                                     // reach Move firmware directly, and we skip them during LED clear.
 /* Map of suspended overtake modules keyed by moduleId. Each entry:
@@ -2307,6 +2308,7 @@ function clearModuleParamShims() {
     }
     delete globalThis.host_module_set_param_blocking;
     delete globalThis.host_exit_module;
+    delete globalThis.host_suspend_overtake;
     delete globalThis.host_swap_module;
     delete globalThis.host_open_file_in_tool;
 }
@@ -3046,6 +3048,7 @@ function exitOvertakeMode() {
     overtakeModuleId = "";
     overtakeModuleCallbacks = null;
     overtakeSuspendKeepsJs = false;
+    overtakeSuspendSelfManaged = false;
     overtakePassthroughCCs = [];
     if (typeof shadow_set_param_timeout === "function") {
         shadow_set_param_timeout(0, "passthrough", "", 100);  /* clear list */
@@ -3109,6 +3112,7 @@ function suspendOvertakeMode() {
             ledNotes: ledNotesSnapshot,
             ledCCs: ledCCsSnapshot,
             dspPath: currentSlot0DspPath,
+            selfManaged: overtakeSuspendSelfManaged,
             shimGet: globalThis.host_module_get_param,
             shimSet: globalThis.host_module_set_param,
             shimSetBlocking: globalThis.host_module_set_param_blocking
@@ -3119,6 +3123,7 @@ function suspendOvertakeMode() {
         overtakeModuleLoaded = false;
         overtakeModuleCallbacks = null;
         overtakeSuspendKeepsJs = false;
+        overtakeSuspendSelfManaged = false;
 
         /* Tell shim to skip exit hook (module stays loaded). */
         if (typeof shadow_set_suspend_overtake === "function") {
@@ -3195,6 +3200,7 @@ function resumeOvertakeModule(moduleId) {
     overtakeModuleId = parked.id;
     overtakeModuleLoaded = true;
     overtakeSuspendKeepsJs = true;
+    overtakeSuspendSelfManaged = !!parked.selfManaged;
     overtakeInitPending = false;  /* Already ran */
     overtakeExitPending = false;
 
@@ -3287,6 +3293,7 @@ function exitToolOvertake() {
     delete globalThis.host_module_set_param_blocking;
     delete globalThis.host_module_get_param;
     delete globalThis.host_exit_module;
+    delete globalThis.host_suspend_overtake;
     delete globalThis.host_hide_module;
 
     /* Write exiting module ID so shim runs the correct per-module hook */
@@ -3530,6 +3537,10 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
                 exitOvertakeMode();
             }
         };
+        globalThis.host_suspend_overtake = function() {
+            debugLog("host_suspend_overtake called by overtake module");
+            suspendOvertakeMode();
+        };
         globalThis.host_hide_module = function() {
             debugLog("host_hide_module called by overtake module");
             if (toolOvertakeActive) {
@@ -3614,6 +3625,13 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
 
         overtakeModuleLoaded = true;
         overtakeSuspendKeepsJs = !!(moduleInfo.capabilities && moduleInfo.capabilities.suspend_keeps_js);
+        /* suspend_self_managed: the module uses Back for its own navigation and
+         * calls host_suspend_overtake() when it decides to park. It implies
+         * keeps-JS — the closure must stay alive to keep deciding + ticking. An
+         * older host that predates this capability simply ignores it, so the
+         * module degrades to a plain exit on Back. */
+        overtakeSuspendSelfManaged = !!(moduleInfo.capabilities && moduleInfo.capabilities.suspend_self_managed);
+        if (overtakeSuspendSelfManaged) overtakeSuspendKeepsJs = true;
 
         /* button_passthrough: array of CC numbers for buttons the module yields
          * to Move firmware (press events reach Move, LEDs stay Move-driven).
@@ -3666,6 +3684,7 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
         delete globalThis.host_module_set_param;
         delete globalThis.host_module_get_param;
         delete globalThis.host_exit_module;
+        delete globalThis.host_suspend_overtake;
         if (typeof shadow_set_overtake_mode === "function") {
             shadow_set_overtake_mode(0);
         }
@@ -5520,6 +5539,10 @@ function startInteractiveTool(toolModule, filePath) {
                 } else {
                     exitOvertakeMode();
                 }
+            };
+            globalThis.host_suspend_overtake = function() {
+                debugLog("host_suspend_overtake called by overtake module (reconnect)");
+                suspendOvertakeMode();
             };
             globalThis.host_hide_module = function() {
                 debugLog("host_hide_module called by overtake module (reconnect)");

--- a/tests/host/test_lfo_synced_phase.c
+++ b/tests/host/test_lfo_synced_phase.c
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "host/lfo_common.h"
+
+static void fail(const char *m) { fprintf(stderr, "FAIL: %s\n", m); exit(1); }
+static void near(double got, double want, const char *m) {
+    if (fabs(got - want) > 1e-9) {
+        fprintf(stderr, "FAIL: %s (got %f want %f)\n", m, got, want);
+        exit(1);
+    }
+}
+
+/* Find a division index by its beats value so the test doesn't hardcode
+ * table order. */
+static int div_index(float beats) {
+    for (int i = 0; i < LFO_NUM_DIVISIONS; i++)
+        if (fabsf(lfo_divisions[i].beats - beats) < 1e-6f) return i;
+    fail("division not found in table");
+    return -1;
+}
+
+int main(void) {
+    int d1 = div_index(1.0f);   /* 1-beat cycle */
+    int d4 = div_index(4.0f);   /* 1-bar cycle */
+
+    near(lfo_synced_phase(0.0, d1), 0.0, "beat 0 -> phase 0");
+    near(lfo_synced_phase(0.5, d1), 0.5, "half beat -> phase 0.5 on 1-beat div");
+    near(lfo_synced_phase(7.0, d1), 0.0, "whole beats wrap to 0");
+    near(lfo_synced_phase(6.0, d4), 0.5, "beat 6 -> phase 0.5 on 4-beat div");
+    near(lfo_synced_phase(9.0, d4), 0.25, "beat 9 -> phase 0.25 on 4-beat div");
+    /* Out-of-range division indexes clamp, never crash. */
+    (void)lfo_synced_phase(1.0, -5);
+    (void)lfo_synced_phase(1.0, LFO_NUM_DIVISIONS + 5);
+
+    printf("PASS: test_lfo_synced_phase\n");
+    return 0;
+}

--- a/tests/host/test_lfo_synced_phase.sh
+++ b/tests/host/test_lfo_synced_phase.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+bin="build/tests/test_lfo_synced_phase"
+mkdir -p "$(dirname "$bin")"
+cc -std=c11 -Wall -Wextra -Werror -Isrc \
+  tests/host/test_lfo_synced_phase.c \
+  -lm -o "$bin"
+"$bin"

--- a/tests/host/test_shadow_transport.c
+++ b/tests/host/test_shadow_transport.c
@@ -63,10 +63,17 @@ int main(void) {
     shadow_transport_on_realtime(TRANSPORT_SRC_MOVE, 0xFC);
     if (shadow_transport_source() != TRANSPORT_SRC_INTERNAL) fail("falls back to internal");
 
-    /* --- stop: no transport = negative beat position --- */
+    /* --- last-known tempo survives stop (LFO free-run keeps movy's rate) --- */
+    shadow_transport_init(44100);
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xFA);
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xF8);
+    run_ticks(TRANSPORT_SRC_INTERNAL, 24);
     shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xFC);
+    shadow_transport_advance_block(128);  /* stop takes effect */
     if (shadow_transport_beat_position() >= 0.0) fail("stopped = beat < 0");
-    if (shadow_transport_source() != TRANSPORT_SRC_NONE) fail("stopped = no source");
+    if (shadow_transport_source() != TRANSPORT_SRC_NONE) fail("stopped = no active source");
+    if (shadow_transport_last_source() != TRANSPORT_SRC_INTERNAL) fail("last source = internal after stop");
+    expect_near((double)shadow_transport_last_bpm(), 125.0, 2.5, "last bpm retained after stop");
 
     /* --- staleness: ticks stop arriving -> transport flips off --- */
     shadow_transport_init(44100);

--- a/tests/host/test_shadow_transport.c
+++ b/tests/host/test_shadow_transport.c
@@ -1,0 +1,86 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include "host/shadow_transport.h"
+
+static void fail(const char *msg) { fprintf(stderr, "FAIL: %s\n", msg); exit(1); }
+static void expect_near(double got, double want, double tol, const char *msg) {
+    if (fabs(got - want) > tol) {
+        fprintf(stderr, "FAIL: %s (got %f want %f)\n", msg, got, want);
+        exit(1);
+    }
+}
+
+/* 125 BPM at 24 PPQN and 44100 Hz = exactly 882 samples per tick. */
+#define TICK_SAMPLES 882
+
+/* Advance in 128-frame blocks, firing a tick each time the boundary passes. */
+static void run_ticks(transport_src_t src, int ticks) {
+    static long long carry = 0;
+    for (int t = 0; t < ticks; t++) {
+        carry += TICK_SAMPLES;
+        while (carry > 0) { shadow_transport_advance_block(128); carry -= 128; }
+        shadow_transport_on_realtime(src, 0xF8);
+    }
+}
+
+int main(void) {
+    /* --- start anchor: FA then first F8 = beat 0 --- */
+    shadow_transport_init(44100);
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xFA);
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xF8);
+    expect_near(shadow_transport_beat_position(), 0.0, 1e-9, "beat 0 at first tick");
+    if (shadow_transport_source() != TRANSPORT_SRC_INTERNAL) fail("internal source active");
+
+    /* --- 24 ticks later = beat 1; measured bpm ~= 125 ---
+     * Beat position is exact (tick-count driven, tol 0.02 beat). The measured
+     * bpm is intentionally jitter-tolerant: block-quantized ticks alternate
+     * 768/896 samples around the true 882 (design §6), so the instantaneous
+     * EMA readout swings a couple BPM about 125. The tight beat-position
+     * assertion is what pins tempo precisely; this only rules out gross error. */
+    run_ticks(TRANSPORT_SRC_INTERNAL, 24);
+    expect_near(shadow_transport_beat_position(), 1.0, 0.02, "beat 1 after 24 ticks");
+    expect_near((double)shadow_transport_bpm(), 125.0, 2.5, "bpm measured ~125");
+
+    /* --- interpolation: half a tick of silence advances ~half a tick --- */
+    double before = shadow_transport_beat_position();
+    shadow_transport_advance_block(TICK_SAMPLES / 2);
+    double mid = shadow_transport_beat_position();
+    expect_near(mid - before, 0.5 / 24.0, 0.01, "interpolated half tick");
+
+    /* --- interpolation clamps: a very late tick never overshoots --- */
+    shadow_transport_advance_block(TICK_SAMPLES * 3);
+    double late = shadow_transport_beat_position();
+    if (late > before + 1.5 / 24.0) fail("interpolation must clamp at one tick");
+
+    /* --- arbitration: Move start takes over; Move stop hands back --- */
+    shadow_transport_init(44100);
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xFA);
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xF8);
+    shadow_transport_on_realtime(TRANSPORT_SRC_MOVE, 0xFA);
+    shadow_transport_on_realtime(TRANSPORT_SRC_MOVE, 0xF8);
+    if (shadow_transport_source() != TRANSPORT_SRC_MOVE) fail("Move wins while running");
+    shadow_transport_on_realtime(TRANSPORT_SRC_MOVE, 0xFC);
+    if (shadow_transport_source() != TRANSPORT_SRC_INTERNAL) fail("falls back to internal");
+
+    /* --- stop: no transport = negative beat position --- */
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xFC);
+    if (shadow_transport_beat_position() >= 0.0) fail("stopped = beat < 0");
+    if (shadow_transport_source() != TRANSPORT_SRC_NONE) fail("stopped = no source");
+
+    /* --- staleness: ticks stop arriving -> transport flips off --- */
+    shadow_transport_init(44100);
+    shadow_transport_on_realtime(TRANSPORT_SRC_INTERNAL, 0xFA);
+    run_ticks(TRANSPORT_SRC_INTERNAL, 4);
+    shadow_transport_advance_block(44100);  /* 1 s of silence > 0.5 s staleness */
+    if (shadow_transport_beat_position() >= 0.0) fail("stale clock = beat < 0");
+
+    /* --- unanchored clock (tool opened mid-song): F8 without FA still runs --- */
+    shadow_transport_init(44100);
+    run_ticks(TRANSPORT_SRC_MOVE, 26);
+    if (shadow_transport_beat_position() < 0.0) fail("bare clock runs unanchored");
+    expect_near((double)shadow_transport_bpm(), 125.0, 2.5, "bpm from bare clock");
+
+    printf("PASS: test_shadow_transport\n");
+    return 0;
+}

--- a/tests/host/test_shadow_transport.sh
+++ b/tests/host/test_shadow_transport.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+bin="build/tests/test_shadow_transport"
+mkdir -p "$(dirname "$bin")"
+cc -std=c11 -Wall -Wextra -Werror -Isrc \
+  tests/host/test_shadow_transport.c \
+  src/host/shadow_transport.c \
+  -lm -o "$bin"
+"$bin"


### PR DESCRIPTION
Adds a first-class way for an overtake **tool** to background itself and keep its DSP + JS ticking, while owning the Back button for its own navigation. Built for Movy (keep sequencing under Move's native UI so synced LFOs stay locked), but the mechanism is generic and upstreamable.

### Stacked on #161
This branch is based on `feat/transport-beat-clock` (#161), so the diff currently includes that PR's commits. **The new work here is just the two `shadow_ui.js` commits:**

- `5b761e58` **host_suspend_overtake() + suspend_self_managed capability** — a new JS host fn that parks the active overtake module, plus a `suspend_self_managed` capability. It implies keeps-JS and is persisted across suspend/resume. Older hosts ignore the capability, so a module that declares it degrades to a plain exit.
- `1097bc54` **Back pass-through + `overtakeParked` signal** — for a self-managed module, plain Back falls through to the module's `onMidiMessageInternal` (Shift+Back stays the host's universal full-exit); the parked-tick loop sets `globalThis.overtakeParked` so a backgrounded module can skip its display/LED work.

(The two are code-independent from #161 — #161 is shim/host C, this is `shadow_ui.js` — but Movy's background mode is most useful *with* #161, since a parked sequencer keeps emitting the Phase 1 clock. Once #161 merges, this diff collapses to those two commits.)

### How a module opts in
```jsonc
// module.json
"capabilities": { "suspend_self_managed": true }
```
The module decides when to park (e.g. Back at its root view) and calls `host_suspend_overtake()`; it reads `globalThis.overtakeParked` in `tick()` to skip render/LED work while backgrounded, and can implement `onResume()` to repaint on return.

### Testing
- Cross-compiles clean.
- **Device-verified** end-to-end on `move.local` with Movy: Back → module parks (`suspend_keeps_js` path, DSP stays loaded, sequencer keeps playing and autosaving while parked) → reopen → module resumes the parked instance (no DSP reload, `onResume` fires). Shift+Back full-exit and the old-host graceful-degrade path both confirmed.

The consumer side (Movy's module.json capability, root-Back Leave-Movy modal, parked-tick skip, `onResume`) lives in the Movy module repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)