### PR TITLE
catalog: add Noisemaker (TAL NoiseMaker port)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1166,6 +1166,17 @@
       "default_branch": "main",
       "asset_name": "mono-voice-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "noisemaker",
+      "name": "Noisemaker",
+      "description": "Virtual-analog synth ported from TAL NoiseMaker (Patrick Kunz). 6-voice, dual osc + sub, 12 multimode filters, 2 LFOs, spline mod-envelope, chorus + reverb + delay. 256 factory presets.",
+      "author": "Patrick Kunz / TAL (engine) · port: legsmechanical",
+      "component_type": "sound_generator",
+      "github_repo": "legsmechanical/schwung-noisemaker",
+      "default_branch": "main",
+      "asset_name": "noisemaker-module.tar.gz",
+      "min_host_version": "0.11.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Noisemaker** to the module catalog — a port of TAL NoiseMaker (Patrick Kunz, GPL-2.0) built on the current DISTRHO codebase.

- **Repo:** legsmechanical/schwung-noisemaker · **Release:** v0.1.0
- 6-voice virtual-analog: dual osc + sub, ring mod, FM, sync, bitcrush, vintage noise
- 12 multimode filters (LP/HP/BP/Notch + State-Variable + Moog) with drive
- Filter + amp ADSR, free AD envelope, and TAL's spline **Envelope Editor** mod source
- 2 tempo-syncable LFOs, velocity + pitch-wheel routing
- Chorus, reverb, delay
- **256** factory presets
- On-device canvas Editor (TAL-style grouping, filter-response curve + waveform displays), full slot integration (preset browse, module-preset save, custom knob destinations)

`component_type: sound_generator`, `min_host_version: 0.11.0`. The v0.1.0 release asset (`noisemaker-module.tar.gz`) is published and the download URL resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014YsawaiSiwiFCbgy7WmT2X