### PR TITLE
docs: CI, branch protection, and contributor workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,16 @@ Cross-compile via `${CROSS_PREFIX}gcc` for Move's ARM. See `BUILDING.md`.
 ## Testing
 
 Static/regression suite: `for t in tests/{host,shadow,store,build}/*.sh; do bash "$t"; done`
-(~95 shell tests: source-invariant pins, compiled C units, node-run .mjs units —
-not wired into CI; ~20 stale failures pin since-moved code, see the cleanup
-review doc). On-hardware behavior is verified manually. Enable the unified logger:
+(~95 shell tests: source-invariant pins, compiled C units, node-run .mjs units).
+**CI gates the `tests/host/` subset** — `.github/workflows/ci.yml` runs `host-tests`
+(`make -C tests/host test` + all `tests/host/*.sh`, all green), `go`
+(`schwung-manager`), and `cross-compile` (ARM64 Docker build) on every PR and push
+to `main`. `main` is branch-protected: **all three checks are required and direct
+pushes are blocked** — work on a branch and open a PR (see `CONTRIBUTING.md`;
+install the fast local checks with `./scripts/install-hooks.sh`). The broader
+`tests/{shadow,store,build}` suites are **not** run by CI — ~20 stale failures pin
+since-moved code (see the cleanup review doc). On-hardware behavior is verified
+manually. Enable the unified logger:
 
 ```bash
 ssh ableton@move.local "touch /data/UserData/schwung/debug_log_on"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Schwung
+
+Thanks for hacking on Schwung — it's a community project and PRs are welcome.
+
+## Workflow
+
+`main` is protected. **Direct pushes to `main` are blocked** (for everyone,
+maintainers included), so every change lands through a pull request that passes
+CI:
+
+1. Branch off `main`, or fork: `git switch -c my-change`
+2. Commit your work.
+3. Push and open a PR against `main`.
+4. Wait for the three required checks to go green.
+5. A maintainer merges once it's green.
+
+We use a **trunk-based** flow — short-lived feature branches, no long-lived
+`develop` branch. Merging code to `main` is *not* the same as shipping: the host
+only reaches devices when a maintainer bumps `host.latest_version` in
+`module-catalog.json` and pushes a release tag. Releases are cut with tags
+(`git tag vX.Y.Z && git push --tags`), which are unaffected by branch protection.
+See the Release Checklist in [CLAUDE.md](CLAUDE.md) and [BUILDING.md](BUILDING.md).
+
+> The catalog *is* served live from `main`, so edits to `module-catalog.json`
+> (module entries, descriptions) take effect for users as soon as they merge.
+
+## Continuous integration
+
+Every PR and push to `main` runs
+[`.github/workflows/ci.yml`](.github/workflows/ci.yml). Three required jobs:
+
+| Job | What it proves |
+|-----|----------------|
+| `host-tests` | Device-free unit + contract/invariant tests: `make -C tests/host test` and all `tests/host/*.sh`. |
+| `go` | `go vet` / `build` / `test` for `schwung-manager`. |
+| `cross-compile` | The app actually compiles for ARM64 (the same Docker build `release.yml` uses), and every expected artifact is present and `aarch64`. |
+
+CI is **fork-safe by design**: it uses the `pull_request` trigger (never
+`pull_request_target`), a read-only token, and no repository secrets. A
+first-time contributor's workflow run needs a maintainer to click
+**"Approve and run"** before it executes — that's a GitHub security gate, not a
+failure.
+
+> Only `tests/host/` is wired into CI. The broader `tests/{shadow,store,build}`
+> suites still contain stale failures and are run manually.
+
+## Run the checks locally
+
+Install the pre-commit hook once per clone. It runs the two fast jobs
+(`host-tests` + `go`, ~10s, no Docker or ARM toolchain) on every commit:
+
+```bash
+./scripts/install-hooks.sh
+```
+
+Bypass a single commit with `git commit --no-verify`, or
+`SCHWUNG_SKIP_HOOKS=1 git commit …`. The ARM64 `cross-compile` job is
+intentionally CI-only (it needs Docker + the toolchain, ~2.5 min).
+
+## On-device testing
+
+CI proves the code compiles and the contracts hold — it does **not** run on Move
+hardware. Behavior changes (audio, MIDI, UI, timing) still need manual
+verification on a device before release. See the Testing section of
+[CLAUDE.md](CLAUDE.md) for the unified logger and the opt-in on-device E2E
+harness (`tools/pytest-schwung/`).
+
+## Code style & module requirements
+
+Conventions live in [CLAUDE.md](CLAUDE.md) (C `snake_case` with `mm_`/`js_`
+prefixes, `.mjs` shared modules vs `.js` UI, lowercase-hyphenated module IDs,
+`lowercase_underscored` param keys). New modules go through the module-development
+guide in [docs/MODULES.md](docs/MODULES.md) and must ship a `help.json` plus
+screen-reader support (`src/shared/screen_reader.mjs`).

--- a/README.md
+++ b/README.md
@@ -90,11 +90,20 @@ curl -L https://raw.githubusercontent.com/charlesvestal/schwung/main/scripts/uni
 ## Documentation
 
 - [Schwung Manual](https://schwung.dev/manual.html) - User guide and shortcuts
+- [CONTRIBUTING.md](CONTRIBUTING.md) - Dev workflow, CI, and pull-request checks
 - [BUILDING.md](BUILDING.md) - Build instructions
 - [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) - System and Shadow UI architecture
 - [docs/MODULES.md](docs/MODULES.md) - Module development, Shadow UI integration, overtake modules
 - [docs/API.md](docs/API.md) - JavaScript module API
 - [src/modules/chain/README.md](src/modules/chain/README.md) - Signal Chain module notes
+
+## Contributing
+
+PRs welcome. `main` is protected and CI-gated: every change lands via a pull
+request that passes three checks (`host-tests`, `go`, `cross-compile`) — direct
+pushes to `main` are blocked. Branch off `main` (or fork), open a PR, and
+optionally install the fast local checks with `./scripts/install-hooks.sh`. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
 ## Available Modules
 


### PR DESCRIPTION
Documents the CI + branch-protection setup that landed with #169 so contributors (and future readers) know the rules — and dogfoods the new gate as the first `pull_request`-triggered CI run against this repo.

## Changes (docs-only, no code/version change)
- **`CONTRIBUTING.md` (new)** — the canonical contributor doc GitHub surfaces on PRs: trunk-based branch → PR → green-checks → merge flow; the three required jobs (`host-tests`, `go`, `cross-compile`) and what each proves; fork-safety (`pull_request`, read-only token, first-run "Approve and run"); the local pre-commit hook (`./scripts/install-hooks.sh`); on-device testing is still manual; code-style/module pointers.
- **`CLAUDE.md`** — fixes the now-false "not wired into CI" line in Testing: `tests/host/` is gated, `tests/{shadow,store,build}` are not; notes `main` is protected and direct pushes are blocked.
- **`README.md`** — adds a short **Contributing** section + a `CONTRIBUTING.md` link in the docs index.

## Why trunk-based (documented, not just asserted)
Merging code to `main` ≠ shipping — the host only reaches devices on a `host.latest_version` bump + release tag, so the tag is the stabilization point and a long-lived `develop` branch would just duplicate it. The one thing live-on-merge is the catalog (served from raw `main`), noted explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)