### PR TITLE
Remote UI v2 for overtake tools — off-thread snapshots, lossless edits, server-driven push

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -382,6 +382,54 @@ That means:
   Task 5). Bump `min_host_version` in your catalog entry if your
   module depends on it.
 
+### Remote UI for overtake tools (the Tool tab)
+
+Overtake tools (dsp.so loaded by the shim as `overtake_dsp`, not a chain slot)
+get their own browser view: schwung-manager serves the tool's `web_ui.html`
+under the **Tool tab**, addressed via the `overtake_dsp:<key>` param prefix.
+
+- **Opt in** by answering `get_param("module_id")` with your module id. The
+  manager probes it to discover the active tool, announces arrival/departure
+  to open Tool tabs, and serves `web_ui.html` from your module folder.
+- **Reads**: the manager seeds and refreshes the browser from
+  `get_param("state")` — return a **flat JSON object of delimited string
+  values** (nested arrays/objects are dropped by the param explosion).
+- **Writes**: browser `setParam` calls with values under 256 bytes arrive as
+  ordinary `set_param` dispatched from the shim's **web-set ring drain**
+  (lossless, ~one SPI frame, immune to param-mailbox contention); larger
+  values take the shadow_param mailbox (serialized round-trip, up to 64 KB).
+  **No per-buffer coalescing** on either path (unlike the on-device JS
+  channel). Ordering across the two paths is not guaranteed — keep any
+  op-sequencing within one size class.
+- **Off-audio-thread snapshots (optional)**: answer
+  `get_param("remote_snapshot_rt_safe")` with `"1"` and the host serializes
+  your `"state"` snapshot on a low-priority worker thread into a cached,
+  rev-stamped double buffer; the audio thread then serves browser pulls with
+  a single memcpy instead of running your serializer in the SPI frame budget.
+  **Contract:** every byte of instance memory reachable by your `"state"` /
+  `"rui_poll"` get_param must stay valid for the LIFETIME of the instance —
+  never freed or realloc'd by `render_block` OR `set_param` (frees only in
+  `destroy_instance`; use grow-only / clear-and-keep pools). Torn or
+  one-rev-stale snapshots are acceptable (the manager re-pulls until the
+  snapshot's own rev matches the digest); a use-after-free is not. Include
+  your current rev in the `"state"` JSON so the manager can tell what it
+  received. Note: a BULK_GET (request_type 3) of `"state"` bypasses this
+  cache and runs your serializer on the audio thread — don't put `"state"`
+  in bulk reads if you opt in.
+- **Live sync (optional but recommended)**: expose a monotonic edit counter
+  and a cheap digest, and the host pushes changes to the browser on-change:
+  - `get_param("rui_poll")` → `rev:on:tick:bpm[:devms]` — `rev` bumps on every
+    snapshot-visible edit; `on/tick/bpm` describe transport; `devms` (playing
+    only — the stopped digest must stay byte-stable) is a free-running
+    device-clock ms that lets the browser time-base its playhead independent
+    of delivery latency. The shim probes this in-process every few frames and
+    pushes changes through the notify ring; without it the manager falls back
+    to polling.
+  - Key-naming convention: keys suffixed `_ruisel` / `_cc_focus` and the key
+    `transport` are treated as selection/transport (the manager echoes
+    snapshots to their sender immediately instead of applying the editing
+    quiet-window).
+
 ## Drop-In Modules
 
 Modules are discovered at runtime from `/data/UserData/schwung/modules`.

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -36,12 +36,46 @@ type RemoteUI struct {
 
 	mu      sync.Mutex
 	clients map[*ruClient]struct{}
+
+	// toolPresent latches whether an overtake tool was active on the previous
+	// tool-tick, so a transition to "no tool" fires exactly one tool_info(gone)
+	// signal to Tool-tab clients. Guarded by mu.
+	toolPresent bool
+	// toolID caches the last successfully probed overtake tool id while
+	// toolPresent — so a subscribe that races mailbox contention can still
+	// seed the client instead of dead-ending it on "no tool".
+	toolID string
+	// toolGoneStreak counts consecutive confirmed-absent ticks; tool-gone is
+	// only signaled once it reaches the debounce threshold (a single absent
+	// answer can be a stomped-mailbox artifact, and a false gone dead-ends
+	// the client's tool UI).
+	toolGoneStreak int
+
+	// toolKick delivers a shim-pushed "rui_poll" digest (notify ring, F4 push
+	// path) to toolTickLoop so it services Tool-tab clients immediately instead
+	// of waiting for the next poll tick. Buffered(1); a pending kick is replaced
+	// by the newer digest.
+	toolKick chan string
+	// lastToolNotify is the UnixNano of the last shim rui_poll push. While
+	// recent, the tool ticker relaxes to a slow backstop — the notify ring is
+	// the primary update source. Guarded by mu.
+	lastToolNotify time.Time
+	// lastToolFull throttles full tool-state reads/fan-outs: rapid edit streams
+	// (FX knob drags) bump the rev per set_param, and servicing every kick with
+	// a 64KB read + full push melts the WiFi link. Guarded by mu.
+	lastToolFull time.Time
 }
 
 // ruClient represents a single WebSocket connection.
 type ruClient struct {
 	conn *websocket.Conn
-	mu   sync.Mutex // serialises writes
+	// mu guards client STATE (subs, tool cursors). It must never be held
+	// across a network write — a wedged client would then stall every loop
+	// that touches this client's state for up to the write timeout.
+	mu sync.Mutex
+	// writeMu serialises conn writes (wsjson.Write allows one writer at a
+	// time). Kept separate from mu so a stalled write blocks only writers.
+	writeMu sync.Mutex
 
 	// slots this client is subscribed to (slot index -> true)
 	subs map[uint8]bool
@@ -56,6 +90,17 @@ type ruClient struct {
 	toolSynced   bool
 	toolLastRev  int64
 	toolLastTick int64
+	toolLastOn   bool      // last pushed play-state; start/stop EDGES must be pushed
+	toolPlayAt   time.Time // last playhead push — rate-limited (edges exempt)
+	// toolLastEditAt: when this client last sent an overtake CONTENT edit —
+	// used to arm the quiet window only for edit STORMS (see handleSetParam).
+	toolLastEditAt time.Time
+	// toolQuietUntil: this client sent an overtake set_param recently, so it is
+	// mid-edit. Skip snapshot pushes to it until the window passes — its UI is
+	// optimistic and REJECTS echoes of its own edits anyway, and during a knob
+	// drag those echoes (a 64KB read + ~150KB WS frame per rev bump) saturate
+	// the WiFi link and stall everything for tens of seconds.
+	toolQuietUntil time.Time
 }
 
 // per-slot cached state used by the poll loop.
@@ -146,6 +191,7 @@ func NewRemoteUI(shm *ShmParams, setRing *ShmWebParamSetRing, basePath string, l
 		basePath: basePath,
 		logger:   logger,
 		clients:  make(map[*ruClient]struct{}),
+		toolKick: make(chan string, 1),
 	}
 }
 
@@ -158,13 +204,22 @@ const overtakeParamPrefix = "overtake_dsp:"
 // setParam writes a param using the fast ring buffer if available,
 // falling back to the old shared memory path.
 func (ru *RemoteUI) setParam(slot uint8, key, value string) error {
-	// Overtake-tool params MUST go through the reliable shadow_param ring
-	// (request_type=1), which the shim routes to the overtake DSP. The fast
-	// web_param_set ring's shadow_direct_set_param has no "overtake_dsp:"
-	// branch, so it would mis-route the key to a chain slot. The slow ring is
-	// fine here: overtake-tool edits are discrete ops, not knob-drag streams,
-	// and it lifts the fast ring's 255-byte value cap (64KB on the slow ring).
+	// Overtake-tool params: prefer the LOSSLESS web_param_set ring — drained by
+	// the shim every SPI frame and dispatched straight to the overtake DSP (the
+	// drain has an "overtake_dsp:" branch; requires the paired shim, deployed
+	// together). Unlike the mailbox, ring entries cannot be stomped by the
+	// device UI's fire-and-forget mailbox producer, which was killing overtake
+	// edits in 500ms response timeouts (dropped beat-stretch/legato/nudge ops).
+	// Oversized values (≥256B) still take the blocking mailbox (64KB cap).
 	if strings.HasPrefix(key, overtakeParamPrefix) {
+		if ring := ru.ensureSetRing(); ring != nil &&
+			len(key) < webKeyLen && len(value) < webValueLen {
+			if err := ring.SetParam(slot, key, value); err == nil {
+				return nil
+			}
+			// Ring full/unwritable — fall through to the blocking mailbox
+			// rather than dropping the edit (the loss class this path fixes).
+		}
 		if shm := ru.ensureShm(); shm != nil {
 			return shm.SetParam(slot, key, value)
 		}
@@ -179,25 +234,42 @@ func (ru *RemoteUI) setParam(slot uint8, key, value string) error {
 	return fmt.Errorf("no shared memory available")
 }
 
+// paramAnswered reports whether err came from an ANSWERED request — the shim
+// published an error response (authoritative, e.g. "no overtake DSP is
+// loaded") — rather than a mailbox-contention timeout (idle/response), where
+// the truth is simply unknown this tick. Conflating the two is what caused
+// both the gone→arrived flap loop and, inverted, unreachable gone detection.
+func paramAnswered(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "param get error")
+}
+
 // activeOvertakeToolID returns the module id of the overtake tool currently
 // loaded that opts into a remote UI by answering the
-// "overtake_dsp:module_id" probe, or "" if no such tool is active. The shim
-// returns an error for this GET when no overtake DSP is loaded (or the loaded
-// one predates the probe), so this is backward-safe.
-func (ru *RemoteUI) activeOvertakeToolID(slot uint8) string {
+// "overtake_dsp:module_id" probe. known=false means the answer could not be
+// determined this tick (no shm / mailbox contention timeout) — callers must
+// NOT treat that as "no tool". A genuine no-tool state is id=="" with
+// known==true (the shim answers the GET with an error response when no
+// overtake DSP is loaded — distinguished from a timeout by the error text,
+// not wall-clock).
+func (ru *RemoteUI) activeOvertakeToolID(slot uint8) (id string, known bool) {
 	shm := ru.ensureShm()
 	if shm == nil {
-		return ""
+		return "", false
 	}
 	id, err := shm.GetParam(slot, overtakeParamPrefix+"module_id")
 	if err != nil {
-		return ""
+		return "", paramAnswered(err)
 	}
-	return id
+	return id, true
 }
 
 // ensureSetRing attempts to open the web param set ring if not yet connected.
+// mu-guarded: the eager connect loop races WS handlers here, and a double
+// OpenShmWebParamSetRing would yield two ring objects whose per-object mutex
+// no longer serializes writes to the one shared-memory ring.
 func (ru *RemoteUI) ensureSetRing() *ShmWebParamSetRing {
+	ru.mu.Lock()
+	defer ru.mu.Unlock()
 	if ru.setRing != nil {
 		return ru.setRing
 	}
@@ -210,8 +282,11 @@ func (ru *RemoteUI) ensureSetRing() *ShmWebParamSetRing {
 }
 
 // ensureShm attempts to open shared memory if not yet connected.
-// Returns the ShmParams (possibly nil if still unavailable).
+// Returns the ShmParams (possibly nil if still unavailable). mu-guarded for
+// the same double-open reason as ensureSetRing.
 func (ru *RemoteUI) ensureShm() *ShmParams {
+	ru.mu.Lock()
+	defer ru.mu.Unlock()
 	if ru.shm != nil {
 		return ru.shm
 	}
@@ -228,6 +303,32 @@ func (ru *RemoteUI) Start(ctx context.Context) {
 	go ru.pollLoop(ctx)
 	go ru.notifyLoop(ctx)
 	go ru.refreshLoop(ctx)
+	go ru.toolTickLoop(ctx)
+	go ru.setRingConnectLoop(ctx)
+}
+
+// setRingConnectLoop connects the web param set ring EAGERLY at startup,
+// retrying until the shim has created the segment. Lazy-on-first-use is not
+// enough on this platform: something unlinks every /dev/shm/schwung-* segment
+// shortly after stack start (early mmaps like the notify/params rings survive
+// via their open mappings, but any LATER open gets ENOENT forever). Without
+// this, the manager start races segment creation, the lazy open never
+// succeeds, and overtake edits silently fall back to the stompable mailbox —
+// re-introducing the 500ms-timeout dropped-edit failure the ring path exists
+// to fix. Retry for ~2 min (covers slow boots), then give up quietly (the
+// mailbox fallback still works, just degraded).
+func (ru *RemoteUI) setRingConnectLoop(ctx context.Context) {
+	for i := 0; i < 240; i++ {
+		if ru.ensureSetRing() != nil {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+	}
+	ru.logger.Warn("web param set ring: gave up connecting — overtake edits will use the mailbox (degraded)")
 }
 
 // refreshLoop periodically re-reads all param values for subscribed slots.
@@ -272,7 +373,7 @@ func (ru *RemoteUI) refreshLoop(ctx context.Context) {
 			if toolID, ok, err := shm.TryGetParam(0, overtakeParamPrefix+"module_id"); ok && err == nil && toolID != "" {
 				if params, hit := ru.fetchAllParams(0, "overtake_dsp"); hit {
 					for _, c := range toolClients {
-						ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: 0, Params: params})
+						ru.writeJSONTry(ctx, c, wsParamUpdate{Type: "param_update", Slot: 0, Params: params})
 					}
 				}
 			}
@@ -520,6 +621,15 @@ func (ru *RemoteUI) fetchAllParams(slot uint8, comp string) (map[string]string, 
 	}
 	var values map[string]any
 	if json.Unmarshal([]byte(raw), &values) != nil {
+		// A "state" snapshot that filled the whole param buffer has almost
+		// certainly truncated mid-token → invalid JSON → we drop it here and the
+		// browser silently stops refreshing this component. Surface it so the
+		// failure is diagnosable instead of a mystery "frozen" remote UI; the
+		// module must gate its large snapshot fields below the 64KB cap.
+		if len(raw) >= paramValueLen {
+			ru.logger.Warn("remote UI: snapshot truncated at the param buffer cap → invalid JSON, dropping (component won't refresh)",
+				"comp", comp, "cap", paramValueLen)
+		}
 		return nil, false
 	}
 	params := make(map[string]string, len(values))
@@ -650,6 +760,29 @@ func (ru *RemoteUI) handleSetParam(ctx context.Context, c *ruClient, msg wsMessa
 		ru.sendError(ctx, c, "set_param requires key")
 		return
 	}
+	// Overtake CONTENT edits mark the sender mid-edit: snapshot echoes back to
+	// it are suppressed for a short window (see ruClient.toolQuietUntil) — its
+	// optimistic UI rejects them anyway. Selection/transport/focus keys are
+	// EXEMPT: for those the snapshot IS the requested data (the newly selected
+	// clip's notes, the focused CC lane), not an echo — arming quiet for them
+	// just made the client's own request feel laggy.
+	// STORM-ONLY: a single discrete edit (beat stretch, legato, one note op)
+	// does NOT arm the window — the browser can't optimistically render
+	// destructive ops, so the snapshot echo IS the result and deferring it
+	// just reads as lag. Only a rapid successive stream (knob drag, note
+	// drag) arms it; the optimistic UI covers those.
+	if strings.HasPrefix(msg.Key, overtakeParamPrefix) &&
+		!strings.HasSuffix(msg.Key, "_ruisel") &&
+		!strings.HasSuffix(msg.Key, ":transport") &&
+		!strings.HasSuffix(msg.Key, "_cc_focus") {
+		now := time.Now()
+		c.mu.Lock()
+		if now.Sub(c.toolLastEditAt) < 250*time.Millisecond {
+			c.toolQuietUntil = now.Add(300 * time.Millisecond)
+		}
+		c.toolLastEditAt = now
+		c.mu.Unlock()
+	}
 	if err := ru.setParam(slot, msg.Key, msg.Value); err != nil {
 		ru.logger.Error("set_param failed", "slot", slot, "key", msg.Key, "err", err)
 		ru.sendError(ctx, c, "set_param failed: "+err.Error())
@@ -668,16 +801,7 @@ func (ru *RemoteUI) handleSetParam(ctx context.Context, c *ruClient, msg wsMessa
 			go func() {
 				time.Sleep(50 * time.Millisecond) // Let the plugin process the change
 				// Read shm once and fan out to all subscribers of this slot.
-				clients := ru.subscribedClients(slot)
-				// Pure Tool-tab clients set toolSub, not subs[0], so they're not
-				// in subscribedClients(0). An overtake tool's params live under
-				// the "overtake_dsp" component at slot 0, so include tool clients
-				// here — otherwise the immediate preset refetch skips them and
-				// they only catch the change on their next refetch_tool poll.
-				if comp == strings.TrimSuffix(overtakeParamPrefix, ":") {
-					clients = append(clients, ru.subscribedToolClients()...)
-				}
-				ru.broadcastInitialParamValues(ctx, slot, comp, clients)
+				ru.broadcastInitialParamValues(ctx, slot, comp, ru.subscribedClients(slot))
 			}()
 		}
 	}
@@ -758,7 +882,25 @@ func (ru *RemoteUI) handleSubscribeTool(ctx context.Context, c *ruClient) {
 		return
 	}
 
-	toolID := ru.activeOvertakeToolID(0)
+	toolID, known := ru.activeOvertakeToolID(0)
+	if !known {
+		// Contention at subscribe time — do NOT seed "no tool" (the client
+		// subscribes exactly once; a false empty seed dead-ends the tab).
+		// Fall back to the cached id if a tool is latched present.
+		ru.mu.Lock()
+		if ru.toolPresent {
+			toolID = ru.toolID
+		}
+		ru.mu.Unlock()
+	}
+	if toolID != "" {
+		// Consume the arrival edge BEFORE any network write: this client is
+		// being seeded right here, and it became visible to the ticker's
+		// subscribedToolClients() the moment toolSub was set above — if the
+		// ticker won the edge race mid-seed it would announceToolArrival a
+		// second custom_ui and reload the just-built iframe.
+		ru.markToolPresent()
+	}
 	ru.writeJSON(ctx, c, wsToolInfo{Type: "tool_info", ID: toolID})
 	if toolID == "" {
 		return
@@ -781,60 +923,382 @@ func (ru *RemoteUI) handleUnsubscribeTool(c *ruClient) {
 	ru.logger.Info("ws unsubscribe tool")
 }
 
-// handleRefetchTool picks up device-side changes the web UI polls for (playhead,
-// external edits) that don't notify. Rev-gated: it first reads the tool's CHEAP
-// "rui_poll" digest (rev:on:tick:bpm, no note serialization) and only does the
-// heavy full "state" read (fetchAllParams) when rev changes (a content edit).
-// While playing with no edit it pushes only the moving playhead; when nothing
-// changed it does no work. Params ONLY — never custom_ui/tool_info (which would
-// reload the iframe).
-func (ru *RemoteUI) handleRefetchTool(ctx context.Context, c *ruClient) {
-	// Safety belt: only poll the device for a client actually viewing the Tool tab.
-	if !c.toolSub {
-		return
-	}
-	if !ru.requireShm(ctx, c) {
-		return
-	}
-	digest, ok, err := ru.shm.TryGetParam(0, overtakeParamPrefix+"rui_poll")
-	if !ok {
-		// Shm was busy (another goroutine held s.mu) — skip this poll and let
-		// the next one (~5ms) retry. Falling through to fetchAllParams here
-		// would block on s.mu and run the heavy full-state read, defeating the
-		// rev-gate exactly under the contention it's meant to cheapen.
-		return
-	}
-	if err != nil || digest == "" {
-		// Tool predates the cheap digest key (or a transient error) — fall back
-		// to a full fetch.
-		if params, hit := ru.fetchAllParams(0, "overtake_dsp"); hit {
-			ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: 0, Params: params})
+// handleRefetchTool is retained only so browsers that still send "refetch_tool"
+// on a timer don't get an "unknown message type" error. It is now a NO-OP: the
+// server-side toolTickLoop drives all Tool-tab updates (coalesced across clients
+// + rev-gated). A per-client poll here would double-read the shm channel and
+// race the ticker on the per-client rev cursors. Updates still reach the browser
+// via pushed param_update messages, exactly as before.
+func (ru *RemoteUI) handleRefetchTool(_ context.Context, _ *ruClient) {}
+
+// toolTickLoop drives the overtake-tool remote UI from the SERVER, replacing the
+// per-client browser-driven "refetch_tool" poll. When >=1 client is viewing the
+// Tool tab it reads the tool's cheap "rui_poll" digest once per tick and does the
+// single expensive "state" read only on a rev change — fanned out to every stale
+// tool client at once (coalesced: N tabs = 1 read, not N). Between edits it
+// pushes only the moving playhead. With no tool clients it touches no shm at all.
+//
+// Cadence adapts: ~100ms while a tool is actively playing/editing (tighter than
+// the old browser 150–500ms poll → snappier device→browser sync), backing off
+// when a tool tab is open but idle so steady-state shm traffic stays low.
+func (ru *RemoteUI) toolTickLoop(ctx context.Context) {
+	const noClientsInterval = 500 * time.Millisecond
+	const idleInterval = 400 * time.Millisecond
+	const liveInterval = 100 * time.Millisecond
+	// While the shim is pushing rui_poll digests through the notify ring (F4
+	// push path), kicks are the primary update source and the poll degrades to
+	// a slow backstop that only catches a stalled/overflowed ring.
+	const pushBackstopInterval = 2 * time.Second
+	const notifyFreshWindow = 15 * time.Second
+	const retryInterval = 150 * time.Millisecond
+	interval := noClientsInterval
+	for {
+		var kicked string
+		select {
+		case <-ctx.Done():
+			return
+		case kicked = <-ru.toolKick:
+		case <-time.After(interval):
 		}
-		return
-	}
-	rev, on, tick, bpm := parseRuiPoll(digest)
-	if !c.toolSynced || rev != c.toolLastRev {
-		// Content changed (or first sync) → full snapshot.
-		if params, hit := ru.fetchAllParams(0, "overtake_dsp"); hit {
-			ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: 0, Params: params})
-			c.toolSynced = true
-			c.toolLastRev = rev
-			c.toolLastTick = tick
+		clients := ru.subscribedToolClients()
+		if len(clients) == 0 {
+			interval = noClientsInterval
+			continue
 		}
-		return
-	}
-	// No content change → push only the playhead while playing (cheap).
-	if on && tick != c.toolLastTick {
-		c.toolLastTick = tick
-		ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: 0,
-			Params: map[string]string{
-				overtakeParamPrefix + "rui_play": fmt.Sprintf("%d:%d:%d", boolToInt(on), tick, bpm),
-			}})
+		shm := ru.ensureShm()
+		if shm == nil {
+			interval = idleInterval
+			continue
+		}
+		active, pending := ru.serviceToolClients(ctx, shm, clients, kicked)
+		ru.mu.Lock()
+		notifyFresh := !ru.lastToolNotify.IsZero() && time.Since(ru.lastToolNotify) < notifyFreshWindow
+		ru.mu.Unlock()
+		switch {
+		case pending:
+			// A stale client was deferred (edit-quiet window or full-read
+			// throttle) — retry soon so it syncs right after the window.
+			interval = retryInterval
+		case notifyFresh:
+			interval = pushBackstopInterval
+		case active:
+			interval = liveInterval
+		default:
+			interval = idleInterval
+		}
 	}
 }
 
-// parseRuiPoll parses the overtake tool's cheap "rev:on:tick:bpm" poll digest.
-func parseRuiPoll(s string) (rev int64, on bool, tick int64, bpm int64) {
+// serviceToolClients performs one rev-gated tool poll and fans the result out to
+// all Tool-tab clients. A single shm read per tick; the per-client rev/tick
+// cursors (guarded by c.mu) decide who receives the full snapshot vs. just the
+// playhead. Returns true when the tool is "active" (playing, content changed, or
+// the channel was busy mid-edit) so the caller keeps the tighter cadence.
+func (ru *RemoteUI) serviceToolClients(ctx context.Context, shm *ShmParams, clients []*ruClient, kicked string) (active, pending bool) {
+	var digest string
+	if kicked != "" {
+		// Shim-pushed digest (notify ring) — no shm read needed at all.
+		digest = kicked
+	} else {
+		var ok bool
+		var err error
+		digest, ok, err = shm.TryGetParam(0, overtakeParamPrefix+"rui_poll")
+		if !ok {
+			// Mutex busy (a concurrent SetParam or another read). SKIP this tick
+			// rather than escalate to the heavy "state" read — escalating on
+			// contention defeats the rev-gate exactly when the channel is busiest
+			// (self-amplifying under load). Stay on the fast cadence: busy means a
+			// user is actively editing, so we want to catch up promptly.
+			return true, false
+		}
+		if err != nil {
+			if paramAnswered(err) {
+				// The shim ANSWERED with an error: no overtake DSP is serving
+				// rui_poll — either no tool is loaded (gone path below) or a
+				// legacy tool without the key (module_id disambiguates).
+				// Genuine unloads surface as exactly this, so it must flow
+				// into the no-digest path or tool-gone becomes unreachable.
+				digest = ""
+			} else {
+				// Contention timeout — NOT evidence the tool is gone. Treating
+				// it as absence made the manager flap gone→arrived every few
+				// seconds under device-side param load: each false arrival
+				// reset every client's cursors and re-pushed a full snapshot.
+				// Skip the tick; the next poll/kick retries.
+				return true, false
+			}
+		}
+	}
+	if digest == "" {
+		// No digest: either no active overtake tool, or a tool that predates the
+		// cheap rui_poll key. One module_id read (only on this cold path) tells
+		// them apart, so we can notify the Tool tab when its tool goes away.
+		id, idKnown := ru.activeOvertakeToolID(0)
+		if !idKnown {
+			// Contention — can't tell if the tool is gone. Never signal gone
+			// on uncertainty (flap loop); skip and let the next tick decide.
+			return true, false
+		}
+		if id == "" {
+			// DEBOUNCE: require several consecutive confirmed-absent ticks
+			// before telling clients the tool is gone. A single ambiguous
+			// answer (a stomped mailbox can also produce an answered error)
+			// put clients into a dead "no tool" state mid-session.
+			ru.mu.Lock()
+			ru.toolGoneStreak++
+			confirmed := ru.toolGoneStreak >= 3
+			ru.mu.Unlock()
+			if !confirmed {
+				return true, false
+			}
+			ru.signalToolGone(ctx, clients)
+			return false, false
+		}
+		ru.mu.Lock()
+		ru.toolID = id
+		ru.mu.Unlock()
+		ru.maybeAnnounceArrival(ctx, clients)
+		// Legacy tool without rui_poll → one coalesced full fetch for all.
+		if params, hit := ru.fetchAllParams(0, "overtake_dsp"); hit {
+			for _, c := range clients {
+				ru.writeJSONTry(ctx, c, wsParamUpdate{Type: "param_update", Slot: 0, Params: params})
+			}
+		}
+		return true, false
+	}
+	ru.maybeAnnounceArrival(ctx, clients)
+	rev, on, tick, bpm, devms := parseRuiPoll(digest)
+	// rui_play frame (used by BOTH the snapshot path — play-state edges must
+	// ride along, snapshots don't carry the on flag — and the playhead path).
+	// devms (device-clock ms, playing only) lets the browser time-base
+	// corrections independent of delivery latency.
+	play := fmt.Sprintf("%d:%d:%d", boolToInt(on), tick, bpm)
+	if on && devms > 0 {
+		play = fmt.Sprintf("%d:%d:%d:%d", boolToInt(on), tick, bpm, devms)
+	}
+	playUpdate := wsParamUpdate{Type: "param_update", Slot: 0,
+		Params: map[string]string{overtakeParamPrefix + "rui_play": play}}
+
+	// Which clients need the full snapshot (rev changed, or first sync)?
+	// A client inside its edit-quiet window is deferred, not served: it is
+	// mid-edit, its optimistic UI rejects echoes of its own edits, and echoing
+	// a ~150KB snapshot per knob tick is what melted the WiFi link.
+	tnow := time.Now()
+	needFull := false
+	for _, c := range clients {
+		c.mu.Lock()
+		stale := !c.toolSynced || rev != c.toolLastRev
+		quiet := tnow.Before(c.toolQuietUntil)
+		c.mu.Unlock()
+		if stale && quiet {
+			pending = true
+		}
+		if stale && !quiet {
+			needFull = true
+		}
+	}
+	if needFull {
+		// Global full-read throttle: a rapid edit stream bumps rev per
+		// set_param; without this the kick path does back-to-back 64KB reads
+		// + full pushes. Deferred work is picked up by the retry cadence.
+		ru.mu.Lock()
+		throttled := time.Since(ru.lastToolFull) < 300*time.Millisecond
+		if !throttled {
+			ru.lastToolFull = tnow
+		}
+		ru.mu.Unlock()
+		if throttled {
+			return true, true
+		}
+		params, hit := ru.fetchAllParams(0, "overtake_dsp") // ONE read, fanned out
+		// The shim serves "state" from a worker-maintained cache that may be
+		// one rev behind the digest. The blob carries its own rui_rev — sync
+		// cursors to what we actually RECEIVED, and if it's older than the
+		// digest, keep pending so the retry cadence re-pulls (the shim kicks
+		// its cache refresh on the stale read).
+		blobRev := rev
+		if hit {
+			if s, ok := params[overtakeParamPrefix+"rui_rev"]; ok {
+				if v, perr := strconv.ParseInt(s, 10, 64); perr == nil {
+					blobRev = v
+				}
+			}
+			if blobRev < rev {
+				// Stale cache served — re-pull soon. (blobRev > rev just means
+				// the blob was serialized after the digest read: fresher, fine.)
+				pending = true
+			}
+		} else {
+			pending = true // cold shim cache / busy channel — retry soon
+		}
+		if hit {
+			for _, c := range clients {
+				c.mu.Lock()
+				stale := !c.toolSynced || rev != c.toolLastRev
+				quiet := time.Now().Before(c.toolQuietUntil)
+				c.mu.Unlock()
+				if !stale {
+					continue
+				}
+				if quiet {
+					pending = true // sync right after the quiet window
+					continue
+				}
+				// Non-blocking dispatch: on drop (a write to this client is
+				// still in flight) the cursors stay stale, so the next tick
+				// retries — a wedged client can't stall the whole fan-out.
+				if !ru.writeJSONTry(ctx, c, wsParamUpdate{Type: "param_update", Slot: 0, Params: params}) {
+					pending = true
+					continue
+				}
+				c.mu.Lock()
+				c.toolSynced = true
+				c.toolLastRev = blobRev
+				c.toolLastTick = tick
+				edge := on != c.toolLastOn
+				c.mu.Unlock()
+				// A play-STATE edge must ride along with the snapshot: the
+				// state blob does NOT carry the on flag (rui_play is the
+				// browser's only source of it), and this branch returns before
+				// the playhead section — advancing toolLastOn here without
+				// sending rui_play would swallow the edge FOREVER (a hardware
+				// stop coinciding with a rev bump left the browser playhead
+				// free-running indefinitely). Dispatch it; on drop leave the
+				// cursor so the playhead section retries within retryInterval.
+				if edge {
+					if ru.writeJSONTry(ctx, c, playUpdate) {
+						c.mu.Lock()
+						c.toolLastOn = on
+						c.mu.Unlock()
+					} else {
+						pending = true
+					}
+				}
+			}
+		}
+		return true, pending
+	}
+
+	// No content change → push the playhead. While playing that's the moving
+	// tick; a play-STATE edge must also be pushed even when on=false — without
+	// the stop edge the browser's animated playhead free-runs long after
+	// transport stops (rui_play pushes are its only source of the on flag).
+	// Rate-limit moving-playhead pushes per client (~400ms): the browser
+	// free-runs its own BPM clock and only needs phase corrections, and the
+	// Move's WiFi delivers small frames in bursty clumps — a ~100ms stream
+	// congested the link and starved snapshot pushes behind it. Play-state
+	// EDGES are exempt (always pushed immediately).
+	const playheadMinInterval = 400 * time.Millisecond
+	now := time.Now()
+	for _, c := range clients {
+		c.mu.Lock()
+		edge := on != c.toolLastOn
+		changed := edge || (on && tick != c.toolLastTick &&
+			now.Sub(c.toolPlayAt) >= playheadMinInterval)
+		c.mu.Unlock()
+		if !changed {
+			continue
+		}
+		if !ru.writeJSONTry(ctx, c, playUpdate) {
+			continue // dropped — cursors untouched, next tick retries
+		}
+		c.mu.Lock()
+		c.toolLastOn = on
+		c.toolLastTick = tick
+		c.toolPlayAt = now
+		c.mu.Unlock()
+	}
+	return on, pending
+}
+
+// markToolPresent latches that an overtake tool is currently active, so a later
+// transition to "no tool" fires exactly one tool-gone signal. Returns true when
+// this call is the not-present -> present EDGE (a fresh arrival).
+func (ru *RemoteUI) markToolPresent() bool {
+	ru.mu.Lock()
+	arrived := !ru.toolPresent
+	ru.toolPresent = true
+	ru.mu.Unlock()
+	return arrived
+}
+
+// announceToolArrival is the mirror of signalToolGone: tells subscribed
+// Tool-tab clients that an overtake tool has (re)appeared. Without it a Tool
+// tab opened BEFORE the tool loads (or across an on-device tool swap) sits on
+// "No tool loaded" indefinitely — the browser subscribes exactly once and
+// nothing re-announces. Sends tool_info + custom_ui per client (ordered within
+// a per-client goroutine) and marks every client unsynced so the ticker's
+// normal path fans out a fresh snapshot in the same pass.
+// maybeAnnounceArrival consumes the not-present→present edge and announces the
+// arrival. If the announce cannot complete (module_id unreadable under
+// contention), the edge is UN-latched so the next tick retries — consuming the
+// edge and then silently failing left clients in a dead "no tool" state with
+// snapshots streaming past them (the "browser never updates" failure).
+func (ru *RemoteUI) maybeAnnounceArrival(ctx context.Context, clients []*ruClient) {
+	ru.mu.Lock()
+	ru.toolGoneStreak = 0 // tool observed present — reset the gone debounce
+	ru.mu.Unlock()
+	if !ru.markToolPresent() {
+		return
+	}
+	if !ru.announceToolArrival(ctx, clients) {
+		ru.mu.Lock()
+		ru.toolPresent = false
+		ru.mu.Unlock()
+	}
+}
+
+// announceToolArrival returns false when the announce could not be delivered
+// (tool id unreadable) so the caller can retry the arrival edge.
+func (ru *RemoteUI) announceToolArrival(ctx context.Context, clients []*ruClient) bool {
+	toolID, _ := ru.activeOvertakeToolID(0)
+	if toolID == "" {
+		return false
+	}
+	ru.mu.Lock()
+	ru.toolID = toolID
+	ru.mu.Unlock()
+	url := ru.findModuleWebUI(toolID)
+	for _, c := range clients {
+		c.mu.Lock()
+		c.toolSynced = false
+		c.mu.Unlock()
+		go func(c *ruClient) {
+			ru.writeJSON(ctx, c, wsToolInfo{Type: "tool_info", ID: toolID})
+			if url != "" {
+				ru.sendCustomUI(ctx, c, 0, "tool", url)
+			}
+		}(c)
+	}
+	ru.logger.Info("overtake tool arrived — announced to Tool-tab clients", "tool", toolID)
+	return true
+}
+
+// signalToolGone tells Tool-tab clients (once) that their overtake tool has
+// unloaded, so the browser can clear its iframe instead of polling a dead tool
+// forever. No-op until an active tool has actually been seen.
+func (ru *RemoteUI) signalToolGone(ctx context.Context, clients []*ruClient) {
+	ru.mu.Lock()
+	was := ru.toolPresent
+	ru.toolPresent = false
+	ru.toolID = ""
+	ru.mu.Unlock()
+	if !was {
+		return
+	}
+	for _, c := range clients {
+		// Async (must not be dropped, must not stall the ticker on a wedged
+		// client); per-client writeMu still serialises with in-flight writes.
+		ru.writeJSONAsync(ctx, c, wsToolInfo{Type: "tool_info", ID: ""})
+	}
+	ru.logger.Info("overtake tool unloaded — signaled Tool-tab clients")
+}
+
+// parseRuiPoll parses the overtake tool's cheap "rev:on:tick:bpm[:devms]" poll
+// digest. devms (present only while playing) is the module's free-running
+// device-clock ms for the tick — forwarded so the browser can time-base
+// playhead corrections independent of delivery latency.
+func parseRuiPoll(s string) (rev int64, on bool, tick int64, bpm int64, devms int64) {
 	p := strings.Split(s, ":")
 	if len(p) > 0 {
 		rev, _ = strconv.ParseInt(p[0], 10, 64)
@@ -848,6 +1312,9 @@ func parseRuiPoll(s string) (rev int64, on bool, tick int64, bpm int64) {
 	}
 	if len(p) > 3 {
 		bpm, _ = strconv.ParseInt(p[3], 10, 64)
+	}
+	if len(p) > 4 {
+		devms, _ = strconv.ParseInt(p[4], 10, 64)
 	}
 	return
 }
@@ -989,13 +1456,42 @@ func (ru *RemoteUI) sendError(ctx context.Context, c *ruClient, message string) 
 }
 
 func (ru *RemoteUI) writeJSON(ctx context.Context, c *ruClient, v any) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	if err := wsjson.Write(ctx, c.conn, v); err != nil {
 		ru.logger.Debug("ws write failed", "err", err)
 	}
+}
+
+// writeJSONTry dispatches the write in its own goroutine if no write to this
+// client is already in flight, and reports false (dropped) otherwise. Used by
+// the periodic fan-out loops (tool ticker, notify drain, backstop): every
+// update they push is an ABSOLUTE value, so dropping one while the previous
+// write is still stuck is correct — the caller skips its cursor update and the
+// next tick re-pushes. A wedged client can neither stall the calling loop nor
+// accumulate blocked goroutines (at most one in flight per client).
+func (ru *RemoteUI) writeJSONTry(ctx context.Context, c *ruClient, v any) bool {
+	if !c.writeMu.TryLock() {
+		return false
+	}
+	go func() {
+		defer c.writeMu.Unlock()
+		wctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if err := wsjson.Write(wctx, c.conn, v); err != nil {
+			ru.logger.Debug("ws write failed", "err", err)
+		}
+	}()
+	return true
+}
+
+// writeJSONAsync queues the write in its own goroutine (serialised per client
+// by writeMu). For one-shot messages that must not be dropped (tool_info) but
+// must not stall the calling loop either.
+func (ru *RemoteUI) writeJSONAsync(ctx context.Context, c *ruClient, v any) {
+	go ru.writeJSON(ctx, c, v)
 }
 
 // ---------------------------------------------------------------------------
@@ -1057,6 +1553,29 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 			slotChanges := make(map[uint8]map[string]string)
 			masterFxChanges := make(map[string]string)
 			for _, c := range changes {
+				if c.Slot == 0 && c.Key == overtakeParamPrefix+"rui_poll" {
+					// F4 push: the shim probes the overtake tool's rui_poll
+					// digest and pushes changes here. Don't forward raw —
+					// kick the tool ticker (sole driver of tool cursors)
+					// with the digest; replace any pending kick with the
+					// newer one.
+					ru.mu.Lock()
+					ru.lastToolNotify = time.Now()
+					ru.mu.Unlock()
+					select {
+					case ru.toolKick <- c.Value:
+					default:
+						select {
+						case <-ru.toolKick:
+						default:
+						}
+						select {
+						case ru.toolKick <- c.Value:
+						default:
+						}
+					}
+					continue
+				}
 				if c.Slot == 0 && strings.HasPrefix(c.Key, "master_fx:") {
 					masterFxChanges[c.Key] = c.Value
 					// A device-initiated master-FX preset load reshuffles every
@@ -1093,6 +1612,12 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 				}
 			}
 
+			// Non-blocking dispatch (writeJSONTry): these are absolute values
+			// re-pushed on every change, so dropping one for a client whose
+			// previous write is still in flight is safe — and one wedged
+			// client can no longer stall this 5ms drain loop for up to the
+			// write timeout (which overflowed the 64-entry shim ring and
+			// dropped everyone's live knob updates).
 			for slot, params := range slotChanges {
 				update := wsParamUpdate{Type: "param_update", Slot: slot, Params: params}
 				for _, c := range clients {
@@ -1100,7 +1625,7 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 					subscribed := c.subs[slot]
 					c.mu.Unlock()
 					if subscribed {
-						ru.writeJSON(ctx, c, update)
+						ru.writeJSONTry(ctx, c, update)
 					}
 				}
 			}
@@ -1112,7 +1637,7 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 					subscribed := c.masterFxSub
 					c.mu.Unlock()
 					if subscribed {
-						ru.writeJSON(ctx, c, update)
+						ru.writeJSONTry(ctx, c, update)
 					}
 				}
 			}

--- a/schwung-manager/shmwebring.go
+++ b/schwung-manager/shmwebring.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 	"sync"
+	"sync/atomic"
 	"syscall"
+	"unsafe"
 )
 
 // ShmWebParamSetRing provides fire-and-forget param writes via the
@@ -18,10 +20,21 @@ type ShmWebParamSetRing struct {
 }
 
 // Offsets into web_param_set_ring_t.
+//
+// SPSC protocol (2026-07-19 rework — requires the paired shim): write_idx is a
+// MONOTONIC uint8 producer cursor (entry slot = write_idx % 32; 256 % 32 == 0
+// so the wrap is seamless) and reserved[0] (byte 2) is the shim-published
+// consumer cursor. The old protocol had the shim RESET write_idx to 0 after
+// draining, racing the producer's read-modify-write — an edit landing
+// mid-drain was orphaned or a previous batch was re-applied (double-nudge).
+// Now neither side writes the other's cursor. Header updates go through a CAS
+// on the 4-byte header word: it preserves the shim's concurrent byte-2 store
+// and gives release ordering so entry bytes are visible before the cursor.
 const (
-	webRingOffWriteIdx = 0 // uint8
-	webRingOffReady    = 1 // uint8
-	// reserved[2] at 2-3
+	webRingOffWriteIdx = 0 // uint8, monotonic producer cursor
+	webRingOffReady    = 1 // uint8, legacy change signal (still bumped)
+	webRingOffReadIdx  = 2 // uint8, monotonic consumer cursor (shim-published)
+	// reserved byte at 3
 
 	webEntryStart  = 4 // first entry starts at byte 4
 	webEntrySlot   = 0 // uint8 at offset 0 within entry
@@ -69,13 +82,18 @@ func (r *ShmWebParamSetRing) SetParam(slot uint8, key, value string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	idx := int(r.data[webRingOffWriteIdx])
-	if idx >= webMaxEntries {
+	hdr := (*uint32)(unsafe.Pointer(&r.data[0])) // 4-byte header word, offset 0 (aligned)
+	old := atomic.LoadUint32(hdr)
+	head := uint8(old)       // byte 0 (little-endian ARM64) = write_idx
+	tail := uint8(old >> 16) // byte 2 = shim-published read_idx
+	if head-tail >= webMaxEntries {
+		// Consumer hasn't caught up (or an unpaired old shim never publishes
+		// read_idx) — report full; the caller falls back to the mailbox.
 		return fmt.Errorf("web param set ring full")
 	}
 
-	// Write entry
-	entryOff := webEntryStart + idx*webEntrySize
+	// Write entry at the monotonic slot
+	entryOff := webEntryStart + (int(head)%webMaxEntries)*webEntrySize
 	r.data[entryOff+webEntrySlot] = slot
 
 	// Write key (null-terminated)
@@ -92,10 +110,17 @@ func (r *ShmWebParamSetRing) SetParam(slot uint8, key, value string) error {
 	}
 	copy(r.data[valOff:], value)
 
-	// Increment write_idx and toggle ready
-	r.data[webRingOffWriteIdx] = uint8(idx + 1)
-	r.data[webRingOffReady]++
-
+	// Publish: advance write_idx + bump ready via CAS on the header word —
+	// preserves the shim's concurrent read_idx byte and orders the entry
+	// stores before the cursor becomes visible.
+	for {
+		old = atomic.LoadUint32(hdr)
+		ready := uint8(old >> 8)
+		newHdr := (old &^ 0x0000FFFF) | uint32(head+1) | uint32(ready+1)<<8
+		if atomic.CompareAndSwapUint32(hdr, old, newHdr) {
+			break
+		}
+	}
 	return nil
 }
 

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -60,7 +60,9 @@
     // Active overtake-tool state. A tool is not a chain slot; its
     // params live under the "overtake_dsp:" prefix and its UI shows in the Tool
     // tab. id == "" means no tool with a remote UI is loaded.
-    var tool = { id: "", customUI: null, params: {} };
+    // known=false until the first tool_info answer arrives, so the Tool tab can
+    // show "checking…" instead of a premature (and alarming) "No tool loaded".
+    var tool = { id: "", customUI: null, params: {}, known: false };
 
     // Read initial slot from URL hash (#slot1, #slot2, #slot3, #slot4, #master-fx, #tool)
     var initialSlot = 0;
@@ -300,6 +302,7 @@
     // ------------------------------------------------------------------
 
     function handleToolInfo(msg) {
+        tool.known = true;
         tool.id = msg.id || "";
         if (!tool.id) {
             // Tool unloaded — drop its custom UI + cached params.
@@ -2036,7 +2039,9 @@
             note.className = "text-muted";
             note.textContent = tool.id
                 ? ("Loading " + tool.id + "…")
-                : "No tool loaded. Open a tool on the Move and it will appear here.";
+                : (tool.known
+                    ? "No tool loaded. Open a tool on the Move and it will appear here."
+                    : "Connecting to the Move — checking for a loaded tool…");
             slotContentEl.appendChild(note);
             return;
         }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1165,6 +1165,18 @@ ssh_root_with_retry "test -u /data/UserData/schwung/schwung-shim.so" || fail "Sh
 # Remove web shim symlink (no longer used as of 0.9.2)
 ssh_root_with_retry "rm -f /usr/lib/schwung-web-shim.so" || true
 
+# Keep POSIX shared memory alive across ableton login sessions.
+# MoveOriginal runs as user 'ableton' and creates every /dev/shm/schwung-*
+# segment under that uid. systemd-logind's default RemoveIPC=yes purges a
+# regular user's IPC (including POSIX shm) when their LAST login session ends,
+# so any ssh/scp-as-ableton disconnect (deploy scripts do this constantly)
+# silently unlinks all schwung segments while the stack runs on. Early mmap
+# holders keep working via stale maps, but any LATER open() gets ENOENT
+# forever -- e.g. schwung-manager's lazily-opened remote-UI web-set ring can
+# never connect. A logind drop-in disables the purge; applied on the reboot
+# below.
+ssh_root_with_retry "mkdir -p /etc/systemd/logind.conf.d && printf '[Login]\nRemoveIPC=no\n' > /etc/systemd/logind.conf.d/schwung-removeipc.conf" || true
+
 # Deploy TTS libraries (eSpeak-NG + Flite) from /data to /usr/lib via symlink.
 # Root partition is nearly full, so symlink libraries instead of copying.
 # Use direct predicate checks so expected test failures don't print misleading

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -26,6 +26,7 @@
 #include <linux/spi/spidev.h>
 #include <pthread.h>
 #include <sched.h>
+#include <semaphore.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <netinet/in.h>
@@ -418,6 +419,25 @@ static void *overtake_dsp_gen_inst = NULL;          /* Generator instance */
 static audio_fx_api_v2_t *overtake_dsp_fx = NULL;  /* V2 FX plugin */
 static void *overtake_dsp_fx_inst = NULL;           /* FX instance */
 static host_api_v1_t overtake_host_api;             /* Host API provided to plugin */
+
+/* Remote-UI push probe state (see shadow_overtake_rui_probe). Reset on every
+ * overtake DSP load/unload so a new tool re-probes rui_poll support. */
+static uint8_t  overtake_rui_unsupported = 0;   /* module answered <0 once */
+static char     overtake_rui_last[64] = {0};    /* last digest pushed */
+static unsigned long overtake_rui_last_rev = 0; /* rev field of last push */
+static int      overtake_rui_last_on = -1;      /* on field of last push (-1 = none) */
+static uint8_t  overtake_rui_have_rev = 0;
+static uint32_t overtake_rui_frame = 0;         /* SPI frame divider */
+static uint32_t overtake_rui_ph_count = 0;      /* playhead-only change divider */
+
+static void shadow_overtake_rui_reset(void) {
+    overtake_rui_unsupported = 0;
+    overtake_rui_last[0] = '\0';
+    overtake_rui_last_rev = 0;
+    overtake_rui_last_on = -1;
+    overtake_rui_have_rev = 0;
+    overtake_rui_ph_count = 0;
+}
 
 /* Per-CC passthrough bitmap. When an overtake module declares
  * capabilities.button_passthrough = [cc, ...], those CCs are routed through
@@ -1433,15 +1453,110 @@ static void overtake_ext_drain_into_shadow(uint8_t *shadow) {
     overtake_ext_ring.tail = tail;
 }
 
+/* ---- Off-RT cached remote snapshot (generic opt-in facility) -------------
+ * A connected browser editor pulls the overtake DSP's big read-only "state"
+ * snapshot (O(notes), up to SHADOW_PARAM_VALUE_LEN) on every rev-bump.
+ * Serialized inline on the SPI RT thread it overruns the ~900µs frame budget
+ * and hitches the sequencer clock + MIDI. Deferring the mailbox GET to a
+ * worker (v1 of this facility) fixed the hitch but held the single param
+ * mailbox for the whole worker latency — the other producer's fire-and-forget
+ * SETs stomped it and manager requests died in 500ms timeouts.
+ *
+ * v2: the worker maintains a rev-stamped, double-buffered serialization of
+ * the module's "state"; the RT servicer answers a GET inline with a memcpy
+ * (~tens of µs for 64KB — well inside budget) in ONE frame, so the mailbox is
+ * never held longer than any other GET. The worker re-serializes when kicked:
+ * on a rev change while snapshot-hot (a GET arrived recently) and on any GET
+ * that observed a stale or missing cache. A served snapshot may be one rev
+ * stale; it carries its own rev (module JSON) so the manager re-pulls until
+ * revs converge — usually the proactive rev-change kick has already
+ * refreshed the cache by then.
+ *
+ * Module contract (get_param "remote_snapshot_rt_safe" == "1"): ALL instance
+ * memory reachable by its "state"/"rui_poll" get_param is never freed or
+ * realloc'd while the instance lives (frees only at destroy) — so the worker
+ * may read concurrently with render_block AND set_param. Worst case is a
+ * torn/stale snapshot, self-corrected by the next rev-gated pull — never a
+ * use-after-free. The host still drains the worker before destroy/unload/
+ * load-over. With no browser attached no snapshot GET ever arrives, the
+ * cache stays cold and the worker sleeps on the semaphore → zero added cost. */
+static int               g_snap_rt_safe = 0;    /* loaded module opted in */
+static sem_t             g_snap_sem;
+static int               g_snap_sem_ok  = 0;
+static volatile int      g_snap_busy    = 0;    /* worker serializing */
+static volatile int      g_snap_kick    = 0;    /* coalesced re-serialize request */
+static volatile uint32_t g_snap_cur_rev = 0;    /* latest rev seen by the RT probe */
+static int               g_snap_hot     = 0;    /* frames of remaining interest (RT only) */
+#define SNAP_HOT_FRAMES 4000                    /* ~11.6s of SPI frames */
+/* Double buffer: worker writes the inactive side, then flips g_snap_active.
+ * Per-side seqlock (odd = mid-write) guards the rare reuse-while-copying race. */
+static char              g_snap_buf[2][SHADOW_PARAM_VALUE_LEN];
+static volatile int      g_snap_len[2] = {-1, -1};
+static volatile uint32_t g_snap_rev[2];
+static volatile uint32_t g_snap_seq[2];
+static volatile int      g_snap_active = -1;    /* -1 = no valid snapshot yet */
+
+/* Wait (BOUNDED) for the worker to go idle before a path frees the overtake
+ * instance (unload/load-over). Cheap when idle (one load). Callers must clear
+ * g_snap_rt_safe first so no new kick starts a serialize. Returns 1 when the
+ * worker is idle; 0 on timeout — the worker (FIFO 10, cores 0-2) can in
+ * principle be starved by Move's FIFO-70 threads, and an unbounded spin here
+ * runs on the SPI RT thread. On timeout the caller must NOT free instance
+ * memory or dlclose (leak instead — safe; pathological load only). */
+static inline int snap_wait_idle(void) {
+    if (!__atomic_load_n(&g_snap_busy, __ATOMIC_ACQUIRE)) return 1;
+    struct timespec t0, t;
+    clock_gettime(CLOCK_MONOTONIC, &t0);
+    while (__atomic_load_n(&g_snap_busy, __ATOMIC_ACQUIRE)) {
+        clock_gettime(CLOCK_MONOTONIC, &t);
+        long ms = (t.tv_sec - t0.tv_sec) * 1000L + (t.tv_nsec - t0.tv_nsec) / 1000000L;
+        if (ms > 200) return 0;
+    }
+    return 1;
+}
+
+/* Ask the worker for a (re-)serialization. RT-safe: coalesces via g_snap_kick;
+ * sem_post only on the idle->busy edge so the semaphore never accumulates. */
+static inline void snap_kick(void) {
+    if (!g_snap_rt_safe || !g_snap_sem_ok) return;
+    __atomic_store_n(&g_snap_kick, 1, __ATOMIC_RELEASE);
+    if (!__atomic_exchange_n(&g_snap_busy, 1, __ATOMIC_ACQ_REL))
+        sem_post(&g_snap_sem);
+}
+
+/* Epoch counter: bumped by snap_cache_reset so a worker that straddles a
+ * module unload/load (wedged mid-serialize during the bounded drain) can
+ * detect its result belongs to a dead epoch and must not publish it. */
+static volatile uint32_t g_snap_epoch = 0;
+
+/* Invalidate the cache across module load/unload boundaries. Caller must have
+ * cleared g_snap_rt_safe and drained the worker (snap_wait_idle) first. */
+static inline void snap_cache_reset(void) {
+    __atomic_add_fetch(&g_snap_epoch, 1, __ATOMIC_ACQ_REL);
+    g_snap_active  = -1;
+    g_snap_len[0]  = g_snap_len[1] = -1;
+    g_snap_cur_rev = 0;
+    g_snap_hot     = 0;
+    g_snap_kick    = 0;
+}
+
 static void shadow_overtake_dsp_load(const char *path) {
+    shadow_overtake_rui_reset();
     /* Unload previous if any */
     if (overtake_dsp_handle) {
         shadow_log("Overtake DSP: unloading previous before loading new");
-        if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->destroy_instance)
+        /* Stop new off-RT snapshot reads and drain any in flight before freeing. */
+        g_snap_rt_safe = 0;
+        int snap_idle = snap_wait_idle();
+        snap_cache_reset();
+        if (!snap_idle)
+            shadow_log("Overtake DSP: snapshot worker wedged — leaking previous instance + handle (safe)");
+        if (snap_idle && overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->destroy_instance)
             overtake_dsp_gen->destroy_instance(overtake_dsp_gen_inst);
         if (overtake_dsp_fx && overtake_dsp_fx_inst && overtake_dsp_fx->destroy_instance)
             overtake_dsp_fx->destroy_instance(overtake_dsp_fx_inst);
-        dlclose(overtake_dsp_handle);
+        if (snap_idle)
+            dlclose(overtake_dsp_handle);
         overtake_dsp_handle = NULL;
         overtake_dsp_gen = NULL;
         overtake_dsp_gen_inst = NULL;
@@ -1514,8 +1629,23 @@ static void shadow_overtake_dsp_load(const char *path) {
             if (defaults) free(defaults);
 
             if (overtake_dsp_gen_inst) {
+                /* One-time capability query: may this module's read-only snapshot
+                 * be serialized on a worker thread concurrently with render AND
+                 * set_param? The module answers "1" only if instance memory the
+                 * snapshot can reach is never freed/realloc'd while the instance
+                 * lives (see the g_snap_* contract comment). Any module that
+                 * doesn't implement the key returns <=0 → snapshot GETs stay
+                 * inline on the RT thread (today's behavior). */
+                g_snap_rt_safe = 0;
+                if (overtake_dsp_gen->get_param) {
+                    char cap[8] = {0};
+                    int cl = overtake_dsp_gen->get_param(overtake_dsp_gen_inst,
+                                 "remote_snapshot_rt_safe", cap, sizeof(cap));
+                    if (cl > 0 && cap[0] == '1') g_snap_rt_safe = 1;
+                }
                 char msg[256];
-                snprintf(msg, sizeof(msg), "Overtake DSP: loaded generator from %s", path);
+                snprintf(msg, sizeof(msg), "Overtake DSP: loaded generator from %s (snapshot_rt_safe=%d)",
+                         path, g_snap_rt_safe);
                 shadow_log(msg);
                 return;
             }
@@ -1550,8 +1680,16 @@ static void shadow_overtake_dsp_load(const char *path) {
 
 static void shadow_overtake_dsp_unload(void) {
     if (!overtake_dsp_handle) return;
+    shadow_overtake_rui_reset();
 
-    if (overtake_dsp_gen && overtake_dsp_gen_inst) {
+    /* Stop new off-RT snapshot reads and drain any in flight before freeing. */
+    g_snap_rt_safe = 0;
+    int snap_idle = snap_wait_idle();
+    snap_cache_reset();
+    if (!snap_idle)
+        shadow_log("Overtake DSP: snapshot worker wedged — leaking instance + handle (safe)");
+
+    if (snap_idle && overtake_dsp_gen && overtake_dsp_gen_inst) {
         if (overtake_dsp_gen->destroy_instance)
             overtake_dsp_gen->destroy_instance(overtake_dsp_gen_inst);
         shadow_log("Overtake DSP: generator unloaded");
@@ -1562,7 +1700,8 @@ static void shadow_overtake_dsp_unload(void) {
         shadow_log("Overtake DSP: FX unloaded");
     }
 
-    dlclose(overtake_dsp_handle);
+    if (snap_idle)
+        dlclose(overtake_dsp_handle);
     overtake_dsp_handle = NULL;
     overtake_dsp_gen = NULL;
     overtake_dsp_gen_inst = NULL;
@@ -3367,30 +3506,60 @@ static float shim_get_bpm(void) {
  * ========================================================================= */
 static void shadow_drain_web_param_set(void) {
     if (!web_param_set_shm) return;
-    static uint8_t last_ready = 0;
-    if (web_param_set_shm->ready == last_ready) return;
-    last_ready = web_param_set_shm->ready;
-
-    int count = web_param_set_shm->write_idx;
-    if (count <= 0 || count > WEB_PARAM_SET_ENTRIES) {
-        web_param_set_shm->write_idx = 0;
+    /* SPSC protocol (2026-07-19 rework, paired with the manager): write_idx is
+     * the producer's MONOTONIC cursor (slot = idx % 32, clean uint8 wrap) and
+     * reserved[0] is our published consumer cursor. The old scheme (count =
+     * write_idx, then reset to 0) raced the producer's read-modify-write: an
+     * edit landing mid-drain was orphaned, or the previous batch re-applied
+     * (double-nudge). Now neither side writes the other's cursor. */
+    static uint8_t tail;
+    static int     tail_init = 0;
+    uint8_t head = __atomic_load_n(&web_param_set_shm->write_idx, __ATOMIC_ACQUIRE);
+    if (!tail_init) {
+        /* First drain after (re)start: skip any pre-attach history — a
+         * surviving SHM segment may hold a stale cursor from a prior run. */
+        tail = head;
+        tail_init = 1;
         return;
     }
-
-    /* Snapshot entries, then reset */
-    web_param_set_entry_t local[WEB_PARAM_SET_ENTRIES];
-    memcpy(local, (const void *)web_param_set_shm->entries, count * sizeof(web_param_set_entry_t));
-    __sync_synchronize();
-    web_param_set_shm->write_idx = 0;
+    uint8_t count = (uint8_t)(head - tail);
+    if (count == 0) return;
+    if (count > WEB_PARAM_SET_ENTRIES) {
+        /* Producer overran our ack (shouldn't happen — it checks fill) —
+         * resync to the newest window rather than replaying garbage. */
+        tail  = (uint8_t)(head - WEB_PARAM_SET_ENTRIES);
+        count = WEB_PARAM_SET_ENTRIES;
+    }
 
     /* Process each set request via direct dispatch — does NOT touch shadow_param,
-     * so it's safe to run while shadow_ui.js has a request in-flight. */
-    for (int i = 0; i < count; i++) {
-        web_param_set_entry_t *e = &local[i];
-        if (e->key[0] == '\0') continue;
+     * so it's safe to run while shadow_ui.js has a request in-flight. Copy each
+     * entry locally before dispatch (the producer may only reuse a slot after we
+     * publish tail, but the copy keeps dispatch immune to a buggy producer). */
+    for (uint8_t i = 0; i < count; i++) {
+        web_param_set_entry_t e;
+        memcpy(&e, (const void *)&web_param_set_shm->entries[(uint8_t)(tail + i) % WEB_PARAM_SET_ENTRIES],
+               sizeof(e));
+        if (e.key[0] == '\0') continue;
 
-        shadow_direct_set_param(e->slot, e->key, e->value);
+        /* Overtake-tool params dispatch straight to the overtake DSP (gen,
+         * else fx — mirrors the mailbox SET dispatch). This is the browser
+         * editor's lossless edit path: ring entries can't be stomped by the
+         * shadow_ui mailbox producer (fire-and-forget in overtake mode),
+         * unlike mailbox SETs, which died in 500ms manager timeouts under
+         * contention. Values >255B still take the mailbox (ring entry cap) —
+         * the manager routes by size. */
+        if (strncmp(e.key, "overtake_dsp:", 13) == 0) {
+            if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->set_param)
+                overtake_dsp_gen->set_param(overtake_dsp_gen_inst, e.key + 13, e.value);
+            else if (overtake_dsp_fx && overtake_dsp_fx_inst && overtake_dsp_fx->set_param)
+                overtake_dsp_fx->set_param(overtake_dsp_fx_inst, e.key + 13, e.value);
+            continue;
+        }
+
+        shadow_direct_set_param(e.slot, e.key, e.value);
     }
+    tail = head;
+    __atomic_store_n(&web_param_set_shm->reserved[0], tail, __ATOMIC_RELEASE);
 }
 
 /* =========================================================================
@@ -3411,6 +3580,73 @@ void web_param_notify_push(uint8_t slot, const char *key, const char *value) {
     __sync_synchronize();
     web_param_notify_shm->write_idx = idx + 1;
     web_param_notify_shm->ready++;
+}
+
+/* Remote-UI push (F4): probe the loaded overtake DSP's cheap "rui_poll" digest
+ * ("rev:on:tick:bpm") IN-PROCESS every RUI_PROBE_FRAMES SPI frames and push
+ * changes into the web param notify ring, so schwung-manager learns about tool
+ * edits on-change instead of polling the shared shadow_param channel (which
+ * contends with browser SetParams). Runs where param serves already run
+ * (post-transfer path); RT-safe: no alloc, no logging, no I/O — one in-process
+ * get_param + a strcmp per interval, nothing at all when no overtake DSP is
+ * loaded or the module doesn't implement rui_poll (latched after one <0
+ * answer until the next overtake load).
+ * Rate rule: a rev-field change (content edit) pushes immediately; a digest
+ * change with the same rev (playhead tick/bpm only) pushes every
+ * RUI_PLAYHEAD_DIVIDER-th changed probe (~96ms) so playback doesn't spam the
+ * 64-entry ring — the manager's own poll cadence covered playhead at ~100ms. */
+#define RUI_PROBE_FRAMES 4       /* probe every 4th SPI frame (~12ms) */
+/* Playhead-only pushes every 24th changed probe (~280ms). The browser free-runs
+ * a local BPM clock and only needs occasional phase corrections; a ~100ms
+ * playhead stream measurably congested the Move's bursty WiFi and starved the
+ * big snapshot pushes behind it (clip selects took up to 1.7s while playing). */
+#define RUI_PLAYHEAD_DIVIDER 24
+static void shadow_overtake_rui_probe(void) {
+    if (!overtake_dsp_gen || !overtake_dsp_gen_inst || !overtake_dsp_gen->get_param)
+        return;
+    if (overtake_rui_unsupported || !web_param_notify_shm)
+        return;
+    if (++overtake_rui_frame % RUI_PROBE_FRAMES)
+        return;
+    if (g_snap_hot > 0) g_snap_hot -= RUI_PROBE_FRAMES;   /* interest decay */
+    char digest[64];
+    int len = overtake_dsp_gen->get_param(overtake_dsp_gen_inst, "rui_poll",
+                                          digest, (int)sizeof(digest));
+    if (len < 0) { overtake_rui_unsupported = 1; return; }
+    if (len >= (int)sizeof(digest)) return;   /* not a rui_poll-shaped digest */
+    digest[len] = '\0';
+    if (strcmp(digest, overtake_rui_last) == 0)
+        return;
+    /* digest = "rev:on:tick:bpm". rev and on changes push IMMEDIATELY — a
+     * missed/late on-edge leaves the browser's playhead animating after stop
+     * (once stopped the digest freezes, so a divider-deferred push would
+     * never come at all). Only tick/bpm-only changes take the divider. */
+    unsigned long rev = strtoul(digest, NULL, 10);
+    const char *colon = strchr(digest, ':');
+    int on = (colon && colon[1] == '1') ? 1 : 0;
+    /* Track the live rev for the snapshot cache; while a browser is actively
+     * pulling (snapshot-hot), refresh the cache proactively on every rev
+     * change so the manager's rev-gated pull usually hits a fresh cache. */
+    if ((uint32_t)rev != __atomic_load_n(&g_snap_cur_rev, __ATOMIC_RELAXED)) {
+        __atomic_store_n(&g_snap_cur_rev, (uint32_t)rev, __ATOMIC_RELEASE);
+        if (g_snap_hot > 0) snap_kick();
+    }
+    int push;
+    if (!overtake_rui_have_rev || rev != overtake_rui_last_rev
+            || on != overtake_rui_last_on) {
+        push = 1;
+        overtake_rui_ph_count = 0;
+    } else {
+        push = (++overtake_rui_ph_count % RUI_PLAYHEAD_DIVIDER) == 0;
+    }
+    if (!push)
+        return;
+    overtake_rui_last_rev = rev;
+    overtake_rui_last_on = on;
+    overtake_rui_have_rev = 1;
+    strncpy(overtake_rui_last, digest, sizeof(overtake_rui_last) - 1);
+    overtake_rui_last[sizeof(overtake_rui_last) - 1] = '\0';
+    web_param_notify_push(0, "overtake_dsp:rui_poll", digest);
 }
 
 /* ---- Bulk param get/set (request_type 3 / 4) ------------------------- *
@@ -3534,6 +3770,84 @@ static void shim_handle_param_bulk(uint8_t req_type) {
     shadow_param->error = 0; shadow_param->result_len = off;
 }
 
+/* Worker thread for the cached remote snapshot declared above the overtake
+ * load path (see g_snap_* + snap_kick + snap_wait_idle). Serializes into its
+ * own double buffer — NEVER into the shared param mailbox (v1 did, and a
+ * producer-timeout could hand the mailbox to a new request mid-write). */
+static void *snap_worker_main(void *arg) {
+    (void)arg;
+    /* Cores 0-2 only (keep core 3 free for the SPI SCHED_FIFO 90 audio callback).
+     * LOW real-time priority (well below the audio thread's 90 and Move's FIFO
+     * 70 threads) so a re-serialization isn't starved behind the manager /
+     * shadow_ui SCHED_OTHER load. The snapshot is a ~ms CPU burst, then the
+     * worker blocks on the semaphore, so it can't monopolise a core. */
+    cpu_set_t mask; CPU_ZERO(&mask);
+    CPU_SET(0, &mask); CPU_SET(1, &mask); CPU_SET(2, &mask);
+    pthread_setaffinity_np(pthread_self(), sizeof(mask), &mask);
+    struct sched_param sp = { .sched_priority = 10 };
+    if (pthread_setschedparam(pthread_self(), SCHED_FIFO, &sp) == 0) {
+        shadow_log("snap worker: SCHED_FIFO prio 10 (cores 0-2)");
+    } else {
+        /* Fall back to SCHED_OTHER if RT priority isn't permitted. Log it —
+         * a starved SCHED_OTHER worker is a known seconds-of-lag failure mode. */
+        sp.sched_priority = 0;
+        pthread_setschedparam(pthread_self(), SCHED_OTHER, &sp);
+        shadow_log("snap worker: SCHED_FIFO denied, falling back to SCHED_OTHER");
+    }
+    for (;;) {
+        if (sem_wait(&g_snap_sem) != 0) { if (errno == EINTR) continue; break; }
+        for (;;) {
+            __atomic_store_n(&g_snap_kick, 0, __ATOMIC_RELEASE);
+            uint32_t epoch = __atomic_load_n(&g_snap_epoch, __ATOMIC_ACQUIRE);
+            if (g_snap_rt_safe && overtake_dsp_gen && overtake_dsp_gen_inst
+                    && overtake_dsp_gen->get_param) {
+                /* Stamp the rev observed BEFORE serializing: content is at
+                 * least this new, so a mid-serialize edit reads as "stale"
+                 * and triggers one more refresh rather than a missed one. */
+                uint32_t rev = __atomic_load_n(&g_snap_cur_rev, __ATOMIC_ACQUIRE);
+                int idx = (__atomic_load_n(&g_snap_active, __ATOMIC_RELAXED) == 0) ? 1 : 0;
+                /* Seqlock write side: the odd store must be globally visible
+                 * BEFORE any data store — a release store only orders PRIOR
+                 * writes, so an explicit fence is required after it (ARMv8
+                 * would otherwise let the buffer fill overtake the odd mark
+                 * and the reader could copy a torn buffer with matching seq). */
+                __atomic_store_n(&g_snap_seq[idx], g_snap_seq[idx] + 1, __ATOMIC_RELAXED); /* odd */
+                __atomic_thread_fence(__ATOMIC_SEQ_CST);
+                int len = overtake_dsp_gen->get_param(overtake_dsp_gen_inst, "state",
+                                                      g_snap_buf[idx], SHADOW_PARAM_VALUE_LEN);
+                g_snap_len[idx] = len;
+                g_snap_rev[idx] = rev;
+                __atomic_store_n(&g_snap_seq[idx], g_snap_seq[idx] + 1, __ATOMIC_RELEASE); /* even */
+                /* Publish only if no unload/load happened mid-serialize
+                 * (epoch check) — else this blob belongs to a dead module. */
+                if (len >= 0 && epoch == __atomic_load_n(&g_snap_epoch, __ATOMIC_ACQUIRE))
+                    __atomic_store_n(&g_snap_active, idx, __ATOMIC_RELEASE);
+            }
+            if (__atomic_load_n(&g_snap_kick, __ATOMIC_ACQUIRE)) continue;
+            __atomic_store_n(&g_snap_busy, 0, __ATOMIC_RELEASE);
+            /* Kick raced our busy-clear? Reclaim and loop, else sleep. */
+            if (__atomic_load_n(&g_snap_kick, __ATOMIC_ACQUIRE)
+                    && !__atomic_exchange_n(&g_snap_busy, 1, __ATOMIC_ACQ_REL))
+                continue;
+            break;
+        }
+    }
+    return NULL;
+}
+
+static void snap_worker_start(void) {
+    static volatile int started = 0;
+    if (__sync_lock_test_and_set(&started, 1)) return;
+    if (sem_init(&g_snap_sem, 0, 0) != 0) { started = 0; return; }
+    g_snap_sem_ok = 1;
+    pthread_t tid;
+    if (pthread_create(&tid, NULL, snap_worker_main, NULL) != 0) {
+        started = 0; g_snap_sem_ok = 0;
+        return;
+    }
+    pthread_detach(tid);
+}
+
 /* Callback for chain_mgmt: handle shim-specific param prefixes.
  * Reads/writes shadow_param->key/value/error/result_len directly.
  * Returns 1 if handled, 0 if not. */
@@ -3560,6 +3874,9 @@ static int shim_handle_param_special(uint8_t req_type, uint32_t req_id) {
                 shadow_param->error = 0;
                 shadow_param->result_len = 0;
             } else if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->set_param) {
+                /* No snap_wait_idle here: the remote_snapshot_rt_safe contract
+                 * guarantees set_param never frees snapshot-reachable memory,
+                 * so the worker may read concurrently (torn at worst). */
                 overtake_dsp_gen->set_param(overtake_dsp_gen_inst, param_key, shadow_param->value);
                 shadow_param->error = 0;
                 shadow_param->result_len = 0;
@@ -3572,6 +3889,56 @@ static int shim_handle_param_special(uint8_t req_type, uint32_t req_id) {
                 shadow_param->result_len = -1;
             }
         } else if (req_type == 2) {  /* GET */
+            /* Cached snapshot: when the module opted in, answer the big
+             * read-only "state" GET from the worker-maintained cache with a
+             * memcpy — one frame, mailbox never held, audio thread never
+             * serializes. A miss (cold cache / torn read) returns error 14;
+             * the manager's retry cadence re-pulls after the kicked worker
+             * has filled the cache. */
+            if (g_snap_rt_safe && g_snap_sem_ok && strcmp(param_key, "state") == 0
+                    && overtake_dsp_gen && overtake_dsp_gen_inst) {
+                g_snap_hot = SNAP_HOT_FRAMES;   /* browser interest: keep cache fresh */
+                int served = 0;
+                int idx = __atomic_load_n(&g_snap_active, __ATOMIC_ACQUIRE);
+                for (int tries = 0; tries < 2 && idx >= 0 && !served; tries++) {
+                    uint32_t s1 = __atomic_load_n(&g_snap_seq[idx], __ATOMIC_ACQUIRE);
+                    int len = g_snap_len[idx];
+                    uint32_t rv = g_snap_rev[idx];
+                    if (!(s1 & 1) && len >= 0 && len <= SHADOW_PARAM_VALUE_LEN - 1) {
+                        memcpy(shadow_param->value, g_snap_buf[idx], (size_t)len);
+                        shadow_param->value[len] = '\0';
+                        /* Seqlock read side: the copy's loads must complete
+                         * before the confirming seq load (an acquire load
+                         * doesn't stop prior loads sinking past it). */
+                        __atomic_thread_fence(__ATOMIC_ACQUIRE);
+                        uint32_t s2 = __atomic_load_n(&g_snap_seq[idx], __ATOMIC_RELAXED);
+                        if (s1 == s2) {
+                            shadow_param->error = 0;
+                            shadow_param->result_len = len;
+                            served = 1;
+                            /* Cache older than the live rev? Refresh for the
+                             * manager's follow-up pull. */
+                            if (rv != __atomic_load_n(&g_snap_cur_rev, __ATOMIC_RELAXED))
+                                snap_kick();
+                            break;
+                        }
+                    }
+                    idx = __atomic_load_n(&g_snap_active, __ATOMIC_ACQUIRE);
+                }
+                if (!served) {
+                    /* Kick only when the cache is COLD or STALE — a fresh
+                     * cache that is unservable (module state overflowed the
+                     * 64KB value buffer, len<0/oversize) would otherwise
+                     * re-serialize on every pull in a futile churn loop. */
+                    int a = __atomic_load_n(&g_snap_active, __ATOMIC_ACQUIRE);
+                    if (a < 0 || g_snap_rev[a] !=
+                            __atomic_load_n(&g_snap_cur_rev, __ATOMIC_RELAXED))
+                        snap_kick();
+                    shadow_param->error = 14;
+                    shadow_param->result_len = -1;
+                }
+                return 1;
+            }
             int len = -1;
             if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->get_param) {
                 len = overtake_dsp_gen->get_param(overtake_dsp_gen_inst, param_key,
@@ -4710,6 +5077,7 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
      * param.get span via the SHM-propagated trace context (Phase 2b). */
     shadow_inprocess_handle_param_request();
     shadow_drain_web_param_set();  /* Web UI fire-and-forget param sets */
+    shadow_overtake_rui_probe();   /* Remote-UI push: overtake rui_poll → notify ring */
     TIME_SECTION_END(spi_param_req_sum, spi_param_req_max);
 
     /* Forward CC/pitch bend/aftertouch from external MIDI to MIDI_OUT so DSP
@@ -7745,6 +8113,7 @@ static void shim_spi_init(void)
         shim_worker_set_hooks(&hooks);
     }
     shim_worker_start();
+    snap_worker_start();   /* off-RT remote-snapshot servicer (idle until a browser pulls) */
 
     /* Start LED capture logger thread (gated by flag file) */
     {


### PR DESCRIPTION
## Remote UI v2 for overtake tools — off-thread snapshots, lossless edits, server-driven push

Follows on from #148 (which added the overtake-tool **Tool tab**). That shipped the
plumbing; this makes it hold up under a dense, edit-heavy session over a bursty WiFi
link — and, crucially, never runs a module's `state` serializer inside the SPI frame.

Everything here is either **manager-only Go** or **shim code gated behind an opt-in**, so
it costs nothing when no browser is attached (the worker sleeps on a semaphore).

### What changes

**1. Server-driven poll (manager)**
A single coalesced, rev-gated tool poll replaces the per-client browser refetch. It
skips on mutex-busy instead of escalating to a full `state` read, and one coalesced
`state` read fans out to every stale Tool-tab client. Adaptive ~100 ms active / 400 ms
idle cadence.

**2. True push + transport edges (manager + shim)**
The shim probes `rui_poll` in-process every few frames and pushes changes through the
notify ring (the poll degrades to a 2 s backstop). Transport stop-edges and a
device-clock ms field (`devms`) are forwarded so the browser can time-base its playhead
independent of delivery latency. Playhead pushes are rate-limited for the WiFi link; an
edit-storm quiet window + full-read throttle stop snapshot floods during rapid editing
(selection / transport keys are exempt so they still echo immediately).

**3. Off-audio-thread snapshot cache + lossless edit ring (shim + manager)**
Modules opt in with `get_param("remote_snapshot_rt_safe") == "1"`. A low-priority worker
keeps a rev-stamped, seqlock double-buffered serialization of the tool's `state`; the
audio thread then serves browser pulls with a single `memcpy` instead of running the
serializer in-frame. Browser writes under 256 bytes flow through an SPSC web-set ring
(monotonic cursors, CAS header) dispatched from the shim drain — lossless and immune to
param-mailbox contention; larger writes fall back to the mailbox. The manager gains
eager ring connect, typed `paramAnswered` errors, tool-gone debounce + arrival retry,
ring-vs-mailbox routing, and blob-rev cursors.

**4. Keep POSIX shm alive across login sessions (`install.sh`)**
MoveOriginal creates every `/dev/shm/schwung-*` segment as user `ableton`, and
systemd-logind's default `RemoveIPC=yes` purges that user's IPC when their **last login
session ends** — so any ssh/scp-as-`ableton` disconnect (deploy scripts do this
constantly) silently unlinks all schwung segments while the stack runs on. Early mmap
holders survive on stale maps, but any *later* `open()` gets `ENOENT` forever — which is
exactly how the manager's lazily-opened web-set ring (layer 3 above) could never connect.
`install.sh` now drops in `/etc/systemd/logind.conf.d/schwung-removeipc.conf`
(`RemoveIPC=no`), applied on the install reboot. Any late shm joiner benefits, so this is
useful independent of the remote-UI work.

### Module contract (documented in `docs/MODULES.md`)

The snapshot opt-in requires that **every byte reachable by `state` / `rui_poll`
get_param stays valid for the lifetime of the instance** — freed only in
`destroy_instance`, never by `render_block` or `set_param` (use grow-only /
clear-and-keep pools). Torn or one-rev-stale reads are tolerated (the manager re-pulls
until the snapshot's own rev matches the digest); a use-after-free is not.

### Note for review

- A **`BULK_GET` (request_type 3) of `"state"` bypasses the snapshot cache** and runs the
  serializer on the audio thread. A module that opts into off-thread snapshots should not
  put `"state"` in a bulk read. A host-side guard (or at least a doc warning beyond the
  MODULES.md note here) may be worth adding upstream — happy to follow up.

- **RemoveIPC drop-in (layer 4) portability.** The fix is pure systemd-logind config —
  `RemoveIPC` is a stock logind default (v212+, 2014) with no dependency on hardware or a
  particular OS image, so it applies identically on any systemd-based Move. It's written
  unconditionally but terminated with `|| true`, so it's a harmless no-op if a unit isn't
  logind-managed, and `RemoveIPC=no` on a single-user appliance has no real downside. The
  one thing I couldn't verify from my side is whether a **bone-stock** unit actually
  triggers the purge — i.e. whether ssh-as-`ableton` registers as a logind session
  (`loginctl list-sessions`, needs `pam_systemd` in the sshd PAM stack). If it doesn't,
  stock users never hit this; if it does, this fixes it the same way. Shipping it
  unconditionally covers both cases, but a quick check on a stock device would confirm
  whether it's load-bearing there.

### Testing

- `schwung-manager`: `go build ./...` + `go vet ./...` clean (arm64, go 1.26).
- Shim: cross-compiles + links clean (aarch64) on a stock tree — no new deps.
- Exercised on a real Move over WiFi with a browser open and editing a dense pattern:
  the playback hitches on browser rev-bumps are gone, and browser edits are no longer
  dropped under contention.

