### PR TITLE
catalog: Forge — mention per-voice CC control (Movy) for v0.2.1

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -916,7 +916,7 @@
     {
       "id": "forge",
       "name": "Forge",
-      "description": "8-voice FM/subtractive hybrid drum synthesiser for Ableton Move — Kit A↔B morph across 16 pads, 5 voice algorithms, a self-oscillating ladder filter, dedicated noise oscillator, enveloped FM, per-voice resonator, Ctrl-All performance macros, three concurrent FX buses & 137 factory kits",
+      "description": "8-voice FM/subtractive hybrid drum synthesiser for Ableton Move — Kit A↔B morph across 16 pads, 5 voice algorithms, a self-oscillating ladder filter, dedicated noise oscillator, enveloped FM, per-voice resonator, Ctrl-All performance macros, three concurrent FX buses, 137 factory kits & per-voice CC control (Movy)",
       "author": "filliformes",
       "component_type": "sound_generator",
       "github_repo": "filliformes/forge-move",


### PR DESCRIPTION
Forge v0.2.1 adds **per-voice CC control & automation** (`pv<N>_` keys) so the **Movy** knob tool and any CC/automation host can address individual voices deterministically and simultaneously (and ships a `movy_config.json` layout). This one-line change adds that to the catalog description.

Version/download are unchanged (resolved from the repo's release.json, already at v0.2.1). Follows up the merged #155.

Release: https://github.com/filliformes/forge-move/releases/tag/v0.2.1