### PR TITLE
Let suspend-kept overtake modules handle modal Back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,11 @@ globalThis.onMidiMessageInternal = function(data) { }   // Move hardware MIDI
 globalThis.onMidiMessageExternal = function(data) { }   // External USB MIDI (overtake only)
 ```
 
+Overtake modules may also provide `onUnload()`, `onResume()`, and a
+side-effect-free `wantsBack()` query. For `suspend_keeps_js` modules,
+`wantsBack()` can temporarily claim Back for an internal modal; returning
+false restores the host's normal Back-to-suspend behavior. See `docs/API.md`.
+
 `data` is a Uint8Array `[status, cc/note, value]`. Filter noise with `shouldFilterMessage()` from `input_filter.mjs`.
 
 Loading styles:

--- a/docs/ADDRESSING_MOVE_SYNTHS.md
+++ b/docs/ADDRESSING_MOVE_SYNTHS.md
@@ -66,6 +66,9 @@ Key choices:
 - `capabilities.suspend_keeps_js: true` — Back suspends the UI but the
   DSP keeps ticking; Shift+Back fully exits. Essential for a sequencer
   that should keep playing while the user browses Move.
+- If the sequencer has its own preset or setup modal, expose a side-effect-free
+  `globalThis.wantsBack()` that returns true while that modal is open. The host
+  then forwards Back to the module before restoring normal suspend behavior.
 - `capabilities.button_passthrough: [85]` — the Play button still
   reaches Move (so Move's transport stays in sync) while your module
   also handles its own play/stop.

--- a/docs/API.md
+++ b/docs/API.md
@@ -99,9 +99,18 @@ globalThis.onUnload = function() {
 globalThis.onResume = function() {
     // Invalidate LED delta-cache, force a full repaint, etc.
 }
+
+// Optional for suspend_keeps_js overtakes with internal modal screens.
+// Return true only while Back should be forwarded to the module instead of
+// suspending it; handle the forwarded press in onMidiMessageInternal().
+globalThis.wantsBack = function() {
+    return presetBrowserOpen || setupScreenOpen;
+}
 ```
 
 `onResume()` fires once each time a suspended `suspend_keeps_js` overtake module is brought back to the foreground — it is **not** called on first load (`init()` handles that). While the module is backgrounded its hardware LEDs were cleared, so the typical use is to invalidate any on-change LED delta-cache and force a full repaint on the next `tick()`. It is optional and opt-in: modules that do not define it are unaffected.
+
+`wantsBack()` is queried only when Back is pressed in an active `suspend_keeps_js` overtake. Return `true` while an internal preset browser, setup page, or similar modal needs to consume Back. The host then forwards the original Back MIDI message to `onMidiMessageInternal()`; when the callback returns `false` again, Back resumes its normal host-level suspend behavior. Keep this callback side-effect free.
 
 ## Menu Layout Helpers
 
@@ -460,6 +469,7 @@ The host tracks these inputs locally (independent of the shim) to ensure escape 
 | Shift (CC 49) | Tracked by host for escape; passed to module |
 | Volume touch (Note 8) | Tracked by host for escape; passed to module |
 | Jog click (CC 3) | If Shift+Vol held, triggers escape; otherwise passed to module |
+| Back (CC 51) | Suspends a `suspend_keeps_js` overtake unless its `wantsBack()` callback currently returns true; then passed to the module |
 | All other MIDI | Passed directly to module |
 
 Modules receive full MIDI access and can send to both internal (LEDs) and external (USB-A) targets.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1927,10 +1927,13 @@ The progressive LED clearing prevents MIDI buffer overflow (the buffer holds ~64
 
 #### Optional lifecycle hooks
 
-Beyond `init()`, `tick()`, and `onMidiMessageInternal()`/`onMidiMessageExternal()`, overtake modules may define two optional hooks:
+Beyond `init()`, `tick()`, and `onMidiMessageInternal()`/`onMidiMessageExternal()`, overtake modules may define three optional hooks:
 
 - `globalThis.onUnload()` — called once when the module is being torn down. Use it to release resources or persist state.
-- `globalThis.onResume()` — called once each time a suspended `suspend_keeps_js` overtake module is brought back to the foreground. It is **not** called on first load (`init()` handles that). While the module was backgrounded its hardware LEDs were cleared, so the typical use is to invalidate any on-change LED delta-cache and force a full repaint on the next `tick()`. Both hooks are opt-in: modules that do not define them are unaffected.
+- `globalThis.onResume()` — called once each time a suspended `suspend_keeps_js` overtake module is brought back to the foreground. It is **not** called on first load (`init()` handles that). While the module was backgrounded its hardware LEDs were cleared, so the typical use is to invalidate any on-change LED delta-cache and force a full repaint on the next `tick()`.
+- `globalThis.wantsBack()` — queried when Back is pressed in a `suspend_keeps_js` overtake. Return `true` only while an internal modal should receive Back through `onMidiMessageInternal()`; otherwise the host suspends the overtake normally. Keep the query side-effect free.
+
+All three hooks are opt-in; modules that do not define them are unaffected.
 
 ### Host-Level Escape
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -24,7 +24,7 @@ import {
     MoveKnob1, MoveKnob2, MoveKnob3, MoveKnob4,
     MoveKnob5, MoveKnob6, MoveKnob7, MoveKnob8,
     MoveKnob1Touch, MoveKnob8Touch,  // Capacitive touch notes (0-7)
-    MidiNoteOn
+    MidiNoteOn, MidiNoteOff
 } from '/data/UserData/schwung/shared/constants.mjs';
 
 import {
@@ -568,7 +568,7 @@ let overtakeModuleLoaded = false; // True if an overtake module is running
 let overtakeModulePath = "";      // Path to loaded overtake module
 let overtakeModuleId = "";         // ID of loaded overtake module (for per-module exit hooks)
 let previousView = VIEWS.SLOTS;   // View to return to after overtake
-let overtakeModuleCallbacks = null; // {init, tick, onMidiMessageInternal} for loaded module
+let overtakeModuleCallbacks = null; // {init, tick, onMidiMessageInternal, wantsBack, ...}
 let overtakeSuspendKeepsJs = false; // Current module opted in to JS-alive suspend
 let overtakePassthroughCCs = [];    // CCs declared in capabilities.button_passthrough — shim lets these
                                     // reach Move firmware directly, and we skip them during LED clear.
@@ -2957,6 +2957,23 @@ function invokeModuleOnResume(callbacks, moduleId) {
     }
 }
 
+/* Ask an overtake module whether the current Back press belongs to one of its
+ * own modal views. `suspend_keeps_js` normally reserves Back for the host, but
+ * preset browsers and setup screens need one level of local navigation before
+ * that host-level suspend behavior resumes. The callback is deliberately a
+ * side-effect-free query; the original MIDI message is forwarded normally
+ * when it returns true. */
+function overtakeModuleWantsBack() {
+    if (!overtakeModuleCallbacks ||
+        typeof overtakeModuleCallbacks.wantsBack !== "function") return false;
+    try {
+        return !!runToolCallback(overtakeModuleCallbacks.wantsBack);
+    } catch (e) {
+        debugLog("overtake wantsBack threw: " + e);
+        return false;
+    }
+}
+
 /* Enter the overtake module selection menu */
 function enterOvertakeMenu() {
     /* Flush set state before entering overtake — periodic autosave is gated
@@ -3463,6 +3480,7 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
         const savedInit = globalThis.init;
         const savedTick = globalThis.tick;
         const savedMidi = globalThis.onMidiMessageInternal;
+        const savedWantsBack = globalThis.wantsBack;
 
         overtakeModulePath = moduleInfo.uiPath;
         overtakeModuleId = moduleInfo.id || "";
@@ -3570,6 +3588,11 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
             const result = shadow_load_ui_module(moduleInfo.uiPath);
             debugLog("loadOvertakeModule: shadow_load_ui_module returned " + result);
             if (!result) {
+                globalThis.init = savedInit;
+                globalThis.tick = savedTick;
+                globalThis.onMidiMessageInternal = savedMidi;
+                if (savedWantsBack === undefined) delete globalThis.wantsBack;
+                else globalThis.wantsBack = savedWantsBack;
                 deactivateLedQueue();
                 overtakeModuleLoaded = false;
                 overtakeModuleCallbacks = null;
@@ -3583,6 +3606,8 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
             }
         } else {
             debugLog("loadOvertakeModule: shadow_load_ui_module not available");
+            if (savedWantsBack === undefined) delete globalThis.wantsBack;
+            else globalThis.wantsBack = savedWantsBack;
             deactivateLedQueue();
             delete globalThis.host_module_set_param;
             delete globalThis.host_module_get_param;
@@ -3594,6 +3619,7 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
             init: (globalThis.init !== savedInit) ? globalThis.init : null,
             tick: (globalThis.tick !== savedTick) ? globalThis.tick : null,
             onMidiMessageInternal: (globalThis.onMidiMessageInternal !== savedMidi) ? globalThis.onMidiMessageInternal : null,
+            wantsBack: (globalThis.wantsBack !== savedWantsBack) ? globalThis.wantsBack : null,
             onUnload: (typeof globalThis.onUnload === "function") ? globalThis.onUnload : null,
             /* onResume(): optional. Called once each time the module is
              * resumed from suspend (init() is NOT re-run). See
@@ -3605,6 +3631,8 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
         globalThis.init = savedInit;
         globalThis.tick = savedTick;
         globalThis.onMidiMessageInternal = savedMidi;
+        if (savedWantsBack === undefined) delete globalThis.wantsBack;
+        else globalThis.wantsBack = savedWantsBack;
         if (typeof globalThis.onUnload === "function") delete globalThis.onUnload;
         if (typeof globalThis.onResume === "function") delete globalThis.onResume;
 
@@ -5490,6 +5518,7 @@ function startInteractiveTool(toolModule, filePath) {
             const savedInit = globalThis.init;
             const savedTick = globalThis.tick;
             const savedMidi = globalThis.onMidiMessageInternal;
+            const savedWantsBack = globalThis.wantsBack;
 
             /* Reinstall shims before loading the ES module.
              * QuickJS resolves bare global identifiers at compile time,
@@ -5542,6 +5571,11 @@ function startInteractiveTool(toolModule, filePath) {
                 const result = shadow_load_ui_module(uiPath);
                 debugLog("startInteractiveTool reconnect: shadow_load_ui_module returned " + result);
                 if (!result) {
+                    globalThis.init = savedInit;
+                    globalThis.tick = savedTick;
+                    globalThis.onMidiMessageInternal = savedMidi;
+                    if (savedWantsBack === undefined) delete globalThis.wantsBack;
+                    else globalThis.wantsBack = savedWantsBack;
                     debugLog("startInteractiveTool reconnect: failed to load UI");
                     toolOvertakeActive = false;
                     setView(VIEWS.TOOL_RESULT);
@@ -5551,6 +5585,8 @@ function startInteractiveTool(toolModule, filePath) {
                     return;
                 }
             } else {
+                if (savedWantsBack === undefined) delete globalThis.wantsBack;
+                else globalThis.wantsBack = savedWantsBack;
                 debugLog("startInteractiveTool reconnect: shadow_load_ui_module not available");
                 toolOvertakeActive = false;
                 setView(VIEWS.TOOL_RESULT);
@@ -5565,6 +5601,7 @@ function startInteractiveTool(toolModule, filePath) {
                 init: (globalThis.init !== savedInit) ? globalThis.init : null,
                 tick: (globalThis.tick !== savedTick) ? globalThis.tick : null,
                 onMidiMessageInternal: (globalThis.onMidiMessageInternal !== savedMidi) ? globalThis.onMidiMessageInternal : null,
+                wantsBack: (globalThis.wantsBack !== savedWantsBack) ? globalThis.wantsBack : null,
                 onUnload: (typeof globalThis.onUnload === "function") ? globalThis.onUnload : null,
                 /* onResume(): optional. Called once each time the module is
                  * resumed from suspend (init() is NOT re-run). See
@@ -5574,6 +5611,8 @@ function startInteractiveTool(toolModule, filePath) {
             globalThis.init = savedInit;
             globalThis.tick = savedTick;
             globalThis.onMidiMessageInternal = savedMidi;
+            if (savedWantsBack === undefined) delete globalThis.wantsBack;
+            else globalThis.wantsBack = savedWantsBack;
             if (typeof globalThis.onUnload === "function") delete globalThis.onUnload;
             if (typeof globalThis.onResume === "function") delete globalThis.onResume;
             debugLog("startInteractiveTool reconnect: callbacks captured - init:" + !!overtakeModuleCallbacks.init +
@@ -15214,11 +15253,13 @@ globalThis.onMidiMessageInternal = function(data) {
             hostShiftHeld = (d2 > 0);
         }
 
-        /* Track volume knob touch for Shift+Vol+Jog escape detection */
-        if ((status & 0xF0) === MidiNoteOn) {
-            if (d1 === VOLUME_TOUCH_NOTE) {
-                hostVolumeKnobTouched = (d2 > 0);
-            }
+        /* Track both possible release encodings for the volume touch sensor.
+         * Move may send either Note On velocity 0 or a real Note Off. Ignoring
+         * the latter latches the emergency Shift+Vol+Jog chord after the user
+         * lets go, so a later ordinary Shift+Jog click exits unexpectedly. */
+        if (((status & 0xF0) === MidiNoteOn ||
+             (status & 0xF0) === MidiNoteOff) && d1 === VOLUME_TOUCH_NOTE) {
+            hostVolumeKnobTouched = (status & 0xF0) === MidiNoteOn && d2 > 0;
         }
 
         /* Debug: log key state */
@@ -15243,16 +15284,20 @@ globalThis.onMidiMessageInternal = function(data) {
          * Back alone: suspend (module parks in background, ticks continue).
          * Shift+Back: full exit (unload module).
          * Skip while co-run is active: the chain editor claims Back. */
-        if ((status & 0xF0) === 0xB0 && d1 === MoveBack && d2 > 0 && overtakeSuspendKeepsJs && !coRunUiActive()) {
-            if (hostShiftHeld) {
-                debugLog("HOST: Shift+Back → full exit (suspend_keeps_js module)");
-                if (toolOvertakeActive) exitToolOvertake();
-                else exitOvertakeMode();
-            } else {
-                debugLog("HOST: Back → suspend (module parks in background)");
-                suspendOvertakeMode();
+        if ((status & 0xF0) === 0xB0 && d1 === MoveBack && d2 > 0 &&
+            overtakeSuspendKeepsJs && !coRunUiActive()) {
+            if (!overtakeModuleWantsBack()) {
+                if (hostShiftHeld) {
+                    debugLog("HOST: Shift+Back → full exit (suspend_keeps_js module)");
+                    if (toolOvertakeActive) exitToolOvertake();
+                    else exitOvertakeMode();
+                } else {
+                    debugLog("HOST: Back → suspend (module parks in background)");
+                    suspendOvertakeMode();
+                }
+                return;
             }
-            return;
+            debugLog("HOST: Back claimed by overtake module modal");
         }
 
         /* CO-RUN: intercept chain-editor navigation CCs (jog turn, jog click,

--- a/tests/shadow/test_overtake_modal_back_and_escape_release.sh
+++ b/tests/shadow/test_overtake_modal_back_and_escape_release.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression: suspend_keeps_js overtakes may claim Back for an internal modal,
+# and a real Note Off from the volume touch sensor must release the emergency
+# Shift+Volume+Jog escape chord.
+
+file="src/shadow/shadow_ui.js"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "rg is required to run this test" >&2
+  exit 1
+fi
+
+if ! rg -q 'MidiNoteOn, MidiNoteOff' "$file"; then
+  echo "FAIL: overtake escape tracking does not import MidiNoteOff" >&2
+  exit 1
+fi
+
+if ! perl -0ne 'exit((/\(status & 0xF0\) === MidiNoteOn \|\|[\s\S]*\(status & 0xF0\) === MidiNoteOff\)[\s\S]*hostVolumeKnobTouched = \(status & 0xF0\) === MidiNoteOn && d2 > 0;/s) ? 0 : 1)' "$file"; then
+  echo "FAIL: volume touch release does not handle both Note On 0 and Note Off" >&2
+  exit 1
+fi
+
+captures=$(rg -c 'wantsBack: \(globalThis\.wantsBack !== savedWantsBack\)' "$file")
+if [ "$captures" -ne 2 ]; then
+  echo "FAIL: wantsBack must be captured for fresh and reconnected overtakes" >&2
+  exit 1
+fi
+
+if ! rg -q 'function overtakeModuleWantsBack\(\)' "$file"; then
+  echo "FAIL: missing safe wantsBack callback wrapper" >&2
+  exit 1
+fi
+
+if ! perl -0ne 'exit((/d1 === MoveBack && d2 > 0 &&[\s\S]*overtakeSuspendKeepsJs[\s\S]*if \(!overtakeModuleWantsBack\(\)\)[\s\S]*suspendOvertakeMode\(\);/s) ? 0 : 1)' "$file"; then
+  echo "FAIL: host suspend still runs before an overtake modal can claim Back" >&2
+  exit 1
+fi
+
+echo "PASS: overtake modal Back routing and volume-touch release are guarded"


### PR DESCRIPTION
## Summary

- add an optional side-effect-free `globalThis.wantsBack()` contract for `suspend_keeps_js` overtake modules
- forward Back to the active module only while it reports an internal modal, preserving normal Back-to-suspend everywhere else
- keep the post-suspend volume-touch release path from leaving the native volume overlay stuck
- document the lifecycle contract for module authors

This enables modules such as Mono to close their own preset/setup screens without accidentally suspending the overtake UI.

## Verification

- `bash tests/shadow/test_overtake_modal_back_and_escape_release.sh`
- `node --check src/shadow/shadow_ui.js`
- `git diff --check upstream/main...HEAD`
- full shadow shell sweep: the new regression passes; 19 existing source-pin failures remain, consistent with the repository's documented stale-test baseline (including the pre-existing parked-overtake fixture's missing `corunTeardown`)