### PR TITLE
Point Smack store entries at dedicated release feeds

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1085,7 +1085,7 @@
       "description": "Quantized live-loop capture with 26 seeded per-slice glitch effects, slice reordering, A/B punch, step editing, and Pad Play",
       "author": "timncox",
       "component_type": "audio_fx",
-      "github_repo": "timncox/schwung-smack",
+      "github_repo": "timncox/schwung-smack-fx",
       "default_branch": "main",
       "asset_name": "smack-module.tar.gz",
       "min_host_version": "0.3.0"
@@ -1096,7 +1096,7 @@
       "description": "Standalone mic/line/USB-C build of Smack with the same 26-effect seeded slice engine, Pad Play, and browser step editor",
       "author": "timncox",
       "component_type": "sound_generator",
-      "github_repo": "timncox/schwung-smack-in",
+      "github_repo": "timncox/schwung-smack-voice",
       "default_branch": "main",
       "asset_name": "smack-in-module.tar.gz",
       "min_host_version": "0.3.0"


### PR DESCRIPTION
## What changed

- Point the `smack` catalog entry at `timncox/schwung-smack-fx`.
- Point the `smack-in` catalog entry at `timncox/schwung-smack-voice`.

## Why

The catalog currently points Smack at the multi-module source repository and Smack In at the retired/noncanonical `timncox/schwung-smack-in` path. Dedicated distribution repositories now provide stable single-module `release.json` feeds, matching the existing Oversmack setup.

All three feeds currently advertise v0.15.1 and resolve to public, versioned release archives from the canonical source repository. This makes Smack and Smack In reliably appear and update in Schwung Manager.

## Validation

- `jq empty module-catalog.json`
- `tests/store/test_release_json_fallback_to_catalog_asset.sh`
- `tests/store/test_release_json_removed_module_surfaced.sh`
- Verified all three public `release.json` feeds report v0.15.1.
- Verified all three release archive URLs return HTTP 200.