### PR TITLE
Trace the param write path, and find where the UI tick actually goes

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -58,9 +58,50 @@ collector or import directly into Tempo/Jaeger.
 - `js.tick` — root around the JS `tick()` call.
 - `param.get` — child around the synchronous `shadow_get_param` round-trip (the
   JS side busy-waits for the shim to service it once per SPI frame).
+- `param.set` — the same for `shadow_set_param`. Only fire-and-forget under
+  overtake (`overtake_mode >= 2`); everywhere else it is a blocking round-trip
+  like the read, despite what some JS comments say.
+- `param.set.idle` — child of `param.set` covering only the wait for the single
+  SHM request slot to free. Split out so contention (someone else's request in
+  flight) is distinguishable from frame quantisation (waiting for the shim to
+  service ours); they call for different fixes.
 
 JS modules (overtake/chain, e.g. ion) add their own spans under `js.tick` — see
 [Adding spans](#adding-spans).
+
+### What this measured (2026-08-19, on device)
+
+The first thing these spans were pointed at, recorded here because it is the
+kind of number that otherwise ends up in a comment and rots:
+
+| span | count | p50 | share |
+| --- | --- | --- | --- |
+| `js.tick` | 767 | 19.95 ms | — |
+| `param.get` (JS side) | 5939 | 2.55 ms | 91% of tick time |
+| `param.set` (JS side) | 787 | 1.06 ms | 7% of tick time |
+| `param.set.idle` | 787 | 426 ns | ~0 |
+| `param.serve` (shim side) | — | 9.8 µs | 0.3% of a round-trip |
+
+**A parameter round-trip costs ~2.9 ms, of which the shim spends ~10 µs.** The
+other 99.7% is the shadow UI process in `usleep(200)` waiting for the next SPI
+frame. `param.get`'s distribution is not a spread but a spike: 97% of samples
+fall in a 2.0–4.0 ms band centred on the 2.9 ms frame period. It is
+quantisation, not work.
+
+Two consequences worth keeping in mind before optimising anything here:
+
+- **Reads dominate writes ~12:1.** Knob writes are already throttled to ~1 per
+  tick (`SETPARAM_THROTTLE_MS`) and `param.set.idle` shows no contention at
+  all, so the write path is real but minor. Spinning a knob barely moves the
+  frame rate — 21.5 fps during a spin against ~21 fps idle.
+- **The shim is not the constraint.** It served 0.44 requests per SPI frame at
+  9.8 µs each, against a 172 µs `spi.pre`. Throughput is bounded by
+  one-request-at-a-time round-trip latency, not by capacity — which is why the
+  useful direction is batching or pipelining the protocol, not making the
+  handler faster.
+
+`tools/tracing/span_stats.mjs` produces the tables above from a pulled capture
+without standing up a collector.
 
 ## How it works
 

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -2342,11 +2342,15 @@ void shadow_inprocess_handle_param_request(void) {
         static uint32_t s_pserve_nid = 0;       /* SPI thread only → no init race */
         if (!s_pserve_nid) s_pserve_nid = schwung_trace_intern("param.serve");
         _ps.nid       = s_pserve_nid;
-        /* Only GET requests carry trace context — get_param stamps it. A SET
-         * leaves the SHM trace fields stale (from a prior GET), so ignore them
-         * and let param.serve be its own root rather than a phantom child. */
-        _ps.trace_id  = (req_type == 2) ? shadow_param->trace_id : 0;
-        _ps.parent_id = (req_type == 2) ? shadow_param->parent_span_id : 0;
+        /* Both GET and SET now stamp trace context before the release-store
+         * (shadow_set_param_common / js_shadow_get_param), and the test daemon
+         * zeroes it, so every producer leaves these fields meaning what they
+         * say. A 0/0 pair still mints a fresh root, which is what an untraced
+         * or unstamped producer gets. (Before the SET path stamped, these held
+         * a prior GET's context and had to be ignored on a SET to avoid a
+         * phantom parent.) */
+        _ps.trace_id  = shadow_param->trace_id;
+        _ps.parent_id = shadow_param->parent_span_id;
         _ps.t0        = schwung_trace_now_ns();
         _ps.on        = 1;
     }

--- a/src/host/test_daemon/commands.c
+++ b/src/host/test_daemon/commands.c
@@ -549,6 +549,12 @@ static int testd_param_do_set(int fd, const char *key, const char *value, size_t
     g_shm.param->error = 0;
     g_shm.param->response_id = 0;
     g_shm.param->request_id = req_id;
+    /* No span is open here, and the shim reads these fields on every request
+     * now that SET stamps them too — so clear them rather than leave whatever
+     * the last shadow_ui request wrote, which would parent the shim's
+     * param.serve to an unrelated span. 0/0 means "mint a fresh root". */
+    g_shm.param->trace_id = 0;
+    g_shm.param->parent_span_id = 0;
     /* Release-fence: ensure key/value/slot writes are visible before
      * the peer sees request_type != 0. */
     __atomic_store_n(&g_shm.param->request_type, 1, __ATOMIC_RELEASE);
@@ -620,6 +626,10 @@ static int cmd_get_param(int fd, const char *args) {
     g_shm.param->error = 0;
     g_shm.param->response_id = 0;
     g_shm.param->request_id = req_id;
+    /* See the SET path above — 0/0 so the shim roots its param.serve rather
+     * than parenting it to whatever shadow_ui last wrote here. */
+    g_shm.param->trace_id = 0;
+    g_shm.param->parent_span_id = 0;
     __atomic_store_n(&g_shm.param->request_type, 2, __ATOMIC_RELEASE);
 
     int rc = testd_param_wait_response(req_id, TESTD_PARAM_TIMEOUT_MS);
@@ -738,6 +748,8 @@ static int cmd_dump_param_file(int fd, const char *args) {
     g_shm.param->error = 0;
     g_shm.param->response_id = 0;
     g_shm.param->request_id = req_id;
+    g_shm.param->trace_id = 0;
+    g_shm.param->parent_span_id = 0;
     __atomic_store_n(&g_shm.param->request_type, 2, __ATOMIC_RELEASE);
 
     int rc = testd_param_wait_response(req_id, TESTD_PARAM_TIMEOUT_MS);

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -725,8 +725,23 @@ static int shadow_param_wait_response(uint32_t req_id, int timeout_ms) {
 static int shadow_set_param_common(int slot, const char *key, const char *value, int timeout_ms, int force_blocking) {
     const int overtake_fire_and_forget = !force_blocking && (shadow_control && shadow_control->overtake_mode >= 2);
 
+    /* Span the write the same way param.get spans the read. This path is only
+     * fire-and-forget under overtake (mode >= 2); everywhere else — including
+     * the param-pages knob grid, which is a shadow UI view and not an overtake
+     * module — it is a synchronous round-trip to the shim, serviced once per
+     * SPI frame. That makes a knob stream a sequence of frame-quantised waits
+     * rather than the cheap writes the JS comments describe, and until now the
+     * read path was instrumented and the write path was not. */
+    TRACE_SCOPE("param.set");
+
     if (!overtake_fire_and_forget) {
-        if (!shadow_param_wait_idle(timeout_ms)) {
+        /* Split out so the trace distinguishes the two ways this blocks:
+         * waiting for the single SHM slot to free (contention with another
+         * request) from waiting for the shim to service ours (frame
+         * quantisation). They call for different fixes. */
+        int idle;
+        { TRACE_SCOPE("param.set.idle"); idle = shadow_param_wait_idle(timeout_ms); }
+        if (!idle) {
             return 0;
         }
     }
@@ -738,6 +753,17 @@ static int shadow_set_param_common(int slot, const char *key, const char *value,
     shadow_param->key[SHADOW_PARAM_KEY_LEN - 1] = '\0';
     strncpy(shadow_param->value, value, SHADOW_PARAM_VALUE_LEN - 1);
     shadow_param->value[SHADOW_PARAM_VALUE_LEN - 1] = '\0';
+
+    /* Propagate the open param.set span so the shim emits its param.serve as
+     * our child, exactly as get_param does (0/0 when tracing is off). Until
+     * this was added the SET path left these fields holding a PRIOR GET's
+     * context, which is why shadow_chain_mgmt.c deliberately ignored them on a
+     * SET and let param.serve float as its own root — a served SET could not
+     * be tied back to the JS call that asked for it. */
+    uint64_t _tr = 0, _sp = 0;
+    schwung_trace_current(&_tr, &_sp);
+    shadow_param->trace_id = _tr;
+    shadow_param->parent_span_id = _sp;
 
     /* Set up request */
     shadow_param->slot = (uint8_t)slot;

--- a/tools/tracing/span_stats.mjs
+++ b/tools/tracing/span_stats.mjs
@@ -1,0 +1,198 @@
+/**
+ * span_stats.mjs — turn OTLP/JSONL trace dumps into a duration report.
+ *
+ * `docs/tracing.md` explains how to arm tracing and pull the files; this is
+ * what reads them without standing up Tempo or Jaeger. A collector is the
+ * right tool for exploring one trace; this is the right tool for the question
+ * "what does this operation cost, over thousands of samples" — which is the
+ * question a perf claim in a code comment has to answer.
+ *
+ *   node tools/tracing/span_stats.mjs traces/*.otlp.jsonl
+ *   node tools/tracing/span_stats.mjs --name param.set traces/*.jsonl
+ *   node tools/tracing/span_stats.mjs --children param.set traces/*.jsonl
+ *
+ * Reports count, mean, median, p95, p99 and max per span name. Percentiles
+ * matter more than the mean here: an operation that waits for the next SPI
+ * frame is quantised, not normally distributed, so the mean hides both the
+ * cheap path and the worst case a user actually feels.
+ *
+ * --children <name> additionally breaks <name> down by what nested inside it,
+ * including the share of time NOT covered by any child ("unaccounted"), which
+ * is where a busy-wait with no span of its own shows up.
+ */
+
+import fs from "node:fs";
+
+const args = process.argv.slice(2);
+const files = [];
+let filterName = null, childrenOf = null, histogramOf = null;
+for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--name") filterName = args[++i];
+    else if (args[i] === "--children") childrenOf = args[++i];
+    else if (args[i] === "--histogram") histogramOf = args[++i];
+    else if (args[i] === "--help" || args[i] === "-h") { usage(); process.exit(0); }
+    else files.push(args[i]);
+}
+if (!files.length) { usage(); process.exit(1); }
+
+function usage() {
+    console.log(`usage: node tools/tracing/span_stats.mjs [--name N] [--children N] [--histogram N] <file.otlp.jsonl ...>
+
+  --name N        report only spans called N
+  --children N    break N down by nested span, incl. unaccounted time
+  --histogram N   bucket N's durations, to see quantisation`);
+}
+
+/* ---- parse ------------------------------------------------------------- */
+
+const spans = [];
+for (const f of files) {
+    let text;
+    try { text = fs.readFileSync(f, "utf8"); }
+    catch (e) { console.error(`skipping ${f}: ${e.message}`); continue; }
+    let lineNo = 0, bad = 0;
+    for (const line of text.split("\n")) {
+        lineNo++;
+        if (!line.trim()) continue;
+        let obj;
+        /* The exporter flushes per batch; a file pulled while tracing is still
+         * running can end mid-line. Skip the torn tail rather than refuse the
+         * whole capture. */
+        try { obj = JSON.parse(line); } catch (e) { bad++; continue; }
+        for (const rs of obj.resourceSpans || []) {
+            const svc = (rs.resource?.attributes || [])
+                .find((a) => a.key === "service.name")?.value?.stringValue || "?";
+            for (const ss of rs.scopeSpans || []) {
+                for (const s of ss.spans || []) {
+                    const t0 = BigInt(s.startTimeUnixNano), t1 = BigInt(s.endTimeUnixNano);
+                    spans.push({
+                        svc,
+                        name: s.name,
+                        id: s.spanId,
+                        parent: s.parentSpanId || null,
+                        trace: s.traceId,
+                        t0, t1,
+                        ns: Number(t1 - t0),
+                    });
+                }
+            }
+        }
+    }
+    if (bad) console.error(`${f}: skipped ${bad} unparseable line(s) (torn tail?)`);
+}
+
+if (!spans.length) { console.error("no spans found"); process.exit(1); }
+
+/* ---- stats ------------------------------------------------------------- */
+
+function pct(sorted, p) {
+    if (!sorted.length) return 0;
+    const i = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+    return sorted[i];
+}
+function fmt(ns) {
+    if (ns >= 1e6) return (ns / 1e6).toFixed(2) + "ms";
+    if (ns >= 1e3) return (ns / 1e3).toFixed(1) + "us";
+    return ns.toFixed(0) + "ns";
+}
+function pad(s, n) { s = String(s); return s.length >= n ? s : s + " ".repeat(n - s.length); }
+function lpad(s, n) { s = String(s); return s.length >= n ? s : " ".repeat(n - s.length) + s; }
+
+const byName = new Map();
+for (const s of spans) {
+    if (filterName && s.name !== filterName) continue;
+    const k = s.svc + "  " + s.name;
+    if (!byName.has(k)) byName.set(k, []);
+    byName.get(k).push(s.ns);
+}
+
+console.log(`\n${spans.length} spans from ${files.length} file(s)\n`);
+console.log(pad("service / span", 40) + lpad("count", 8) + lpad("mean", 10) +
+            lpad("p50", 10) + lpad("p95", 10) + lpad("p99", 10) + lpad("max", 10) + lpad("total", 11));
+console.log("-".repeat(109));
+
+const rows = [...byName.entries()].map(([k, arr]) => {
+    const sorted = arr.slice().sort((a, b) => a - b);
+    const total = arr.reduce((a, b) => a + b, 0);
+    return { k, n: arr.length, mean: total / arr.length, p50: pct(sorted, 50),
+             p95: pct(sorted, 95), p99: pct(sorted, 99), max: sorted[sorted.length - 1], total };
+});
+rows.sort((a, b) => b.total - a.total);
+for (const r of rows) {
+    console.log(pad(r.k, 40) + lpad(r.n, 8) + lpad(fmt(r.mean), 10) + lpad(fmt(r.p50), 10) +
+                lpad(fmt(r.p95), 10) + lpad(fmt(r.p99), 10) + lpad(fmt(r.max), 10) +
+                lpad(fmt(r.total), 11));
+}
+
+/* ---- child breakdown --------------------------------------------------- */
+
+if (childrenOf) {
+    const byId = new Map(spans.map((s) => [s.id, s]));
+    const kids = new Map();          /* parentId -> [child] */
+    for (const s of spans) {
+        if (!s.parent) continue;
+        if (!kids.has(s.parent)) kids.set(s.parent, []);
+        kids.get(s.parent).push(s);
+    }
+    const parents = spans.filter((s) => s.name === childrenOf);
+    if (!parents.length) {
+        console.log(`\nno spans named ${childrenOf}`);
+    } else {
+        const agg = new Map();
+        let unaccounted = 0, parentTotal = 0;
+        for (const p of parents) {
+            parentTotal += p.ns;
+            let covered = 0;
+            for (const c of (kids.get(p.id) || [])) {
+                covered += c.ns;
+                agg.set(c.name, (agg.get(c.name) || 0) + c.ns);
+            }
+            /* Clamp: a child in another process can overhang its parent by a
+             * hair on a different clock read. Negative would be noise, not a
+             * finding. */
+            unaccounted += Math.max(0, p.ns - covered);
+        }
+        console.log(`\n${childrenOf}: ${parents.length} spans, ${fmt(parentTotal)} total — where it goes:`);
+        const items = [...agg.entries()].sort((a, b) => b[1] - a[1]);
+        items.push(["(unaccounted — no child span)", unaccounted]);
+        for (const [name, ns] of items) {
+            const share = parentTotal ? (100 * ns / parentTotal).toFixed(1) : "0.0";
+            console.log("  " + pad(name, 38) + lpad(fmt(ns), 11) + lpad(share + "%", 9));
+        }
+        /* Cross-process children are the point of the trace-id propagation, so
+         * say plainly whether any showed up. */
+        const svcs = new Set();
+        for (const p of parents) for (const c of (kids.get(p.id) || [])) svcs.add(c.svc);
+        if (svcs.size) console.log("  child services seen: " + [...svcs].join(", "));
+        else console.log("  no child spans found — is the other service's file included?");
+    }
+}
+
+/* ---- histogram --------------------------------------------------------- */
+
+if (histogramOf) {
+    const arr = spans.filter((s) => s.name === histogramOf).map((s) => s.ns).sort((a, b) => a - b);
+    if (!arr.length) {
+        console.log(`\nno spans named ${histogramOf}`);
+    } else {
+        console.log(`\n${histogramOf}: ${arr.length} samples, distribution`);
+        /* Fixed sub-millisecond buckets: the hypothesis under test is that this
+         * path is quantised by the ~2.9ms SPI frame, and even buckets across
+         * the range would smear exactly the structure we are looking for. */
+        const edges = [0, 100e3, 250e3, 500e3, 1e6, 1.5e6, 2e6, 2.9e6, 4e6, 6e6, 10e6, Infinity];
+        const counts = new Array(edges.length - 1).fill(0);
+        for (const v of arr) {
+            for (let i = 0; i < counts.length; i++) {
+                if (v < edges[i + 1]) { counts[i]++; break; }
+            }
+        }
+        const maxCount = Math.max(...counts);
+        for (let i = 0; i < counts.length; i++) {
+            if (!counts[i]) continue;
+            const lo = fmt(edges[i]), hi = edges[i + 1] === Infinity ? "+" : fmt(edges[i + 1]);
+            const bar = "#".repeat(Math.max(1, Math.round(40 * counts[i] / maxCount)));
+            console.log("  " + lpad(lo, 8) + " .. " + pad(hi, 8) + lpad(counts[i], 7) + "  " + bar);
+        }
+    }
+}
+console.log("");


### PR DESCRIPTION
Follow-up to #211. The draw path was measured and exonerated there (a QuickJS→C crossing is ~490ns, a whole page render 1.62ms). This points the same instrument at the remaining suspect — the param IPC — and gets an answer.

## What was missing

`param.get` had a span. `param.set` had nothing. So the standing hypothesis — that a fast knob spin is what makes the grid slow, which is why `SETPARAM_THROTTLE_MS` exists — could not be checked against a trace.

This adds:

- **`param.set`**, spanning the write the way `param.get` spans the read.
- **`param.set.idle`**, a child covering only the wait for the single SHM request slot. Split out so *contention* (another request in flight) is distinguishable from *frame quantisation* (waiting for the shim). They call for different fixes.
- **Trace context on SET**, so the shim's `param.serve` nests under the JS span cross-process, as it already did for GET.
- **`tools/tracing/span_stats.mjs`** — turns a pulled capture into duration distributions, child breakdowns and histograms without standing up Tempo or Jaeger. A collector is right for exploring one trace; this is right for "what does this cost over thousands of samples", which is the question a perf claim has to answer.

## What it measured

On device, param-pages grid up, one knob spun hard for 35s:

| span | count | p50 | share of tick |
|---|---|---|---|
| `js.tick` | 767 | 19.95ms | — |
| `param.get` (JS) | 5939 | 2.55ms | **91%** |
| `param.set` (JS) | 787 | 1.06ms | 7% |
| `param.set.idle` | 787 | 426ns | ~0 |
| `param.serve` (shim) | — | 9.8µs | 0.3% of a round-trip |

**A round-trip costs ~2.9ms, of which the shim spends ~10µs.** The other 99.7% is the shadow UI in `usleep(200)` waiting for the next SPI frame. `param.get`'s distribution is a spike rather than a spread — 97% of samples inside 2.0–4.0ms around the 2.9ms frame period. That is quantisation, not work.

**Param IPC is 98.2% of tick time.**

## The hypothesis was half right

It *is* the param IPC. But the volume is in **reads, not writes** — 12:1 by total time:

- Writes are already throttled to ~1/tick, and `param.set.idle` at 426ns shows **zero slot contention**.
- Spinning a knob moves the frame rate from ~21fps to **21.5fps**. The knob is not what anyone is feeling.
- The param-pages controller's staggered read behaves exactly as designed — **one** `getParam` per tick. The other **~6.7 gets/tick come from `shadow_ui.js` itself** and are so far unattributed.

## Where this points (not in this PR)

The shim served **0.44 requests per SPI frame** at 9.8µs each, against a 172µs `spi.pre`. It is nowhere near saturated — throughput is bounded by one-request-at-a-time round-trip latency, not capacity. So the useful direction is **batching or pipelining the param protocol**, or attributing and removing the ~6.7 reads/tick, not making the handler faster or throttling writes harder.

Attributing those reads needs the key in the span name — a small change and another capture.

## Also fixed

A latent instrumentation bug: the SET path left `trace_id`/`parent_span_id` holding a **prior GET's** context, which `shadow_chain_mgmt.c` worked around by ignoring them on a SET (so a served SET floated as an unparented root). Both request types stamp them now and the test daemon zeroes them, so the shim can trust the fields on every request.

## Cost and verification

No behaviour change with tracing off, which is the default — `TRACE_SCOPE` is an atomic load and a branch.

- `make -C tests/host test` passes; no real failures across `tests/host/*.sh`.
- ARM64 cross-compile clean, deployed to hardware, and the captures above came from that build.
- Cross-process correlation verified end to end (`child services seen: schwung-shim`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56