### PR TITLE
catalog: add RRVerb-10 (audio_fx)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1232,6 +1232,18 @@
       "default_branch": "main",
       "asset_name": "groovebank-module.tar.gz",
       "min_host_version": "0.11.5"
+    },
+    {
+      "id": "rrverb10",
+      "name": "RRVerb-10",
+      "description": "Chip-level emulation of an 80s Micro Rack digital reverb: rooms, halls, plates, multi-tap delay, reverse and gate",
+      "author": "Sergey V. Mikayev (MUNT gate-array emulation) · giulioz (ROM research) · port: legsmechanical",
+      "component_type": "audio_fx",
+      "github_repo": "legsmechanical/schwung-rrverb10",
+      "default_branch": "main",
+      "asset_name": "rrverb10-module.tar.gz",
+      "min_host_version": "0.9.16",
+      "requires": "16 KB program ROM dump (place in module's roms/ folder as rrv10.bin)"
     }
   ]
 }


### PR DESCRIPTION
Adds **RRVerb-10** to the module catalog — a chip-level emulation of an 80s Micro Rack digital reverb.

Nine programs (Room 1/2, Hall 1/2, Plate 1/2, Multi-Tap delay, Multi-Tap reverse, Gate) executed from the unit's own 16 KB program ROM via [MUNT](https://github.com/munt/munt)'s `BossEmu` (LGPL-2.1+, © Sergey V. Mikayev). The reverb isn't modelled by ear — the ROM is the algorithm and the emulator runs it.

**Repo:** https://github.com/legsmechanical/schwung-rrverb10 · **Release:** v0.3.0

### ROM
Not redistributable and not shipped. The module declares it in an `assets` block, so schwung-manager shows an upload slot and validates size + crc32. Without it the effect loads and passes audio through unprocessed rather than failing — flagged in the catalog's `requires` field.

### min_host_version 0.9.16
The module sets `requires_continuous_processing`, introduced in `3d4a13db`. Without it a reverb tail gets idle-parked through silence.

### Notes
- Runs the gate array at its real 31250 Hz (8.000 MHz / 256 cycles per sample) rather than one chip cycle per host sample. The shortcut runs the emulation 41% fast — decays 29% short, response up 5.97 semitones. Resamples 44100 → 31237.5 → 44100 at 17/24; a unit test pins the multi-tap echo to its ROM-derived hardware position so it can't regress.
- Measured on device: 95.2 µs per 128-frame block, 3.28% of one core.
- Single-page on-device Bank Editor built with canvaskit; also declares `host_canvas_ui`.

Catalog entry only — no host code touched.