### PR TITLE
Route module suites through canonical repositories

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1154,7 +1154,7 @@
       "github_repo": "timncox/schwung-mono",
       "default_branch": "main",
       "asset_name": "mono-module.tar.gz",
-      "min_host_version": "0.11.4"
+      "min_host_version": "0.11.6"
     },
     {
       "id": "mono-voice",

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1096,7 +1096,7 @@
       "description": "Standalone mic/line/USB-C build of Smack with the same 26-effect seeded slice engine, Pad Play, and browser step editor",
       "author": "timncox",
       "component_type": "sound_generator",
-      "github_repo": "timncox/schwung-smack-in",
+      "github_repo": "timncox/schwung-smack",
       "default_branch": "main",
       "asset_name": "smack-in-module.tar.gz",
       "min_host_version": "0.3.0"
@@ -1107,7 +1107,7 @@
       "description": "Full-surface Smack input looper: whole-grid step-FX editing, palette pinning, pressure punch effects, dual-mono lanes, and browser editor",
       "author": "timncox",
       "component_type": "overtake",
-      "github_repo": "timncox/schwung-oversmack",
+      "github_repo": "timncox/schwung-smack",
       "default_branch": "main",
       "asset_name": "oversmack-module.tar.gz",
       "min_host_version": "0.11.4"
@@ -1140,7 +1140,7 @@
       "description": "Standalone mic/line/USB-C Belt: tuned lead vocal, four scale-aware harmonies, HARD punch, tuner strip, doubler, and formant shift in one slot",
       "author": "timncox",
       "component_type": "sound_generator",
-      "github_repo": "timncox/schwung-belt-in",
+      "github_repo": "timncox/schwung-belt",
       "default_branch": "main",
       "asset_name": "belt-in-module.tar.gz",
       "min_host_version": "0.3.0"
@@ -1162,7 +1162,7 @@
       "description": "Elektron-style digital machine synth voice with SuperWave, SID, DigiPRO, FM, deep modulation, and arp latch",
       "author": "timncox",
       "component_type": "sound_generator",
-      "github_repo": "timncox/schwung-mono-voice",
+      "github_repo": "timncox/schwung-mono",
       "default_branch": "main",
       "asset_name": "mono-voice-module.tar.gz",
       "min_host_version": "0.3.0"


### PR DESCRIPTION
## What changed

Route related catalog entries through their canonical multi-module repositories:

- `mono-voice` → `timncox/schwung-mono`
- `smack-in` and `oversmack` → `timncox/schwung-smack`
- `belt-in` → `timncox/schwung-belt`

The module IDs, component types, asset names, and minimum host versions are unchanged. Mark remains a single-module repository.

## Why

Schwung 0.11.6 supports catalog-ID keyed `release.json` entries, so projects that share an engine can publish one authoritative release while retaining separate installable modules. The compatibility repositories remain available for Custom GitHub installs.

## Published assets

- Mono `v0.3.2`: `mono-module.tar.gz`, `mono-voice-module.tar.gz`
- Smack `v0.14.0`: `smack-module.tar.gz`, `smack-in-module.tar.gz`, `oversmack-module.tar.gz`
- Belt `v0.1.2`: `belt-module.tar.gz`, `belt-in-module.tar.gz`

## Checks

- `jq empty module-catalog.json`
- `tests/store/test_release_json_fallback_to_catalog_asset.sh`
- `tests/store/test_release_json_removed_module_surfaced.sh`
- `tests/shadow/test_store_single_install_path.sh`
- verified each canonical GitHub Release contains its catalog asset names