### PR TITLE
Fix native LED repaint after overtake suspend

### DIFF
--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -138,7 +138,7 @@ typedef struct shadow_control_t {
     volatile uint8_t overlay_rect_h;      /* Overlay rect height (pixels) */
     volatile uint16_t tts_debounce_ms;   /* Screen reader debounce in ms (0-1000, default 300) */
     volatile uint8_t set_pages_enabled;  /* 0=off, 1=on (Shift+Vol+Left/Right page switching) */
-    volatile uint8_t skip_led_clear;     /* 1=don't clear LEDs on overtake entry, restore snapshot instead */
+    volatile uint8_t skip_led_clear;     /* 1=preserve native LEDs on entry, or request native repaint on exit */
     volatile uint8_t move_ui_mode;       /* Move's UI mode: 0=unknown, 1=session, 2=note, 3=set_overview */
     volatile uint8_t sampler_cmd;        /* 0=none, 1=start (path in file), 2=stop */
     volatile uint8_t sampler_state_val;  /* Mirrors sampler_state_t: 0=idle,1=armed,2=recording,3=preroll */

--- a/src/host/shadow_led_queue.c
+++ b/src/host/shadow_led_queue.c
@@ -116,6 +116,9 @@ static int move_led_clear_pending = 0;
 static int move_led_pass_count = 0;  /* how many clear/restore passes remain */
 static int prev_overtake_mode = 0;
 
+/* Defined alongside the Move sysex cache near the end of this file. */
+static void cancel_move_sysex_restore_and_thaw(void);
+
 /* ============================================================================
  * Hardware LED indices — only target LEDs that physically exist on Move.
  * ============================================================================ */
@@ -268,6 +271,23 @@ static void queue_hw_leds_restore(void) {
     }
 }
 
+/* A suspend-keeps-JS tool can explicitly hand LED ownership back to Move.
+ * In that path, replaying any queued tool LEDs after the mode transition would
+ * immediately overwrite Move's native note-layout repaint. Drop every pending
+ * framework write and thaw the pre-overtake sysex cache instead. */
+static void discard_pending_shadow_leds(void) {
+    shadow_init_led_queue();
+    for (int i = 0; i < 128; i++) {
+        shadow_pending_note_color[i] = -1;
+        shadow_pending_cc_color[i] = -1;
+    }
+    raw_queue_tail = raw_queue_head;
+    move_led_restore_pending = 0;
+    move_led_clear_pending = 0;
+    move_led_pass_count = 0;
+    cancel_move_sysex_restore_and_thaw();
+}
+
 void shadow_clear_move_leds_if_overtake(void) {
     shadow_control_t *ctrl = host.shadow_control ? *host.shadow_control : NULL;
     int cur_overtake = (ctrl && ctrl->overtake_mode >= 2) ? 1 : 0;
@@ -345,13 +365,17 @@ void shadow_clear_move_leds_if_overtake(void) {
         }
     }
 
-    /* On transition out of overtake: restore from snapshot.
+    /* On transition out of overtake: normally restore from snapshot.
      * LEDs we captured get restored; unknowns get turned off.
      * Two passes to catch stragglers.
      * If skip_led_clear was active at entry, LEDs have been passing through
-     * live so Move's current state is already on hardware — no restore needed. */
-    if (prev_overtake_mode && !cur_overtake && snapshot_valid) {
-        if (!snapshot_skip_restore) {
+     * live so Move's current state is already on hardware — no restore needed.
+     * A suspend-keeps-JS tool may also set skip_led_clear immediately before
+     * dropping overtake_mode. That is a one-shot request to let Move repaint
+     * natively instead of replaying an incomplete entry snapshot. */
+    if (prev_overtake_mode && !cur_overtake) {
+        int native_repaint = (ctrl && ctrl->skip_led_clear) ? 1 : 0;
+        if (snapshot_valid && !snapshot_skip_restore && !native_repaint) {
             queue_hw_leds_restore();
             move_led_restore_pending = 1;
             move_led_clear_pending = 0;
@@ -359,8 +383,16 @@ void shadow_clear_move_leds_if_overtake(void) {
             /* Also restore Move-firmware-side sysex RGB commands so track row
              * and other RGB LEDs get their pre-overtake colors back. */
             led_queue_restore_move_sysex_leds();
+        } else if (native_repaint && !snapshot_skip_restore) {
+            /* The entry snapshot can be incomplete for dynamic note layouts
+             * and Shift-row icons. Keep Move's fresh output authoritative. */
+            discard_pending_shadow_leds();
         }
+        /* skip_led_clear doubles as the exit repaint request. Consume it on
+         * the audio-side transition so JS cannot clear it too early. */
+        if (ctrl) ctrl->skip_led_clear = 0;
         snapshot_skip_restore = 0;
+        snapshot_valid = 0;
     }
 
     prev_overtake_mode = cur_overtake;
@@ -1123,6 +1155,14 @@ void led_queue_restore_move_sysex_leds(void) {
 
 void led_queue_freeze_move_sysex_cache(void) {
     move_sysex_cache_frozen = 1;
+}
+
+static void cancel_move_sysex_restore_and_thaw(void) {
+    move_sysex_restore_pending = 0;
+    move_sysex_restore_subcmd = 0;
+    move_sysex_restore_index = 0;
+    move_sysex_restore_pass = 0;
+    move_sysex_cache_frozen = 0;
 }
 
 int led_queue_move_sysex_restore_pending(void) {

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -534,8 +534,9 @@ static JSValue js_shadow_consume_resume_last_tool(JSContext *ctx, JSValueConst t
 }
 
 /* shadow_set_skip_led_clear(flag) -> void
- * Set skip_led_clear flag so the LED queue preserves pad colors on overtake entry.
- * Must be called BEFORE shadow_set_overtake_mode(2).
+ * Set skip_led_clear so the LED queue preserves native LEDs on overtake entry,
+ * or (when set immediately before mode 0) skips snapshot replay and lets Move
+ * repaint its native surface. The audio-side exit transition consumes the flag.
  */
 static JSValue js_shadow_set_skip_led_clear(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
     (void)this_val;

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -3105,9 +3105,8 @@ function exitOvertakeMode() {
     for (let k = 0; k < NUM_KNOBS; k++) overtakeKnobDelta[k] = 0;
     overtakeJogDelta = 0;
 
-    /* NOTE: skip_led_clear is cleared in completeOvertakeExit() AFTER
-     * overtake_mode drops to 0, so the C-side transition sees it and
-     * skips its snapshot restore (which may have stale/polluted state). */
+    /* NOTE: skip_led_clear is consumed by the C-side when it observes the
+     * overtake_mode transition. JS must not clear it in the same tick. */
 
     /* Signal exit — C-side LED cache will restore Move's LEDs
      * when overtake_mode transitions back to 0 */
@@ -3175,12 +3174,15 @@ function suspendOvertakeMode() {
             shadow_set_suspend_overtake(1);
         }
 
-        /* Drop overtake mode so shim stops routing events to the (now-parked) module. */
+        /* Ask the audio-side transition to leave Move's fresh native LED output
+         * authoritative. Mono's entry snapshot can be incomplete for dynamic
+         * scale colors and the Shift row, so replaying it here leaves the grid
+         * dark or stale. The C-side consumes skip_led_clear after mode reaches 0. */
         if (typeof shadow_set_overtake_mode === "function") {
+            if (typeof shadow_set_skip_led_clear === "function") {
+                shadow_set_skip_led_clear(1);
+            }
             shadow_set_overtake_mode(0);
-        }
-        if (typeof shadow_set_skip_led_clear === "function") {
-            shadow_set_skip_led_clear(0);
         }
         /* Clear the opt-in sysex suppression so it never leaks to the next tool. */
         if (typeof shadow_set_overtake_suppress_sysex === "function") {
@@ -3358,15 +3360,10 @@ function exitToolOvertake() {
     for (let k = 0; k < NUM_KNOBS; k++) overtakeKnobDelta[k] = 0;
     overtakeJogDelta = 0;
 
-    /* Disable overtake mode first, THEN clear skip_led_clear.
-     * The C-side checks skip_led_clear during the overtake→0 transition
-     * to decide whether to restore its LED snapshot. skip_led_clear must
-     * still be set at that moment so the restore is skipped. */
+    /* Disable overtake mode. The C-side consumes skip_led_clear when it
+     * observes this transition; clearing it here would race the audio thread. */
     if (!toolNonOvertake && typeof shadow_set_overtake_mode === "function") {
         shadow_set_overtake_mode(0);
-    }
-    if (typeof shadow_set_skip_led_clear === "function") {
-        shadow_set_skip_led_clear(0);
     }
 
     /* Return to tools menu — preserve hidden session state if one exists
@@ -3403,9 +3400,6 @@ function hideToolOvertake() {
     if (!toolNonOvertake && typeof shadow_set_overtake_mode === "function") {
         shadow_set_overtake_mode(0);
     }
-    if (typeof shadow_set_skip_led_clear === "function") {
-        shadow_set_skip_led_clear(0);
-    }
 
     /* Mark as hidden, not fully exited */
     toolOvertakeActive = false;
@@ -3433,14 +3427,8 @@ function completeOvertakeExit() {
         shadow_set_overtake_mode(0);
     }
 
-    /* Clear skip_led_clear AFTER overtake_mode drops to 0.
-     * The C-side overtake transition checks skip_led_clear to decide
-     * whether to restore its snapshot. With skip_led_clear still set,
-     * it skips the restore (good — the snapshot may be polluted from
-     * Move's MIDI_OUT during the session). Move reasserts its own LEDs. */
-    if (typeof shadow_set_skip_led_clear === "function") {
-        shadow_set_skip_led_clear(0);
-    }
+    /* The C-side consumes skip_led_clear when it observes the transition.
+     * Do not clear it here: JS and the audio thread run independently. */
 
     /* If exiting an interactive tool, return to tools menu instead of Move */
     if (toolOvertakeActive) {
@@ -3493,10 +3481,12 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
          * and everything else (pads, steps, knobs) passes through to Move normally.
          * If skip_led_clear, tell C-side to preserve LED state on overtake entry. */
         if (!skipOvertake && typeof shadow_set_overtake_mode === "function") {
-            const wantSkipLed = moduleInfo.capabilities && moduleInfo.capabilities.skip_led_clear;
-            if (wantSkipLed && typeof shadow_set_skip_led_clear === "function") {
-                shadow_set_skip_led_clear(1);
-                debugLog("loadOvertakeModule: skip_led_clear set");
+            const wantSkipLed = !!(moduleInfo.capabilities && moduleInfo.capabilities.skip_led_clear);
+            if (typeof shadow_set_skip_led_clear === "function") {
+                /* Set both branches explicitly so an interrupted prior tool
+                 * cannot leak native-LED ownership into this module. */
+                shadow_set_skip_led_clear(wantSkipLed ? 1 : 0);
+                if (wantSkipLed) debugLog("loadOvertakeModule: skip_led_clear set");
             }
             shadow_set_overtake_mode(2);  /* 2 = module mode (all events) */
             debugLog("loadOvertakeModule: overtake_mode=2 (module)");

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -14,7 +14,8 @@ LDFLAGS = -lpthread
 
 BUILD_DIR = ../../build/tests/host
 
-TARGETS = $(BUILD_DIR)/test_midi_inject_writer
+TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
+	$(BUILD_DIR)/test_overtake_native_led_repaint
 
 .PHONY: all test clean
 
@@ -25,6 +26,9 @@ $(BUILD_DIR):
 
 $(BUILD_DIR)/%: %.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/test_overtake_native_led_repaint: test_overtake_native_led_repaint.c ../../src/host/shadow_led_queue.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 test: $(TARGETS)
 	@for t in $(TARGETS); do \

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -28,7 +28,7 @@ $(BUILD_DIR)/%: %.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_overtake_native_led_repaint: test_overtake_native_led_repaint.c ../../src/host/shadow_led_queue.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 test: $(TARGETS)
 	@for t in $(TARGETS); do \

--- a/tests/host/test_overtake_native_led_repaint.c
+++ b/tests/host/test_overtake_native_led_repaint.c
@@ -1,0 +1,119 @@
+/* Regression test for suspend-keeps-JS overtake LED handoff.
+ *
+ * A native note-layout snapshot can be incomplete when an overtake starts.
+ * When the tool requests a native repaint on exit, the host must not replay
+ * that snapshot or any queued tool LED writes over Move's fresh output.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "shadow_led_queue.h"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } \
+} while (0)
+
+static shadow_control_t control;
+static shadow_control_t *control_ptr = &control;
+static uint8_t midi_out[HW_MIDI_OUT_SIZE];
+static uint8_t *ui_midi;
+
+static void begin_host(void) {
+    memset(&control, 0, sizeof control);
+    memset(midi_out, 0, sizeof midi_out);
+    led_queue_host_t host = {
+        .midi_out_buf = midi_out,
+        .shadow_control = &control_ptr,
+        .shadow_ui_midi_shm = &ui_midi,
+        .passthrough_ccs = NULL,
+    };
+    led_queue_init(&host);
+}
+
+static void empty_frame(void) {
+    memset(midi_out, 0, sizeof midi_out);
+}
+
+static int packet_present(uint8_t type, uint8_t data1, uint8_t data2) {
+    for (int i = 0; i < HW_MIDI_OUT_SIZE; i += 4) {
+        if ((midi_out[i + 1] & 0xF0) == type &&
+            midi_out[i + 2] == data1 && midi_out[i + 3] == data2) return 1;
+    }
+    return 0;
+}
+
+static void capture_native_then_enter_overtake(void) {
+    /* Cache a representative C-major pad color and Shift-row icon. */
+    midi_out[0] = 0x09; midi_out[1] = 0x90; midi_out[2] = 68; midi_out[3] = 17;
+    midi_out[4] = 0x0B; midi_out[5] = 0xB0; midi_out[6] = 16; midi_out[7] = 5;
+    shadow_clear_move_leds_if_overtake();
+
+    control.overtake_mode = 2;
+    shadow_clear_move_leds_if_overtake();
+
+    /* Drain the entry clear ceremony so it cannot affect exit assertions. */
+    for (int i = 0; i < 12; i++) {
+        empty_frame();
+        shadow_flush_pending_leds();
+    }
+}
+
+static void test_default_exit_still_restores_snapshot(void) {
+    begin_host();
+    capture_native_then_enter_overtake();
+
+    control.overtake_mode = 0;
+    empty_frame();
+    shadow_clear_move_leds_if_overtake();
+
+    int restored_pad = 0;
+    int restored_shift_row = 0;
+    for (int i = 0; i < 12; i++) {
+        empty_frame();
+        shadow_flush_pending_leds();
+        restored_pad |= packet_present(0x90, 68, 17);
+        restored_shift_row |= packet_present(0xB0, 16, 5);
+    }
+    CHECK(restored_pad, "ordinary overtake exit restores cached native pad color");
+    CHECK(restored_shift_row, "ordinary overtake exit restores cached Shift-row icon");
+}
+
+static void test_native_repaint_discards_snapshot_and_tool_queue(void) {
+    begin_host();
+    capture_native_then_enter_overtake();
+
+    /* Simulate one last Mono LED write waiting in the host queue. */
+    shadow_queue_led(0x09, 0x90, 68, 99);
+
+    /* JS sets this before mode=0 and leaves it for the audio thread. */
+    control.skip_led_clear = 1;
+    control.overtake_mode = 0;
+    empty_frame();
+    shadow_clear_move_leds_if_overtake();
+
+    CHECK(control.skip_led_clear == 0,
+          "audio-side exit transition consumes native repaint request");
+
+    for (int i = 0; i < 12; i++) {
+        empty_frame();
+        shadow_flush_pending_leds();
+        CHECK(!packet_present(0x90, 68, 17),
+              "native repaint exit does not replay entry snapshot");
+        CHECK(!packet_present(0x90, 68, 99),
+              "native repaint exit drops queued tool LED writes");
+        CHECK(!packet_present(0xB0, 16, 5),
+              "native repaint exit does not replay stale Shift-row icon");
+    }
+}
+
+int main(void) {
+    test_default_exit_still_restores_snapshot();
+    test_native_repaint_discards_snapshot_and_tool_queue();
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    puts("PASS: overtake native LED repaint handoff");
+    return 0;
+}

--- a/tests/shadow/test_parked_overtake_shim_isolation.mjs
+++ b/tests/shadow/test_parked_overtake_shim_isolation.mjs
@@ -61,10 +61,12 @@ function extractParkedTickBlock() {
 const sandbox = {
     console,
     debugLog: () => {},
+    corunTeardown: () => {},
     activateLedQueue: () => {},
     deactivateLedQueue: () => {},
     flushLedQueue: () => {},
     invokeModuleOnUnload: () => {},
+    invokeModuleOnResume: () => {},
     setView: () => {},
     VIEWS: { SLOTS: 0, OVERTAKE_MODULE: 1 },
     needsRedraw: false,
@@ -78,6 +80,7 @@ const sandbox = {
     overtakeModulePath: "",
     overtakeModuleCallbacks: null,
     overtakeSuspendKeepsJs: false,
+    overtakeSuspendSelfManaged: false,
     overtakePassthroughCCs: [],
     suspendedOvertakes: {},
     lastSuspendedToolId: "",
@@ -85,6 +88,9 @@ const sandbox = {
     ledQueueNotes: {},
     ledQueueCCs: {},
     ledClearIndex: 0,
+    paramShimsInstalled: false,
+    originalHostGetParam: null,
+    originalHostSetParam: null,
     getSlotParam: (slot, key) => `chain[${slot}:${key}]`,
     setSlotParam: () => {},
     getComponentParamPrefix: (k) => k === "midiFx" ? "midi_fx1" : k,
@@ -230,6 +236,32 @@ console.log("Scenario 2: two parked modules stay isolated");
     const b = sandbox._readsB[sandbox._readsB.length - 1];
     check("parked module A reads its own DSP", a === "A-DSP:k", `got ${JSON.stringify(a)}`);
     check("parked module B reads its own DSP", b === "B-DSP:k", `got ${JSON.stringify(b)}`);
+}
+
+// ---- Scenario 3: native LED repaint request survives until C transition ----
+console.log("Scenario 3: suspend hands native LEDs back atomically");
+{
+    sandbox.suspendedOvertakes = {};
+    const handoffCalls = [];
+    sandbox.shadow_set_suspend_overtake = (value) => handoffCalls.push(`suspend:${value}`);
+    sandbox.shadow_set_skip_led_clear = (value) => handoffCalls.push(`skip:${value}`);
+    sandbox.shadow_set_overtake_mode = (value) => handoffCalls.push(`mode:${value}`);
+    sandbox.shadow_request_exit = () => handoffCalls.push('exit');
+
+    installOvertakeShim("mono-DSP");
+    setActive("mono", "/modules/mono/dsp.so", () => {});
+    vm.runInContext(`suspendOvertakeMode();`, sandbox);
+
+    check("native repaint is requested before overtake mode drops",
+          handoffCalls.indexOf('skip:1') >= 0 &&
+          handoffCalls.indexOf('skip:1') < handoffCalls.indexOf('mode:0'),
+          `calls ${JSON.stringify(handoffCalls)}`);
+    check("JS does not clear the repaint request before the audio thread consumes it",
+          !handoffCalls.includes('skip:0'),
+          `calls ${JSON.stringify(handoffCalls)}`);
+    check("shadow UI exits only after the handoff",
+          handoffCalls.indexOf('mode:0') < handoffCalls.indexOf('exit'),
+          `calls ${JSON.stringify(handoffCalls)}`);
 }
 
 // --- exit -------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Treat `skip_led_clear` as a one-shot native repaint request when a parked overtake tool returns to Move.
- Keep that request set until the audio-side overtake transition consumes it, avoiding the JS/audio-thread race.
- Drop queued tool LED writes and thaw the Move sysex cache when native repaint is requested.
- Explicitly initialize LED ownership for each newly loaded overtake module.
- Add host and JS regressions for the handoff while preserving ordinary snapshot restoration.

## Why

After suspending a `suspend_keeps_js` overtake such as Mono, Schwung replayed the LED snapshot captured when the tool opened. That snapshot can be incomplete for Move's dynamic note layout and Shift-row icons. It could overwrite Move's fresh native repaint, leaving the grid dark or showing stale channel colors until Move was power-cycled.

The teardown comments expected `skip_led_clear` to remain visible during the overtake-to-native transition, but JS cleared it immediately while the audio thread observed the transition later.

## User impact

Returning from Mono or another parked overtake now restores Move's current native scale/channel colors and the buttons beneath the sequencer steps without cycling power. Ordinary overtake exits retain their existing snapshot-restore behavior.

## Validation

- `bash tests/shadow/test_parked_overtake_shim_isolation.sh`
- `make -C tests/host test`
- `scripts/hooks/pre-commit` (host checks passed; local Go executable unavailable)
- Full Docker ARM64 build via `./scripts/build.sh`
- Installed on Ableton Move; shim checksum matched the build, Move remained stable after restart, Mono remained installed, and the native grid/Shift-row repaint was confirmed on hardware
