### PR TITLE
Route Smack and Belt variants to dedicated repos

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1085,7 +1085,7 @@
       "description": "Quantized live-loop capture with 26 seeded per-slice glitch effects, slice reordering, A/B punch, step editing, and Pad Play",
       "author": "timncox",
       "component_type": "audio_fx",
-      "github_repo": "timncox/schwung-smack",
+      "github_repo": "timncox/schwung-smack-fx",
       "default_branch": "main",
       "asset_name": "smack-module.tar.gz",
       "min_host_version": "0.3.0"
@@ -1096,7 +1096,7 @@
       "description": "Standalone mic/line/USB-C build of Smack with the same 26-effect seeded slice engine, Pad Play, and browser step editor",
       "author": "timncox",
       "component_type": "sound_generator",
-      "github_repo": "timncox/schwung-smack-in",
+      "github_repo": "timncox/schwung-smack-voice",
       "default_branch": "main",
       "asset_name": "smack-in-module.tar.gz",
       "min_host_version": "0.3.0"
@@ -1129,7 +1129,7 @@
       "description": "Live vocal processor for Signal Chain and Master FX: autotune, four scale-aware harmonies, HARD punch, tuner strip, doubler, and formant shift",
       "author": "timncox",
       "component_type": "audio_fx",
-      "github_repo": "timncox/schwung-belt",
+      "github_repo": "timncox/schwung-belt-fx",
       "default_branch": "main",
       "asset_name": "belt-module.tar.gz",
       "min_host_version": "0.3.0"
@@ -1140,7 +1140,7 @@
       "description": "Standalone mic/line/USB-C Belt: tuned lead vocal, four scale-aware harmonies, HARD punch, tuner strip, doubler, and formant shift in one slot",
       "author": "timncox",
       "component_type": "sound_generator",
-      "github_repo": "timncox/schwung-belt-in",
+      "github_repo": "timncox/schwung-belt-voice",
       "default_branch": "main",
       "asset_name": "belt-in-module.tar.gz",
       "min_host_version": "0.3.0"


### PR DESCRIPTION
## What changed

- Routes `smack` to `timncox/schwung-smack-fx`
- Routes `smack-in` to `timncox/schwung-smack-voice`
- Routes `belt` to `timncox/schwung-belt-fx`
- Routes `belt-in` to `timncox/schwung-belt-voice`

The module IDs, component types, minimum host versions, and asset names stay
unchanged, so existing installations continue to update in place.

## Why

Each catalog ID now has a dedicated, unambiguous FX or Voice distribution
repository. The combined SMACK and BELT repositories remain the canonical
source and issue trackers.

## Verification

- All four public `release.json` feeds resolve on `main`
- All four GitHub releases contain the catalog's expected asset name
- Uploaded asset SHA-256 digests match the locally validated archives
- `module-catalog.json` passes `python3 -m json.tool`
- SMACK and BELT native simulator suites pass
