### PR TITLE
docs: point README and MODULES.md at the provenance policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,11 @@ pushes to `main` are blocked. Branch off `main` (or fork), open a PR, and
 optionally install the fast local checks with `./scripts/install-hooks.sh`. See
 [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
 
+Before you start, read the
+[contribution provenance](CONTRIBUTING.md#contribution-provenance) policy: please
+disclose which AI coding tools you used, and note that contributions developed
+with Grok aren't accepted.
+
 ## Available Modules
 
 Browse the full module catalog at [schwung.dev/catalog.html](https://schwung.dev/catalog.html). Modules are installable via [Schwung Manager](http://move.local:7700) on the device or the desktop installer. The catalog source lives in [module-catalog.json](module-catalog.json).

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2,6 +2,11 @@
 
 Modules are self-contained packages that extend Schwung with new functionality.
 
+> **Contributing back to Schwung?** Read the
+> [contribution provenance](../CONTRIBUTING.md#contribution-provenance) policy
+> first: please disclose which AI coding tools you used, and note that
+> contributions developed with Grok aren't accepted.
+
 ## Module Structure
 
 ```


### PR DESCRIPTION
Follow-up to #195. Adds pointers to the **Contribution provenance** policy from the two places contributors actually start:

- `README.md` — a short paragraph at the end of the existing Contributing section.
- `docs/MODULES.md` — a blockquote at the top of the module development guide, since external module authors often land there directly and may never open the root `CONTRIBUTING.md`.

Rationale: GitHub only surfaces `CONTRIBUTING.md` at PR-open time, i.e. after the work is done. These links let people self-select out before starting.

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TCCYkb8cCAMrQ1JfTbJaCS