### PR TITLE
Repair the Shift release swallowed during overtake init (#191)

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -3057,6 +3057,46 @@ function invokeModuleOnUnload(callbacks, moduleId) {
  * nothing on resume simply omits it.
  *
  * Wrapped in try/catch so a buggy module can't break the resume path. */
+/* Every gesture that starts or resumes an overtake module holds Shift
+ * (Shift+Vol+jog click to launch, Shift+Vol+Step13 / Shift+long-press to
+ * resume). The release lands during the blackout when the module is not yet
+ * receiving MIDI, so it is discarded and both the host and the module stay
+ * latched in shift-mode for the whole session — issue #191.
+ *
+ * It does not present as one bug. In timncox's module it showed up as a knob
+ * editing a base value instead of writing a parameter lock, a pad loading
+ * machine +21, and the slot pad opening the sample browser: three unrelated
+ * hardware reports, one cause.
+ *
+ * loadOvertakeModule already clears hostShiftHeld, but too early — the stale
+ * state arrives afterwards, once MIDI starts flowing. So repair it at the
+ * point the blackout actually ends: clear the host flag and synthesise the
+ * release the module never got.
+ *
+ * Width of the window is the module's own init(): ~300ms for a small module,
+ * measured at ~6s for a moderate one, which is why this reproduces reliably
+ * for some modules and never for others.
+ *
+ * Unconditional by design. A Shift-up delivered to a module that already
+ * thinks Shift is up is a no-op, whereas guessing from the shim's own
+ * shift_held is not safe here — shadow_ui tracks Shift locally precisely
+ * because the shim's tracking does not hold up in overtake mode. The cost of
+ * being wrong is that someone still physically holding Shift through init has
+ * to re-press it; the cost of not doing it is a latched session. */
+function repairSwallowedShiftRelease(reason) {
+    hostShiftHeld = false;
+    hostVolumeKnobTouched = false;
+    if (!overtakeModuleCallbacks || !overtakeModuleCallbacks.onMidiMessageInternal) return;
+    try {
+        runToolCallback(function() {
+            overtakeModuleCallbacks.onMidiMessageInternal([0xB0, 49, 0]);  /* CC 49 = Shift, released */
+        });
+        debugLog("repairSwallowedShiftRelease(" + reason + "): synthesised Shift-up");
+    } catch (e) {
+        debugLog("repairSwallowedShiftRelease(" + reason + ") threw: " + e);
+    }
+}
+
 function invokeModuleOnResume(callbacks, moduleId) {
     if (callbacks && typeof callbacks.onResume === "function") {
         try {
@@ -3355,28 +3395,9 @@ function resumeOvertakeModule(moduleId) {
     setView(VIEWS.OVERTAKE_MODULE);
     needsRedraw = true;
 
-    /* Clear held-modifier state, the way loadOvertakeModule does on a fresh
-     * load. The resume gesture is Shift+Vol+Step13 / Shift+long-press, so
-     * Shift is physically down at this instant and its release lands after
-     * we return — leaving the host latched in shift-mode. */
-    hostShiftHeld = false;
-    hostVolumeKnobTouched = false;
-
-    /* The module's OWN shift flag is stale for the same reason, and worse:
-     * init() is deliberately not re-run on resume, so nothing resets it. It
-     * was parked while the user released Shift from the previous session, so
-     * that release was never delivered. Synthesise one. Sent before
-     * onResume() so a module that tracks its own modifiers can still override
-     * in the hook. */
-    if (overtakeModuleCallbacks && overtakeModuleCallbacks.onMidiMessageInternal) {
-        try {
-            runToolCallback(function() {
-                overtakeModuleCallbacks.onMidiMessageInternal([0xB0, 49, 0]);  /* Shift up */
-            });
-        } catch (e) {
-            debugLog("resumeOvertakeModule: synthetic shift-off threw: " + e);
-        }
-    }
+    /* Sent before onResume() so a module that tracks its own modifiers can
+     * still override in the hook. */
+    repairSwallowedShiftRelease("resume");
 
     /* Fire the module's onResume() hook (init() is NOT re-run on resume).
      * Called after the full callback / LED-queue / shim restore above so
@@ -15312,6 +15333,7 @@ globalThis.tick = function() {
                             try {
                                 overtakeModuleCallbacks.init();
                                 debugLog("loadOvertakeModule: init() returned successfully");
+                                repairSwallowedShiftRelease("launch");
                             } catch (e) {
                                 debugLog("loadOvertakeModule: init() threw exception: " + e);
                                 /* Exit overtake on init error */

--- a/tests/shadow/test_parked_overtake_shim_isolation.mjs
+++ b/tests/shadow/test_parked_overtake_shim_isolation.mjs
@@ -135,6 +135,7 @@ vm.createContext(sandbox);
 
 // --- inject extracted bodies ------------------------------------------------
 for (const name of ['setupModuleParamShims', 'clearModuleParamShims',
+                    'repairSwallowedShiftRelease',
                     'suspendOvertakeMode', 'resumeOvertakeModule']) {
     vm.runInContext(extractFn(name), sandbox);
 }
@@ -311,6 +312,37 @@ console.log("Scenario 4: suspend hands native LEDs back atomically");
     check("shadow UI exits only after the handoff",
           handoffCalls.indexOf('mode:0') < handoffCalls.indexOf('exit'),
           `calls ${JSON.stringify(handoffCalls)}`);
+}
+
+// ---- Scenario 5: the launch path repairs the swallowed Shift release -------
+// Issue #191. Every gesture that opens an overtake module holds Shift, and the
+// release lands during init()'s blackout when MIDI is not forwarded, so both
+// the host flag and the module stay latched. loadOvertakeModule clears
+// hostShiftHeld too early to help; the repair has to run where the blackout
+// ends. Reproduces only on modules with a slow init() (~6s measured) which is
+// why a fast module cannot demonstrate the bug either way.
+console.log("Scenario 5: launch repairs the swallowed Shift release");
+{
+    vm.runInContext(`globalThis._launchMidi = [];`, sandbox);
+    sandbox.overtakeModuleCallbacks = {
+        init: () => {},
+        tick: () => {},
+        onMidiMessageInternal: vm.runInContext(
+            `globalThis._launchFn = function(m) { _launchMidi.push(m.slice()); }; globalThis._launchFn`, sandbox),
+    };
+
+    // User launched with Shift down; the release was swallowed during init().
+    sandbox.hostShiftHeld = true;
+    sandbox.hostVolumeKnobTouched = true;
+
+    vm.runInContext(`repairSwallowedShiftRelease("launch");`, sandbox);
+
+    check("host shift flag cleared after init()", sandbox.hostShiftHeld === false,
+          `hostShiftHeld=${sandbox.hostShiftHeld}`);
+    const seen = sandbox._launchMidi || [];
+    const up = seen.find(m => m[0] === 0xB0 && m[1] === 49 && m[2] === 0);
+    check("module received the Shift-up it never got from hardware", !!up,
+          `midi seen: ${JSON.stringify(seen)}`);
 }
 
 // --- exit -------------------------------------------------------------------


### PR DESCRIPTION
Fixes #191.

Every gesture that opens an overtake module holds Shift — `Shift+Vol+jog click`
to launch, `Shift+Vol+Step13` / `Shift+long-press` to resume. The release lands
during the blackout where MIDI is not yet forwarded to the module, so it is
discarded and both the host flag and the module's own tracking stay latched in
shift-mode for the rest of the session.

`loadOvertakeModule` already does `hostShiftHeld = false`, but as @timncox
identified that fires **too early** — the stale state arrives afterwards, once
MIDI starts flowing post-`init()`. The repair has to run where the blackout
actually ends.

`repairSwallowedShiftRelease()` clears the host flag and synthesises the CC 49
release the module never received, called right after `init()` returns on the
launch path. The resume path had the same hole, fixed separately in #204, and
now shares the helper.

**Unconditional by design.** A Shift-up delivered to a module that already
thinks Shift is up is a no-op. Gating on the shim's own `shift_held` is not
safe here — `shadow_ui` tracks Shift locally *precisely because* the shim's
tracking does not hold up in overtake mode, and the issue reports the two
disagreeing (`994 hostShift=true` in JS against `shift_held=0` from the shim).

## On reproduction

The window is the module's own `init()`. Measured on device:

```
09:13:15.344  loading DSP from .../performance-fx/dsp.so
09:13:15.657  init delay complete, calling init()      ← 313ms
```

against roughly **6 seconds** reported for a module of moderate size. At 313 ms
you would have to release Shift within a third of a second of the jog click to
lose it; at 6 s you lose it nearly every time. So a fast module cannot
demonstrate the bug in either direction, and a negative result on one proves
nothing — which is why this is fixed by construction rather than closed on
observation.

For the record, an earlier hypothesis that #190's inject rerouting had already
fixed this is **wrong**: the entry shift-off inject fires only when the shim's
own `shadow_shift_held` is set, and it fired 0 times across 25026 overtake MIDI
messages.

## Testing

Scenario 5 added to `tests/shadow/test_parked_overtake_shim_isolation.mjs`,
covering the launch path alongside the existing resume scenario. Verified RED
without the change. Clean ARM64 build.