### PR TITLE
docs: state the viz adjacency gate as a gate, and document the defaults

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1058,18 +1058,51 @@ Kinds and their roles:
 
 Two rules worth knowing:
 
-- **Params in a group should be declared adjacently.** The page planner seats a
-  group together on one row so the graphic can span it; a group split across two
-  pages cannot be drawn and falls back to plain controls.
+- **A group's params must land contiguously on one row.** This is a hard gate,
+  not a style preference: a page is two rows of four, and a graphic can span
+  neither the gap between them nor a hole in the middle of a run. A group whose
+  roles straddle the row boundary — or sit on different pages — is not drawn at
+  all, and its members fall back to plain controls. Since knob order comes from
+  `ui_hierarchy`, declaring a group can force you to reorder that level's knobs
+  so the roles sit together. `validate.mjs` reports the failure as
+  `viz-declared-not-adjacent`.
 - **A group is only as good as its roles.** Do not group unrelated params to get
   a picture — an envelope drawn over four params that are not an envelope is
   worse than four honest knobs.
+
+#### What happens when you declare nothing
+
+Resolution order is: the module's own `chain_params` `viz` → a host override →
+the detectors → nothing. A module always outranks the host, and both outrank a
+detector.
+
+The detectors run in risk order — envelope, filter, LFO, waveform, fader,
+switch, EQ, sample — and each key the earlier ones claim is off the table for
+the rest. None of them fire on a name alone; every one corroborates against
+declared metadata. An envelope needs 2–4 numeric roles that share a key stem
+(`f_attack`/`f_decay` group; `amp_attack`/`filter_decay` do not), a filter needs
+both cutoff and resonance, a fader rejects a bipolar range as a pan or trim
+rather than a level, and an EQ band gain must be bipolar and roughly symmetric.
+All of them still require the contiguous-row run above.
+
+A param no detector claims gets an ordinary knob dial — the same cell it would
+have had before graphics existed. That is the default, and for most params it is
+the right one: leaving something undeclared is a real choice, not a gap to fill.
+Prefer it over inventing a group, and use `viz: false` when a detector keeps
+claiming something it should not.
+
+One page-wide exception: a graphic needs a row at least 14 px tall and a cell at
+least 26 px wide. A page that cannot give it that drops to plain dials
+*entirely*, rather than clipping pictures or mixing them with dials.
 
 Check what a module declares, and what is being guessed on its behalf, with:
 
 ```bash
 node tools/param-pages/validate.mjs <module-id>
 ```
+
+`viz-inferred` findings are the detector reporting a guess it made — each one is
+a group you could confirm or correct by declaring it.
 
 ### Child Selectors (for repeated elements)
 


### PR DESCRIPTION
Documentation only — no code changes.

Two gaps in `docs/MODULES.md` → "Parameter visualisations (`viz`)" that surfaced while migrating the first module (braids).

## The adjacency rule was understated

The doc said a group's params "should be declared adjacently" and that a group "split across two pages" cannot be drawn. Both undersell what `isAdjacentRun()` in `src/shared/param_pages/viz.mjs` actually enforces:

- the roles must be contiguous **and within a single row** — a page is two rows of four, so a group straddling the row 0/1 boundary on the *same* page is rejected too, not just one split across pages
- "should" reads as a style preference when failing it means the graphic is not drawn at all

This is exactly the rule that forced braids' filter level to reorder its knobs (`f_attack..f_release` moved to slots 0–3) before either filter graphic would appear, and the doc as written would not have predicted that. The revised bullet also names the finding (`viz-declared-not-adjacent`) and points at `ui_hierarchy` as where knob order actually comes from, since declaring a group can force a layout change.

## The host defaults were undocumented

What happens to an undeclared param was only readable in `viz.mjs`. Added a subsection covering:

- resolution order: module `chain_params` → host override → detectors → nothing
- the detector chain in risk order, and the metadata corroboration each one applies (stem agreement, faders rejecting bipolar ranges, `isGainRange` for EQ bands)
- the plain knob dial as the default, framed as a legitimate choice rather than a gap to fill — so an author weighing whether to declare something can see what they get if they don't
- `viz: false`
- the page-wide size gate (a row under 14 px or cell under 26 px drops the whole page to dials)
- what a `viz-inferred` finding means

Figures verified against source: `render_page.mjs:540` (`geo.rowH >= VIZ_ROWS + 1 && cellW >= VIZ_MIN_W`), `viz_draw.mjs` (`VIZ_ROWS = 13`, `VIZ_MIN_W = 26`), rule names at `validate_contract.mjs:273,280`. No test asserts on doc text.

Relevant to the remaining ~45 modules in the tracker at `docs/plans/2026-08-16-viz-migration-guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1c1uu1486Nw1myHT97KAH