### PR TITLE
Overtake: shift-off reaches Move, fresh metadata on relaunch, opt-in LED handoff

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -541,6 +541,52 @@ void shadow_inject_ui_midi_out(void)
     }
 }
 
+/* ---- Shim-originated packets bound for Move's firmware --------------------
+ *
+ * Separate from the test-bus inject ring on purpose. Since the ring became
+ * overtake-owned (a packet published while overtake_mode != 0 is drained by
+ * schwung_shim.c onto the module, and shadow_drain_midi_inject returns early),
+ * nothing pushed there during overtake can reach Move's firmware any more.
+ *
+ * The shim needs exactly that, though: on overtake ENTRY it has to tell Move
+ * "Shift is up", or Move's firmware stays in shift-mode for the rest of the
+ * session and the volume knob is stuck in fine mode. That packet is for the
+ * firmware only — the module must never see it — so it does not belong in the
+ * ring at all.
+ *
+ * One slot is enough: the only producer is the overtake transition, and a
+ * second entry cannot happen before the first is delivered. */
+static volatile uint8_t shim_to_move_pkt[4];
+static volatile int     shim_to_move_pending = 0;
+
+void shadow_queue_packet_to_move(const uint8_t pkt[4])
+{
+    shim_to_move_pkt[0] = pkt[0];
+    shim_to_move_pkt[1] = pkt[1];
+    shim_to_move_pkt[2] = pkt[2];
+    shim_to_move_pkt[3] = pkt[3];
+    __sync_synchronize();
+    shim_to_move_pending = 1;
+}
+
+/* Place the pending shim packet into MIDI_IN. Only when MIDI_IN is completely
+ * idle — writing alongside hardware events races Move's firmware MIDI read
+ * path and causes SIGABRT, and unlike the ring drain we have no "leave it and
+ * retry" position to protect, so we take the strictest form of that guard and
+ * simply wait for a quiet frame. */
+static void shadow_deliver_pending_to_move(uint8_t *midi_in, int stride, int max_bytes)
+{
+    if (!shim_to_move_pending || !midi_in) return;
+    for (int j = 0; j < max_bytes; j += stride)
+        if (midi_in[j] != 0) return;            /* busy — try again next frame */
+
+    memcpy(&midi_in[0], (const void *)shim_to_move_pkt, 4);
+    memset(&midi_in[4], 0, 4);                  /* zero the timestamp */
+    shim_to_move_pending = 0;
+
+    if (host_log) host_log("MIDI inject: delivered shim packet to Move MIDI_IN");
+}
+
 /* Drain MIDI inject buffer into Move's MIDI_IN (post-ioctl).
  * Copies USB-MIDI packets from SHM into empty slots in shadow_mailbox+MIDI_IN_OFFSET,
  * making Move process them as if they came from physical hardware.
@@ -555,6 +601,12 @@ void shadow_drain_midi_inject(void)
     const int MIDI_IN_EVT_STRIDE = 8;
     const int MIDI_IN_MAX_EVTS   = 31;              /* SCHWUNG_MIDI_IN_MAX */
     const int MIDI_IN_MAX_BYTES  = MIDI_IN_EVT_STRIDE * MIDI_IN_MAX_EVTS;
+
+    /* Shim-originated packets first, and independent of the ring: they must
+     * still reach Move while an overtake module is up, which is precisely when
+     * the ring below belongs to someone else. */
+    shadow_deliver_pending_to_move(host_shadow_mailbox + MIDI_IN_OFFSET,
+                                   MIDI_IN_EVT_STRIDE, MIDI_IN_MAX_BYTES);
 
     if (!inject_shm) return;
 

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -152,6 +152,13 @@ void shadow_drain_ui_midi_dsp(void);
 /* Drain MIDI inject buffer into Move's MIDI_IN (post-ioctl). */
 void shadow_drain_midi_inject(void);
 
+/* Queue a 4-byte USB-MIDI packet for Move's firmware only, bypassing the
+ * test-bus inject ring (which is owned by the overtake publisher whenever a
+ * module is up). Single slot; the only producer is the overtake transition.
+ * Delivered by shadow_drain_midi_inject on the next frame where MIDI_IN is
+ * idle, and never routed to an overtake module. */
+void shadow_queue_packet_to_move(const uint8_t pkt[4]);
+
 /* Queue a 4-byte USB-MIDI packet for MIDI_IN injection (Pre-mode MIDI FX).
  * The cable nibble in msg[0] is preserved by the drain. Callers choose:
  *   cable 0 → internal hardware (Move treats as pad/button input)

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -6339,12 +6339,42 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
          * firmware doesn't stay in shift-mode (which slows the volume knob, etc.).
          * Cable-0 input is filtered during overtake, so the eventual physical release
          * never reaches Move otherwise. */
-        if (prev_overtake_mode == 0 && overtake_mode != 0 && shadow_midi_inject_shm &&
-            shadow_shift_held) {
+        if (prev_overtake_mode == 0 && overtake_mode != 0 && shadow_midi_inject_shm) {
+            /* Deliberately NOT gated on shadow_shift_held. That gate made this
+             * never fire in the case it was written for.
+             *
+             * Cable-0 input is filtered while overtake_mode is set, so the shim
+             * never observes a Shift press made *during* overtake — which is
+             * exactly when the resume gesture happens. Sequence for
+             * Shift+long-press-Step13 while a module is open:
+             *
+             *   1. module open (mode 2), cable-0 filtered -> the Shift press is
+             *      never seen here, shadow_shift_held stays 0
+             *   2. the shortcut exits the module, mode -> 0, filtering stops
+             *   3. Shift is still physically down, so Move's firmware sees it
+             *      now and enters shift-mode
+             *   4. the relaunch takes mode -> 2, filtering resumes
+             *   5. the physical release never reaches Move, which stays in
+             *      shift-mode: the volume knob is stuck in fine mode until the
+             *      user presses and releases Shift again outside overtake
+             *
+             * Measured on device: 0 injects across a whole session of resumes,
+             * with the volume knob stuck fine-mode every time.
+             *
+             * Sending Shift-off when Move is not in shift-mode is a no-op, so
+             * firing unconditionally costs one 4-byte packet per overtake entry
+             * and removes the dependency on shim-side Shift tracking being
+             * correct in the one situation where it cannot be. */
             const uint8_t shift_off[4] = {0x0B, 0xB0, CC_SHIFT, 0};
-            if (shadow_midi_inject_push(shadow_midi_inject_shm, shift_off) == 0) {
-                shadow_log("Overtake entry with shift held: injected shift-off");
-            }
+            /* Straight to Move, NOT via the inject ring. The ring is drained by
+             * the overtake publisher while a module is up, so a packet pushed
+             * there at this transition reaches the module and never Move —
+             * observed on device: the inject logged as sent on every resume and
+             * the volume knob stayed in fine mode regardless. */
+            shadow_queue_packet_to_move(shift_off);
+            shadow_log(shadow_shift_held
+                       ? "Overtake entry: queued shift-off to Move (shim saw shift held)"
+                       : "Overtake entry: queued shift-off to Move (shim did not see the press)");
         }
         /* Clear JACK display override on overtake exit (always — Move needs display back) */
         if (prev_overtake_mode != 0 && overtake_mode == 0 && g_jack_shm) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -574,7 +574,8 @@ let overtakeModuleLoaded = false; // True if an overtake module is running
 let overtakeModulePath = "";      // Path to loaded overtake module
 let overtakeModuleId = "";         // ID of loaded overtake module (for per-module exit hooks)
 let previousView = VIEWS.SLOTS;   // View to return to after overtake
-let overtakeModuleCallbacks = null; // {init, tick, onMidiMessageInternal} for loaded module
+let overtakeModuleCallbacks = null;
+let overtakeModuleCaps = null;      // capabilities of the loaded overtake module
 let overtakeSuspendKeepsJs = false; // Current module opted in to JS-alive suspend
 let overtakeSuspendSelfManaged = false; // Module owns Back; suspends via host_suspend_overtake()
 let overtakePassthroughCCs = [];    // CCs declared in capabilities.button_passthrough — shim lets these
@@ -3203,6 +3204,7 @@ function exitOvertakeMode() {
     overtakeModulePath = "";
     overtakeModuleId = "";
     overtakeModuleCallbacks = null;
+    overtakeModuleCaps = null;
     overtakeSuspendKeepsJs = false;
     overtakeSuspendSelfManaged = false;
     overtakePassthroughCCs = [];
@@ -3228,6 +3230,8 @@ function exitOvertakeMode() {
 /* Suspend overtake mode — leave background processes running */
 function suspendOvertakeMode() {
     corunTeardown();
+    /* Capabilities of the module being parked, for the LED-handoff decision. */
+    const parkedCaps = (overtakeModuleCallbacks && overtakeModuleCaps) ? overtakeModuleCaps : null;
     if (overtakeSuspendKeepsJs && overtakeModuleCallbacks && overtakeModuleId) {
         debugLog("suspendOvertakeMode: suspend_keeps_js — parking " + overtakeModuleId + " in background");
 
@@ -3267,6 +3271,7 @@ function suspendOvertakeMode() {
             ledNotes: ledNotesSnapshot,
             ledCCs: ledCCsSnapshot,
             dspPath: currentSlot0DspPath,
+            caps: overtakeModuleCaps,
             selfManaged: overtakeSuspendSelfManaged,
             shimGet: globalThis.host_module_get_param,
             shimSet: globalThis.host_module_set_param,
@@ -3288,9 +3293,20 @@ function suspendOvertakeMode() {
         /* Ask the audio-side transition to leave Move's fresh native LED output
          * authoritative. Mono's entry snapshot can be incomplete for dynamic
          * scale colors and the Shift row, so replaying it here leaves the grid
-         * dark or stale. The C-side consumes skip_led_clear after mode reaches 0. */
+         * dark or stale. The C-side consumes skip_led_clear after mode reaches 0.
+         *
+         * Opt-in per module. This used to fire for EVERY suspend_keeps_js
+         * module, which regressed the ones it was not written for: "let Move
+         * repaint" only clears the module's LEDs if Move actually has a reason
+         * to repaint those surfaces. Performance FX suspends with 32 lit pads
+         * that Move never touches, so its colors just stayed on the hardware.
+         * Without the flag we fall back to the ordinary snapshot restore, which
+         * puts Move's pre-overtake LEDs back and turns unknowns off — correct
+         * for anything that does not own a dynamic native layout. */
+        const wantsNativeRepaint = !!(parkedCaps && parkedCaps.native_led_repaint_on_suspend);
         if (typeof shadow_set_overtake_mode === "function") {
-            if (typeof shadow_set_skip_led_clear === "function") {
+            if (wantsNativeRepaint && typeof shadow_set_skip_led_clear === "function") {
+                debugLog("suspendOvertakeMode: module wants native LED repaint");
                 shadow_set_skip_led_clear(1);
             }
             shadow_set_overtake_mode(0);
@@ -3354,6 +3370,7 @@ function resumeOvertakeModule(moduleId) {
 
     /* Restore active-module state from the parked entry. */
     overtakeModuleCallbacks = parked.callbacks;
+    overtakeModuleCaps = parked.caps || overtakeModuleCaps;
     overtakeModulePath = parked.path;
     overtakeModuleId = parked.id;
     overtakeModuleLoaded = true;
@@ -3628,6 +3645,8 @@ function loadOvertakeModule(moduleInfo, skipOvertake) {
          * final Move+ME mix rather than the ME bus alone, so a whole-mix effect
          * hears Move's own tracks without Link Audio routing. Cleared on exit
          * in completeOvertakeExit(). */
+        overtakeModuleCaps = moduleInfo.capabilities || null;
+
         if (typeof shadow_set_overtake_fx_end_of_chain === "function") {
             const eoc = !!(moduleInfo.capabilities && moduleInfo.capabilities.end_of_chain);
             shadow_set_overtake_fx_end_of_chain(eoc ? 1 : 0);
@@ -13781,7 +13800,25 @@ function tryResumeSuspendedTool() {
             startInteractiveTool(t.module, t.filePath);
             return true;
         }
-        return loadOvertakeModule(t.module, t.skipOvertake);
+        /* Re-scan rather than trusting the descriptor captured at the original
+         * load. It is a snapshot of module.json from whenever the module was
+         * first opened this session, so a module updated on disk since — new
+         * capabilities, a Module Store update — would keep relaunching with its
+         * old metadata until a full menu visit refreshed it. Observed with a
+         * newly added suspend_keeps_js: the file on disk had it, every relaunch
+         * ignored it. Fall back to the cached descriptor if the scan cannot
+         * find the id (module uninstalled mid-session). */
+        let mod = t.module;
+        try {
+            const fresh = (scanForOvertakeModules() || []).find(o => o.id === mod.id);
+            if (fresh) {
+                mod = fresh;
+                lastLaunchedTool.module = fresh;
+            }
+        } catch (e) {
+            debugLog("tryResumeSuspendedTool: re-scan failed, using cached descriptor: " + e);
+        }
+        return loadOvertakeModule(mod, t.skipOvertake);
     }
 
     debugLog("tryResumeSuspendedTool: nothing suspended or previously launched");


### PR DESCRIPTION
Three overtake fixes found while making Performance FX suspendable. Two are
regressions from PRs merged earlier today.

## Shift left Move's volume knob in fine mode

Resuming a module with `Shift+long-press-Step13` left Move's **firmware** in
shift-mode for the rest of the session — the volume knob stuck in fine mode,
clearable only by pressing and releasing Shift outside overtake.

Distinct from #191/#205, which fixed the *module's* and the *shadow UI's* view
of Shift. Move's firmware needs an actual MIDI packet, and the shim has always
injected one at overtake entry. Two things stopped it working:

1. It was gated on `shadow_shift_held`, which is structurally 0 here. Cable-0
   input is filtered while `overtake_mode` is set, so a Shift press made
   *during* overtake is never observed — and that is exactly the resume gesture.
   Measured: **0 injects across a whole session of resumes.**

2. With the gate removed it fired and the knob was *still* stuck, because the
   packet no longer reached Move at all. Since #190 the test-bus ring is
   overtake-owned — `shadow_drain_midi_inject` returns early while
   `overtake_mode != 0`, and the shim drains the ring onto the module instead —
   so the packet went to the module. This one is for the firmware only.

Adds a dedicated single-slot shim→Move channel delivered ahead of the overtake
early-return. It writes only when MIDI_IN is completely idle, because injecting
alongside hardware events races Move's read path and causes SIGABRT; unlike the
ring drain there is no queue position to protect, so waiting a frame is free.

## Relaunch reused stale module metadata

The Tools-shortcut relaunch reused the descriptor captured when the module was
first opened this session, so anything changed in `module.json` since — new
capabilities, **a Module Store update** — was invisible until a full menu visit.
Found because a newly added `suspend_keeps_js` was ignored on every relaunch.
Now re-scans and refreshes the cached descriptor.

## Suspend LED handoff is opt-in

#189 asks the audio-side transition to leave Move's native repaint
authoritative. Right for Mono, which owns a dynamic native layout — but it was
applied to **every** `suspend_keeps_js` module, and "let Move repaint" only
clears a module's LEDs if Move actually repaints those surfaces. Performance FX
parks with 32 lit pads Move never touches, so they stayed on the hardware.

Now gated on a `native_led_repaint_on_suspend` capability. Modules that do not
declare it get the ordinary snapshot restore back.

**Mono needs the flag** — PR opened: timncox/schwung-mono#13. No other module in
the catalog declares it, so nothing else changes.

## Testing

All three verified on hardware across repeated suspend/resume cycles: Move's
LEDs return on suspend, the module's return on resume, the volume knob behaves,
and the relaunch shortcut picks up module.json changes.