### PR TITLE
catalog: add Chord Finder

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1232,6 +1232,18 @@
       "default_branch": "main",
       "asset_name": "groovebank-module.tar.gz",
       "min_host_version": "0.11.5"
+    },
+    {
+      "id": "chord-finder",
+      "name": "Chord Finder",
+      "description": "Scale-aware chord progression finder with 16 ranked chord choices, root-driven revoicing, a piano-note display, and eight-slot MIDI loop capture.",
+      "author": "lukeco11",
+      "component_type": "tool",
+      "github_repo": "lukeco11/chord-finder-for-move",
+      "default_branch": "main",
+      "asset_name": "chord-finder-module.tar.gz",
+      "min_host_version": "0.11.6",
+      "requires": "Ableton Move 1.8 or newer; Move/USB-C audition requires matching Move track MIDI routing"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds **Chord Finder** to `module-catalog.json` as a full-surface `tool`.

Chord Finder splits Move's pad grid into scale notes and 16 ranked chord choices. It supports root-driven held-chord revoicing, ROOT/NEXT/VOICE exploration modes, an on-screen piano-note display, and eight-slot MIDI progression capture and playback. It sends MIDI to a native Move track, USB-A, or both; it does not include its own sound generator.

- Repository: https://github.com/lukeco11/chord-finder-for-move
- Release: https://github.com/lukeco11/chord-finder-for-move/releases/tag/v0.4.2
- Asset: `chord-finder-module.tar.gz`
- Minimum host: Schwung 0.11.6

## Validation

- public `release.json` resolves to v0.4.2 and the release asset returns successfully
- archive extracts to `chord-finder/` and contains matching `id`, version, and `component_type: tool` metadata
- native `dsp.so` and install helper are aarch64 ELF binaries
- catalog JSON parses and all module IDs remain unique
- `tests/store/test_release_json_fallback_to_catalog_asset.sh`
- `tests/store/test_release_json_removed_module_surfaced.sh`
- Schwung pre-commit host tests pass; local Go checks were skipped because Go is not installed, so the required PR CI remains authoritative
- module repository: 50 JavaScript tests, native DSP harness, and package verification pass

The module has been installed and exercised on a physical Ableton Move with Schwung 0.11.6, including chord audition, root-driven revoicing, progression capture, the display, and LED startup/resume behavior. USB-C DAW forwarding remains dependent on matching Move track routing and firmware, which is stated in the catalog requirement.

## AI assistance

The Chord Finder module and this catalog contribution were developed with human direction using OpenAI Codex. No Grok or xAI tooling was used.