### PR TITLE
catalog: add Beat Bank + Groove Bank (Mission Minnow)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1210,6 +1210,28 @@
       "default_branch": "main",
       "asset_name": "overwork-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "beatbank",
+      "name": "Beat Bank",
+      "description": "Library of standard drum patterns from editable .beat files — pick a pattern, it prints one bar into Move.",
+      "author": "Mission Minnow",
+      "component_type": "midi_fx",
+      "github_repo": "mission-minnow/beatbank",
+      "default_branch": "main",
+      "asset_name": "beatbank-module.tar.gz",
+      "min_host_version": "0.11.5"
+    },
+    {
+      "id": "groovebank",
+      "name": "Groove Bank",
+      "description": "Retrigger the chord you hold on a library of standard rhythm templates — genre-first grooves, played by your hands.",
+      "author": "Mission Minnow",
+      "component_type": "midi_fx",
+      "github_repo": "mission-minnow/groovebank",
+      "default_branch": "main",
+      "asset_name": "groovebank-module.tar.gz",
+      "min_host_version": "0.11.5"
     }
   ]
 }


### PR DESCRIPTION
Adds two new `midi_fx` modules to the catalog:

- **Beat Bank** (`mission-minnow/beatbank`) — a library of standard drum patterns from editable `.beat` files; loops the selected pattern on Move's clock and plays the slot's drum synth.
- **Groove Bank** (`mission-minnow/groovebank`) — hold a chord and a browsable, genre-organized rhythm template retriggers it on the beat. Beat Bank's melodic/chordal sibling (same 'Bank' UX).

Both are `pre_capable` and rely on the clock-driven Pre-mode inject from #150 (first shipped in **0.11.5**), so `min_host_version` is `0.11.5`.

Release tarballs + `release.json` are live on each repo's `main` (Beat Bank v0.1.4, Groove Bank v0.1.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)