### PR TITLE
test-bus: let injected MIDI reach overtake modules, and let open_tool open them

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -558,6 +558,23 @@ void shadow_drain_midi_inject(void)
 
     if (!inject_shm) return;
 
+    /* In OVERTAKE mode the queue belongs to the overtake publisher in
+     * schwung_shim.c, not to us.
+     *
+     * The two consumers are mutually exclusive by necessity: this ring is
+     * documented single-consumer, and popping from both would corrupt it. The
+     * split is also what makes injection reach an overtake module at all —
+     * this function writes into Move's MAILBOX MIDI_IN, which Move's firmware
+     * reads, while an overtake module is fed from the raw HARDWARE buffer. An
+     * injected packet written here could therefore never reach the module, and
+     * with the firmware suppressed during overtake it had nowhere useful to go
+     * either. Measured on device 2026-07-29: injected pads moved neither a
+     * parameter nor any of the 32 pad LEDs. */
+    {
+        shadow_control_t *sc = host_shadow_control ? *host_shadow_control : NULL;
+        if (sc && sc->overtake_mode != 0) return;
+    }
+
     /* Hold the inject drain for a few frames after an overtake module exits
      * (Back-to-suspend or full exit) before draining anything into Move's
      * MIDI_IN. On the overtake->native transition the shim queues cleanup

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -7129,6 +7129,57 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
             }
         }
 
+        /* === TEST-BUS INJECT, OVERTAKE PATH ===
+         *
+         * An overtake module is fed from the raw HARDWARE buffer scanned
+         * above, while shadow_drain_midi_inject writes into Move's MAILBOX
+         * MIDI_IN for the firmware to read. Injected packets therefore could
+         * never reach an overtake module: measured on device 2026-07-29,
+         * pressing a palette pad through the test bus moved neither a
+         * parameter nor any of the 32 pad LEDs, and produced no OVERTAKE MIDI
+         * line in the log. Without this, pytest-schwung can read an overtake
+         * module's state but cannot drive its surface — which is most of what
+         * a UI test needs to do.
+         *
+         * So in overtake mode the inject ring is drained HERE instead, onto
+         * exactly the route a hardware press takes: publish to the shadow UI,
+         * and hand note events to the overtake DSP. shadow_drain_midi_inject
+         * returns early while overtake_mode is set, so the ring keeps its
+         * single consumer.
+         *
+         * Realtime: peek/pop are lock-free atomic loads over a preallocated
+         * ring, and the loop is bounded, so this adds no allocation and no
+         * unbounded work to the SPI callback. */
+        if (overtake_mode && shadow_midi_inject_shm) {
+            uint8_t pkt[4];
+            int budget = 16;            /* bounded: never stall the callback */
+            while (budget-- > 0 && shadow_midi_inject_peek(shadow_midi_inject_shm, pkt)) {
+                shadow_midi_inject_pop(shadow_midi_inject_shm);
+
+                const uint8_t hdr    = pkt[0];
+                const uint8_t status = pkt[1];
+                const uint8_t d1     = pkt[2];
+                const uint8_t d2     = pkt[3];
+                const uint8_t type   = status & 0xF0;
+
+                if (shadow_ui_midi_shm)
+                    shadow_ui_midi_publish(hdr, status, d1, d2);
+
+                /* Note events also reach the overtake DSP, matching what the
+                 * hardware path above does — otherwise an injected pad would
+                 * drive the UI but never the engine. */
+                if (type == 0x90 || type == 0x80) {
+                    uint8_t msg[3] = { status, d1, d2 };
+                    if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->on_midi)
+                        overtake_dsp_gen->on_midi(overtake_dsp_gen_inst, msg, 3,
+                                                  MOVE_MIDI_SOURCE_INTERNAL);
+                    else if (overtake_dsp_fx && overtake_dsp_fx_inst && overtake_dsp_fx->on_midi)
+                        overtake_dsp_fx->on_midi(overtake_dsp_fx_inst, msg, 3,
+                                                 MOVE_MIDI_SOURCE_INTERNAL);
+                }
+            }
+        }
+
         /* Flush pending input LED queue (for cable 2 external MIDI in overtake mode) */
         shadow_flush_pending_input_leds();
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -14610,7 +14610,26 @@ globalThis.tick = function() {
                             unloadModuleUi();
                             startInteractiveTool(tool, cmd.file_path);
                         } else {
-                            debugLog("open_tool_cmd: tool not found: " + cmd.tool_id);
+                            /* Fall back to the OVERTAKE list before giving up.
+                             * The two live in different scans — component_type
+                             * "tool" here, "overtake" there — so an overtake
+                             * module could never be opened this way, and the
+                             * command answered "tool not found" for an id that
+                             * plainly exists on disk. That blocks
+                             * pytest-schwung from launching one, which is the
+                             * difference between an unattended UI test run and
+                             * one that needs a person to press a button first. */
+                            const overtakes = scanForOvertakeModules() || [];
+                            const ot = overtakes.find(o => o.id === cmd.tool_id);
+                            if (ot) {
+                                debugLog("open_tool_cmd: " + cmd.tool_id +
+                                         " is an overtake module, loading it");
+                                unloadModuleUi();
+                                loadOvertakeModule(ot);
+                            } else {
+                                debugLog("open_tool_cmd: not found as tool or " +
+                                         "overtake module: " + cmd.tool_id);
+                            }
                         }
                     }
                 } catch (e) {


### PR DESCRIPTION
`pytest-schwung` advertises MIDI injection as a core primitive, but with an
overtake module active it silently does nothing. Two independent gaps, both
measured on a device before and after.

## Injected MIDI never reaches an overtake module

An overtake module is fed from the raw **hardware** buffer the shim scans each
frame, while `shadow_drain_midi_inject` writes into Move's **mailbox** MIDI_IN
for the firmware to read. The two never meet — so an injected packet cannot
reach the module, and with the firmware suppressed during overtake it has
nowhere useful to go either.

Measured before the change: pressing palette pad 93 through the bus left the
module's `machine1` unchanged, moved **none** of the 32 pad LEDs, and produced
no `OVERTAKE MIDI` line in the log.

The shim now drains the ring onto the overtake route instead — publish to the
shadow UI, and hand note events to the overtake DSP, exactly as a hardware
press goes. `shadow_drain_midi_inject` returns early while `overtake_mode` is
set, because the ring is documented single-consumer and popping from both would
corrupt it.

Realtime: the drain is bounded to 16 packets per frame and uses only the
existing lock-free `peek`/`pop`, so it adds no allocation and no unbounded work
to the SPI callback.

## `open_tool` cannot open an overtake module

`set_open_tool` answered `tool not found` for an id plainly present on disk:
the lookup searched `scanForToolModules()` (`component_type: "tool"`) while
overtake modules come from `scanForOvertakeModules()`. It now falls back to the
overtake list and calls `loadOvertakeModule`.

## Result

Confirmed end to end against a Move:

```
set_open_tool('overwork')  ->  overtake_mode == 2
press_step(16)             ->  step0  '0:0:0:0:0:100:0' -> '1:0:0:0:0:100:0'
```

Together these make an unattended UI test run possible for overtake modules.
In my own module it immediately caught a bug that no mocked harness could have
found — step buttons are notes 16-31, my handler was in the CC branch, and my
mock had the same wrong assumption, so the suite was green while the sequencer
was unplayable on hardware.

## Testing

- `make -C tests/host test` — ALL PASS
- all 38 `tests/host/*.sh` — pass
- on-device: an overtake module launched and driven from `pytest-schwung`, with
  parameters and pad LEDs read back to confirm effect

## Related

Filed separately: a latched-SHIFT bug in `shadow_ui` that this work surfaced.
It is not fixed here because the right fix is in `shadow_ui`'s lifecycle rather
than in the test bus.
