### PR TITLE
test-bus: wait on overtake DSP readiness, not just overtake_mode

### DIFF
--- a/tools/pytest-schwung/README.md
+++ b/tools/pytest-schwung/README.md
@@ -289,3 +289,33 @@ it out and the next test sees a stale socket. Use:
 ```
 ssh -o ServerAliveInterval=30 -L 47777:localhost:47777 ableton@move.local -N
 ```
+
+### Opening a module: `overtake_mode == 2` does not mean it can play
+
+The overtake DSP load runs on the shim worker, not the SPI thread
+(`dlopen()` + `create_instance()` was stalling the audio callback
+~11.5ms on every module open). So the mode flips when the load is
+**requested**, and the instance appears up to ~200ms later. A test that
+does `set_open_tool(...)` → poll for `overtake_mode == 2` → press a pad
+will intermittently lose that first press: the shim drops injected MIDI
+against its `overtake_dsp_gen && overtake_dsp_gen_inst` guards while the
+instance is missing.
+
+Polling the `overtake_dsp:__ready` param instead is not sufficient on
+its own either. It answers `"1"` whenever *nothing* is loading, which
+includes the window before the load starts — `loadOvertakeModule` sets
+the overtake mode several statements before it requests the DSP load, so
+a bare `__ready` poll can pass against the previous module's state.
+
+Use `wait_for_overtake_dsp()`, which gates on both in the right order:
+
+```py
+bus.set_open_tool("overwork")
+bus.wait_for_overtake_dsp()   # mode == 2, then __ready != "0"
+bus.press_step(16)            # now guaranteed to reach the module
+```
+
+Modules with no `dsp` in their manifest never request a load, so
+`__ready` reads `"1"` throughout and the helper returns as soon as the
+mode flips. Hosts predating the param error on the GET, which is treated
+as ready — matching shadow_ui's own fallback.

--- a/tools/pytest-schwung/src/schwung_bus/client.py
+++ b/tools/pytest-schwung/src/schwung_bus/client.py
@@ -505,10 +505,17 @@ class SchwungBus:
 
         Returns as soon as the daemon has written the file and set
         the flag. The actual module load completes asynchronously
-        (~500 ms-2 s depending on module size). Caller should poll
-        ``state().overtake_mode == 2`` to wait for the load — use
-        the ``ion_loaded`` / module-loaded fixtures rather than
-        calling this directly when you can.
+        (~500 ms-2 s depending on module size), so this must be
+        followed by :meth:`wait_for_overtake_dsp` before the module
+        is driven.
+
+        Do NOT gate on ``state().overtake_mode == 2`` alone. The DSP
+        load now runs on the shim worker, so the mode flips when the
+        load is *requested* and the instance appears up to ~200ms
+        later; input sent in that window is dropped by the shim's
+        instance guards. :meth:`wait_for_overtake_dsp` waits on the
+        mode and the ``overtake_dsp:__ready`` param together, which
+        is the combination that actually means "playable".
 
         ``module_id`` must match ``[a-zA-Z0-9_-]+``, max 64 chars
         — daemon enforces this and rejects anything else.
@@ -732,6 +739,94 @@ class SchwungBus:
         raise SchwungBusError(
             f"wait_for_shim_ready: shim never recovered after freeze at "
             f"counter={frozen_at_value} within {timeout}s"
+        )
+
+    def wait_for_overtake_dsp(
+        self,
+        timeout: float = 10.0,
+        poll_interval: float = 0.1,
+    ) -> None:
+        """Wait until a module opened by :meth:`set_open_tool` can accept input.
+
+        Two gates, in this order:
+
+        1. ``state().overtake_mode == BusState.OVERTAKE_MODULE`` — the
+           host has accepted the load request.
+        2. ``overtake_dsp:__ready`` reads something other than ``"0"``
+           — the DSP instance actually exists.
+
+        Both are required, and the order matters.
+
+        The mode alone is not enough. The DSP load runs on the shim
+        worker rather than the SPI thread (``dlopen()`` +
+        ``create_instance()`` was stalling the audio callback ~11.5ms
+        on every module open), so **overtake_mode == 2 no longer
+        implies a live instance** — the mode flips when the load is
+        *requested*, and the instance appears up to ~200ms later. A
+        test that presses a pad on the mode alone intermittently loses
+        its first press, because the shim drops MIDI against its
+        ``overtake_dsp_gen && overtake_dsp_gen_inst`` guards.
+
+        ``__ready`` alone is not enough either. The shim answers
+        ``"1"`` whenever nothing is loading, which includes the window
+        *before* the load starts: ``loadOvertakeModule`` sets the
+        overtake mode several statements before it requests the DSP
+        load, so a bare ``__ready`` poll can pass against the previous
+        module's state. Gating on the mode first closes that window —
+        the two statements sit in one synchronous shadow_ui tick, well
+        under the ~23ms an SHM param round-trip costs.
+
+        Modules with no ``dsp`` in their manifest never request a load,
+        so ``__ready`` reads ``"1"`` throughout and this returns as
+        soon as the mode flips.
+
+        Hosts predating the ``__ready`` param raise on the GET; that is
+        treated as ready, mirroring shadow_ui's own ``catch`` fallback,
+        so this helper stays safe against older device firmware.
+
+        Raises :class:`SchwungBusError` if either gate misses
+        ``timeout``.
+        """
+        deadline = time.monotonic() + timeout
+
+        # Gate 1: the host has accepted the load request.
+        mode: Optional[int] = None
+        reached_module = False
+        while time.monotonic() < deadline:
+            try:
+                st = self.state()
+                mode = st.overtake_mode
+                if mode == BusState.OVERTAKE_MODULE:
+                    reached_module = True
+                    break
+            except SchwungBusError:
+                # shadow_ui can be briefly unresponsive mid-load.
+                pass
+            time.sleep(poll_interval)
+        if not reached_module:
+            raise SchwungBusError(
+                f"wait_for_overtake_dsp: overtake_mode never reached "
+                f"{BusState.OVERTAKE_MODULE} within {timeout}s "
+                f"(last mode={mode}) — did set_open_tool() name a real "
+                f"module id?"
+            )
+
+        # Gate 2: the DSP instance exists.
+        ready: Optional[str] = None
+        while time.monotonic() < deadline:
+            try:
+                ready = self.get_param("__ready")
+            except SchwungBusError:
+                # Unknown param => host predates __ready. Nothing to
+                # wait for; the load was synchronous on those builds.
+                return
+            if ready != "0":
+                return
+            time.sleep(poll_interval)
+        raise SchwungBusError(
+            f"wait_for_overtake_dsp: DSP still loading after {timeout}s "
+            f"(overtake_dsp:__ready={ready!r}) — the module's dsp.so may "
+            f"have failed to load; check the shim log"
         )
 
     # ----- button helpers ---------------------------------------------------

--- a/tools/pytest-schwung/tests/test_overtake_dsp_ready.py
+++ b/tools/pytest-schwung/tests/test_overtake_dsp_ready.py
@@ -1,0 +1,124 @@
+"""Unit tests for SchwungBus.wait_for_overtake_dsp().
+
+These tests don't need a running daemon — SchwungBus connects lazily,
+so state() and get_param() are stubbed directly. Run with
+`pytest tools/pytest-schwung/tests` on the dev machine.
+
+The behaviour under test exists because the overtake DSP load moved off
+the SPI thread: overtake_mode flips when the load is *requested*, and
+the instance appears up to ~200ms later. Gating on either signal alone
+is wrong in a different way, so the ordering is the thing worth pinning.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from schwung_bus import SchwungBus, SchwungBusError, BusState
+
+
+def make_bus(modes, readys):
+    """A bus whose state()/get_param() replay the given sequences.
+
+    The last element of each sequence repeats once exhausted, so a test
+    only has to spell out the transitions it cares about.
+    """
+    bus = SchwungBus(host="127.0.0.1", port=1)  # never connected
+    calls = {"state": 0, "ready": 0, "order": []}
+
+    def fake_state():
+        i = min(calls["state"], len(modes) - 1)
+        calls["state"] += 1
+        calls["order"].append("state")
+        mode = modes[i]
+        if isinstance(mode, Exception):
+            raise mode
+        return BusState(
+            move_ui_mode=0, overtake_mode=mode, shift_held=0,
+            selected_slot=0, ui_slot=0, shim_counter=0,
+            transport_playing=0, speaker_active=0,
+            line_in_connected=0, display_mode=0,
+        )
+
+    def fake_get_param(key, overtake=True):
+        assert key == "__ready", f"unexpected param GET: {key!r}"
+        assert overtake is True, "must route through the overtake_dsp: prefix"
+        i = min(calls["ready"], len(readys) - 1)
+        calls["ready"] += 1
+        calls["order"].append("ready")
+        val = readys[i]
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    bus.state = fake_state           # type: ignore[method-assign]
+    bus.get_param = fake_get_param   # type: ignore[method-assign]
+    bus._calls = calls               # type: ignore[attr-defined]
+    return bus
+
+
+def test_returns_once_mode_flips_and_dsp_reports_ready():
+    bus = make_bus(modes=[0, 0, 2], readys=["0", "0", "1"])
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
+    assert bus._calls["state"] == 3
+    assert bus._calls["ready"] == 3
+
+
+def test_stale_ready_before_mode_flip_does_not_return_early():
+    """The regression this helper exists for.
+
+    __ready answers "1" whenever *nothing* is loading, which includes the
+    window before the load starts. A bare __ready poll would pass instantly
+    against the previous module's state. Gating on the mode first must stop
+    that: no param GET may happen until overtake_mode == 2.
+    """
+    bus = make_bus(modes=[0, 0, 0, 2], readys=["1"])
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
+
+    order = bus._calls["order"]
+    first_ready = order.index("ready")
+    # Every state() poll that returned a non-module mode must precede the
+    # first param GET — i.e. we never consulted __ready while mode was 0.
+    assert order[:first_ready] == ["state"] * 4, order
+    assert bus._calls["ready"] == 1
+
+
+def test_module_without_dsp_returns_as_soon_as_mode_flips():
+    """No dsp.so => no load requested => __ready reads "1" throughout."""
+    bus = make_bus(modes=[2], readys=["1"])
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
+    assert bus._calls["ready"] == 1
+
+
+def test_host_without_ready_param_is_treated_as_ready():
+    """Older firmware errors on the unknown key; mirror shadow_ui's catch."""
+    bus = make_bus(modes=[2], readys=[SchwungBusError("param GET error 14")])
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
+
+
+def test_transient_state_errors_are_tolerated():
+    """shadow_ui can be briefly unresponsive mid-load."""
+    bus = make_bus(
+        modes=[SchwungBusError("param SHM busy"), 2],
+        readys=["1"],
+    )
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
+
+
+def test_raises_when_mode_never_reaches_module():
+    bus = make_bus(modes=[0], readys=["1"])
+    with pytest.raises(SchwungBusError, match="overtake_mode never reached"):
+        bus.wait_for_overtake_dsp(timeout=0.2, poll_interval=0.05)
+    # Gate 1 never passed, so __ready must never have been consulted.
+    assert bus._calls["ready"] == 0
+
+
+def test_raises_when_dsp_never_finishes_loading():
+    bus = make_bus(modes=[2], readys=["0"])
+    with pytest.raises(SchwungBusError, match="DSP still loading"):
+        bus.wait_for_overtake_dsp(timeout=0.2, poll_interval=0.05)
+
+
+def test_busstate_module_constant_is_two():
+    """The wire value the shim reports for module mode."""
+    assert BusState.OVERTAKE_MODULE == 2


### PR DESCRIPTION
Follows up on your note in #190 — thanks for flagging it, and for moving the load off the SPI thread in the first place. An 11.5ms stall in the audio callback on every module open is well worth this.

You suggested `pytest-schwung` poll `overtake_dsp:__ready` after `set_open_tool` instead of trusting the mode. That's what this does, with one addition: it waits on **both** signals, in order.

## Why both

Polling `__ready` on its own isn't sufficient. The shim answers `"1"` whenever nothing is loading — which includes the window *before* the load starts:

```c
shadow_param->value[0] = overtake_dsp_loading ? '0' : '1';
```

`loadOvertakeModule` sets the overtake mode at `shadow_ui.js:3635` and doesn't request the DSP load until `:3685`. In between, `overtake_dsp_loading` is still `0`, so a bare `__ready` poll reads `"1"` and passes against the *previous* module's state — the same lost-first-press failure, just arrived at differently.

Gating on the mode first closes that window. The two statements sit in one synchronous shadow_ui tick, which is comfortably shorter than the ~23ms an SHM param round-trip costs, so once the harness observes `overtake_mode == 2` the load has been requested and `__ready` is meaningful.

So the contract is: **mode says the load was requested, `__ready` says the instance exists.** Neither alone means "playable".

## What's here

`SchwungBus.wait_for_overtake_dsp()` — waits for `overtake_mode == 2`, then polls `overtake_dsp:__ready` until it reads other than `"0"`.

```py
bus.set_open_tool("overwork")
bus.wait_for_overtake_dsp()
bus.press_step(16)
```

Two edge cases handled:

- **Modules with no `dsp`** never request a load, so `__ready` reads `"1"` throughout and it returns as soon as the mode flips — no spurious wait.
- **Hosts predating `__ready`** error on the unknown key. Treated as ready, mirroring shadow_ui's own `catch (e) { dspReady = true; }`, so the harness still runs against older device firmware.

Also fixes the `set_open_tool` docstring, which told callers to poll `overtake_mode == 2` — now the wrong advice — and pointed at an `ion_loaded` fixture that doesn't exist anywhere in the repo.

## Tests

Eight unit tests, no hardware needed — `SchwungBus` connects lazily, so `state()` / `get_param()` are stubbed. They pin the ordering rather than just the happy path; the notable one is `test_stale_ready_before_mode_flip_does_not_return_early`, which asserts no param GET happens before the mode flips.

Verified they have teeth by mutation: bypassing the mode gate fails 3 of the 8. Full suite is 32 passed.

No changes to shim or shadow_ui — this is harness-side only.
