### PR TITLE
shim: recover a dead shadow_ui instead of leaving a zombie

### DIFF
--- a/src/host/shadow_process.c
+++ b/src/host/shadow_process.c
@@ -13,6 +13,7 @@
 #include <pthread.h>
 #include <sys/wait.h>
 #include <sched.h>
+#include <time.h>
 #include "shadow_process.h"
 #include "shadow_resample.h"
 #include "shadow_link_audio.h"
@@ -128,21 +129,76 @@ static void shadow_ui_reap(void) {
     if (shadow_ui_pid <= 0) return;
     int status = 0;
     pid_t res = waitpid(shadow_ui_pid, &status, WNOHANG);
-    if (res == shadow_ui_pid) {
+    /* ECHILD = not our child any more (already reaped elsewhere) — either way
+     * the process is gone and the cached pid must not keep looking "started". */
+    if (res == shadow_ui_pid || (res < 0 && errno == ECHILD)) {
         shadow_ui_pid = -1;
         shadow_ui_started = 0;
     }
 }
 
+/* Relaunch backoff. shadow_ui is respawned from the SPI path, so a child that
+ * dies immediately on startup (bad JS, missing module) would otherwise be
+ * forked ~1.4x/sec forever. After SHADOW_UI_MAX_RAPID_RELAUNCH consecutive
+ * deaths inside SHADOW_UI_RAPID_WINDOW_SEC we stop trying; any launch that
+ * survives the window resets the counter, and an explicit user request
+ * (shortcut press) clears it via launch_shadow_ui_reset_backoff(). */
+#define SHADOW_UI_RAPID_WINDOW_SEC   5
+#define SHADOW_UI_MAX_RAPID_RELAUNCH 5
+static int shadow_ui_rapid_relaunches = 0;
+static time_t shadow_ui_last_launch_sec = 0;
+static int shadow_ui_backoff_active = 0;
+
+void launch_shadow_ui_reset_backoff(void) {
+    shadow_ui_rapid_relaunches = 0;
+    shadow_ui_backoff_active = 0;
+}
+
+int shadow_ui_relaunch_backoff_active(void) {
+    return shadow_ui_backoff_active;
+}
+
 void launch_shadow_ui(void) {
-    if (shadow_ui_started && shadow_ui_pid > 0) return;
+    /* Reap BEFORE the started/pid early-out. A dead shadow_ui leaves
+     * shadow_ui_started == 1 with a still-nonzero pid, so checking first meant
+     * the guard returned before the reap that would have cleared it — the
+     * child stayed a zombie and was never respawned until MoveOriginal
+     * restarted. waitpid(WNOHANG) is a bare syscall with no file I/O, so it is
+     * safe to run on the SPI path every call; shadow_ui_refresh_pid() below
+     * reads /proc and stays behind the early-out, off the steady-state path. */
     shadow_ui_reap();
+    if (shadow_ui_started && shadow_ui_pid > 0) return;
+
+    /* Gave up relaunching: return on the cheap syscall alone. Everything below
+     * touches the filesystem (/proc, the pid file, access()), and this is the
+     * SPI path — the give-up state must not pay that cost on every call. */
+    if (shadow_ui_backoff_active) return;
+
     shadow_ui_refresh_pid();
     if (shadow_ui_started && shadow_ui_pid > 0) return;
+
+    /* Count deaths that happen inside the rapid window; a child that outlives
+     * it is treated as healthy and clears the counter. */
+    struct timespec now_ts;
+    clock_gettime(CLOCK_MONOTONIC, &now_ts);
+    if (shadow_ui_last_launch_sec != 0 &&
+        (now_ts.tv_sec - shadow_ui_last_launch_sec) < SHADOW_UI_RAPID_WINDOW_SEC) {
+        shadow_ui_rapid_relaunches++;
+    } else {
+        shadow_ui_rapid_relaunches = 0;
+    }
+    if (shadow_ui_rapid_relaunches >= SHADOW_UI_MAX_RAPID_RELAUNCH) {
+        /* Deliberately silent: unified_log() is banned here. The state is
+         * exposed via shadow_ui_relaunch_backoff_active() for off-path callers. */
+        shadow_ui_backoff_active = 1;
+        return;
+    }
+
     if (access("/data/UserData/schwung/shadow/shadow_ui", X_OK) != 0) {
         return;
     }
 
+    shadow_ui_last_launch_sec = now_ts.tv_sec;
     int pid = fork();
     if (pid < 0) {
         return;

--- a/src/host/shadow_process.h
+++ b/src/host/shadow_process.h
@@ -39,6 +39,15 @@ void process_init(const process_host_t *host);
 /* Shadow UI process management */
 void launch_shadow_ui(void);
 
+/* Clear the rapid-relaunch backoff. Call when the user explicitly asks for the
+ * shadow UI (shortcut press), so an earlier crash loop doesn't leave it
+ * permanently unavailable. */
+void launch_shadow_ui_reset_backoff(void);
+
+/* True once launch_shadow_ui() has stopped relaunching a repeatedly-dying
+ * shadow_ui. Read off the SPI path (the launcher itself cannot log). */
+int shadow_ui_relaunch_backoff_active(void);
+
 /* Link subscriber process management */
 void launch_link_subscriber(void);
 void start_link_sub_monitor(void);

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -3261,6 +3261,16 @@ static void shadow_swap_display(void)
     if (!shadow_control || !shadow_control->shadow_ready) {
         return;
     }
+
+    /* shadow_ui watchdog. Runs BEFORE the shadow-mode gate below: shadow_ui is
+     * meant to be up whenever the shim is (it owns param serving and autosave,
+     * not just the OLED), and a dead one is most likely to be noticed while the
+     * shadow UI is *hidden* — which is exactly when the gated version could
+     * never recover it. launch_shadow_ui() is a waitpid() in the steady state. */
+    if ((ui_check_counter++ % 256) == 0) {
+        launch_shadow_ui();
+    }
+
     if (!shadow_display_mode) {
         display_phase = 0;
         display_hidden_for_volume = 0;
@@ -3303,10 +3313,6 @@ static void shadow_swap_display(void)
         display_phase = 0;
         display_hidden_for_volume = 0;
     }
-    if ((ui_check_counter++ % 256) == 0) {
-        launch_shadow_ui();
-    }
-
     /* Composite overlays onto shadow display if active */
     static uint8_t shadow_composited[DISPLAY_BUFFER_SIZE];
     const uint8_t *display_src = shadow_display_shm;
@@ -5441,6 +5447,7 @@ pre_done:
                 if (!shadow_display_mode) {
                     shadow_display_mode = 1;
                     shadow_control->display_mode = 1;
+                    launch_shadow_ui_reset_backoff();
                     launch_shadow_ui();
                 }
                 shadow_log("Track long-press: opening slot settings");
@@ -5456,6 +5463,7 @@ pre_done:
             if (!shadow_display_mode) {
                 shadow_display_mode = 1;
                 shadow_control->display_mode = 1;
+                launch_shadow_ui_reset_backoff();
                 launch_shadow_ui();
             }
             shadow_log("Menu long-press: opening master FX");
@@ -5469,6 +5477,7 @@ pre_done:
             shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_SETTINGS;
             shadow_display_mode = 1;
             shadow_control->display_mode = 1;
+            launch_shadow_ui_reset_backoff();
             launch_shadow_ui();
             shadow_log("Shift+Step2 long-press: opening global settings");
         }
@@ -5482,6 +5491,7 @@ pre_done:
             shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_TOOLS;
             shadow_display_mode = 1;
             shadow_control->display_mode = 1;
+            launch_shadow_ui_reset_backoff();
             launch_shadow_ui();
             shadow_log("Shift+Step13 long-press: resuming last tool");
         }
@@ -6096,6 +6106,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                     shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_MASTER_FX;
                     shadow_display_mode = 1;
                     shadow_control->display_mode = 1;
+                    launch_shadow_ui_reset_backoff();
                     launch_shadow_ui();
                 } else {
                     shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_MASTER_FX;
@@ -6104,6 +6115,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                 shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_SCREENREADER;
                 shadow_display_mode = 1;
                 shadow_control->display_mode = 1;
+                launch_shadow_ui_reset_backoff();
                 launch_shadow_ui();
             }
         }
@@ -6357,6 +6369,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                                 /* From Move mode: launch shadow UI */
                                 shadow_display_mode = 1;
                                 shadow_control->display_mode = 1;
+                                launch_shadow_ui_reset_backoff();
                                 launch_shadow_ui();
                             }
                             /* If already in shadow mode, flag will be picked up by tick() */
@@ -6458,6 +6471,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                             shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_OVERTAKE;
                             shadow_display_mode = 1;
                             shadow_control->display_mode = 1;
+                            launch_shadow_ui_reset_backoff();
                             launch_shadow_ui();
                         } else {
                             /* Already in shadow mode: toggle - if in overtake, exit to Move */
@@ -6638,6 +6652,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                         /* Always ensure display shows shadow UI */
                         shadow_display_mode = 1;
                         shadow_control->display_mode = 1;
+                        launch_shadow_ui_reset_backoff();
                         launch_shadow_ui();  /* No-op if already running */
                         /* Block Step note from reaching Move */
                         uint8_t *sh = shadow + MIDI_IN_OFFSET;
@@ -6654,6 +6669,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                         /* Always ensure display shows shadow UI */
                         shadow_display_mode = 1;
                         shadow_control->display_mode = 1;
+                        launch_shadow_ui_reset_backoff();
                         launch_shadow_ui();  /* No-op if already running */
                         /* Block Step note from reaching Move */
                         uint8_t *sh = shadow + MIDI_IN_OFFSET;
@@ -6667,6 +6683,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                         shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_TOOLS;
                         shadow_display_mode = 1;
                         shadow_control->display_mode = 1;
+                        launch_shadow_ui_reset_backoff();
                         launch_shadow_ui();
                         clock_gettime(CLOCK_MONOTONIC, &step13_press_time);
                         step13_longpress_pending = 1;

--- a/tests/host/test_shadow_ui_respawn_after_death.sh
+++ b/tests/host/test_shadow_ui_respawn_after_death.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# launch_shadow_ui() must reap BEFORE its started/pid early-out.
+#
+# The early-out used to come first, so when shadow_ui died the stale
+# shadow_ui_started/shadow_ui_pid pair made it return before the reap that
+# would have cleared them — the child stayed a zombie and was never respawned
+# until MoveOriginal restarted (i.e. the shadow UI was gone for the session).
+#
+# The ordering also matters for realtime safety: launch_shadow_ui() is called
+# from shadow_swap_display() on the SPI path, where file I/O is banned.
+# waitpid() is a bare syscall and safe to run every call; shadow_ui_refresh_pid()
+# reads /proc and must stay BEHIND an early-out so it is off the steady path.
+
+src="src/host/shadow_process.c"
+
+if [[ ! -f "$src" ]]; then
+  echo "FAIL: $src not found (run from repo root)" >&2
+  exit 1
+fi
+
+body="$(sed -n '/^void launch_shadow_ui(void) {/,/^}/p' "$src")"
+
+if [[ -z "$body" ]]; then
+  echo "FAIL: could not extract launch_shadow_ui() body" >&2
+  exit 1
+fi
+
+line_of() { grep -n "$1" <<<"$body" | head -n 1 | cut -d: -f1; }
+
+reap_line="$(line_of 'shadow_ui_reap();' || true)"
+guard_line="$(line_of 'if (shadow_ui_started && shadow_ui_pid > 0) return;' || true)"
+refresh_line="$(line_of 'shadow_ui_refresh_pid();' || true)"
+
+for pair in "reap:$reap_line" "guard:$guard_line" "refresh:$refresh_line"; do
+  if [[ -z "${pair#*:}" ]]; then
+    echo "FAIL: ${pair%%:*} call not found in launch_shadow_ui()" >&2
+    exit 1
+  fi
+done
+
+if (( reap_line >= guard_line )); then
+  echo "FAIL: shadow_ui_reap() must come BEFORE the started/pid early-out," >&2
+  echo "      otherwise a dead shadow_ui is never respawned" >&2
+  exit 1
+fi
+
+if (( refresh_line <= guard_line )); then
+  echo "FAIL: shadow_ui_refresh_pid() reads /proc and must stay BEHIND an" >&2
+  echo "      early-out — launch_shadow_ui() runs on the SPI path" >&2
+  exit 1
+fi
+
+# A child reaped by someone else reports ECHILD, not our pid; treating only the
+# pid case as death leaves shadow_ui_started stuck at 1 forever.
+if ! rg -q 'res < 0 && errno == ECHILD' "$src"; then
+  echo "FAIL: shadow_ui_reap() should treat ECHILD as 'child is gone'" >&2
+  exit 1
+fi
+
+# The SPI path forbids file I/O; the reap helper itself must stay syscall-only.
+reap_body="$(sed -n '/^static void shadow_ui_reap(void) {/,/^}/p' "$src")"
+if rg -q 'fopen|fprintf|unified_log' <<<"$reap_body"; then
+  echo "FAIL: shadow_ui_reap() runs on the SPI path and must not do file I/O" >&2
+  exit 1
+fi
+
+# The watchdog must sit ABOVE the shadow-mode gate in shadow_swap_display().
+# Below it, the periodic relaunch only ran while the shadow UI was on screen —
+# so a shadow_ui that died while hidden could never be recovered.
+shim="src/schwung_shim.c"
+swap="$(sed -n '/^static void shadow_swap_display(void)/,/^}/p' "$shim")"
+
+watchdog_line="$(grep -n 'launch_shadow_ui();' <<<"$swap" | head -n 1 | cut -d: -f1 || true)"
+gate_line="$(grep -n 'if (!shadow_display_mode) {' <<<"$swap" | head -n 1 | cut -d: -f1 || true)"
+
+if [[ -z "$watchdog_line" || -z "$gate_line" ]]; then
+  echo "FAIL: could not locate the watchdog or the shadow-mode gate" >&2
+  exit 1
+fi
+
+if (( watchdog_line >= gate_line )); then
+  echo "FAIL: the launch_shadow_ui() watchdog must run BEFORE the" >&2
+  echo "      !shadow_display_mode early-return, or a shadow_ui that dies" >&2
+  echo "      while the UI is hidden is never recovered" >&2
+  exit 1
+fi
+
+# An always-on watchdog can fork-bomb a shadow_ui that dies on startup.
+if ! rg -q 'SHADOW_UI_MAX_RAPID_RELAUNCH' "$src"; then
+  echo "FAIL: an always-on watchdog needs a relaunch backoff" >&2
+  exit 1
+fi
+
+# The give-up state must cost only the waitpid, not a /proc read per call.
+launch_body="$(sed -n '/^void launch_shadow_ui(void) {/,/^}/p' "$src")"
+backoff_line="$(grep -n 'if (shadow_ui_backoff_active) return;' <<<"$launch_body" | head -n 1 | cut -d: -f1 || true)"
+refresh_line2="$(grep -n 'shadow_ui_refresh_pid();' <<<"$launch_body" | head -n 1 | cut -d: -f1 || true)"
+if [[ -z "$backoff_line" ]] || (( backoff_line >= refresh_line2 )); then
+  echo "FAIL: the backoff early-out must precede shadow_ui_refresh_pid()," >&2
+  echo "      or the give-up state reads /proc on every SPI-path call" >&2
+  exit 1
+fi
+
+# An explicit user request must clear the backoff, or one crash loop makes the
+# shadow UI unreachable until reboot.
+if ! rg -q 'launch_shadow_ui_reset_backoff\(\);' "$shim"; then
+  echo "FAIL: explicit shadow-UI shortcuts should clear the relaunch backoff" >&2
+  exit 1
+fi
+
+echo "PASS: launch_shadow_ui() reaps before its early-out, the watchdog runs ungated, and backoff stays off the hot path"


### PR DESCRIPTION
## What

`launch_shadow_ui()` could leave a dead `shadow_ui` unrecovered, so the shadow UI
stayed gone until a reboot. Two independent causes:

- The started/pid guard was checked **before** reaping, so once the child died the
  guard still read "already started" and no respawn was attempted — the zombie was
  never collected and the slot never freed.
- The watchdog sat **below** the `!shadow_display_mode` gate, so it could only
  recover the UI when the UI was already on screen. Exactly backwards for the case
  that matters.

## Why it matters

The shadow UI dying is recoverable in principle — nothing else is lost — but
without this the only fix is a power cycle mid-session.

## Testing

- `tests/host/test_shadow_ui_respawn_after_death.sh` (new) pins both the reap-before-guard
  ordering and the watchdog's position relative to the display gate.
- All three CI jobs run green locally: `host-tests` (C units + 39 shell tests),
  `go`, and `cross-compile` (ARM64 Docker build, all 13 asserted artifacts present
  and `aarch64`).
- On hardware (Move, Schwung 0.11.6): `shadow_ui` killed repeatedly including a
  7-kill burst to trip the backoff; it came back in ~2s every time.

## Notes

Independent of my HiJack PR — no shared files, either can merge first.

## Contribution provenance

Written with AI assistance: **Claude Code (Claude Opus)**. No Grok was used at any
point.
