### PR TITLE
Add Norns to the Schwung module catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1173,7 +1173,7 @@
       "description": "Monome Norns sound computer on Move with Lua scripts, SuperCollider engines, Softcut, Maiden, MIDI keys, and virtual Grid controls",
       "author": "DJ Hard Rich",
       "component_type": "tool",
-      "github_repo": "djhardrich/schwung-norns",
+      "github_repo": "timncox/schwung-norns",
       "default_branch": "main",
       "asset_name": "norns-module.tar.gz",
       "min_host_version": "0.11.6",

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1166,6 +1166,18 @@
       "default_branch": "main",
       "asset_name": "mono-voice-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "norns",
+      "name": "Norns",
+      "description": "Monome Norns sound computer on Move with Lua scripts, SuperCollider engines, Softcut, Maiden, MIDI keys, and virtual Grid controls",
+      "author": "DJ Hard Rich",
+      "component_type": "tool",
+      "github_repo": "djhardrich/schwung-norns",
+      "default_branch": "main",
+      "asset_name": "norns-module.tar.gz",
+      "min_host_version": "0.11.6",
+      "requires": "Requires RNBO Takeover and a one-time Debian chroot/root bootstrap. After installing, run: ssh root@move.local 'sh /data/UserData/schwung/modules/tools/norns/bootstrap-norns.sh'. See the repository README."
     }
   ]
 }

--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1173,7 +1173,7 @@
       "description": "Monome Norns sound computer on Move with Lua scripts, SuperCollider engines, Softcut, Maiden, MIDI keys, and virtual Grid controls",
       "author": "DJ Hard Rich",
       "component_type": "tool",
-      "github_repo": "timncox/schwung-norns",
+      "github_repo": "djhardrich/schwung-norns",
       "default_branch": "main",
       "asset_name": "norns-module.tar.gz",
       "min_host_version": "0.11.6",


### PR DESCRIPTION
## Summary

- add Norns as a Schwung `tool` module
- require Schwung 0.11.6, matching the tested host
- expose the RNBO, Debian chroot, and one-time root bootstrap requirements directly in Schwung Manager before installation
- use the accepted upstream `djhardrich/schwung-norns` repository as the catalog source

## Release source

The compatibility and Store packaging work was merged upstream in [djhardrich/schwung-norns#9](https://github.com/djhardrich/schwung-norns/pull/9). The catalog now points directly to [`djhardrich/schwung-norns`](https://github.com/djhardrich/schwung-norns).

The upstream repository's `release.json` points to `v0.4.3/norns-module.tar.gz`, but that tag and release asset have not been published yet. This PR should remain a draft until the upstream `v0.4.3` release exists and the asset can be verified.

The catalog entry deliberately does not claim a rootless one-click install: Schwung Manager installs the module archive, while the one-time privileged bootstrap prepares the existing Norns chroot/helper.

## Validation

- catalog parses as JSON
- catalog version remains v2
- all module IDs remain unique
- Norns resolves to `component_type: tool` with `min_host_version: 0.11.6`

The local machine does not have Go installed, so the manager's Go suite was left to repository CI; this change is JSON-only.
