### PR TITLE
Let a ui_hierarchy address the browser without claiming the device editor

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+name: Deploy landing page to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths: ['docs/**']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -889,6 +889,36 @@ Modules expose a navigable parameter hierarchy to the Shadow UI via `ui_hierarch
 }
 ```
 
+### `remote_only` — publish for the browser, keep your own device editor
+
+A hierarchy means two different things to the two surfaces that read it.
+
+schwung-manager builds the **Remote UI's** control list from `ui_hierarchy` and
+has no other source for it: `chain_params` supplies metadata for keys the
+hierarchy already lists, so a module without a hierarchy renders "No parameters
+available" in the browser no matter what else it exposes.
+
+On the **device**, publishing it is stronger than a description — it is a
+claim. `enterComponentEdit()` hands the screen to the generic hierarchy editor
+and the module's own `ui_chain.js` never loads.
+
+That forced a module shipping a real chain UI to pick one surface. Set
+`remote_only` on the hierarchy to have it addressed only to the browser:
+
+```json
+{"remote_only": true, "levels": {"root": {"name": "Work", "params": [...]}}}
+```
+
+The device then falls through to `ui_chain.js` exactly as if no hierarchy were
+published, and the Remote UI is unaffected — it ignores the field. Only the
+literal `true` counts; anything else leaves the device editor claimed, so a
+module cannot lose its on-device UI to a stray `"true"`.
+
+Use it when your `ui_chain.js` is better than the generic editor would be —
+typically when labels follow a runtime selection. The generic editor re-reads
+`chain_params` only on preset change or for keys matching `/_rate_mode$/`, so a
+module whose knob labels change with a loaded machine will show stale ones.
+
 ### Level Fields
 
 | Field | Description |

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Schwung Modules by Tim Cox — Instruments &amp; FX for Ableton Move</title>
+<meta name="description" content="Free, open-source Schwung modules for the Ableton Move by Tim Cox: Smack (seeded loop glitcher), Belt (live vocal processor), Mark (five-track live looper), and Mono (Monomachine-inspired six-track synth).">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🎛️</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Big+Shoulders+Display:wght@500;700;900&family=Archivo:wght@400;500;600;700&family=Martian+Mono:wght@400;700&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg:#0c0b09; --panel:#14120e; --panel2:#191611; --ink:#e8e2d5; --dim:#968d7a;
+  --line:rgba(232,226,213,.13); --line2:rgba(232,226,213,.07);
+  --smack:#ff7733; --belt:#d8551a; --mark:#4dd06a; --mono-acc:#b5ff9e;
+  --disp:"Big Shoulders Display",Impact,sans-serif;
+  --monoft:"Martian Mono","SFMono-Regular",Consolas,monospace;
+  --body:"Archivo","Helvetica Neue",sans-serif;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+body{background:var(--bg);color:var(--ink);font-family:var(--body);font-size:16px;line-height:1.6;overflow-x:hidden}
+body::before{
+  content:"";position:fixed;inset:0;z-index:0;pointer-events:none;
+  background-image:
+    repeating-linear-gradient(0deg,var(--line2) 0 1px,transparent 1px 64px),
+    repeating-linear-gradient(90deg,var(--line2) 0 1px,transparent 1px 64px);
+  mask-image:radial-gradient(ellipse 90% 70% at 50% 0%,#000 0%,transparent 75%);
+  -webkit-mask-image:radial-gradient(ellipse 90% 70% at 50% 0%,#000 0%,transparent 75%);
+}
+body::after{
+  content:"";position:fixed;inset:0;z-index:99;pointer-events:none;opacity:.05;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2'/%3E%3C/filter%3E%3Crect width='160' height='160' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+a{color:inherit;text-decoration:none}
+code,kbd{font-family:var(--monoft);font-size:.82em;background:var(--panel2);border:1px solid var(--line);border-radius:4px;padding:.1em .4em;white-space:nowrap}
+.wrap{max-width:1100px;margin:0 auto;padding:0 24px;position:relative;z-index:1}
+
+/* ---------- nav ---------- */
+nav{position:sticky;top:0;z-index:50;background:rgba(12,11,9,.88);backdrop-filter:blur(8px);border-bottom:1px solid var(--line)}
+nav .wrap{display:flex;align-items:center;gap:18px;height:52px;overflow-x:auto;scrollbar-width:none}
+nav .wrap::-webkit-scrollbar{display:none}
+nav .logo{font-family:var(--disp);font-weight:900;font-size:22px;letter-spacing:.04em;flex:none}
+nav .logo em{color:var(--smack);font-style:normal}
+nav a.s{font-family:var(--monoft);font-size:10.5px;letter-spacing:.06em;color:var(--dim);flex:none;text-transform:uppercase;padding:4px 0}
+nav a.s:hover{color:var(--ink)}
+
+/* ---------- masthead ---------- */
+header{padding:72px 0 40px}
+.kicker{font-family:var(--monoft);font-size:12px;letter-spacing:.28em;color:var(--smack);text-transform:uppercase;margin-bottom:10px}
+h1.title{font-family:var(--disp);font-weight:900;line-height:.85;font-size:clamp(64px,13vw,180px);letter-spacing:.01em;text-transform:uppercase}
+.subtitle{font-family:var(--disp);font-weight:500;font-size:clamp(20px,3.2vw,32px);letter-spacing:.14em;text-transform:uppercase;color:var(--dim);margin-top:14px}
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:22px}
+.chip{font-family:var(--monoft);font-size:11px;letter-spacing:.05em;padding:5px 10px;border:1px solid var(--line);border-radius:999px;color:var(--dim)}
+.chip b{color:var(--ink);font-weight:400}
+.lede{max-width:680px;margin-top:26px;font-size:18px}
+.lede a{color:var(--smack);border-bottom:1px solid rgba(255,119,51,.35)}
+.lede a:hover{border-bottom-color:var(--smack)}
+
+/* ---------- family sections ---------- */
+section.family{padding:56px 0 8px;border-top:1px solid var(--line);margin-top:48px}
+.fam-head{display:flex;align-items:baseline;gap:16px;flex-wrap:wrap}
+.fam-head .emoji{font-size:34px;line-height:1}
+.fam-head h2{font-family:var(--disp);font-weight:900;font-size:clamp(44px,7vw,84px);letter-spacing:.02em;text-transform:uppercase;line-height:.9}
+.fam-head .tag{font-family:var(--monoft);font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--dim)}
+.fam-lede{max-width:680px;margin-top:14px;color:var(--ink)}
+.fam-links{display:flex;flex-wrap:wrap;gap:10px;margin-top:18px}
+.btn{font-family:var(--monoft);font-size:11.5px;letter-spacing:.08em;text-transform:uppercase;padding:9px 16px;border:1px solid var(--line);border-radius:6px;color:var(--ink);transition:border-color .15s,color .15s}
+.btn:hover{border-color:var(--famacc)}
+.btn.primary{border-color:var(--famacc);color:var(--famacc)}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:16px;margin-top:26px}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:22px 22px 18px;position:relative;overflow:hidden}
+.card::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--famacc)}
+.card h3{font-family:var(--disp);font-weight:700;font-size:30px;letter-spacing:.03em;text-transform:uppercase}
+.meta{display:flex;flex-wrap:wrap;gap:8px;margin:8px 0 12px}
+.badge{font-family:var(--monoft);font-size:10px;letter-spacing:.1em;text-transform:uppercase;padding:3px 8px;border-radius:4px;border:1px solid var(--famacc);color:var(--famacc)}
+.ver{font-family:var(--monoft);font-size:10px;letter-spacing:.1em;padding:3px 8px;border-radius:4px;border:1px solid var(--line);color:var(--dim)}
+.card p{color:var(--ink);font-size:15px;margin-bottom:10px}
+.card ul{list-style:none;margin:0 0 12px}
+.card li{font-size:13.5px;color:var(--dim);padding-left:16px;position:relative;margin-bottom:4px}
+.card li::before{content:"▸";position:absolute;left:0;color:var(--famacc)}
+.install{font-family:var(--monoft);font-size:11px;color:var(--dim);line-height:1.8;border-top:1px solid var(--line2);padding-top:10px;margin-top:auto}
+.install a{color:var(--ink);border-bottom:1px solid var(--line)}
+.install a:hover{border-bottom-color:var(--famacc)}
+#smack{--famacc:var(--smack)} #belt{--famacc:var(--belt)} #mark{--famacc:var(--mark)} #mono{--famacc:var(--mono-acc)}
+
+/* ---------- install / footer ---------- */
+#get-started{padding:64px 0 24px;border-top:1px solid var(--line);margin-top:56px}
+#get-started h2{font-family:var(--disp);font-weight:900;font-size:clamp(40px,6vw,72px);text-transform:uppercase;letter-spacing:.02em}
+.steps{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:16px;margin-top:26px}
+.step{background:var(--panel);border:1px solid var(--line);border-radius:10px;padding:20px}
+.step .n{font-family:var(--disp);font-weight:900;font-size:34px;color:var(--smack)}
+.step h3{font-family:var(--disp);font-weight:700;font-size:22px;text-transform:uppercase;letter-spacing:.05em;margin:4px 0 8px}
+.step p{font-size:14px;color:var(--dim)}
+.step a{color:var(--ink);border-bottom:1px solid var(--line)}
+.step a:hover{border-bottom-color:var(--smack)}
+footer{border-top:1px solid var(--line);margin-top:56px;padding:28px 0 48px}
+footer .wrap{display:flex;flex-wrap:wrap;gap:12px 24px;align-items:center;justify-content:space-between}
+footer p{font-family:var(--monoft);font-size:11px;letter-spacing:.06em;color:var(--dim)}
+footer a{color:var(--ink);border-bottom:1px solid var(--line)}
+footer a:hover{border-bottom-color:var(--smack)}
+</style>
+</head>
+<body>
+
+<nav><div class="wrap">
+  <a class="logo" href="#top">TIMNCOX<em>//</em>MODULES</a>
+  <a class="s" href="#smack">Smack</a>
+  <a class="s" href="#belt">Belt</a>
+  <a class="s" href="#mark">Mark</a>
+  <a class="s" href="#mono">Mono</a>
+  <a class="s" href="#get-started">Install</a>
+  <a class="s" href="https://github.com/timncox">GitHub</a>
+</div></nav>
+
+<header id="top"><div class="wrap">
+  <div class="kicker">Tim Cox · Schwung · Ableton Move</div>
+  <h1 class="title">Modules</h1>
+  <div class="subtitle">Instruments &amp; effects for the Ableton Move</div>
+  <div class="chips">
+    <span class="chip"><b>8</b> modules</span>
+    <span class="chip"><b>4</b> families</span>
+    <span class="chip">free &amp; open source</span>
+    <span class="chip">MIT licensed</span>
+    <span class="chip">interactive manuals</span>
+  </div>
+  <p class="lede">Loop glitching, live vocal processing, performance looping, and a
+  six-track machine synth — all running natively on the Move via
+  <a href="https://github.com/charlesvestal/schwung">Schwung</a>, the framework for
+  custom modules on Ableton Move hardware. Every module ships with a full
+  interactive operation manual and on-device help.</p>
+</div></header>
+
+<!-- ================= SMACK ================= -->
+<section class="family" id="smack"><div class="wrap">
+  <div class="fam-head"><span class="emoji">👊</span><h2>Smack</h2><span class="tag">Seeded loop glitcher · three builds, one core</span></div>
+  <p class="fam-lede">Grab a quantized loop of live audio, auto-slice it, and let
+  seeded randomness assign glitch effects and a new play order to the slices.
+  Inspired by Sugar Bytes Looperator and dblue Glitch — patterns repeat identically
+  every pass until you re-roll, and the Seed knob browses them by number.</p>
+  <div class="fam-links">
+    <a class="btn primary" href="https://timncox.github.io/schwung-smack/">📖 Operation manual</a>
+    <a class="btn" href="https://github.com/timncox/schwung-smack">Source</a>
+  </div>
+  <div class="cards">
+    <div class="card">
+      <h3>Smack</h3>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.13.3</span></div>
+      <p>Runs in Signal Chain slots and Master FX — glitch a synth, or the whole Move mix.</p>
+      <ul>
+        <li>Retroactive capture: loop the last 1 step – 16 bars you just played</li>
+        <li>26 effects: retrigger, varispeed, tape stop, vinyl scratch, vowel filter, granular scatter…</li>
+        <li>Seeded per-slice FX + slice-reorder patterns; step buttons edit &amp; mute</li>
+        <li>A/B punch between clean loop and pattern; dual-mono lanes with per-side patterns</li>
+      </ul>
+      <div class="install">Module Store: <b>smack</b> · Custom install: <a href="https://github.com/timncox/schwung-smack-fx">timncox/schwung-smack-fx</a></div>
+    </div>
+    <div class="card">
+      <h3>Smack In</h3>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.13.3</span></div>
+      <p>Standalone build that reads Move's selected input — mic, line-in, or USB-C — directly in one slot. No routing required.</p>
+      <ul>
+        <li>Same capture / slice / seed engine as Smack</li>
+        <li>Perfect for glitching external gear through the Move</li>
+      </ul>
+      <div class="install">Module Store: <b>smack-in</b> · Custom install: <a href="https://github.com/timncox/schwung-smack-voice">timncox/schwung-smack-voice</a></div>
+    </div>
+    <div class="card">
+      <h3>Oversmack</h3>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.10.2</span></div>
+      <p>Full-surface Smack: the whole pad grid becomes a step-FX editor for the input loop.</p>
+      <ul>
+        <li>Steps show the pattern and select slices; playhead chase</li>
+        <li>Upper pad rows are a rearrangeable 22-effect palette — pins survive Re-Roll</li>
+        <li>Move's clock keeps running; Back hides the UI while audio keeps processing</li>
+      </ul>
+      <div class="install">Module Store: <b>oversmack</b> · Custom install: <a href="https://github.com/timncox/schwung-oversmack">timncox/schwung-oversmack</a></div>
+    </div>
+  </div>
+</div></section>
+
+<!-- ================= BELT ================= -->
+<section class="family" id="belt"><div class="wrap">
+  <div class="fam-head"><span class="emoji">🎤</span><h2>Belt</h2><span class="tag">Live vocal processor · named because it makes you sound like you can</span></div>
+  <p class="fam-lede">Autotune-style pitch correction, up to four diatonic backing-vocal
+  harmonies, a stereo doubler, and a formant knob — on the Move's own mic, line-in, or
+  USB-C input. One YIN pitch analysis drives every TD-PSOLA voice, so seven voices cost
+  barely more than one, at ~26 ms fixed latency.</p>
+  <div class="fam-links">
+    <a class="btn primary" href="https://timncox.github.io/schwung-belt/">📖 Operation manual</a>
+    <a class="btn" href="https://github.com/timncox/schwung-belt">Source</a>
+  </div>
+  <div class="cards">
+    <div class="card">
+      <h3>Belt</h3>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.1.2</span></div>
+      <p>Chain + Master FX build — processes whatever is upstream in the signal chain.</p>
+      <ul>
+        <li>Retune 0 = instant hard-tune robot, higher = transparent correction</li>
+        <li>Harmony voices 1–4: scale-aware 3rds, 5ths, octaves with per-voice detune &amp; spread</li>
+        <li>HARD pad for momentary or latched T-Pain punch</li>
+        <li>Tuner strip on steps 1–12; Flex / Humanize keeps your slides and vibrato</li>
+      </ul>
+      <div class="install">Module Store: <b>belt</b> · Custom install: <a href="https://github.com/timncox/schwung-belt-fx">timncox/schwung-belt-fx</a></div>
+    </div>
+    <div class="card">
+      <h3>Belt In</h3>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.1.2</span></div>
+      <p>The live-vocals build: a standalone slot synth on the hardware input, same chain UI and engine.</p>
+      <ul>
+        <li>Sing straight into the Move's mic, line-in, or USB-C</li>
+        <li>Feedback-safe: auto-mutes when the speaker would howl (Monitor pad overrides)</li>
+      </ul>
+      <div class="install">Module Store: <b>belt-in</b> · Custom install: <a href="https://github.com/timncox/schwung-belt-voice">timncox/schwung-belt-voice</a></div>
+    </div>
+  </div>
+</div></section>
+
+<!-- ================= MARK ================= -->
+<section class="family" id="mark"><div class="wrap">
+  <div class="fam-head"><span class="emoji">🔁</span><h2>Mark</h2><span class="tag">Five-track live loop station · named after Marc Rebillet</span></div>
+  <p class="fam-lede">The Boss RC-505 workflow on the Move's pad grid: five independent
+  stereo loop tracks cycling record → play → overdub, measure-snapped to the first
+  loop or Move's MIDI clock. Move keeps playing underneath, so its own tracks are
+  your rhythm section.</p>
+  <div class="fam-links">
+    <a class="btn primary" href="https://timncox.github.io/schwung-mark/">📖 Operation manual</a>
+    <a class="btn" href="https://github.com/timncox/schwung-mark">Source</a>
+  </div>
+  <div class="cards">
+    <div class="card">
+      <h3>Mark</h3>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.4.0</span></div>
+      <p>Per-track stop/clear, level, pan, reverse and one-shot, with single-level undo/redo of the last take.</p>
+      <ul>
+        <li>16 session slots: loop audio + settings, saved on the Move, survive reinstalls</li>
+        <li>Per-track FX insert: built-ins or any chainable Schwung Audio FX (yes, including Smack and Belt)</li>
+        <li>Single mode turns the five tracks into exclusive song sections</li>
+        <li>Web mixer at <code>move.local</code>: faders, pans, FX, modes, session grid</li>
+      </ul>
+      <div class="install">Module Store: <b>mark</b> · Custom install: <a href="https://github.com/timncox/schwung-mark">timncox/schwung-mark</a></div>
+    </div>
+  </div>
+</div></section>
+
+<!-- ================= MONO ================= -->
+<section class="family" id="mono"><div class="wrap">
+  <div class="fam-head"><span class="emoji">🎛️</span><h2>Mono</h2><span class="tag">Clean-room, Monomachine-inspired digital instrument</span></div>
+  <p class="fam-lede">Six machine types — SuperWave Saw / Pulse / Ensemble, a SID
+  6581-style oscillator, a DigiPRO-style 12-bit wavetable, and two-block FM — each
+  with an AHDR envelope, dual-cutoff resonant filter, distortion, EQ, sample-rate
+  reduction, stereo filtered delay, and three assignable LFOs with 114 destinations.</p>
+  <div class="fam-links">
+    <a class="btn primary" href="https://timncox.github.io/schwung-mono/">📖 Operation manual</a>
+    <a class="btn" href="https://github.com/timncox/schwung-mono">Source</a>
+  </div>
+  <div class="cards">
+    <div class="card">
+      <h3>Mono</h3>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.3.1</span></div>
+      <p>Full-surface six-track machine synth with an internal 64-step sequencer.</p>
+      <ul>
+        <li>Per-step parameter locks, probability, retrigs, conditions, and slide</li>
+        <li>Independent track timing, arp, neighbor routing, and song mode</li>
+        <li>Per-machine sound memory: switch machines and your settings come back</li>
+      </ul>
+      <div class="install">Custom install: <a href="https://github.com/timncox/schwung-mono">timncox/schwung-mono</a></div>
+    </div>
+    <div class="card">
+      <h3>Mono Voice</h3>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.3.1</span></div>
+      <p>One machine voice inside a normal Move track, driven by Move's own pads and sequencer.</p>
+      <ul>
+        <li>Same six machines and full synthesis panel as Mono</li>
+        <li>Shift-banks add Drift, Fold, Bits, Noise, envelope curves, filter drive &amp; more</li>
+      </ul>
+      <div class="install">Custom install: <a href="https://github.com/timncox/schwung-mono-voice">timncox/schwung-mono-voice</a></div>
+    </div>
+  </div>
+</div></section>
+
+<!-- ================= INSTALL ================= -->
+<section id="get-started"><div class="wrap">
+  <h2>Get started</h2>
+  <div class="steps">
+    <div class="step"><div class="n">1</div><h3>Install Schwung</h3>
+      <p>All modules run on <a href="https://github.com/charlesvestal/schwung">Schwung</a>,
+      the open framework for custom JavaScript and native DSP modules on the Ableton Move.</p></div>
+    <div class="step"><div class="n">2</div><h3>Open the manager</h3>
+      <p>Browse to <code>move.local:7700</code> on the same network as your Move and open the
+      <b>Module Store</b>.</p></div>
+    <div class="step"><div class="n">3</div><h3>Install a module</h3>
+      <p>Search the store by name, or use <b>Install Custom Module</b> with any of the
+      repository links above. Updates show up in the manager automatically.</p></div>
+  </div>
+</div></section>
+
+<footer><div class="wrap">
+  <p>© Tim Cox · MIT licensed · built on <a href="https://github.com/charlesvestal/schwung">Schwung</a> for the Ableton Move</p>
+  <p><a href="https://github.com/timncox">github.com/timncox</a></p>
+</div></footer>
+
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -280,10 +280,10 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work</h3>
-      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.1.0</span></div>
-      <p>Twenty FX machines inspired by the Elektron Tonverk, in two insert slots with two FX LFOs.</p>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.2.0</span></div>
+      <p>Twenty-one FX machines inspired by the Elektron Tonverk, in two insert slots with two FX LFOs.</p>
       <ul>
-        <li>Reverbs, delays, filters, a wavefolder, a frequency shifter, a barber-pole flanger and more</li>
+        <li>Three distinct reverb algorithms, delays, filters, a wavefolder, a frequency shifter, a barber-pole flanger, a granulator</li>
         <li>Each machine&rsquo;s eight parameters land on Move&rsquo;s eight knobs 1:1</li>
         <li>Works in a Signal Chain slot and in Master FX</li>
       </ul>
@@ -292,8 +292,8 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work In</h3>
-      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.1.0</span></div>
-      <p>The same twenty machines, loaded into a chain slot as the source so Move&rsquo;s own effects come after them.</p>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.2.0</span></div>
+      <p>The same twenty-one machines, loaded into a chain slot as the source so Move&rsquo;s own effects come after them.</p>
       <ul>
         <li>Reads the live input directly &mdash; mic, line or USB-C</li>
         <li>Same knob pages as Work, with the feedback guard applied</li>
@@ -303,12 +303,13 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Overwork</h3>
-      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.1.0</span></div>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.2.0</span></div>
       <p>Full-surface Work: the twenty machines on the live input, with an Elektron-style step sequencer driving parameter locks.</p>
       <ul>
         <li>Hold a step button and turn a knob to parameter-lock it</li>
         <li>64 steps, trig conditions, micro-timing and retrig</li>
-        <li>The pads become a twenty-machine palette</li>
+        <li>The pads become a twenty-one-machine palette</li>
+        <li>Preset browser on Shift + jog click</li>
       </ul>
       <div class="install">Custom install: <a href="https://github.com/timncox/schwung-overwork">timncox/schwung-overwork</a> &middot; <a href="https://timncox.github.io/schwung-work/">manual</a></div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -280,8 +280,8 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work</h3>
-      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.2.0</span></div>
-      <p>Twenty-one FX machines inspired by the Elektron Tonverk, in two insert slots with two FX LFOs.</p>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.3.0</span></div>
+      <p>Twenty-one FX machines inspired by the Elektron Tonverk, in two insert slots, with three FX LFOs, a modulation envelope and MIDI CC control.</p>
       <ul>
         <li>Three distinct reverb algorithms, delays, filters, a wavefolder, a frequency shifter, a barber-pole flanger, a granulator</li>
         <li>Each machine&rsquo;s eight parameters land on Move&rsquo;s eight knobs 1:1</li>
@@ -292,7 +292,7 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work In</h3>
-      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.2.0</span></div>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.3.0</span></div>
       <p>The same twenty-one machines, loaded into a chain slot as the source so Move&rsquo;s own effects come after them.</p>
       <ul>
         <li>Reads the live input directly &mdash; mic, line or USB-C</li>
@@ -303,13 +303,13 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Overwork</h3>
-      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.2.0</span></div>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.3.0</span></div>
       <p>Full-surface Work: the twenty machines on the live input, with an Elektron-style step sequencer driving parameter locks.</p>
       <ul>
         <li>Hold a step button and turn a knob to parameter-lock it</li>
         <li>64 steps, trig conditions, micro-timing and retrig</li>
         <li>The pads become a twenty-one-machine palette</li>
-        <li>Preset browser on Shift + jog click</li>
+        <li>Preset browser, live parameter-lock recording, per-step probability</li>
       </ul>
       <div class="install">Custom install: <a href="https://github.com/timncox/schwung-overwork">timncox/schwung-overwork</a> &middot; <a href="https://timncox.github.io/schwung-work/">manual</a></div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -280,7 +280,7 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work</h3>
-      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.3.0</span></div>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.4.0</span></div>
       <p>Twenty-one FX machines inspired by the Elektron Tonverk, in two insert slots, with three FX LFOs, a modulation envelope and MIDI CC control.</p>
       <ul>
         <li>Three distinct reverb algorithms, delays, filters, a wavefolder, a frequency shifter, a barber-pole flanger, a granulator</li>
@@ -292,7 +292,7 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work In</h3>
-      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.3.0</span></div>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.4.0</span></div>
       <p>The same twenty-one machines, loaded into a chain slot as the source so Move&rsquo;s own effects come after them.</p>
       <ul>
         <li>Reads the live input directly &mdash; mic, line or USB-C</li>
@@ -303,13 +303,14 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Overwork</h3>
-      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.3.0</span></div>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.4.0</span></div>
       <p>Full-surface Work: the twenty machines on the live input, with an Elektron-style step sequencer driving parameter locks.</p>
       <ul>
         <li>Hold a step button and turn a knob to parameter-lock it</li>
         <li>64 steps, trig conditions, micro-timing and retrig</li>
         <li>The pads become a twenty-one-machine palette</li>
-        <li>Preset browser, live parameter-lock recording, per-step probability</li>
+        <li>16-pattern bank, song mode, undo/redo, presets</li>
+        <li>Live parameter-lock recording and per-step probability</li>
       </ul>
       <div class="install">Custom install: <a href="https://github.com/timncox/schwung-overwork">timncox/schwung-overwork</a> &middot; <a href="https://timncox.github.io/schwung-work/">manual</a></div>
     </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -280,7 +280,7 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work</h3>
-      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.4.0</span></div>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.5.0</span></div>
       <p>Twenty-one FX machines inspired by the Elektron Tonverk, in two insert slots, with three FX LFOs, a modulation envelope and MIDI CC control.</p>
       <ul>
         <li>Three distinct reverb algorithms, delays, filters, a wavefolder, a frequency shifter, a barber-pole flanger, a granulator</li>
@@ -292,7 +292,7 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Work In</h3>
-      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.4.0</span></div>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.5.0</span></div>
       <p>The same twenty-one machines, loaded into a chain slot as the source so Move&rsquo;s own effects come after them.</p>
       <ul>
         <li>Reads the live input directly &mdash; mic, line or USB-C</li>
@@ -303,13 +303,14 @@ footer a:hover{border-bottom-color:var(--smack)}
 
     <div class="card">
       <h3>Overwork</h3>
-      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.4.0</span></div>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.5.0</span></div>
       <p>Full-surface Work: the twenty machines on the live input, with an Elektron-style step sequencer driving parameter locks.</p>
       <ul>
         <li>Hold a step button and turn a knob to parameter-lock it</li>
         <li>64 steps, trig conditions, micro-timing and retrig</li>
         <li>The pads become a twenty-one-machine palette</li>
         <li>16-pattern bank, song mode, undo/redo, presets</li>
+        <li>Feedback protection for mic input</li>
         <li>Live parameter-lock recording and per-step probability</li>
       </ul>
       <div class="install">Custom install: <a href="https://github.com/timncox/schwung-overwork">timncox/schwung-overwork</a> &middot; <a href="https://timncox.github.io/schwung-work/">manual</a></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -168,7 +168,7 @@ footer a:hover{border-bottom-color:var(--smack)}
     </div>
     <div class="card">
       <h3>Oversmack</h3>
-      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.10.2</span></div>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.15.0</span></div>
       <p>Full-surface Smack: the whole pad grid becomes a step-FX editor for the input loop.</p>
       <ul>
         <li>Steps show the pattern and select slices; playhead chase</li>
@@ -231,7 +231,7 @@ footer a:hover{border-bottom-color:var(--smack)}
   <div class="cards">
     <div class="card">
       <h3>Mark</h3>
-      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.4.0</span></div>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.5.0</span></div>
       <p>Per-track stop/clear, level, pan, reverse and one-shot, with single-level undo/redo of the last take.</p>
       <ul>
         <li>16 session slots: loop audio + settings, saved on the Move, survive reinstalls</li>
@@ -258,7 +258,7 @@ footer a:hover{border-bottom-color:var(--smack)}
   <div class="cards">
     <div class="card">
       <h3>Mono</h3>
-      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.3.1</span></div>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.4.1</span></div>
       <p>Full-surface six-track machine synth with an internal 64-step sequencer.</p>
       <ul>
         <li>Per-step parameter locks, probability, retrigs, conditions, and slide</li>
@@ -269,7 +269,7 @@ footer a:hover{border-bottom-color:var(--smack)}
     </div>
     <div class="card">
       <h3>Mono Voice</h3>
-      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.3.1</span></div>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.4.0</span></div>
       <p>One machine voice inside a normal Move track, driven by Move's own pads and sequencer.</p>
       <ul>
         <li>Same six machines and full synthesis panel as Mono</li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -146,7 +146,7 @@ footer a:hover{border-bottom-color:var(--smack)}
   <div class="cards">
     <div class="card">
       <h3>Smack</h3>
-      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.13.3</span></div>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.15.1</span></div>
       <p>Runs in Signal Chain slots and Master FX — glitch a synth, or the whole Move mix.</p>
       <ul>
         <li>Retroactive capture: loop the last 1 step – 16 bars you just played</li>
@@ -158,7 +158,7 @@ footer a:hover{border-bottom-color:var(--smack)}
     </div>
     <div class="card">
       <h3>Smack In</h3>
-      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.13.3</span></div>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.15.0</span></div>
       <p>Standalone build that reads Move's selected input — mic, line-in, or USB-C — directly in one slot. No routing required.</p>
       <ul>
         <li>Same capture / slice / seed engine as Smack</li>
@@ -194,7 +194,7 @@ footer a:hover{border-bottom-color:var(--smack)}
   <div class="cards">
     <div class="card">
       <h3>Belt</h3>
-      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.1.2</span></div>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.2.0</span></div>
       <p>Chain + Master FX build — processes whatever is upstream in the signal chain.</p>
       <ul>
         <li>Retune 0 = instant hard-tune robot, higher = transparent correction</li>
@@ -206,7 +206,7 @@ footer a:hover{border-bottom-color:var(--smack)}
     </div>
     <div class="card">
       <h3>Belt In</h3>
-      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.1.2</span></div>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.2.0</span></div>
       <p>The live-vocals build: a standalone slot synth on the hardware input, same chain UI and engine.</p>
       <ul>
         <li>Sing straight into the Move's mic, line-in, or USB-C</li>
@@ -276,6 +276,41 @@ footer a:hover{border-bottom-color:var(--smack)}
         <li>Shift-banks add Drift, Fold, Bits, Noise, envelope curves, filter drive &amp; more</li>
       </ul>
       <div class="install">Custom install: <a href="https://github.com/timncox/schwung-mono-voice">timncox/schwung-mono-voice</a></div>
+    </div>
+
+    <div class="card">
+      <h3>Work</h3>
+      <div class="meta"><span class="badge">Audio FX</span><span class="ver">v0.1.0</span></div>
+      <p>Twenty FX machines inspired by the Elektron Tonverk, in two insert slots with two FX LFOs.</p>
+      <ul>
+        <li>Reverbs, delays, filters, a wavefolder, a frequency shifter, a barber-pole flanger and more</li>
+        <li>Each machine&rsquo;s eight parameters land on Move&rsquo;s eight knobs 1:1</li>
+        <li>Works in a Signal Chain slot and in Master FX</li>
+      </ul>
+      <div class="install">Custom install: <a href="https://github.com/timncox/schwung-work">timncox/schwung-work</a> &middot; <a href="https://timncox.github.io/schwung-work/">manual</a></div>
+    </div>
+
+    <div class="card">
+      <h3>Work In</h3>
+      <div class="meta"><span class="badge">Voice</span><span class="ver">v0.1.0</span></div>
+      <p>The same twenty machines, loaded into a chain slot as the source so Move&rsquo;s own effects come after them.</p>
+      <ul>
+        <li>Reads the live input directly &mdash; mic, line or USB-C</li>
+        <li>Same knob pages as Work, with the feedback guard applied</li>
+      </ul>
+      <div class="install">Custom install: <a href="https://github.com/timncox/schwung-work-in">timncox/schwung-work-in</a></div>
+    </div>
+
+    <div class="card">
+      <h3>Overwork</h3>
+      <div class="meta"><span class="badge">Overtake</span><span class="ver">v0.1.0</span></div>
+      <p>Full-surface Work: the twenty machines on the live input, with an Elektron-style step sequencer driving parameter locks.</p>
+      <ul>
+        <li>Hold a step button and turn a knob to parameter-lock it</li>
+        <li>64 steps, trig conditions, micro-timing and retrig</li>
+        <li>The pads become a twenty-machine palette</li>
+      </ul>
+      <div class="install">Custom install: <a href="https://github.com/timncox/schwung-overwork">timncox/schwung-overwork</a> &middot; <a href="https://timncox.github.io/schwung-work/">manual</a></div>
     </div>
   </div>
 </div></section>

--- a/src/host/test_daemon/commands.c
+++ b/src/host/test_daemon/commands.c
@@ -464,13 +464,67 @@ static int cmd_set_open_tool(int fd, const char *args) {
 /* shadow_param request-id sequence. Single-producer relative to the
  * daemon (one client at a time per Phase 1 contract), so no atomics
  * needed. Starts at 1 — 0 is the "no response yet" sentinel that
- * shadow_param->response_id uses. */
+ * shadow_param->response_id uses.
+ *
+ * HIGH HALF, and that is the whole point. shadow_ui is the other producer on
+ * this slot and its shadow_param_next_request_id() is the same generator:
+ * ++, wrap to 1. Two independent counters over ONE id space, so both sides'
+ * `response_id == req_id` check matches the OTHER side's response as soon as
+ * the counters coincide — which they do constantly, because they both start
+ * at 1 and advance together.
+ *
+ * The daemon then reads a value it never asked for. Observed while running an
+ * overtake module that polls four keys 22 times a second: the test client got
+ * back "seq_pos7" and "eff_src4", which are not values at all — they are the
+ * module's BULK response buffer, key and value concatenated in the bulk wire
+ * format. Roughly half of on-device test runs failed that way, each one
+ * looking like a different module bug.
+ *
+ * Setting the top bit gives the daemon its own namespace. shadow_ui would have
+ * to issue 2^31 requests to reach it — at its observed rate, decades. Neither
+ * side can now match the other, and the failure mode degrades from "accepts
+ * the wrong data" to "times out", which both sides already handle.
+ *
+ * This does NOT close the underlying race: both producers still do
+ * check-then-write on request_type rather than an atomic claim, so their
+ * writes can still interleave. Closing that needs a claim value the shim
+ * agrees to ignore, and the shim clears any non-zero request_type it does not
+ * recognise — a change in the audio-path binary, which is not worth making
+ * for a test tool. What is left after this is a lost request, caught by the
+ * key check in testd_param_check_served(). */
+#define TESTD_PARAM_ID_SPACE 0x80000000u
+
 static uint32_t g_testd_param_seq = 0;
 
 static uint32_t testd_param_next_request_id(void) {
     g_testd_param_seq++;
     if (g_testd_param_seq == 0) g_testd_param_seq = 1;
-    return g_testd_param_seq;
+    return g_testd_param_seq | TESTD_PARAM_ID_SPACE;
+}
+
+/* Did the peer serve OUR key?
+ *
+ * Belt to the id namespace's braces, and it catches a different failure: the
+ * two producers claim the slot with check-then-write, so shadow_ui can write
+ * its key between our wait_idle() and our own key write. If the shim reads the
+ * slot in that window it serves a request that is half ours and half theirs.
+ * The id check cannot see that — the id is whatever was written last.
+ *
+ * The key can. If what the slot holds is not what we asked for, the value
+ * beside it is not ours either. Returns 1 when the response can be trusted. */
+static int testd_param_check_served(const char *key, uint32_t req_id) {
+    /* The key alone is not enough, because a BULK request carries its keys in
+     * `value` and leaves `key` untouched — so the slot can hold our key beside
+     * someone else's bulk payload and the comparison passes. Seen on device as
+     * a GET returning "4 7 seq_pos7 eff_src4 eff14 eff2": the module's bulk
+     * response, whole, under our key.
+     *
+     * request_id catches it. Ours has the top bit set (TESTD_PARAM_ID_SPACE);
+     * the other producer's never does, so anything that is not exactly our id
+     * means our request was overwritten between firing it and reading back. */
+    if (__atomic_load_n(&g_shm.param->request_id, __ATOMIC_ACQUIRE) != req_id)
+        return 0;
+    return strncmp(g_shm.param->key, key, SHADOW_PARAM_KEY_LEN - 1) == 0;
 }
 
 /* Busy-wait until shadow_param->request_type clears (peer drained the
@@ -556,6 +610,12 @@ static int testd_param_do_set(int fd, const char *key, const char *value, size_t
     int rc = testd_param_wait_response(req_id, TESTD_PARAM_TIMEOUT_MS);
     if (rc == 0) return protocol_reply_err(fd, "param SET timeout");
     if (rc < 0) return protocol_reply_err(fd, "param SET error from peer");
+    if (!testd_param_check_served(key, req_id)) {
+        /* Worse here than on a GET: a raced SET reports OK while the value
+         * went nowhere, and the test then measures the parameter it thought
+         * it had just written. */
+        return protocol_reply_err(fd, "param SET raced with shadow_ui (retry)");
+    }
     return protocol_reply(fd, "OK");
 }
 
@@ -625,6 +685,12 @@ static int cmd_get_param(int fd, const char *args) {
     int rc = testd_param_wait_response(req_id, TESTD_PARAM_TIMEOUT_MS);
     if (rc == 0) return protocol_reply_err(fd, "param GET timeout");
     if (rc < 0) return protocol_reply_err(fd, "param GET error from peer");
+    if (!testd_param_check_served(args, req_id)) {
+        /* The slot is holding someone else's request. Say so rather than
+         * returning the value sitting next to it — a wrong value is far worse
+         * than an error, because the caller believes it. */
+        return protocol_reply_err(fd, "param GET raced with shadow_ui (retry)");
+    }
 
     /* Response value must fit on the line. The cap is TESTD_LINE_MAX
      * (4 KiB). The snprintf below writes "OK %s" (3 bytes prefix +

--- a/src/host/test_daemon/protocol.c
+++ b/src/host/test_daemon/protocol.c
@@ -53,7 +53,33 @@ int protocol_send_line(int fd, const char *s) {
 
 int protocol_reply(int fd, const char *line) {
     char buf[TESTD_LINE_MAX + 2];
-    snprintf(buf, sizeof(buf), "%s\n", line);
+    int n = snprintf(buf, sizeof(buf), "%s\n", line);
+    if (n < 0) return -1;
+    if ((size_t)n >= sizeof(buf)) n = (int)sizeof(buf) - 1;
+
+    /* A reply is ONE line. Anything embedded in it that looks like a line
+     * ending is not payload, it is a protocol break.
+     *
+     * This is a line protocol and the client reads it a line at a time, so a
+     * value carrying a newline arrives as several replies: the client takes
+     * the first fragment as this command's answer and every fragment after it
+     * as an answer to a LATER command. The socket never recovers. One bad
+     * value therefore does not fail one test, it fails the rest of the run.
+     *
+     * That is exactly what was seen on device. The param slot has two
+     * producers, so a GET could come back holding a module's BULK response —
+     * and the bulk wire format is "<count>\n" then "<len>\n<bytes>" records,
+     * newlines throughout. The client reported `unexpected reply 'seq_pos7'`,
+     * which is not a value at all: it is the tail of someone else's buffer
+     * being read as a fresh reply. Runs failed five to eight tests at a time
+     * from a single collision.
+     *
+     * Neutering the newlines keeps the desync from ever starting. The reply is
+     * still wrong when this fires — the caller's own checks are what catch
+     * that — but it is wrong for one command instead of all of them. */
+    for (int i = 0; i < n - 1; ++i) {
+        if (buf[i] == '\n' || buf[i] == '\r') buf[i] = ' ';
+    }
     return protocol_send_line(fd, buf);
 }
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -3764,6 +3764,23 @@ function getComponentHierarchy(slot, componentKey) {
     }
 }
 
+/* Does this hierarchy drive the DEVICE's editor, or is it published only for
+ * the browser?
+ *
+ * schwung-manager builds the Remote UI's control list from ui_hierarchy and has
+ * no other source for it — no hierarchy, no controls, just "No parameters
+ * available". On the device the same key means something stronger: publishing
+ * it diverts enterComponentEdit() to the generic hierarchy editor, and the
+ * module's own ui_chain.js never loads.
+ *
+ * So a module that ships a real chain UI had to choose one surface or the
+ * other, and the ones that chose the device (work, smack) have no Remote UI at
+ * all. "remote_only" splits the two meanings: publish for the browser, keep
+ * your own editor here. */
+function hierarchyDrivesDeviceEditor(hierarchy) {
+    return !!hierarchy && hierarchy.remote_only !== true;
+}
+
 /* Fetch chain_params metadata from a Master FX slot */
 function getMasterFxChainParams(fxSlot) {
     if (fxSlot < 0 || fxSlot >= 4) return [];
@@ -7510,10 +7527,12 @@ function enterComponentEdit(slotIndex, componentKey) {
         return;
     }
 
-    /* Try hierarchy editor first (for plugins with ui_hierarchy) */
+    /* Try hierarchy editor first (for plugins with ui_hierarchy). A
+     * remote_only hierarchy is for the browser and does not claim this
+     * screen — fall through to the module's own ui_chain.js. */
     const hierarchy = getComponentHierarchy(slotIndex, componentKey);
     debugLog(`enterComponentEdit: hierarchy=${hierarchy ? 'found' : 'null'}`);
-    if (hierarchy) {
+    if (hierarchyDrivesDeviceEditor(hierarchy)) {
         debugLog(`enterComponentEdit: calling enterHierarchyEditor`);
         enterHierarchyEditor(slotIndex, componentKey);
         return;
@@ -7687,8 +7706,9 @@ function enterMasterFxHierarchyEditor(fxSlot) {
     if (fxSlot < 0 || fxSlot >= 4) return;
 
     const hierarchy = getMasterFxHierarchy(fxSlot);
-    if (!hierarchy) {
-        /* No hierarchy - just return, module selection is available */
+    if (!hierarchyDrivesDeviceEditor(hierarchy)) {
+        /* No hierarchy (or a browser-only one) - just return, module
+         * selection is available */
         return;
     }
 
@@ -8474,7 +8494,7 @@ function buildKnobContextForKnob(knobIndex) {
 
             /* Try ui_hierarchy first for explicit knob mappings */
             const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
-            if (hierarchy && hierarchy.levels) {
+            if (hierarchyDrivesDeviceEditor(hierarchy) && hierarchy.levels) {
                 let levelDef = hierarchy.levels.root || hierarchy.levels[Object.keys(hierarchy.levels)[0]];
                 /* If root has no knobs but has children, use first child level for knob mapping */
                 if (levelDef && (!levelDef.knobs || levelDef.knobs.length === 0) && levelDef.children) {
@@ -11348,7 +11368,7 @@ function handleSelect() {
                     if (moduleData && moduleData.module) {
                         /* Module is loaded - try hierarchy editor first */
                         const hierarchy = getMasterFxHierarchy(selectedMasterFxComponent);
-                        if (hierarchy) {
+                        if (hierarchyDrivesDeviceEditor(hierarchy)) {
                             enterMasterFxHierarchyEditor(selectedMasterFxComponent);
                         } else {
                             /* No hierarchy - enter module selection to swap */

--- a/tests/shadow/test_hierarchy_remote_only.mjs
+++ b/tests/shadow/test_hierarchy_remote_only.mjs
@@ -1,0 +1,97 @@
+// A module may publish ui_hierarchy for the BROWSER without surrendering its
+// own on-device editor.
+//
+// The two surfaces read the same key and mean different things by it.
+// schwung-manager builds the Remote UI's control list from ui_hierarchy and
+// has no other source — no hierarchy, no controls, just "No parameters
+// available". On the device, publishing it diverts enterComponentEdit() to the
+// generic hierarchy editor and the module's own ui_chain.js never loads.
+//
+// So a module shipping a real chain UI had to pick one surface. work and smack
+// both picked the device and have no Remote UI at all. "remote_only" lets a
+// hierarchy address the browser only.
+//
+// Guards the predicate AND that every device-side divert actually consults it —
+// a helper nothing calls would pass a behaviour test and change nothing.
+
+import { readFileSync } from 'node:fs';
+import vm from 'node:vm';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../..');
+const source = readFileSync(path.join(repoRoot, 'src/shadow/shadow_ui.js'), 'utf8');
+
+function extractFn(name) {
+    const re = new RegExp(`(^|\\n)function\\s+${name}\\s*\\(`);
+    const m = re.exec(source);
+    if (!m) throw new Error(`function ${name} not found`);
+    const start = m.index + (m[1] ? 1 : 0);
+    let i = source.indexOf('{', start);
+    let depth = 1, pos = i + 1;
+    while (depth > 0 && pos < source.length) {
+        const c = source[pos++];
+        if (c === '{') depth++;
+        else if (c === '}') depth--;
+    }
+    return source.slice(start, pos);
+}
+
+const sandbox = { console };
+sandbox.globalThis = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(extractFn('hierarchyDrivesDeviceEditor'), sandbox);
+const drives = sandbox.hierarchyDrivesDeviceEditor;
+
+let failed = 0;
+function check(cond, what) {
+    if (cond) return;
+    console.error(`FAIL: ${what}`);
+    failed++;
+}
+
+const levels = { levels: { root: { label: 'X', params: ['a'] } } };
+
+/* The behaviour that already existed must not change: a plain hierarchy still
+ * claims the device editor, and no hierarchy still falls through. */
+check(drives(levels) === true, 'an ordinary hierarchy still drives the device editor');
+check(drives(null) === false, 'a missing hierarchy does not drive the device editor');
+check(drives(undefined) === false, 'undefined does not drive the device editor');
+
+/* The new behaviour. */
+check(drives({ ...levels, remote_only: true }) === false,
+      'remote_only: true releases the device editor');
+
+/* Only the literal true. A module that sends "true", 1, or a stray non-empty
+ * string should NOT silently lose its device editor — the failure mode of a
+ * loose check is a module that ships fine and then has no UI on hardware,
+ * which is exactly the bug this flag exists to avoid causing. */
+for (const loose of ['true', 1, 'yes', {}]) {
+    check(drives({ ...levels, remote_only: loose }) === true,
+          `remote_only: ${JSON.stringify(loose)} is not the literal true, so the device editor stays`);
+}
+check(drives({ ...levels, remote_only: false }) === true, 'remote_only: false keeps the device editor');
+
+/* Every place a hierarchy takes over a device screen must ask. Counting the
+ * call sites is the part that would rot silently: a new divert added later
+ * would reintroduce the fork for remote_only modules. */
+const callSites = (source.match(/hierarchyDrivesDeviceEditor\(/g) || []).length;
+check(callSites >= 5,
+      `expected the predicate at its definition plus every divert site, found ${callSites}`);
+
+/* And no divert may still test the hierarchy's raw truthiness. */
+const rawDiverts = [
+    /if \(hierarchy\) \{\s*\n\s*debugLog\(`enterComponentEdit/,
+    /const hierarchy = getMasterFxHierarchy\(selectedMasterFxComponent\);\s*\n\s*if \(hierarchy\) \{/,
+];
+for (const re of rawDiverts) {
+    check(!re.test(source),
+          `a device divert still branches on the raw hierarchy: ${re}`);
+}
+
+if (failed) {
+    console.error(`${failed} failed`);
+    process.exit(1);
+}
+console.log('PASS: remote_only hierarchies address the browser without claiming the device editor');

--- a/tests/shadow/test_hierarchy_remote_only.sh
+++ b/tests/shadow/test_hierarchy_remote_only.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+exec node "$SCRIPT_DIR/test_hierarchy_remote_only.mjs"

--- a/tools/pytest-schwung/src/schwung_bus/client.py
+++ b/tools/pytest-schwung/src/schwung_bus/client.py
@@ -546,6 +546,13 @@ class SchwungBus:
         "param SET timeout",
         "param GET timeout",
         "DUMP_PARAM_FILE: GET timeout",
+        # The daemon found someone else's key in the slot when its response
+        # came back. shadow_ui is the other producer on that single slot and
+        # both sides claim it with check-then-write, so their writes can
+        # interleave. Retrying is right: the next attempt usually lands in a
+        # gap, and the alternative the daemon used to have was returning the
+        # value sitting beside the wrong key.
+        "raced with shadow_ui",
     )
 
     def _param_request_with_retry(self, line: str) -> str:


### PR DESCRIPTION
## Why

`ui_hierarchy` means two different things to the two surfaces that read it.

**schwung-manager** builds the Remote UI's control list from it and has no other source. `chain_params` only supplies *metadata* for keys a hierarchy already lists (`findParamMeta` in `remote-ui.js`), so a module without a hierarchy renders "No parameters available" in the browser no matter what else it exposes.

**On the device**, publishing it is a claim rather than a description: `enterComponentEdit()` hands the screen to the generic hierarchy editor and the module's own `ui_chain.js` never loads.

So a module shipping a real chain UI had to pick one surface. `work` and `smack` both picked the device and have no Remote UI at all.

Work is the case in hand. Its knob labels follow whichever machine each stage currently holds, and the generic editor re-reads `chain_params` only on preset change (`shadow_ui.js` ~7906) or for keys matching `/_rate_mode$/` (`shouldRefreshDynamicRateMeta`). A machine change matches neither, so its labels would sit stale until you exited and re-entered — which is exactly why it stopped serving the key in the first place.

## What

`hierarchyDrivesDeviceEditor(hierarchy)` gates every place a hierarchy takes over a device screen:

- `enterComponentEdit` — the divert that costs a module its `ui_chain.js`
- `enterMasterFxHierarchyEditor`
- the Master FX knob-mapping lookup
- the Master FX enter-editor branch

A hierarchy carrying `"remote_only": true` releases all four; the device falls through exactly as if none were published. The Remote UI is untouched — it ignores the field.

Only the literal `true` counts. A loose check would let a stray `"true"` cost a module its on-device UI, which is the failure this flag exists to prevent rather than cause.

## Tests

`tests/shadow/test_hierarchy_remote_only.{sh,mjs}` extracts the predicate and exercises it, then checks that every divert consults it — a helper nothing calls would pass a behaviour test and change nothing. Verified red before the change and green after.

`tests/host` is fully green. `tests/shadow` has the same 19 pre-existing failures before and after this branch (the stale pins CLAUDE.md documents); none are new.

## Docs

`docs/MODULES.md` gains a `remote_only` section under Shadow UI Parameter Hierarchy, including when to reach for it.