### PR TITLE
Revert PR #154: stop capturing Copy/Delete/Undo CCs in chain-shadow mode

### DIFF
--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -5916,15 +5916,6 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                         if (d1 == CC_JOG_WHEEL || d1 == CC_JOG_CLICK || d1 == CC_BACK) {
                             filter = 1;
                         }
-                        /* Copy/Delete/Undo: a chainable module's shadow-UI pad
-                         * tools consume these. Block from Move
-                         * firmware so a press doesn't also delete a clip or undo
-                         * a Move edit in the background. Forwarded to the shadow
-                         * UI by the post-ioctl loop. (Mute/CC88 is intentionally
-                         * NOT blocked — Move-native Mute+Pad relies on it.) */
-                        if (d1 == CC_UNDO || d1 == CC_COPY || d1 == CC_DELETE) {
-                            filter = 1;
-                        }
                         /* Filter Menu unless long-press mode dismisses shadow on tap */
                         if (d1 == CC_MENU && !LONG_PRESS_ACTIVE()) {
                             filter = 1;
@@ -7035,14 +7026,10 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                  * - CC 14 (jog wheel), CC 3 (jog click), CC 51 (back)
                  * - CC 40-43 (track buttons)
                  * - CC 71-78 (knobs)
-                 * - CC 88 (mute) — used as a modifier for Mute+JogClick module bypass
-                 * - CC 56/60/119 (undo/copy/delete) — chainable-module pad tools.
-                 *   Blocked from Move firmware in
-                 *   the pre-ioctl filter so a press only drives the shadow UI. */
+                 * - CC 88 (mute) — used as a modifier for Mute+JogClick module bypass */
                 int forward_to_shadow = (d1 == 14 || d1 == 3 || d1 == 51 ||
                                          (d1 >= 40 && d1 <= 43) || (d1 >= 71 && d1 <= 78) ||
-                                         d1 == 88 ||
-                                         d1 == 56 || d1 == 60 || d1 == 119);
+                                         d1 == 88);
 
                 if (forward_to_shadow && shadow_ui_midi_shm) {
                     shadow_ui_midi_publish(0x0B, status, d1, d2);


### PR DESCRIPTION
## Summary

Reverts `3fb9c9be` (PR #154), which filtered CC 56 (Undo), CC 60 (Copy), and CC 119 (Delete) out of the Move firmware path — and forwarded them to the loaded shadow module — whenever the **shadow display** is active.

## Why

The capture is gated on shadow-*display* mode, not on whether the loaded module actually wants those buttons. So during ordinary chain use (a shadow module on screen), Move's native **Undo/Copy/Delete stop working** — most painfully, you can't undo note edits on Move. That trade isn't worth it for the common case.

## Key finding: overtake modules never needed this

Tracing the shim input path, **overtake modules already receive CC 56/60/119**. In overtake mode the surface is fully owned — every hardware message is forwarded straight to the module (`shadow_ui_midi_publish(...); continue; /* skip normal processing in overtake mode */`) and Move firmware is blocked regardless. PR #154's mechanism only changed the **non-overtake chain-shadow** path, which is exactly where it's harmful.

So this revert effectively makes edit-CC capture "overtake-only" (which is where it was already free), while restoring Move-native Undo/Copy/Delete everywhere else.

## Trade-off

BD-1200 (a *chainable* module, not overtake) loses its hold-Copy / hold-Delete / tap-Undo pad gestures — that was PR #154's motivating case. If we want those back for chainable modules, the clean shape is a **capability opt-in** (module declares it claims the edit CCs) so the host only captures them for modules that ask. Discussion on #154.

## Validation

- Diff is exactly the inverse of `3fb9c9be` (two blocks removed in `src/schwung_shim.c`); nothing else touched.
- Cross-compiled + deployed to hardware; shim md5 matches across local build / `/data` / `/usr/lib` at 0.11.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iHgzw26w7vxVvzBZEK64y