### PR TITLE
Support multi-module release.json in schwung-manager

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -543,6 +543,27 @@ External modules can specify where they should be installed via `release.json`.
 }
 ```
 
+One repository may publish multiple catalog modules by nesting releases under
+their catalog IDs:
+
+```json
+{
+  "modules": {
+    "module-a": {
+      "version": "0.2.1",
+      "download_url": "https://github.com/user/repo/releases/download/v0.2.1/module-a-module.tar.gz"
+    },
+    "module-b": {
+      "version": "0.2.1",
+      "download_url": "https://github.com/user/repo/releases/download/v0.2.1/module-b-module.tar.gz"
+    }
+  }
+}
+```
+
+The catalog `id` selects the matching nested entry. Keep the original top-level
+shape for repositories that publish only one module.
+
 | Field | Required | Description |
 |-------|----------|-------------|
 | `version` | Yes | Semantic version (without `v` prefix) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,6 +460,17 @@ The manager also serves a **file browser** (`/files`, under `/data/UserData/`) a
  "download_url": "https://github.com/user/move-anything-mymodule/releases/download/v0.2.0/mymodule-module.tar.gz"}
 ```
 
+Repositories that publish multiple catalog modules may key each release by
+catalog ID. Schwung Manager and the shared store utilities select the matching
+entry before downloading:
+
+```json
+{"modules": {
+  "module-a": {"version": "0.2.0", "download_url": "https://.../module-a-module.tar.gz"},
+  "module-b": {"version": "0.2.0", "download_url": "https://.../module-b-module.tar.gz"}
+}}
+```
+
 Optional: `install_path`, `name`, `description`, `requires`, `post_install`, `repo_url`. Release workflow should auto-update this file on each tagged release.
 
 ### Catalog Entry

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2228,6 +2228,29 @@ Each module repo must have a `release.json` on its main branch. The Module Store
 }
 ```
 
+For a repository that publishes more than one catalog module, use a `modules`
+object keyed by the exact catalog IDs. Each entry has the same fields as a
+single-module release:
+
+```json
+{
+  "modules": {
+    "module-a": {
+      "version": "0.2.0",
+      "download_url": "https://github.com/username/repo/releases/download/v0.2.0/module-a-module.tar.gz"
+    },
+    "module-b": {
+      "version": "0.2.0",
+      "download_url": "https://github.com/username/repo/releases/download/v0.2.0/module-b-module.tar.gz"
+    }
+  }
+}
+```
+
+Schwung Manager and the shared store utilities select the entry matching the
+catalog module ID. If it is missing, the manager falls back to the catalog's
+`asset_name` latest-release URL.
+
 Optional fields: `install_path`, `name`, `description`, `requires`, `post_install`, `repo_url`. Fields like `name`, `description`, and `requires` in `release.json` override their catalog equivalents.
 
 The release workflow should auto-update `release.json` on each tagged release (see the workflow template above for an example).

--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -1093,8 +1093,21 @@ func getInstallSubdir(componentType string) string {
 
 // ReleaseJSON is the structure of a module's release.json file.
 type ReleaseJSON struct {
-	Version     string `json:"version"`
-	DownloadURL string `json:"download_url"`
+	Version     string                 `json:"version"`
+	DownloadURL string                 `json:"download_url"`
+	Modules     map[string]ReleaseJSON `json:"modules,omitempty"`
+}
+
+// forModule resolves both the original single-module release.json shape and
+// the multi-module shape used when one repository publishes several catalog
+// entries. A multi-module document must contain the requested catalog ID; the
+// caller can then fall back to the catalog asset name when it does not.
+func (r ReleaseJSON) forModule(moduleID string) (ReleaseJSON, bool) {
+	if len(r.Modules) == 0 {
+		return r, true
+	}
+	moduleRelease, ok := r.Modules[moduleID]
+	return moduleRelease, ok
 }
 
 // installModule downloads and extracts a module from its GitHub release.
@@ -1126,8 +1139,13 @@ func (app *App) installModule(mod *CatalogModule) error {
 		if err := json.NewDecoder(resp.Body).Decode(&rel); err != nil {
 			return fmt.Errorf("decoding release.json: %w", err)
 		}
-		downloadURL = rel.DownloadURL
-		releaseVersion = rel.Version
+		if moduleRelease, ok := rel.forModule(mod.ID); ok {
+			downloadURL = moduleRelease.DownloadURL
+			releaseVersion = moduleRelease.Version
+		} else {
+			app.logger.Warn("module missing from multi-module release.json; using fallback URL",
+				"id", mod.ID)
+		}
 	}
 	if downloadURL == "" {
 		// Fallback: use GitHub releases latest download.

--- a/schwung-manager/release_json_test.go
+++ b/schwung-manager/release_json_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func decodeReleaseJSON(t *testing.T, value string) ReleaseJSON {
+	t.Helper()
+	var release ReleaseJSON
+	if err := json.NewDecoder(strings.NewReader(value)).Decode(&release); err != nil {
+		t.Fatalf("decode release.json: %v", err)
+	}
+	return release
+}
+
+func TestReleaseJSONForModuleSingle(t *testing.T) {
+	release := decodeReleaseJSON(t, `{
+		"version":"1.2.3",
+		"download_url":"https://example.invalid/single.tar.gz"
+	}`)
+
+	got, ok := release.forModule("anything")
+	if !ok {
+		t.Fatal("single-module release unexpectedly rejected")
+	}
+	if got.Version != "1.2.3" || got.DownloadURL != "https://example.invalid/single.tar.gz" {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestReleaseJSONForModuleMulti(t *testing.T) {
+	release := decodeReleaseJSON(t, `{
+		"modules":{
+			"mono":{"version":"0.3.1","download_url":"https://example.invalid/mono.tar.gz"},
+			"mono-voice":{"version":"0.3.1","download_url":"https://example.invalid/mono-voice.tar.gz"}
+		}
+	}`)
+
+	got, ok := release.forModule("mono-voice")
+	if !ok {
+		t.Fatal("multi-module release entry not found")
+	}
+	if got.Version != "0.3.1" || got.DownloadURL != "https://example.invalid/mono-voice.tar.gz" {
+		t.Fatalf("got %+v", got)
+	}
+
+	if _, ok := release.forModule("missing"); ok {
+		t.Fatal("missing multi-module entry unexpectedly accepted")
+	}
+}

--- a/src/shared/store_utils.mjs
+++ b/src/shared/store_utils.mjs
@@ -108,6 +108,17 @@ export function fetchReleaseJson(github_repo, module_id, branch) {
             };
         }
 
+        /* Multi-module document that no longer lists this module: it was
+         * dropped from the repository's release.json. Report it distinctly
+         * instead of silently freezing the module at its last-known version
+         * (the generic "Invalid release.json format" path below would
+         * misattribute a valid-but-narrowed release.json to corruption). The
+         * caller still falls back to the catalog asset_name latest URL. */
+        if (release.modules && module_id) {
+            console.log(`Module '${module_id}' is no longer published in ${github_repo}'s multi-module release.json (removed from repo); update check falls back to catalog asset`);
+            return null;
+        }
+
         /* Single module format (backwards compatible) */
         if (!release.version || !release.download_url) {
             console.log(`Invalid release.json format for ${github_repo}`);

--- a/tests/store/test_release_json_removed_module_surfaced.sh
+++ b/tests/store/test_release_json_removed_module_surfaced.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A module dropped from a repo's multi-module release.json must be reported
+# distinctly (not misattributed to a corrupt "Invalid release.json format"),
+# so a removed module surfaces in the log instead of silently freezing at its
+# last-known version. Pin the explicit branch and its ordering.
+
+file="src/shared/store_utils.mjs"
+
+if [ ! -f "$file" ]; then
+  echo "FAIL: Missing $file" >&2
+  exit 1
+fi
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "FAIL: rg is required to run this test" >&2
+  exit 1
+fi
+
+# The explicit removed-module branch: multi-module doc present, this id absent.
+removed_line=$(rg -n "no longer published in" "$file" | head -n 1 | cut -d: -f1 || true)
+if [ -z "${removed_line}" ]; then
+  echo "FAIL: Missing explicit 'no longer published' branch for dropped multi-module entries" >&2
+  exit 1
+fi
+
+# Its guard must key on the release having a modules map and a requested id.
+ctx=$(sed -n "$((removed_line - 3)),${removed_line}p" "$file")
+if ! echo "$ctx" | rg -q "if \(release\.modules && module_id\)"; then
+  echo "FAIL: 'no longer published' branch not guarded by (release.modules && module_id)" >&2
+  exit 1
+fi
+
+# It must run BEFORE the generic "Invalid release.json format" catch, otherwise
+# a valid multi-module doc missing this id would be misreported as corrupt.
+invalid_line=$(rg -n 'console\.log\(.Invalid release\.json format' "$file" | head -n 1 | cut -d: -f1 || true)
+if [ -z "${invalid_line}" ]; then
+  echo "FAIL: Could not locate the generic invalid-format guard" >&2
+  exit 1
+fi
+if [ "${removed_line}" -ge "${invalid_line}" ]; then
+  echo "FAIL: removed-module branch must precede the generic invalid-format guard" >&2
+  exit 1
+fi
+
+echo "PASS: dropped multi-module entry is surfaced distinctly before the generic invalid-format path"
+exit 0


### PR DESCRIPTION
## Summary

Two related changes to how multi-module `release.json` files are handled:

1. **Re-add multi-module `release.json` support to `schwung-manager`** (the Go install path) so one repository can publish several catalog modules, each keyed by its catalog ID. Backwards-compatible and additive.
2. **Surface a module dropped from a multi-module `release.json`** in the shared JS update path instead of silently freezing it at its last-known version.

## Why

The multi-module format is already an established convention everywhere *except* the live Go install path:

- The shared JS store utilities (`src/shared/store_utils.mjs`) have parsed multi-module `release.json` since the Bristol catalog work (`00ed5524`).
- A shipping module already uses it in the wild — `move-anything-bristol` publishes `bristol-mini` + `bristol-juno` from one `release.json`.
- `schwung-manager` — the single install/update path today — was the odd one out: it ignored the `modules` map and silently fell back to `releases/latest/download/<asset_name>`, losing version pinning and release.json metadata.

The manager support was authored in #171 (`faf670c5`) and then removed there (`8d10f36d`) when Mono switched to dedicated repos. It's split out here as a standalone parity fix, **independent of the Mono catalog entries** (those merged separately in #171 as dedicated repos).

## Changes

**Go (`schwung-manager`)**
- `ReleaseJSON` gains an optional `modules` map + `forModule(id)` resolver. Empty map → identical single-module behavior.
- `installModule` pins `download_url`/`version` from the matching entry; a missing entry warns and falls through to the existing catalog `asset_name` latest-release fallback.
- Unit tests: single, multi, and missing-entry cases (`schwung-manager/release_json_test.go`).

**JS (`store_utils.mjs`)**
- `fetchReleaseJson` now detects the "multi-module doc that no longer lists this module" case explicitly and logs it distinctly, instead of misattributing a valid-but-narrowed release.json to the generic `Invalid release.json format` (corruption) path. Return value is unchanged (`null`), so the catalog-asset fallback still applies — the module just no longer freezes silently; the removal is diagnosable in the log.
- Source-pin test (`tests/store/test_release_json_removed_module_surfaced.sh`) matching the existing `tests/store/` convention (`store_utils.mjs` imports QuickJS `std`/`os`, so it is not node-runnable).

**Docs**: `BUILDING.md`, `CLAUDE.md`, `docs/MODULES.md` document the multi-module format.

## Scope notes

- The **catalog** (`module-catalog.json`) remains the authority for which modules exist. Multi-module `release.json` is purely a hosting/version convenience — adding or deleting a module is still a catalog-PR operation either way.
- The JS fix surfaces the dropped-module condition **at the log layer** (the codebase's standard surface) and preserves the safe fallback. It deliberately does **not** add a new "removed module" entry type to the on-device Updates UI — that surface is intentionally minimal ("detection only; installs happen in the web manager"). That's an available follow-up if desired.

## Validation

- `gofmt -l` clean, `go vet` clean, `go build ./...` OK
- `go test ./...` passes, incl. new `TestReleaseJSONForModule{Single,Multi}`
- `tests/store/test_release_json_removed_module_surfaced.sh` passes; sibling `test_release_json_fallback_to_catalog_asset.sh` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iHgzw26w7vxVvzBZEK64y