### PR TITLE
release: bump host to 0.11.6 (catalog + release.json)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -4,8 +4,8 @@
     "name": "Schwung",
     "github_repo": "charlesvestal/schwung",
     "asset_name": "schwung.tar.gz",
-    "latest_version": "0.11.5",
-    "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.5/schwung.tar.gz",
+    "latest_version": "0.11.6",
+    "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.6/schwung.tar.gz",
     "min_host_version": "0.1.0"
   },
   "modules": [

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.11.5",
-  "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.5/schwung.tar.gz"
+  "version": "0.11.6",
+  "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.11.6/schwung.tar.gz"
 }


### PR DESCRIPTION
Points the catalog `host` block (`latest_version` + `download_url`) and `release.json` at the **v0.11.6** release asset (verified live — HTTP 200). `version.txt` was already bumped to 0.11.6 in #178.

Once merged, 0.11.6 is live to all users. Contents: the #158 feedback-guard fixes (overtake entry + jack-sense debounce).

Note: this is the first release since the `release.yml` fix (#178) — the workflow ran **green** this time (no more GH006 false-failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014iHgzw26w7vxVvzBZEK64y