### PR TITLE
release: bump host to 0.11.5 (catalog + release.json)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -4,8 +4,8 @@
     "name": "Schwung",
     "github_repo": "charlesvestal/schwung",
     "asset_name": "schwung.tar.gz",
-    "latest_version": "0.11.4",
-    "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.4/schwung.tar.gz",
+    "latest_version": "0.11.5",
+    "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.5/schwung.tar.gz",
     "min_host_version": "0.1.0"
   },
   "modules": [

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.11.4",
-  "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.4/schwung.tar.gz"
+  "version": "0.11.5",
+  "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.5/schwung.tar.gz"
 }


### PR DESCRIPTION
Points the catalog `host` block (`latest_version` + `download_url`) and `release.json` at the **v0.11.5** release asset (verified live — HTTP 200).

schwung-manager reads `host.latest_version` from the catalog to offer the host update, so this bump must merge only after the release asset exists (it does).

`release.yml`'s own `release.json` auto-commit step was rejected by branch protection (`GH006: protected branch hook declined`), so this PR carries that update. See note in the session about fixing the workflow (open a PR instead of pushing to `main`, or drop the step since the catalog is authoritative).

Once this merges, 0.11.5 is live to all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iHgzw26w7vxVvzBZEK64y