### PR TITLE
catalog: add 9W9 — TR-909 style drum machine

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1232,6 +1232,17 @@
       "default_branch": "main",
       "asset_name": "groovebank-module.tar.gz",
       "min_host_version": "0.11.5"
+    },
+    {
+      "id": "9w9",
+      "name": "9W9",
+      "description": "TR-909 style drum machine. Circuit-modelled kick (sub/tube/drift), snare, toms, rim and clap; sampled hats and cymbals. Per-voice and master drive/distortion, RD-9 style pad editor, remote web panel, Movy template.",
+      "author": "athousanddetails",
+      "component_type": "sound_generator",
+      "github_repo": "athousanddetails/schwung-9W9",
+      "default_branch": "main",
+      "asset_name": "9w9-module.tar.gz",
+      "min_host_version": "0.11.6"
     }
   ]
 }


### PR DESCRIPTION
Adds **9W9** to the catalog — a TR-909 style drum machine (sound_generator).

- Circuit-modelled kick / snare / toms / rim / clap; sampled hats & cymbals
- Per-voice + master drive/distortion (diode / clip / fold / crush)
- RD-9 style `ui_chain.js` editor: pads select+play, Shift+Pad silent select,
  Mute+Pad per-drum mutes, all controls 0–127 pots
- `web_ui.html` remote panel, `movy_config.json`, `help.json`, screen-reader
  announcements, self-contained `state` (User Presets work)
- Repo: https://github.com/athousanddetails/schwung-9W9 (GPL-3.0), release
  v0.6.0 with `9w9-module.tar.gz` + auto-updated `release.json`
- Started as a port of matthewcieplak/er-99 (GPL-3.0, credited; its engine
  remains selectable); kick architecture after hyperfocusdsp/niner (credited)
- Tested on Move hardware against host 0.11.6, including an on-device test
  that dlopens the packaged dsp.so exactly as the chain host does

Provenance: developed with AI assistance (Claude), human-directed, verified
on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
