### PR TITLE
Catalog Mono and Mono Voice

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1080,6 +1080,28 @@
       "min_host_version": "0.7.11"
     },
     {
+      "id": "mono-voice",
+      "name": "Mono Voice",
+      "description": "Monomachine-inspired digital machine voice with SuperWave, SID, DigiPRO, and FM engines, Shift parameter banks, and three assignable LFOs",
+      "author": "timncox",
+      "component_type": "sound_generator",
+      "github_repo": "timncox/schwung-mono",
+      "default_branch": "main",
+      "asset_name": "mono-voice-module.tar.gz",
+      "min_host_version": "0.11.4"
+    },
+    {
+      "id": "mono",
+      "name": "Mono",
+      "description": "Six-track Monomachine-inspired instrument with digital machine synthesis and a 64-step parameter-lock sequencer",
+      "author": "timncox",
+      "component_type": "overtake",
+      "github_repo": "timncox/schwung-mono",
+      "default_branch": "main",
+      "asset_name": "mono-module.tar.gz",
+      "min_host_version": "0.11.4"
+    },
+    {
       "id": "smack",
       "name": "Smack",
       "description": "Quantized live-loop capture with 26 seeded per-slice glitch effects, slice reordering, A/B punch, step editing, and Pad Play",


### PR DESCRIPTION
## Summary

- add the `mono-voice` sound-generator module to the Schwung store catalog
- add the `mono` Overtake module to the Schwung store catalog
- point both entries at their distinct release assets in `timncox/schwung-mono`

## Validation

- `jq -e . module-catalog.json`
- catalog module IDs are unique
- both Mono entries match the repository, asset-name, and minimum-host fields expected by the store
- `bash tests/store/test_release_json_fallback_to_catalog_asset.sh`

## Release dependency

This PR is intentionally draft until [timncox/schwung-mono#1](https://github.com/timncox/schwung-mono/pull/1) is merged and the `v0.2.0` release publishes both `mono-module.tar.gz` and `mono-voice-module.tar.gz`.