### PR TITLE
catalog: add Work, Work In and Overwork

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1177,6 +1177,39 @@
       "default_branch": "main",
       "asset_name": "noisemaker-module.tar.gz",
       "min_host_version": "0.11.0"
+    },
+    {
+      "id": "work",
+      "name": "Work",
+      "description": "Twenty-six Tonverk-inspired machines in two insert slots — twenty-one effects and five sample sources — with three FX LFOs, a modulation envelope and MIDI CC/NRPN",
+      "author": "timncox",
+      "component_type": "audio_fx",
+      "github_repo": "timncox/schwung-work",
+      "default_branch": "main",
+      "asset_name": "work-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "work-in",
+      "name": "Work In",
+      "description": "The same twenty-six machines on the live input — mic, line or USB-C — with feedback protection",
+      "author": "timncox",
+      "component_type": "sound_generator",
+      "github_repo": "timncox/schwung-work-in",
+      "default_branch": "main",
+      "asset_name": "work-in-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "overwork",
+      "name": "Overwork",
+      "description": "Full-surface Work: hold a step and turn a knob to parameter-lock it. Sample browser, 16-pattern bank, song mode, live recording and presets",
+      "author": "timncox",
+      "component_type": "overtake",
+      "github_repo": "timncox/schwung-overwork",
+      "default_branch": "main",
+      "asset_name": "overwork-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds three catalog entries for the Work family — one engine, three builds.

| id | type | what it is |
| --- | --- | --- |
| `work` | `audio_fx` | Signal Chain or Master FX slot |
| `work-in` | `sound_generator` | the same machines on the live input |
| `overwork` | `overtake` | the full surface, with the sequencer |

**Twenty-six machines** in two insert slots: twenty-one effects and five sample
sources (Single Player, Multi Player, Subtracks, Wavefinder, Shape), plus
Grainer, three FX LFOs, a modulation envelope and MIDI CC/NRPN.

Overwork maps Tonverk's gesture onto Move directly — sixteen step buttons for
sixteen TRIG keys, eight knobs for eight encoders — so **hold a step and turn a
knob to parameter-lock it** works as it does on the hardware.

## Clean room

Every machine is written from the parameter descriptions in Elektron's
**published** Tonverk user manual: which knobs exist, what they are called,
what range they span, what the manual says they do. No Elektron code, no
firmware image, no factory presets or wavetables. The DSP — filter topologies,
the reverb tanks, the pitch-shifter windowing, every coefficient — is original,
and the docs say so rather than implying a bit-exact clone. Where a machine
could not be reproduced faithfully (Multi Player has no multi-sampled
instruments, Subtracks has no subtrack routing) the manual page says which part
is missing instead of letting the name imply it.

## Verified on hardware

Machine selection across the list, loading a WAV and playing it from a
sequencer trig, parameter locks, preset save and reload, Wavefinder's position
sweep morphing continuously, and a sample player in slot 1 feeding Rumsklang
Reverb in slot 2 with no crackling — the heaviest realistic pair.

Not yet heard: Subtracks, Multi Player's polyphony, trig conditions. Stated
plainly in the manual rather than glossed.

- Release: https://github.com/timncox/schwung-work/releases/tag/v0.7.0
- Manual: https://timncox.github.io/schwung-work/
- `release.json` is on main in all three repos, the two thin repos pointing at
  the source repo's assets in the house layout.
