### PR TITLE
Fix the UI stalls: a published param response had no owner

### DIFF
--- a/schwung-manager/shmparams.go
+++ b/schwung-manager/shmparams.go
@@ -21,6 +21,10 @@ type ShmParams struct {
 	data      []byte
 	mu        sync.Mutex
 	nextReqID atomic.Uint32
+	// Set when we commit a request whose response we will never read
+	// (SetParamFast). Nobody will consume that response, so the next claim may
+	// bin it immediately rather than wait out paramStealAfter. Guarded by mu.
+	orphan bool
 }
 
 // Byte offsets into shadow_param_t.
@@ -83,6 +87,14 @@ const (
 	// both processes were minting 1, 2, 3, ... and the invariant was never
 	// actually held.
 	paramWebReqIDBase = 0xFFFF0000
+
+	// response_ready is byte 2 of the 32-bit word at offset 0.
+	paramRespReadyMask = uint32(0x00FF0000)
+
+	// Discard an unread response older than this; only reachable if a
+	// client died between being answered and consuming its answer.
+	// Comfortably longer than any request deadline.
+	paramStealAfter = 250 * time.Millisecond
 )
 
 const shmParamPath = "/dev/shm/schwung-param"
@@ -136,14 +148,35 @@ func (s *ShmParams) claim() error { return s.claimFor(paramIdleTimeout) }
 func (s *ShmParams) claimFor(timeout time.Duration) error {
 	word := (*uint32)(unsafe.Pointer(&s.data[0]))
 	deadline := time.Now().Add(timeout)
+	stealAt := time.Now().Add(paramStealAfter)
 	for {
 		w := atomic.LoadUint32(word)
-		if w&0xFF == 0 {
-			if atomic.CompareAndSwapUint32(word, w, (w&^uint32(0xFF))|paramClaimed) {
+		// Free means idle AND no unread response. The protocol had no
+		// acknowledgement step: the shim sets response_ready=1 and clears
+		// request_type in the same publish, and this claim used to look only
+		// at request_type and then zero response_ready — destroying an answer
+		// the shadow UI was still waiting for, which then blocked for its full
+		// 100ms deadline and returned null. Measured at ~1/sec on device, and
+		// it is the UI's remaining stall. Byte 2 of this word is
+		// response_ready; the owner clears it once it has copied its value out.
+		if w&0xFF == 0 && (w&paramRespReadyMask == 0 || s.orphan) {
+			if atomic.CompareAndSwapUint32(word, w,
+				(w&^(uint32(0xFF)|paramRespReadyMask))|paramClaimed) {
+				s.orphan = false
 				return nil
 			}
 			// Lost the word to a concurrent field write; re-read and retry
 			// without burning the deadline.
+			continue
+		}
+		// Idle but holding an unread response: if it has sat there far longer
+		// than any request deadline its owner is gone, so take it rather than
+		// wedge every param access on the device forever.
+		if w&0xFF == 0 && time.Now().After(stealAt) {
+			if atomic.CompareAndSwapUint32(word, w,
+				(w&^(uint32(0xFF)|paramRespReadyMask))|paramClaimed) {
+				return nil
+			}
 			continue
 		}
 		if time.Now().After(deadline) {
@@ -172,6 +205,20 @@ func (s *ShmParams) commit(reqType byte) {
 // release drops the claim without leaving a servable request behind.
 // Must be called with s.mu held, holding a claim.
 func (s *ShmParams) release() { s.commit(0) }
+
+// consume releases the RESPONSE half of the channel, after this process has
+// copied its value out. Until it is called no one may claim — which is the
+// point: it is what stops the next requester destroying an answer somebody is
+// still waiting for. Must be called on give-up paths too.
+func (s *ShmParams) consume() {
+	word := (*uint32)(unsafe.Pointer(&s.data[0]))
+	for {
+		w := atomic.LoadUint32(word)
+		if atomic.CompareAndSwapUint32(word, w, w&^paramRespReadyMask) {
+			return
+		}
+	}
+}
 
 // releaseIfMine drops the claim ONLY if this process still owns it.
 //
@@ -234,17 +281,20 @@ func (s *ShmParams) TryGetParam(slot uint8, key string) (string, bool, error) {
 
 	if err := s.waitResponse(reqID); err != nil {
 		s.releaseIfMine(2, reqID)
+		s.consume()
 		return "", true, err
 	}
 
 	if s.data[paramOffError] != 0 {
 		s.releaseIfMine(2, reqID)
+		s.consume()
 		return "", true, fmt.Errorf("param get error (slot=%d key=%q)", slot, key)
 	}
 
 	resultLen := int32(binary.LittleEndian.Uint32(s.data[paramOffResultLen:]))
 	if resultLen < 0 {
 		s.releaseIfMine(2, reqID)
+		s.consume()
 		return "", true, fmt.Errorf("param get failed (result_len=%d)", resultLen)
 	}
 	if int(resultLen) > paramValueLen {
@@ -253,6 +303,7 @@ func (s *ShmParams) TryGetParam(slot uint8, key string) (string, bool, error) {
 
 	value := string(s.data[paramOffValue : paramOffValue+int(resultLen)])
 	s.releaseIfMine(2, reqID)
+	s.consume()
 	return value, true, nil
 }
 
@@ -292,7 +343,9 @@ func (s *ShmParams) SetParamFast(slot uint8, key, value string) error {
 	s.data[paramOffValue+len(value)] = 0
 
 	// Fire and forget — shim processes on next audio block (~3ms).
+	// We will never read the answer, so let the next claim bin it.
 	s.commit(1)
+	s.orphan = true
 	return nil
 }
 
@@ -327,12 +380,14 @@ func (s *ShmParams) GetParam(slot uint8, key string) (string, error) {
 	// Wait for response.
 	if err := s.waitResponse(reqID); err != nil {
 		s.releaseIfMine(2, reqID)
+		s.consume()
 		return "", err
 	}
 
 	// Check error flag.
 	if s.data[paramOffError] != 0 {
 		s.releaseIfMine(2, reqID)
+		s.consume()
 		return "", fmt.Errorf("param get error (slot=%d key=%q)", slot, key)
 	}
 
@@ -340,6 +395,7 @@ func (s *ShmParams) GetParam(slot uint8, key string) (string, error) {
 	resultLen := int32(binary.LittleEndian.Uint32(s.data[paramOffResultLen:]))
 	if resultLen < 0 {
 		s.releaseIfMine(2, reqID)
+		s.consume()
 		return "", fmt.Errorf("param get failed (result_len=%d)", resultLen)
 	}
 	if int(resultLen) > paramValueLen {
@@ -349,6 +405,8 @@ func (s *ShmParams) GetParam(slot uint8, key string) (string, error) {
 	value := string(s.data[paramOffValue : paramOffValue+int(resultLen)])
 
 	s.releaseIfMine(2, reqID)
+
+	s.consume()
 	return value, nil
 }
 
@@ -390,15 +448,19 @@ func (s *ShmParams) SetParam(slot uint8, key, value string) error {
 	// Wait for response.
 	if err := s.waitResponse(reqID); err != nil {
 		s.releaseIfMine(1, reqID)
+		s.consume()
 		return err
 	}
 
 	if s.data[paramOffError] != 0 {
 		s.releaseIfMine(1, reqID)
+		s.consume()
 		return fmt.Errorf("param set error (slot=%d key=%q)", slot, key)
 	}
 
 	s.releaseIfMine(1, reqID)
+
+	s.consume()
 	return nil
 }
 

--- a/schwung-manager/shmparams.go
+++ b/schwung-manager/shmparams.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"syscall"
 	"time"
+	"unsafe"
 )
 
 // ShmParams provides access to the shadow_param_t shared memory segment for
@@ -66,6 +67,22 @@ const (
 	paramIdleTimeout     = 200 * time.Millisecond
 	paramResponseTimeout = 500 * time.Millisecond
 	paramPollInterval    = 500 * time.Microsecond
+
+	// SHADOW_PARAM_CLAIMED from shadow_constants.h. Written by a
+	// compare-and-swap to take the channel; see claim().
+	paramClaimed = 0xFF
+
+	// SHADOW_PARAM_WEB_REQ_ID_BASE from shadow_constants.h.
+	//
+	// Request IDs MUST NOT overlap with shadow_ui's, which counts up from 1.
+	// waitResponse matches on response_id == reqID, so overlapping ranges let
+	// this process match the shadow UI's response and read ITS value —
+	// silently wrong data rather than an error. The shim already documents
+	// this split ("web-originated requests use req_id >= 0xFFFF0000") and
+	// keys its skip-re-notify check on it, but nextReqID started at 0, so
+	// both processes were minting 1, 2, 3, ... and the invariant was never
+	// actually held.
+	paramWebReqIDBase = 0xFFFF0000
 )
 
 const shmParamPath = "/dev/shm/schwung-param"
@@ -85,7 +102,105 @@ func OpenShmParams() *ShmParams {
 		return nil
 	}
 
-	return &ShmParams{data: data}
+	s := &ShmParams{data: data}
+	// Start above the shadow UI's range so the two processes can never mint
+	// the same request id. See paramWebReqIDBase.
+	s.nextReqID.Store(paramWebReqIDBase)
+	return s
+}
+
+// claim takes the param channel with an atomic compare-and-swap.
+//
+// The channel is a single slot shared with the shadow_ui process, and the old
+// sequence — spin until request_type reads 0, then write it — is a
+// time-of-check/time-of-use race: both processes can observe idle in the same
+// window, both write, and the loser spins for a response_id that never
+// arrives until its timeout expires. Measured on device, that cost the shadow
+// UI one failed read per second, each blocking it for 100-200ms and returning
+// null to its caller.
+//
+// Claiming with a CAS makes observe-and-take indivisible. paramClaimed is a
+// value the servicer knows to skip, because the key and request id are not
+// written yet.
+//
+// Go has no byte-wide CAS, and request_type shares its 32-bit word with
+// slot / response_ready / error — which the servicer writes — so a plain
+// 32-bit CAS would silently stomp them. Instead CAS the whole word,
+// requiring byte 0 to be zero and carrying the other three bytes through
+// unchanged. If any of them moved under us the CAS simply fails and we
+// retry, which is exactly the behaviour we want.
+//
+// Must be called with s.mu held.
+func (s *ShmParams) claim() error { return s.claimFor(paramIdleTimeout) }
+
+func (s *ShmParams) claimFor(timeout time.Duration) error {
+	word := (*uint32)(unsafe.Pointer(&s.data[0]))
+	deadline := time.Now().Add(timeout)
+	for {
+		w := atomic.LoadUint32(word)
+		if w&0xFF == 0 {
+			if atomic.CompareAndSwapUint32(word, w, (w&^uint32(0xFF))|paramClaimed) {
+				return nil
+			}
+			// Lost the word to a concurrent field write; re-read and retry
+			// without burning the deadline.
+			continue
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("param channel busy (timeout waiting for idle)")
+		}
+		time.Sleep(paramPollInterval)
+	}
+}
+
+// commit publishes the request type, releasing the claim taken by claim().
+//
+// An ATOMIC store, not a plain byte write: it is the barrier that guarantees
+// the key, slot and request_id written above are visible to the shim before
+// it observes a servable request_type. The shim's side of this pair is an
+// __ATOMIC_ACQUIRE load. A plain store carries no such ordering on ARM64, and
+// the shim would be free to read a stale key for a fresh request.
+//
+// Bytes 1-3 of the word are ours while the claim is held, so carrying them
+// through is safe. Must be called with s.mu held, holding a claim.
+func (s *ShmParams) commit(reqType byte) {
+	word := (*uint32)(unsafe.Pointer(&s.data[0]))
+	w := atomic.LoadUint32(word)
+	atomic.StoreUint32(word, (w&^uint32(0xFF))|uint32(reqType))
+}
+
+// release drops the claim without leaving a servable request behind.
+// Must be called with s.mu held, holding a claim.
+func (s *ShmParams) release() { s.commit(0) }
+
+// releaseIfMine drops the claim ONLY if this process still owns it.
+//
+// The servicer clears request_type at the same moment it publishes the
+// response, so by the time we return from waitResponse the channel is
+// already free — and may already have been claimed and filled in by the
+// shadow UI. An unconditional clear here therefore wipes somebody else's
+// in-flight request: the shim never sees it, and that process waits out its
+// entire timeout for a response that will now never be generated. That was
+// the second half of the param-channel bug, and the half that survived
+// making the claim atomic.
+//
+// Checked against BOTH the request type and our own request id, because a
+// concurrent request of the same type would otherwise look like ours.
+// Must be called with s.mu held.
+func (s *ShmParams) releaseIfMine(reqType byte, reqID uint32) {
+	word := (*uint32)(unsafe.Pointer(&s.data[0]))
+	for {
+		w := atomic.LoadUint32(word)
+		if byte(w&0xFF) != reqType {
+			return // servicer already released it, or someone else owns it
+		}
+		if binary.LittleEndian.Uint32(s.data[paramOffRequestID:]) != reqID {
+			return // still our type, but no longer our request
+		}
+		if atomic.CompareAndSwapUint32(word, w, w&^uint32(0xFF)) {
+			return
+		}
+	}
 }
 
 // TryGetParam is like GetParam but returns immediately if the mutex is held
@@ -101,7 +216,7 @@ func (s *ShmParams) TryGetParam(slot uint8, key string) (string, bool, error) {
 		return "", true, fmt.Errorf("key too long (%d >= %d)", len(key), paramKeyLen)
 	}
 
-	if err := s.waitIdle(); err != nil {
+	if err := s.claim(); err != nil {
 		return "", true, err
 	}
 
@@ -115,21 +230,21 @@ func (s *ShmParams) TryGetParam(slot uint8, key string) (string, bool, error) {
 	copy(s.data[paramOffKey:paramOffKey+paramKeyLen], make([]byte, paramKeyLen))
 	copy(s.data[paramOffKey:], key)
 
-	s.data[paramOffRequestType] = 2
+	s.commit(2)
 
 	if err := s.waitResponse(reqID); err != nil {
-		s.data[paramOffRequestType] = 0
+		s.releaseIfMine(2, reqID)
 		return "", true, err
 	}
 
 	if s.data[paramOffError] != 0 {
-		s.data[paramOffRequestType] = 0
+		s.releaseIfMine(2, reqID)
 		return "", true, fmt.Errorf("param get error (slot=%d key=%q)", slot, key)
 	}
 
 	resultLen := int32(binary.LittleEndian.Uint32(s.data[paramOffResultLen:]))
 	if resultLen < 0 {
-		s.data[paramOffRequestType] = 0
+		s.releaseIfMine(2, reqID)
 		return "", true, fmt.Errorf("param get failed (result_len=%d)", resultLen)
 	}
 	if int(resultLen) > paramValueLen {
@@ -137,7 +252,7 @@ func (s *ShmParams) TryGetParam(slot uint8, key string) (string, bool, error) {
 	}
 
 	value := string(s.data[paramOffValue : paramOffValue+int(resultLen)])
-	s.data[paramOffRequestType] = 0
+	s.releaseIfMine(2, reqID)
 	return value, true, nil
 }
 
@@ -155,13 +270,12 @@ func (s *ShmParams) SetParamFast(slot uint8, key, value string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Short idle wait — if shadow_ui.js is mid-request, bail quickly.
-	deadline := time.Now().Add(10 * time.Millisecond)
-	for s.data[paramOffRequestType] != 0 {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("param channel busy")
-		}
-		time.Sleep(paramPollInterval)
+	// Short claim — if shadow_ui is mid-request, bail quickly rather than
+	// hold up the web request. Same atomic claim as everywhere else: the old
+	// inline "spin until it reads 0, then write it" here was a third copy of
+	// the same time-of-check/time-of-use race.
+	if err := s.claimFor(10 * time.Millisecond); err != nil {
+		return fmt.Errorf("param channel busy")
 	}
 
 	reqID := s.nextReqID.Add(1)
@@ -178,7 +292,7 @@ func (s *ShmParams) SetParamFast(slot uint8, key, value string) error {
 	s.data[paramOffValue+len(value)] = 0
 
 	// Fire and forget — shim processes on next audio block (~3ms).
-	s.data[paramOffRequestType] = 1
+	s.commit(1)
 	return nil
 }
 
@@ -191,7 +305,7 @@ func (s *ShmParams) GetParam(slot uint8, key string) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.waitIdle(); err != nil {
+	if err := s.claim(); err != nil {
 		return "", err
 	}
 
@@ -208,24 +322,24 @@ func (s *ShmParams) GetParam(slot uint8, key string) (string, error) {
 	copy(s.data[paramOffKey:], key)
 
 	// Signal: get request.
-	s.data[paramOffRequestType] = 2
+	s.commit(2)
 
 	// Wait for response.
 	if err := s.waitResponse(reqID); err != nil {
-		s.data[paramOffRequestType] = 0 // clean up
+		s.releaseIfMine(2, reqID)
 		return "", err
 	}
 
 	// Check error flag.
 	if s.data[paramOffError] != 0 {
-		s.data[paramOffRequestType] = 0
+		s.releaseIfMine(2, reqID)
 		return "", fmt.Errorf("param get error (slot=%d key=%q)", slot, key)
 	}
 
 	// Read result.
 	resultLen := int32(binary.LittleEndian.Uint32(s.data[paramOffResultLen:]))
 	if resultLen < 0 {
-		s.data[paramOffRequestType] = 0
+		s.releaseIfMine(2, reqID)
 		return "", fmt.Errorf("param get failed (result_len=%d)", resultLen)
 	}
 	if int(resultLen) > paramValueLen {
@@ -234,7 +348,7 @@ func (s *ShmParams) GetParam(slot uint8, key string) (string, error) {
 
 	value := string(s.data[paramOffValue : paramOffValue+int(resultLen)])
 
-	s.data[paramOffRequestType] = 0
+	s.releaseIfMine(2, reqID)
 	return value, nil
 }
 
@@ -250,7 +364,7 @@ func (s *ShmParams) SetParam(slot uint8, key, value string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.waitIdle(); err != nil {
+	if err := s.claim(); err != nil {
 		return err
 	}
 
@@ -271,33 +385,20 @@ func (s *ShmParams) SetParam(slot uint8, key, value string) error {
 	s.data[paramOffValue+len(value)] = 0
 
 	// Signal: set request.
-	s.data[paramOffRequestType] = 1
+	s.commit(1)
 
 	// Wait for response.
 	if err := s.waitResponse(reqID); err != nil {
-		s.data[paramOffRequestType] = 0 // clean up
+		s.releaseIfMine(1, reqID)
 		return err
 	}
 
 	if s.data[paramOffError] != 0 {
-		s.data[paramOffRequestType] = 0
+		s.releaseIfMine(1, reqID)
 		return fmt.Errorf("param set error (slot=%d key=%q)", slot, key)
 	}
 
-	s.data[paramOffRequestType] = 0
-	return nil
-}
-
-// waitIdle spins until request_type == 0, indicating the channel is free.
-// Must be called with s.mu held.
-func (s *ShmParams) waitIdle() error {
-	deadline := time.Now().Add(paramIdleTimeout)
-	for s.data[paramOffRequestType] != 0 {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("param channel busy (timeout waiting for idle)")
-		}
-		time.Sleep(paramPollInterval)
-	}
+	s.releaseIfMine(1, reqID)
 	return nil
 }
 

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -2340,6 +2340,12 @@ void shadow_inprocess_handle_param_request(void) {
      * the trace context (and key/value) it wrote first are visible here. */
     uint8_t req_type = __atomic_load_n(&shadow_param->request_type, __ATOMIC_ACQUIRE);
     if (req_type == 0) return;
+    /* A client has claimed the channel but has not finished filling in the
+     * request. The key, slot and request_id are still whatever the PREVIOUS
+     * request left there, so serving this would answer a garbage request —
+     * and publish_response would then clear request_type, releasing a claim
+     * its owner still believes it holds. Come back next frame. */
+    if (req_type == SHADOW_PARAM_CLAIMED) return;
     uint32_t req_id = shadow_param->request_id;
 
     /* Span the actual servicing of this request (all return paths below),

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -437,8 +437,34 @@ typedef struct shadow_ui_state_t {
  * Parameter request structure for get/set operations.
  * Must fit within SHADOW_PARAM_BUFFER_SIZE bytes.
  */
+/*
+ * request_type value used to CLAIM the channel before the request is filled
+ * in. The channel is a single slot shared by TWO processes (shadow_ui and
+ * schwung-manager), so "spin until it reads 0, then write it" is a
+ * time-of-check/time-of-use race — both can see 0 and both write, and the
+ * loser waits out its whole timeout for a response_id that never comes.
+ * Clients claim with a compare-exchange 0 -> CLAIMED instead.
+ *
+ * The servicer MUST treat CLAIMED as "busy, not mine": the key, slot and
+ * request_id are not written yet, so serving it would answer a garbage
+ * request and — worse — clear request_type, releasing a claim its owner
+ * still believes it holds.
+ */
+#define SHADOW_PARAM_CLAIMED 0xFF
+
+/*
+ * Request-ID ranges are DISJOINT per client, and must stay that way.
+ * waitResponse matches on `response_id == my_request_id`, so if two clients
+ * can mint the same id, one can match the OTHER's response and read its
+ * value — silent wrong data rather than an error.
+ *   shadow_ui        : 1 .. 0xFFFEFFFF
+ *   schwung-manager  : 0xFFFF0000 ..   (also what publish_response uses to
+ *                      recognise web-originated SETs and skip re-notifying)
+ */
+#define SHADOW_PARAM_WEB_REQ_ID_BASE 0xFFFF0000u
+
 typedef struct shadow_param_t {
-    volatile uint8_t request_type;   /* 0=none, 1=set, 2=get */
+    volatile uint8_t request_type;   /* 0=none, 1=set, 2=get, 0xFF=claimed */
     volatile uint8_t slot;           /* Which chain slot (0-3) */
     volatile uint8_t response_ready; /* Set by shim when response is ready */
     volatile uint8_t error;          /* Non-zero on error */

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -2646,6 +2646,130 @@ static int process_shadow_midi(JSContext *ctx, JSValue *onInternal, JSValue *onE
     return handled;
 }
 
+/* =========================================================================
+ * Loop profiler — where a shadow_ui iteration actually spends its time.
+ *
+ * The trace spans `js.tick` and its param children, which is most of the
+ * iteration but NOT all of it. Three things run every loop and carry no
+ * instrument at all:
+ *
+ *   - process_shadow_midi(), which dispatches into JS handlers that call
+ *     setParam — and which runs hardest exactly when a knob is being turned,
+ *     i.e. during the frames the lag is reported on;
+ *   - js_display_pack() + the 1KB memcpy, which the comment says runs every
+ *     30 ticks but actually runs EVERY tick whenever the screen is dirty,
+ *     which on the knob grid is every tick since it now redraws every tick;
+ *   - schwung_trace_poll_enable(), a filesystem check on eMMC.
+ *
+ * A span cannot see them (they are outside the js.tick scope) and the JS-side
+ * fps counter cannot either (it counts draws, not the loop). So the residual
+ * "54-56 not 60, with dips to 45" was being hunted with an instrument that is
+ * blind to a third of the loop.
+ *
+ * This measures the whole iteration, phase by phase, and reports ONCE PER
+ * SECOND — one log line, deliberately, because a diagnostic that writes files
+ * per event is how ~150ms stalls got chased as scheduling contention (see the
+ * param_tally note). Cost when disarmed is five clock_gettime calls per
+ * iteration, ~125ns against a 16.67ms period.
+ *
+ * Arm with:  touch /data/UserData/schwung/loop_stats_on
+ * ========================================================================= */
+#define LOOP_STATS_FLAG "/data/UserData/schwung/loop_stats_on"
+
+typedef struct {
+    uint64_t midi_ns, tick_ns, pack_ns, other_ns, total_ns;
+} loop_phase_t;
+
+static struct {
+    int armed;
+    int iters;
+    int overruns;               /* iterations whose work exceeded the period */
+    uint64_t period_ns;
+    loop_phase_t sum;
+    loop_phase_t max;           /* per-phase maxima, independently */
+    loop_phase_t worst;         /* full breakdown of the single worst iteration */
+    uint64_t late_max_ns;       /* worst wake-up lateness vs the deadline */
+    uint64_t late_sum_ns;
+    uint64_t window_start_ns;
+} loop_stats;
+
+static uint64_t now_ns(void) {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (uint64_t)t.tv_sec * 1000000000ULL + (uint64_t)t.tv_nsec;
+}
+
+static void loop_stats_poll_enable(void) {
+    loop_stats.armed = (access(LOOP_STATS_FLAG, F_OK) == 0);
+}
+
+static void loop_stats_record(const loop_phase_t *p, uint64_t late_ns, uint64_t period_ns) {
+    loop_stats.iters++;
+    loop_stats.period_ns = period_ns;
+    loop_stats.sum.midi_ns  += p->midi_ns;
+    loop_stats.sum.tick_ns  += p->tick_ns;
+    loop_stats.sum.pack_ns  += p->pack_ns;
+    loop_stats.sum.other_ns += p->other_ns;
+    loop_stats.sum.total_ns += p->total_ns;
+    if (p->midi_ns  > loop_stats.max.midi_ns)  loop_stats.max.midi_ns  = p->midi_ns;
+    if (p->tick_ns  > loop_stats.max.tick_ns)  loop_stats.max.tick_ns  = p->tick_ns;
+    if (p->pack_ns  > loop_stats.max.pack_ns)  loop_stats.max.pack_ns  = p->pack_ns;
+    if (p->other_ns > loop_stats.max.other_ns) loop_stats.max.other_ns = p->other_ns;
+    if (p->total_ns > loop_stats.max.total_ns) { loop_stats.max.total_ns = p->total_ns;
+                                                 loop_stats.worst = *p; }
+    if (p->total_ns > period_ns) loop_stats.overruns++;
+    loop_stats.late_sum_ns += late_ns;
+    if (late_ns > loop_stats.late_max_ns) loop_stats.late_max_ns = late_ns;
+}
+
+/* One line per second, or nothing. Returns after resetting the window. */
+static void loop_stats_report(uint64_t now) {
+    if (!loop_stats.window_start_ns) { loop_stats.window_start_ns = now; return; }
+    uint64_t dt = now - loop_stats.window_start_ns;
+    if (dt < 1000000000ULL) return;
+
+    int n = loop_stats.iters ? loop_stats.iters : 1;
+    if (loop_stats.armed) {
+        char line[512];
+        /*
+         * avg is where the time goes; max says whether the dips are one long
+         * stall or a cluster of medium ones — which is the open question. If
+         * `worst` is dominated by a phase, that phase is the answer; if
+         * `late` is large while `total` is small, the process was descheduled
+         * and nothing in this loop is at fault.
+         */
+        snprintf(line, sizeof(line),
+                 "loop_stats: %d iters %d overrun (>%.1fms) | avg us midi=%llu tick=%llu pack=%llu other=%llu total=%llu"
+                 " | max us midi=%llu tick=%llu pack=%llu other=%llu"
+                 " | worst iter us total=%llu (midi=%llu tick=%llu pack=%llu other=%llu)"
+                 " | late us avg=%llu max=%llu",
+                 loop_stats.iters, loop_stats.overruns, loop_stats.period_ns / 1e6,
+                 (unsigned long long)(loop_stats.sum.midi_ns  / n / 1000),
+                 (unsigned long long)(loop_stats.sum.tick_ns  / n / 1000),
+                 (unsigned long long)(loop_stats.sum.pack_ns  / n / 1000),
+                 (unsigned long long)(loop_stats.sum.other_ns / n / 1000),
+                 (unsigned long long)(loop_stats.sum.total_ns / n / 1000),
+                 (unsigned long long)(loop_stats.max.midi_ns  / 1000),
+                 (unsigned long long)(loop_stats.max.tick_ns  / 1000),
+                 (unsigned long long)(loop_stats.max.pack_ns  / 1000),
+                 (unsigned long long)(loop_stats.max.other_ns / 1000),
+                 (unsigned long long)(loop_stats.max.total_ns / 1000),
+                 (unsigned long long)(loop_stats.worst.midi_ns  / 1000),
+                 (unsigned long long)(loop_stats.worst.tick_ns  / 1000),
+                 (unsigned long long)(loop_stats.worst.pack_ns  / 1000),
+                 (unsigned long long)(loop_stats.worst.other_ns / 1000),
+                 (unsigned long long)(loop_stats.late_sum_ns / n / 1000),
+                 (unsigned long long)(loop_stats.late_max_ns / 1000));
+        shadow_ui_log_line(line);
+    }
+    memset(&loop_stats.sum,   0, sizeof(loop_stats.sum));
+    memset(&loop_stats.max,   0, sizeof(loop_stats.max));
+    memset(&loop_stats.worst, 0, sizeof(loop_stats.worst));
+    loop_stats.iters = loop_stats.overruns = 0;
+    loop_stats.late_max_ns = loop_stats.late_sum_ns = 0;
+    loop_stats.window_start_ns = now;
+}
+
 int main(int argc, char *argv[]) {
     const char *script = "/data/UserData/schwung/shadow/shadow_ui.js";
     if (argc > 1) {
@@ -2728,6 +2852,19 @@ int main(int argc, char *argv[]) {
     struct timespec next_tick = { 0, 0 };
 
     while (!global_exit_flag) {
+        /* Loop profiler; see loop_stats above. `t_wake` is when this iteration
+         * actually started, which against the deadline it was sleeping to
+         * gives wake-up lateness — the one number that separates "our work
+         * overran" from "the scheduler did not run us". */
+        loop_phase_t ph = {0};
+        uint64_t t_wake = now_ns(), t_a = t_wake, t_b;
+        uint64_t late_ns = 0;
+        if (next_tick.tv_sec) {
+            uint64_t deadline = (uint64_t)next_tick.tv_sec * 1000000000ULL
+                              + (uint64_t)next_tick.tv_nsec;
+            if (t_wake > deadline) late_ns = t_wake - deadline;
+        }
+
         if (shadow_control && shadow_control->should_exit) {
             if (jsSaveStateIsDefined) {
                 callGlobalFunction(ctx, &JSSaveState, 0);
@@ -2747,11 +2884,13 @@ int main(int argc, char *argv[]) {
              * clear (manifested as dropped pad note-offs under burst). */
             process_shadow_midi(ctx, &JSonMidiMessageInternal, &JSonMidiMessageExternal);
         }
+        t_b = now_ns(); ph.midi_ns = t_b - t_a; t_a = t_b;
 
         if (jsTickIsDefined) {
             TRACE_SCOPE("js.tick");   /* root span; param.get etc. nest under it */
             callGlobalFunction(ctx, &JSTick, 0);
         }
+        t_b = now_ns(); ph.tick_ns = t_b - t_a; t_a = t_b;
         /* The js.tick scope above unwound the per-thread span stack back to
          * depth 0, so any span a JS module opened via host_trace_begin and
          * forgot to host_trace_end() is already dropped from the stack — but its
@@ -2765,12 +2904,23 @@ int main(int argc, char *argv[]) {
 
         refresh_counter++;
         /* Poll the trace touch-file off the hot loop (~once/sec at 60 Hz). */
-        if ((refresh_counter & 0x3F) == 0) schwung_trace_poll_enable();
+        if ((refresh_counter & 0x3F) == 0) { schwung_trace_poll_enable(); loop_stats_poll_enable(); }
+        /* `other` is the two touch-file polls, on their own, because they are
+         * the only eMMC access on this loop and a blocking one would look
+         * exactly like the unexplained periodic dips. Once every 64
+         * iterations, so its MAX is the number to read, not its average. */
+        t_b = now_ns(); ph.other_ns = t_b - t_a; t_a = t_b;
         if ((js_display_screen_dirty || (refresh_counter % 30 == 0)) && shadow_display_shm) {
             js_display_pack(packed_buffer);
             memcpy(shadow_display_shm, packed_buffer, DISPLAY_BUFFER_SIZE);
             js_display_screen_dirty = 0;
         }
+        t_b = now_ns();
+        ph.pack_ns = t_b - t_a;
+        ph.total_ns = t_b - t_wake;
+        loop_stats_record(&ph, late_ns, (uint64_t)((shadow_control && shadow_control->overtake_mode >= 2)
+                                                   ? 2000000L : 16666667L));
+        loop_stats_report(t_b);
 
         /*
          * Sleep to an absolute DEADLINE, not for a fixed duration.

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -725,52 +725,108 @@ static uint32_t shadow_param_next_request_id(void) {
 }
 
 /*
- * Claim the parameter channel ATOMICALLY.
+ * Claim the parameter channel, requiring BOTH that it is idle and that there
+ * is no unread response sitting in it.
  *
- * `/schwung-param` is a single-slot protocol with TWO processes on it —
- * this one and schwung-manager — and the old sequence was:
+ * The protocol had no acknowledgement step, so a published response had no
+ * owner. `shadow_param_publish_response` sets response_ready = 1 and clears
+ * request_type in the same breath, and the next claimer used to CAS on
+ * request_type alone and then zero response_ready as part of filling in its
+ * own request. A response could therefore be destroyed before the client that
+ * asked for it ever looked at it — after which nothing would ever re-publish
+ * it, and that client blocked until its 100ms deadline and returned null.
  *
- *     while (request_type != 0) wait;     // observe idle
- *     ...write key, slot, request_id...
- *     request_type = GET;                 // then claim it
+ * That is the whole of the residual UI stall, and it is why the two earlier
+ * fixes here did not touch it: the atomic claim settled who owns the REQUEST
+ * slot, and releaseIfMine stopped an in-flight request being cleared, but
+ * neither gave a RESPONSE a lifetime.
  *
- * which is a textbook time-of-check/time-of-use race. Both processes can
- * observe idle in the same window, both write, and the loser then spins for
- * a response_id that will never appear until its timeout expires.
+ * Measured signature, consistently: claim=0ms (no contention at all),
+ * response timed out, and at give-up request_type=0, response_ready=1 with a
+ * response_id belonging to the other process. It also explains why pausing
+ * schwung-manager made it disappear, and why the failure was always a full
+ * timeout rather than a slow read — the answer was destroyed, not delayed.
  *
- * Measured on device (knob grid, 25s, 4262 reads): the latency distribution
- * is perfectly bimodal — 4237 reads at 0-10ms, **nothing at all between 10ms
- * and 99ms**, then 25 reads piled against the 100ms-per-stage timeout
- * ceiling. That empty band is the proof they are timeouts, not slow reads.
- * One failed read per second, each blocking the UI thread 100-200ms AND
- * returning null to its caller. Pausing schwung-manager for 30s took the
- * grid from 38-50 to 57-59 ticks/sec and the spikes vanished.
+ * So the channel is now free only when request_type == 0 AND
+ * response_ready == 0, and the owner clears response_ready once it has copied
+ * its value out (shadow_param_consume). Both bytes live in the same 32-bit
+ * word, so one compare-exchange tests and takes them together.
  *
- * A compare-exchange makes observe-and-claim one indivisible step, so only
- * one process can ever hold the channel. CLAIMED is a distinct value rather
- * than a real request type: the shim must see the channel as busy but must
- * NOT try to serve it, because the key and request_id are not written yet.
- * The window it is held is a handful of stores, versus the ~2.9ms SPI frame
- * the old window stayed open for.
- *
- * Deliberately still uses the existing field and no new layout, so the SHM
- * segment is byte-identical and there is no version-skew hazard across the
- * three binaries that map it.
+ * Layout of that word (little-endian): byte0 request_type, byte1 slot,
+ * byte2 response_ready, byte3 error. Carrying bytes 1-3 through unchanged
+ * means a concurrent field write just makes the CAS retry.
  */
+static inline volatile uint32_t *shadow_param_head_word(void) {
+    return (volatile uint32_t *)&shadow_param->request_type;
+}
+
+#define SHADOW_PARAM_RT_MASK 0x000000FFu
+#define SHADOW_PARAM_RR_MASK 0x00FF0000u
+
+/*
+ * If a response goes unread this long, take the channel anyway.
+ *
+ * Only reachable if a client died between being answered and consuming its
+ * answer. Without it that would wedge every parameter read on the device
+ * permanently, which is a far worse failure than the stale response this
+ * discards. Comfortably longer than the 100ms request deadline, so it can
+ * never fire against a client that is merely slow.
+ */
+#define SHADOW_PARAM_STEAL_AFTER_US 250000L
+
+/*
+ * Set when we deliberately walk away from a request without reading its
+ * answer (the overtake fire-and-forget SET). Nobody will ever consume that
+ * response, so the next claim may discard it immediately instead of waiting
+ * out the steal timer — which at encoder-stream rates would otherwise stall
+ * every write behind a dead response.
+ */
+static int shadow_param_orphan_pending = 0;
+
 static int shadow_param_claim(int timeout_ms) {
-    int timeout = shadow_param_timeout_to_polls(timeout_ms);
-    while (timeout > 0) {
-        uint8_t expected = 0;
-        if (__atomic_compare_exchange_n((uint8_t *)&shadow_param->request_type,
-                                        &expected, (uint8_t)SHADOW_PARAM_CLAIMED,
-                                        0 /* strong */,
-                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
-            return 1;
+    long waited_us = 0;
+    const long limit_us =
+        (long)(timeout_ms > 0 ? timeout_ms : SHADOW_PARAM_DEFAULT_TIMEOUT_MS) * 1000L;
+    long blocked_us = 0;
+
+    while (waited_us < limit_us) {
+        uint32_t w = __atomic_load_n(shadow_param_head_word(), __ATOMIC_ACQUIRE);
+        int idle   = (w & SHADOW_PARAM_RT_MASK) == 0;
+        int unread = (w & SHADOW_PARAM_RR_MASK) != 0;
+
+        if (idle && (!unread || shadow_param_orphan_pending
+                     || blocked_us >= SHADOW_PARAM_STEAL_AFTER_US)) {
+            /* Take it, and clear any stale response in the same step so the
+             * next waiter cannot mistake it for its own. */
+            uint32_t nw = (w & ~(SHADOW_PARAM_RT_MASK | SHADOW_PARAM_RR_MASK))
+                        | (uint32_t)SHADOW_PARAM_CLAIMED;
+            if (__atomic_compare_exchange_n(shadow_param_head_word(), &w, nw,
+                                            0 /* strong */,
+                                            __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
+                shadow_param_orphan_pending = 0;
+                return 1;
+            }
+            continue;   /* word moved under us — re-read, do not burn the deadline */
         }
-        usleep(SHADOW_PARAM_POLL_US);
-        timeout--;
+
+        long step = (waited_us < 1000) ? SHADOW_PARAM_POLL_US : 1000;
+        usleep((useconds_t)step);
+        waited_us += step;
+        if (idle && unread) blocked_us += step; else blocked_us = 0;
     }
     return 0;
+}
+
+/*
+ * Release the response half of the channel.
+ *
+ * MUST be called once the value has been copied out, and equally on give-up —
+ * until it is, no one may claim, which is exactly the point: it is what stops
+ * the next requester destroying an answer somebody is still waiting for.
+ */
+static void shadow_param_consume(void) {
+    __atomic_and_fetch(shadow_param_head_word(), ~SHADOW_PARAM_RR_MASK,
+                       __ATOMIC_RELEASE);
 }
 
 /*
@@ -782,60 +838,80 @@ static int shadow_param_claim(int timeout_ms) {
  * writes per event is how a previous round of ~150ms stalls got mistaken for
  * scheduling contention.
  */
+static unsigned param_slow_n, param_slow_max_ms;
+static char param_slow_key[SHADOW_PARAM_KEY_LEN];
+static char param_slow_why[24];
+
+/*
+ * A read that took absurdly long but SUCCEEDED is the case that has resisted
+ * three fixes, and neither a span nor a give-up counter can name it: spans
+ * carry no key, and a success logs no give-up. So record the key, the
+ * duration, and which side of the exchange was slow, for the worst one in
+ * each one-second window.
+ */
+static void shadow_param_note_duration(const char *key, unsigned ms,
+                                       const char *why) {
+    if (ms < 90) return;
+    param_slow_n++;
+    if (ms > param_slow_max_ms) {
+        param_slow_max_ms = ms;
+        if (key) { strncpy(param_slow_key, key, sizeof(param_slow_key) - 1);
+                   param_slow_key[sizeof(param_slow_key) - 1] = '\0'; }
+        strncpy(param_slow_why, why, sizeof(param_slow_why) - 1);
+        param_slow_why[sizeof(param_slow_why) - 1] = '\0';
+    }
+}
+
 static void shadow_param_note_slow(const char *stage, const char *key) {
     static unsigned n_claim, n_resp, n_err;
     static char last_key[SHADOW_PARAM_KEY_LEN];
     static time_t last_report;
 
-    if (stage[0] == 'c') n_claim++;
-    else if (stage[0] == 'r') n_resp++;
-    else n_err++;
-    if (key) { strncpy(last_key, key, sizeof(last_key) - 1);
-               last_key[sizeof(last_key) - 1] = '\0'; }
+    if (stage) {
+        if (stage[0] == 'c') n_claim++;
+        else if (stage[0] == 'r') n_resp++;
+        else n_err++;
+        if (key) { strncpy(last_key, key, sizeof(last_key) - 1);
+                   last_key[sizeof(last_key) - 1] = '\0'; }
+    }
 
     time_t now = time(NULL);
     if (now == last_report) return;
     last_report = now;
-    if (!(n_claim | n_resp | n_err)) return;
-    char line[256];
+    if (!(n_claim | n_resp | n_err | param_slow_n)) return;
+    char line[320];
     snprintf(line, sizeof(line),
-             "param_giveup: claim=%u response=%u error=%u  last_key=%s",
-             n_claim, n_resp, n_err, last_key);
+             "param_giveup: claim=%u response=%u error=%u last_key=%s"
+             " | slow>=90ms: n=%u worst=%ums key=%s where=%s",
+             n_claim, n_resp, n_err, last_key,
+             param_slow_n, param_slow_max_ms,
+             param_slow_key[0] ? param_slow_key : "-",
+             param_slow_why[0] ? param_slow_why : "-");
     shadow_ui_log_line(line);
     n_claim = n_resp = n_err = 0;
+    param_slow_n = param_slow_max_ms = 0;
+    param_slow_key[0] = param_slow_why[0] = '\0';
 }
 
-/*
- * How long to sleep BEFORE polling at all.
- *
- * The shim services this channel from the SPI callback, once per frame, and a
- * frame is ~2.9ms. So the answer is never ready in the first couple of hundred
- * microseconds — yet the loop below used to wake ~14 times discovering that,
- * every single read.
- *
- * Each of those wakeups is a syscall and, more to the point, a chance for the
- * scheduler to give the CPU to something else and not come back promptly. That
- * is the mechanism behind the tail this was chasing: measured on device, ~0.5%
- * of reads took 142-163ms instead of 2.8ms, and they SUCCEEDED — no timeout was
- * recorded — so nothing was lost or contended, the process simply was not
- * running to observe a response that had been sitting there. Sleeping once for
- * most of a frame cuts the wakeups per read from ~14 to ~2, and with them the
- * exposure.
- *
- * Deliberately shorter than a frame: overshooting would add latency to every
- * read to fix a rare one. 2.2ms still lands inside the same frame the old
- * loop's 11th poll would have.
- */
-#define SHADOW_PARAM_FIRST_SLEEP_US 2200
-
 static int shadow_param_wait_response(uint32_t req_id, int timeout_ms) {
-    int timeout = shadow_param_timeout_to_polls(timeout_ms);
-    /* Not ready yet by construction — see above. Skip the pointless polls. */
-    if (__atomic_load_n(&shadow_param->response_ready, __ATOMIC_ACQUIRE) == 0) {
-        usleep(SHADOW_PARAM_FIRST_SLEEP_US);
-        timeout -= SHADOW_PARAM_FIRST_SLEEP_US / SHADOW_PARAM_POLL_US;
-    }
-    while (timeout > 0) {
+    /*
+     * Backoff, NOT a fixed pre-sleep.
+     *
+     * A flat 2.2ms sleep before polling was tried and it made things worse:
+     * measured, 14% of reads complete in under 2ms (the request lands just
+     * before the shim's service point and is answered almost immediately), and
+     * a floor under every read penalises all of them to fix the rare one.
+     *
+     * So: poll fine-grained at first to keep that fast path intact, then
+     * lengthen the sleep. A read that has already waited a millisecond is
+     * waiting on the next SPI frame (~2.9ms) and there is nothing to be gained
+     * from asking 14 more times — each ask is a syscall and a chance to be
+     * descheduled and not come back promptly, which is what stretched a 2.8ms
+     * read into 150ms.
+     */
+    long waited_us = 0;
+    const long limit_us = (timeout_ms > 0 ? timeout_ms : SHADOW_PARAM_DEFAULT_TIMEOUT_MS) * 1000L;
+    while (waited_us < limit_us) {
         /* Acquire-load pairs with the writer's release-store of response_ready
          * (shadow_param_publish_response + the shim sites). It guarantees the
          * response fields (response_id, error, value) written before the flag
@@ -846,8 +922,12 @@ static int shadow_param_wait_response(uint32_t req_id, int timeout_ms) {
             && shadow_param->response_id == req_id) {
             return shadow_param->error ? -1 : 1;
         }
-        usleep(SHADOW_PARAM_POLL_US);
-        timeout--;
+        /* 200us while the fast path is still plausible (first ~1ms), then
+         * 1ms — by then we are simply waiting for the next SPI frame. Turns
+         * a ~14-wakeup read into ~4 without slowing the quick ones. */
+        long step = (waited_us < 1000) ? SHADOW_PARAM_POLL_US : 1000;
+        usleep((useconds_t)step);
+        waited_us += step;
     }
     return 0;
 }
@@ -864,13 +944,20 @@ static int shadow_set_param_common(int slot, const char *key, const char *value,
      * read path was instrumented and the write path was not. */
     TRACE_SCOPE("param.set");
 
-    if (!overtake_fire_and_forget) {
-        /* Split out so the trace distinguishes the two ways this blocks:
+    {
+        /* Claim on BOTH paths. Fire-and-forget used to write key, value, slot
+         * and request_id with no claim at all, which could land on top of a
+         * request another process had in flight — the very race the claim
+         * exists to prevent. It just claims briefly and drops the write if the
+         * channel is busy, which is what "fire and forget" already means.
+         *
+         * Split out so the trace distinguishes the two ways this blocks:
          * waiting for the single SHM slot to free (contention with another
          * request) from waiting for the shim to service ours (frame
          * quantisation). They call for different fixes. */
         int idle;
-        { TRACE_SCOPE("param.set.idle"); idle = shadow_param_claim(timeout_ms); }
+        { TRACE_SCOPE("param.set.idle");
+          idle = shadow_param_claim(overtake_fire_and_forget ? 5 : timeout_ms); }
         if (!idle) {
             return 0;
         }
@@ -908,10 +995,14 @@ static int shadow_set_param_common(int slot, const char *key, const char *value,
     /* In overtake module mode, keep this fire-and-forget so rapid encoder
      * streams do not block UI rendering. */
     if (overtake_fire_and_forget) {
+        /* We will never read the answer; let the next claim bin it. */
+        shadow_param_orphan_pending = 1;
         return 1;
     }
 
-    return shadow_param_wait_response(req_id, timeout_ms) > 0;
+    int ok = shadow_param_wait_response(req_id, timeout_ms) > 0;
+    shadow_param_consume();
+    return ok;
 }
 
 /* shadow_set_param(slot, key, value) -> bool
@@ -1013,14 +1104,18 @@ static JSValue shadow_param_bulk_js(JSContext *ctx, int argc, JSValueConst *argv
      * value payload and request_id written above before it acts on them. */
     __atomic_store_n(&shadow_param->request_type, req_type, __ATOMIC_RELEASE);
 
-    if (shadow_param_wait_response(req_id, SHADOW_PARAM_DEFAULT_TIMEOUT_MS) <= 0)
+    if (shadow_param_wait_response(req_id, SHADOW_PARAM_DEFAULT_TIMEOUT_MS) <= 0) {
+        shadow_param_consume();
         return JS_NULL;
-    if (req_type == 4) return JS_TRUE;          /* BULK_SET — no payload back */
-    if (shadow_param->error) return JS_NULL;
+    }
+    if (req_type == 4) { shadow_param_consume(); return JS_TRUE; }  /* BULK_SET */
+    if (shadow_param->error) { shadow_param_consume(); return JS_NULL; }
     int rlen = shadow_param->result_len;
-    if (rlen < 0) return JS_NULL;
+    if (rlen < 0) { shadow_param_consume(); return JS_NULL; }
     if (rlen >= SHADOW_PARAM_VALUE_LEN) rlen = SHADOW_PARAM_VALUE_LEN - 1;
-    return JS_NewStringLen(ctx, shadow_param->value, (size_t)rlen);
+    JSValue bout = JS_NewStringLen(ctx, shadow_param->value, (size_t)rlen);
+    shadow_param_consume();
+    return bout;
 }
 
 static JSValue js_shadow_get_params(JSContext *ctx, JSValueConst this_val,
@@ -1060,9 +1155,12 @@ static JSValue js_shadow_get_param(JSContext *ctx, JSValueConst this_val, int ar
      * in `response` means our request was accepted and never answered. The
      * ~0.5%-of-reads timeout tail survived two fixes aimed at the first, which
      * is exactly the sort of thing an undifferentiated span hides. */
+    struct timespec _t0, _t1, _t2;
+    clock_gettime(CLOCK_MONOTONIC, &_t0);
     int claimed;
     { TRACE_SCOPE("param.get.claim");
       claimed = shadow_param_claim(SHADOW_PARAM_DEFAULT_TIMEOUT_MS); }
+    clock_gettime(CLOCK_MONOTONIC, &_t1);
     if (!claimed) {
         shadow_param_note_slow("claim", key);
         JS_FreeCString(ctx, key);
@@ -1077,6 +1175,11 @@ static JSValue js_shadow_get_param(JSContext *ctx, JSValueConst this_val, int ar
     /* Clear entire value buffer to prevent any stale data */
     memset(shadow_param->value, 0, SHADOW_PARAM_VALUE_LEN);
 
+    /* Keep the key for the slow-read report below; the JS string is freed here
+     * because the shim already has its own copy in SHM. */
+    char key_copy[SHADOW_PARAM_KEY_LEN];
+    strncpy(key_copy, key, sizeof(key_copy) - 1);
+    key_copy[sizeof(key_copy) - 1] = '\0';
     JS_FreeCString(ctx, key);
 
     /* Propagate the open param.get span as trace context so the shim emits its
@@ -1099,7 +1202,28 @@ static JSValue js_shadow_get_param(JSContext *ctx, JSValueConst this_val, int ar
     int got;
     { TRACE_SCOPE("param.get.response");
       got = shadow_param_wait_response(req_id, SHADOW_PARAM_DEFAULT_TIMEOUT_MS); }
+    clock_gettime(CLOCK_MONOTONIC, &_t2);
+    {
+        unsigned claim_ms = (unsigned)((_t1.tv_sec - _t0.tv_sec) * 1000
+                          + (_t1.tv_nsec - _t0.tv_nsec) / 1000000);
+        unsigned resp_ms  = (unsigned)((_t2.tv_sec - _t1.tv_sec) * 1000
+                          + (_t2.tv_nsec - _t1.tv_nsec) / 1000000);
+        char why[48];   /* "FAIL r=150 rt=0 rr=1 other" is 26 — 24 truncated it */
+        /* On failure, snapshot the channel: rt!=0 means the shim never picked
+         * our request up; rt==0 with rr==1 and a foreign rid means it answered
+         * somebody else over the top of us. */
+        snprintf(why, sizeof(why), "%s r=%u rt=%u rr=%u %s",
+                 got > 0 ? "OK" : "FAIL", resp_ms,
+                 (unsigned)shadow_param->request_type,
+                 (unsigned)shadow_param->response_ready,
+                 (shadow_param->response_id == req_id) ? "mine" : "other");
+        shadow_param_note_duration(key_copy, claim_ms + resp_ms, why);
+    }
     if (got <= 0) {
+        /* Nothing usable, but release the response half anyway: an answer that
+         * landed just after we stopped waiting must not be left for the next
+         * requester to mistake for its own. */
+        shadow_param_consume();
         shadow_param_note_slow(got == 0 ? "response-timeout" : "error", key);
         return JS_NULL;
     }
@@ -1107,16 +1231,14 @@ static JSValue js_shadow_get_param(JSContext *ctx, JSValueConst this_val, int ar
     /*
      * Copy the value, then CHECK IT IS STILL OURS.
      *
-     * The servicer releases the channel (request_type = 0) at the same moment
-     * it publishes the response, so from that instant the other process may
-     * claim it and overwrite `value` while we are still copying it out. The
-     * window is small — we wake within one 200us poll — but it is a silent
-     * wrong-value window, not an error, so it is worth one comparison to
-     * close. If the id moved underneath us the copy is untrustworthy: report
-     * nothing rather than something wrong.
+     * With claim() now refusing a channel that still holds an unread response,
+     * nobody can take it from under us here — this check is belt and braces
+     * for a stale or stolen response, and it is cheap.
      */
     JSValue out = JS_NewString(ctx, shadow_param->value);
-    if (shadow_param->response_id != req_id) {
+    int still_ours = (shadow_param->response_id == req_id);
+    shadow_param_consume();   /* release the response half for the next claimer */
+    if (!still_ours) {
         JS_FreeValue(ctx, out);
         return JS_NULL;
     }

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -724,13 +724,85 @@ static uint32_t shadow_param_next_request_id(void) {
     return shadow_param_request_seq;
 }
 
-static int shadow_param_wait_idle(int timeout_ms) {
+/*
+ * Claim the parameter channel ATOMICALLY.
+ *
+ * `/schwung-param` is a single-slot protocol with TWO processes on it —
+ * this one and schwung-manager — and the old sequence was:
+ *
+ *     while (request_type != 0) wait;     // observe idle
+ *     ...write key, slot, request_id...
+ *     request_type = GET;                 // then claim it
+ *
+ * which is a textbook time-of-check/time-of-use race. Both processes can
+ * observe idle in the same window, both write, and the loser then spins for
+ * a response_id that will never appear until its timeout expires.
+ *
+ * Measured on device (knob grid, 25s, 4262 reads): the latency distribution
+ * is perfectly bimodal — 4237 reads at 0-10ms, **nothing at all between 10ms
+ * and 99ms**, then 25 reads piled against the 100ms-per-stage timeout
+ * ceiling. That empty band is the proof they are timeouts, not slow reads.
+ * One failed read per second, each blocking the UI thread 100-200ms AND
+ * returning null to its caller. Pausing schwung-manager for 30s took the
+ * grid from 38-50 to 57-59 ticks/sec and the spikes vanished.
+ *
+ * A compare-exchange makes observe-and-claim one indivisible step, so only
+ * one process can ever hold the channel. CLAIMED is a distinct value rather
+ * than a real request type: the shim must see the channel as busy but must
+ * NOT try to serve it, because the key and request_id are not written yet.
+ * The window it is held is a handful of stores, versus the ~2.9ms SPI frame
+ * the old window stayed open for.
+ *
+ * Deliberately still uses the existing field and no new layout, so the SHM
+ * segment is byte-identical and there is no version-skew hazard across the
+ * three binaries that map it.
+ */
+static int shadow_param_claim(int timeout_ms) {
     int timeout = shadow_param_timeout_to_polls(timeout_ms);
-    while (shadow_param->request_type != 0 && timeout > 0) {
+    while (timeout > 0) {
+        uint8_t expected = 0;
+        if (__atomic_compare_exchange_n((uint8_t *)&shadow_param->request_type,
+                                        &expected, (uint8_t)SHADOW_PARAM_CLAIMED,
+                                        0 /* strong */,
+                                        __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
+            return 1;
+        }
         usleep(SHADOW_PARAM_POLL_US);
         timeout--;
     }
-    return shadow_param->request_type == 0;
+    return 0;
+}
+
+/*
+ * Report a param call that gave up, with WHICH STAGE gave up and on what key.
+ *
+ * A span carries a name, not a key, and the tail we are chasing is ~0.5% of
+ * reads — rare enough that only naming the actual key and stage will identify
+ * it. Aggregated and emitted at most once a second, because a diagnostic that
+ * writes per event is how a previous round of ~150ms stalls got mistaken for
+ * scheduling contention.
+ */
+static void shadow_param_note_slow(const char *stage, const char *key) {
+    static unsigned n_claim, n_resp, n_err;
+    static char last_key[SHADOW_PARAM_KEY_LEN];
+    static time_t last_report;
+
+    if (stage[0] == 'c') n_claim++;
+    else if (stage[0] == 'r') n_resp++;
+    else n_err++;
+    if (key) { strncpy(last_key, key, sizeof(last_key) - 1);
+               last_key[sizeof(last_key) - 1] = '\0'; }
+
+    time_t now = time(NULL);
+    if (now == last_report) return;
+    last_report = now;
+    if (!(n_claim | n_resp | n_err)) return;
+    char line[256];
+    snprintf(line, sizeof(line),
+             "param_giveup: claim=%u response=%u error=%u  last_key=%s",
+             n_claim, n_resp, n_err, last_key);
+    shadow_ui_log_line(line);
+    n_claim = n_resp = n_err = 0;
 }
 
 static int shadow_param_wait_response(uint32_t req_id, int timeout_ms) {
@@ -770,7 +842,7 @@ static int shadow_set_param_common(int slot, const char *key, const char *value,
          * request) from waiting for the shim to service ours (frame
          * quantisation). They call for different fixes. */
         int idle;
-        { TRACE_SCOPE("param.set.idle"); idle = shadow_param_wait_idle(timeout_ms); }
+        { TRACE_SCOPE("param.set.idle"); idle = shadow_param_claim(timeout_ms); }
         if (!idle) {
             return 0;
         }
@@ -893,7 +965,7 @@ static JSValue shadow_param_bulk_js(JSContext *ctx, int argc, JSValueConst *argv
     if (!value) { JS_FreeCString(ctx, key); return JS_NULL; }
     if (vlen >= SHADOW_PARAM_VALUE_LEN) vlen = SHADOW_PARAM_VALUE_LEN - 1;
 
-    if (!shadow_param_wait_idle(SHADOW_PARAM_DEFAULT_TIMEOUT_MS)) {
+    if (!shadow_param_claim(SHADOW_PARAM_DEFAULT_TIMEOUT_MS)) {
         JS_FreeCString(ctx, key); JS_FreeCString(ctx, value); return JS_NULL;
     }
     uint32_t req_id = shadow_param_next_request_id();
@@ -954,7 +1026,17 @@ static JSValue js_shadow_get_param(JSContext *ctx, JSValueConst this_val, int ar
      * return below via cleanup. */
     TRACE_SCOPE("param.get");
 
-    if (!shadow_param_wait_idle(SHADOW_PARAM_DEFAULT_TIMEOUT_MS)) {
+    /* Claim and response are spanned SEPARATELY because the two failure modes
+     * are completely different problems and the aggregate cannot tell them
+     * apart: time in `claim` means somebody else is holding the channel, time
+     * in `response` means our request was accepted and never answered. The
+     * ~0.5%-of-reads timeout tail survived two fixes aimed at the first, which
+     * is exactly the sort of thing an undifferentiated span hides. */
+    int claimed;
+    { TRACE_SCOPE("param.get.claim");
+      claimed = shadow_param_claim(SHADOW_PARAM_DEFAULT_TIMEOUT_MS); }
+    if (!claimed) {
+        shadow_param_note_slow("claim", key);
         JS_FreeCString(ctx, key);
         return JS_NULL;
     }
@@ -986,11 +1068,31 @@ static JSValue js_shadow_get_param(JSContext *ctx, JSValueConst this_val, int ar
      * parent_span_id / key (written above) before it services this GET. */
     __atomic_store_n(&shadow_param->request_type, (uint8_t)2, __ATOMIC_RELEASE);  /* GET */
 
-    if (shadow_param_wait_response(req_id, SHADOW_PARAM_DEFAULT_TIMEOUT_MS) <= 0) {
+    int got;
+    { TRACE_SCOPE("param.get.response");
+      got = shadow_param_wait_response(req_id, SHADOW_PARAM_DEFAULT_TIMEOUT_MS); }
+    if (got <= 0) {
+        shadow_param_note_slow(got == 0 ? "response-timeout" : "error", key);
         return JS_NULL;
     }
 
-    return JS_NewString(ctx, shadow_param->value);
+    /*
+     * Copy the value, then CHECK IT IS STILL OURS.
+     *
+     * The servicer releases the channel (request_type = 0) at the same moment
+     * it publishes the response, so from that instant the other process may
+     * claim it and overwrite `value` while we are still copying it out. The
+     * window is small — we wake within one 200us poll — but it is a silent
+     * wrong-value window, not an error, so it is worth one comparison to
+     * close. If the id moved underneath us the copy is untrustworthy: report
+     * nothing rather than something wrong.
+     */
+    JSValue out = JS_NewString(ctx, shadow_param->value);
+    if (shadow_param->response_id != req_id) {
+        JS_FreeValue(ctx, out);
+        return JS_NULL;
+    }
+    return out;
 }
 
 /* === MIDI output functions for overtake modules === */

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -805,8 +805,36 @@ static void shadow_param_note_slow(const char *stage, const char *key) {
     n_claim = n_resp = n_err = 0;
 }
 
+/*
+ * How long to sleep BEFORE polling at all.
+ *
+ * The shim services this channel from the SPI callback, once per frame, and a
+ * frame is ~2.9ms. So the answer is never ready in the first couple of hundred
+ * microseconds — yet the loop below used to wake ~14 times discovering that,
+ * every single read.
+ *
+ * Each of those wakeups is a syscall and, more to the point, a chance for the
+ * scheduler to give the CPU to something else and not come back promptly. That
+ * is the mechanism behind the tail this was chasing: measured on device, ~0.5%
+ * of reads took 142-163ms instead of 2.8ms, and they SUCCEEDED — no timeout was
+ * recorded — so nothing was lost or contended, the process simply was not
+ * running to observe a response that had been sitting there. Sleeping once for
+ * most of a frame cuts the wakeups per read from ~14 to ~2, and with them the
+ * exposure.
+ *
+ * Deliberately shorter than a frame: overshooting would add latency to every
+ * read to fix a rare one. 2.2ms still lands inside the same frame the old
+ * loop's 11th poll would have.
+ */
+#define SHADOW_PARAM_FIRST_SLEEP_US 2200
+
 static int shadow_param_wait_response(uint32_t req_id, int timeout_ms) {
     int timeout = shadow_param_timeout_to_polls(timeout_ms);
+    /* Not ready yet by construction — see above. Skip the pointless polls. */
+    if (__atomic_load_n(&shadow_param->response_ready, __ATOMIC_ACQUIRE) == 0) {
+        usleep(SHADOW_PARAM_FIRST_SLEEP_US);
+        timeout -= SHADOW_PARAM_FIRST_SLEEP_US / SHADOW_PARAM_POLL_US;
+    }
     while (timeout > 0) {
         /* Acquire-load pairs with the writer's release-store of response_ready
          * (shadow_param_publish_response + the shim sites). It guarantees the

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -14577,18 +14577,28 @@ globalThis.tick = function() {
      * that have no shared memory representation. No C calls here. */
     if (++_configSyncTickCounter >= CONFIG_SYNC_INTERVAL) {
         _configSyncTickCounter = 0;
-        syncJsOnlySettings();
-
-        /* Check for web-initiated upgrade status and show OLED overlay */
+        /* Spanned: this is TWO eMMC file reads plus a JSON parse landing on a
+         * single tick, roughly every 1.5s — the right shape and cadence for
+         * the periodic dips, and the same class of mistake as the diagnostic
+         * that once caused the stalls it was reporting. Attribute it before
+         * assuming it. */
+        const _h = (typeof host_trace_begin === 'function') ? host_trace_begin("js.config_sync") : 0;
         try {
-            const status = host_read_file("/data/UserData/schwung/upgrade_status");
-            if (status && status.trim()) {
-                _upgradeOverlayText = status.trim();
-            } else if (_upgradeOverlayText) {
+            syncJsOnlySettings();
+
+            /* Check for web-initiated upgrade status and show OLED overlay */
+            try {
+                const status = host_read_file("/data/UserData/schwung/upgrade_status");
+                if (status && status.trim()) {
+                    _upgradeOverlayText = status.trim();
+                } else if (_upgradeOverlayText) {
+                    _upgradeOverlayText = null;
+                }
+            } catch (e) {
                 _upgradeOverlayText = null;
             }
-        } catch (e) {
-            _upgradeOverlayText = null;
+        } finally {
+            if (_h && typeof host_trace_end === 'function') host_trace_end(_h);
         }
     }
 
@@ -14597,7 +14607,16 @@ globalThis.tick = function() {
      * the modal when the shadow UI is on screen. Throttled to a few times/sec. */
     if (++_feedbackHoldTickCounter >= FEEDBACK_HOLD_CHECK_INTERVAL) {
         _feedbackHoldTickCounter = 0;
+        /* Spanned: reads `synth_module` for all FOUR slots unconditionally,
+         * which is four synchronous IPC round trips at ~2.8ms — ~11ms on ONE
+         * tick, six times a second, on top of the grid's own ~7ms. That is
+         * over the 16.67ms period, and six overruns a second is exactly the
+         * unexplained 60 -> 54-56. It also accounts for the 0.4 reads/tick of
+         * `synth_module` the last session logged and attributed elsewhere.
+         * Predicted, not yet measured — this span is the test. */
+        const _h = (typeof host_trace_begin === 'function') ? host_trace_begin("js.feedback_guard") : 0;
         try { reconcileFeedbackHolds(); } catch (e) { debugLog("reconcileFeedbackHolds error: " + e); }
+        finally { if (_h && typeof host_trace_end === 'function') host_trace_end(_h); }
     }
 
     /* Draw upgrade overlay if active (takes priority over normal UI) */

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -453,6 +453,18 @@ let view = VIEWS.SLOTS;
 let needsRedraw = true;
 let refreshCounter = 0;
 let autosaveCounter = 0;
+/* Which step of the spread-out autosave pass is next: 0..SHADOW_UI_SLOTS-1 is
+ * that slot, SHADOW_UI_SLOTS is the master FX chain, null means idle. One step
+ * per tick — see the drain block in globalThis.tick. */
+let autosaveJob = null;
+/* Exact bytes last written to each slot_N.json, so an unchanged slot skips the
+ * eMMC write entirely (measured ~120ms per write — the single most expensive
+ * thing the UI thread did). Cleared whenever the file set changes underneath
+ * us, so the next pass rewrites unconditionally. */
+let lastWrittenSlotJson = [null, null, null, null];
+function invalidateAutosaveWriteCache() {
+    lastWrittenSlotJson = [null, null, null, null];
+}
 let autosaveSuppressUntil = 0;  /* suppress autosave after set change */
 let slotDirtyCache = [false, false, false, false];
 /* Module signature ("synth|midiFx|fx1|fx2") from the last successful autosave.
@@ -2625,7 +2637,22 @@ function getSlotModuleSignature(slotIndex) {
 /* Refresh module signature for a slot and invalidate knob cache on changes */
 function refreshSlotModuleSignature(slotIndex) {
     if (slotIndex < 0 || slotIndex >= SHADOW_UI_SLOTS) return false;
-    const signature = getSlotModuleSignature(slotIndex);
+    return applySlotModuleSignature(slotIndex, getSlotModuleSignature(slotIndex));
+}
+
+/*
+ * The half of refreshSlotModuleSignature that costs nothing, split out so a
+ * caller that already has the signature does not pay for it twice.
+ *
+ * getSlotModuleSignature is FOUR synchronous IPC round trips (~2.8ms each,
+ * ~11ms), and autosave was calling it twice per slot per pass — once through
+ * refreshSlotModuleSignature at the top of the loop and again below as
+ * `currentSig` — i.e. 32 round trips across four slots to compute 16 values,
+ * half of them a second time. That is ~90ms of the ~200ms autosave stall, for
+ * strings that only change when the user swaps a module.
+ */
+function applySlotModuleSignature(slotIndex, signature) {
+    if (slotIndex < 0 || slotIndex >= SHADOW_UI_SLOTS) return false;
     if (signature !== lastSlotModuleSignatures[slotIndex]) {
         lastSlotModuleSignatures[slotIndex] = signature;
         loadChainConfigFromSlot(slotIndex);
@@ -4435,10 +4462,27 @@ function generateSlotPresetName(slotIndex) {
  * round-trip race and return "" — silently dropping the save and losing
  * recent edits (diagnosed 2026-05-12). 3 retries adds up to ~400ms worst
  * case which is well under typical set-change duration. */
-function getSlotStateWithRetry(slotIndex, key) {
+/*
+ * `retries` defaults to the historical 3. Periodic autosave passes 1.
+ *
+ * Every attempt is a synchronous IPC round trip (~2.8ms), and the loop fires
+ * on any FALSY result — which includes a component whose state is genuinely
+ * empty, so such a component paid four round trips (~11ms) on every autosave,
+ * forever, to be told the same thing four times. Across a populated slot set
+ * that is a large share of the ~200ms autosave stall.
+ *
+ * Retrying at all is still right for an explicit save: the retries exist
+ * because a state query can come back empty transiently while a module is
+ * still loading, and an explicit save has no second chance. Periodic autosave
+ * does: the bail-if-empty guard in buildSlotPatchJson preserves the existing
+ * slot_N.json, and the next pass is five seconds away. So it takes one extra
+ * attempt, not three.
+ */
+function getSlotStateWithRetry(slotIndex, key, retries) {
+    const limit = (typeof retries === "number") ? retries : 3;
     let state = getSlotParam(slotIndex, key);
     if (state) return state;
-    for (let attempt = 1; attempt <= 3; attempt++) {
+    for (let attempt = 1; attempt <= limit; attempt++) {
         state = getSlotParam(slotIndex, key);
         if (state) {
             debugLog("getSlotStateWithRetry: slot " + slotIndex + " " +
@@ -4465,6 +4509,10 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
      * is inapplicable anyway — save with whatever we have (possibly empty)
      * so the module selection survives a reboot. */
     const bailIfEmpty = forAutosave && !moduleChanged;
+    /* Periodic autosave gets one extra attempt, not three — see
+     * getSlotStateWithRetry. It has the bail-if-empty guard and another pass
+     * in five seconds; an explicit save has neither. */
+    const stateRetries = forAutosave ? 1 : 3;
 
     const patch = {
         custom_name: name,
@@ -4476,7 +4524,7 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
     if (cfg.synth && cfg.synth.module) {
         /* Try to get full state from synth plugin */
         let synthConfig = cfg.synth.params || {};
-        const stateJson = getSlotStateWithRetry(slotIndex, "synth:state");
+        const stateJson = getSlotStateWithRetry(slotIndex, "synth:state", stateRetries);
         if (stateJson) {
             try {
                 const state = JSON.parse(stateJson);
@@ -4503,7 +4551,7 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
     if (cfg.midiFx && cfg.midiFx.module) {
         /* Try to get full state from midi_fx plugin */
         let midiFxConfig = cfg.midiFx.params || {};
-        const midiFxStateJson = getSlotStateWithRetry(slotIndex, "midi_fx1:state");
+        const midiFxStateJson = getSlotStateWithRetry(slotIndex, "midi_fx1:state", stateRetries);
         if (midiFxStateJson) {
             try {
                 const state = JSON.parse(midiFxStateJson);
@@ -4528,7 +4576,7 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
     if (cfg.fx1 && cfg.fx1.module) {
         /* Try to get full state from fx1 plugin */
         let fx1Config = cfg.fx1.params || {};
-        const fx1StateJson = getSlotStateWithRetry(slotIndex, "fx1:state");
+        const fx1StateJson = getSlotStateWithRetry(slotIndex, "fx1:state", stateRetries);
         if (fx1StateJson) {
             try {
                 const state = JSON.parse(fx1StateJson);
@@ -4552,7 +4600,7 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
     if (cfg.fx2 && cfg.fx2.module) {
         /* Try to get full state from fx2 plugin */
         let fx2Config = cfg.fx2.params || {};
-        const fx2StateJson = getSlotStateWithRetry(slotIndex, "fx2:state");
+        const fx2StateJson = getSlotStateWithRetry(slotIndex, "fx2:state", stateRetries);
         if (fx2StateJson) {
             try {
                 const state = JSON.parse(fx2StateJson);
@@ -4614,7 +4662,13 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
 }
 
 /* Autosave all slot states to slot_state/slot_N.json */
-function autosaveAllSlots() {
+/*
+ * Autosave ONE slot. Split out of autosaveAllSlots so the periodic pass can
+ * spend a slot per tick instead of landing ~70 IPC reads (~200ms) on a
+ * single frame every five seconds. Body is unchanged apart from the
+ * loop's `continue`s becoming `return`s.
+ */
+function autosaveOneSlot(i) {
     /* Never persist an uncommitted preset audition. While the user scrolls
      * User Presets, the live <prefix>:state is the previewed sound, not a
      * committed choice — saving it would let a slot silently adopt a preview
@@ -4622,96 +4676,134 @@ function autosaveAllSlots() {
      * mid-audition). previewActive clears on Load (commit) or Back (revert),
      * after which autosave resumes normally. */
     if (isPresetPreviewActive()) return;
-    for (let i = 0; i < SHADOW_UI_SLOTS; i++) {
-        /* Sync chainConfigs from DSP before checking - prevents clobbering
-         * valid autosave files for slots we haven't navigated to yet */
-        refreshSlotModuleSignature(i);
-        const cfg = chainConfigs[i];
-        const hasSynth = cfg && cfg.synth && cfg.synth.module;
-        const hasFx1 = cfg && cfg.fx1 && cfg.fx1.module;
-        const hasFx2 = cfg && cfg.fx2 && cfg.fx2.module;
-        const hasMidiFx = cfg && cfg.midiFx && cfg.midiFx.module;
-        if (!hasSynth && !hasFx1 && !hasFx2 && !hasMidiFx) {
-            /* Cross-check before clobbering: if the slot has a preset name
-             * but the shim is reporting "no modules" AND the user did not
-             * explicitly clear the slot via the picker, it's a transient
-             * shim-side glitch (e.g. boot-time patch load failure
-             * diagnosed 2026-04-18). Preserve the existing slot_N.json so
-             * the next boot has a chance to reload it.
-             *
-             * slotUserCleared[i] = true means the user picked None for
-             * every component in the slot, so the empty state is real and
-             * must be persisted (otherwise removals never save — diagnosed
-             * 2026-04-29). */
-            const slotName = (slots[i] && slots[i].name) || "";
-            if (!slotUserCleared[i] && slotName !== "") {
-                /* Only guard when there's actually content on disk to protect.
-                 * If slot_N.json is missing/empty, the chain-config name has
-                 * drifted from the saved state — writing the empty marker is
-                 * safe and stops the every-autosave log spam. */
-                const existing = host_read_file(
-                    activeSlotStateDir + "/slot_" + i + ".json");
-                let hasSavedChain = false;
-                if (existing) {
-                    try {
-                        const parsed = JSON.parse(existing);
-                        hasSavedChain = !!(parsed && parsed.chain &&
-                            ((parsed.chain.synth && parsed.chain.synth.module) ||
-                             (parsed.chain.audio_fx && parsed.chain.audio_fx.length) ||
-                             (parsed.chain.midi_fx && parsed.chain.midi_fx.length)));
-                    } catch (e) { /* malformed → treat as no content */ }
-                }
-                if (hasSavedChain) {
-                    debugLog("autosave: slot " + i + " shim reports empty but " +
-                             "preset name=\"" + slotName + "\" and slot_" + i +
-                             ".json has chain — preserving (likely shim glitch)");
-                    slotDirtyCache[i] = false;
-                    continue;
-                }
-                /* No saved chain on disk — chain-config name is stale. Fall
-                 * through to write the empty marker so future autosaves stop
-                 * tripping this branch. */
+    /* Sync chainConfigs from DSP before checking - prevents clobbering
+     * valid autosave files for slots we haven't navigated to yet.
+     * Read ONCE and reused as `currentSig` below — it used to be read
+     * again a few lines down, at four IPC round trips a time. */
+    const currentSig = getSlotModuleSignature(i);
+    applySlotModuleSignature(i, currentSig);
+    const cfg = chainConfigs[i];
+    const hasSynth = cfg && cfg.synth && cfg.synth.module;
+    const hasFx1 = cfg && cfg.fx1 && cfg.fx1.module;
+    const hasFx2 = cfg && cfg.fx2 && cfg.fx2.module;
+    const hasMidiFx = cfg && cfg.midiFx && cfg.midiFx.module;
+    if (!hasSynth && !hasFx1 && !hasFx2 && !hasMidiFx) {
+        /* Cross-check before clobbering: if the slot has a preset name
+         * but the shim is reporting "no modules" AND the user did not
+         * explicitly clear the slot via the picker, it's a transient
+         * shim-side glitch (e.g. boot-time patch load failure
+         * diagnosed 2026-04-18). Preserve the existing slot_N.json so
+         * the next boot has a chance to reload it.
+         *
+         * slotUserCleared[i] = true means the user picked None for
+         * every component in the slot, so the empty state is real and
+         * must be persisted (otherwise removals never save — diagnosed
+         * 2026-04-29). */
+        const slotName = (slots[i] && slots[i].name) || "";
+        if (!slotUserCleared[i] && slotName !== "") {
+            /* Only guard when there's actually content on disk to protect.
+             * If slot_N.json is missing/empty, the chain-config name has
+             * drifted from the saved state — writing the empty marker is
+             * safe and stops the every-autosave log spam. */
+            const existing = host_read_file(
+                activeSlotStateDir + "/slot_" + i + ".json");
+            let hasSavedChain = false;
+            if (existing) {
+                try {
+                    const parsed = JSON.parse(existing);
+                    hasSavedChain = !!(parsed && parsed.chain &&
+                        ((parsed.chain.synth && parsed.chain.synth.module) ||
+                         (parsed.chain.audio_fx && parsed.chain.audio_fx.length) ||
+                         (parsed.chain.midi_fx && parsed.chain.midi_fx.length)));
+                } catch (e) { /* malformed → treat as no content */ }
             }
-            /* Empty slot - write empty marker to clear autosave */
-            if (host_write_file(
-                activeSlotStateDir + "/slot_" + i + ".json",
-                "{}\n"
-            )) {
+            if (hasSavedChain) {
+                debugLog("autosave: slot " + i + " shim reports empty but " +
+                         "preset name=\"" + slotName + "\" and slot_" + i +
+                         ".json has chain — preserving (likely shim glitch)");
                 slotDirtyCache[i] = false;
-                slotUserCleared[i] = false;
-            } else {
-                debugLog("autosave: failed to write empty marker for slot " + i +
-                         " — will retry next autosave");
+                return;
             }
-            continue;
+            /* No saved chain on disk — chain-config name is stale. Fall
+             * through to write the empty marker so future autosaves stop
+             * tripping this branch. */
         }
-
-        const dirty = getSlotParam(i, "dirty");
-        slotDirtyCache[i] = (dirty === "1");
-
-        const currentSig = getSlotModuleSignature(i);
-        const moduleChanged = currentSig !== lastSavedSlotSignature[i];
-        const patchJson = buildSlotPatchJson(i, slots[i].name || "Untitled", true, moduleChanged);
-        if (!patchJson) continue;
-
-        /* Wrap with name, version, modified flag */
-        const wrapper = {
-            name: slots[i].name || "Untitled",
-            version: 1,
-            modified: slotDirtyCache[i],
-            chain: JSON.parse(patchJson)
-        };
-
+        /* Empty slot - write empty marker to clear autosave.
+         * Same skip-if-unchanged as the populated path below: an empty slot
+         * was rewriting "{}" to eMMC every five seconds forever. */
+        if (lastWrittenSlotJson[i] === "{}\n") {
+            slotDirtyCache[i] = false;
+            slotUserCleared[i] = false;
+            return;
+        }
         if (host_write_file(
             activeSlotStateDir + "/slot_" + i + ".json",
-            JSON.stringify(wrapper, null, 2) + "\n"
+            "{}\n"
         )) {
-            lastSavedSlotSignature[i] = currentSig;
+            slotDirtyCache[i] = false;
+            slotUserCleared[i] = false;
+            lastWrittenSlotJson[i] = "{}\n";
         } else {
-            debugLog("autosave: failed to write slot_" + i + ".json — " +
-                     "keeping stale signature so the next autosave retries");
+            lastWrittenSlotJson[i] = null;
+            debugLog("autosave: failed to write empty marker for slot " + i +
+                     " — will retry next autosave");
         }
+        return;
     }
+
+    const dirty = getSlotParam(i, "dirty");
+    slotDirtyCache[i] = (dirty === "1");
+
+    const moduleChanged = currentSig !== lastSavedSlotSignature[i];
+    const patchJson = buildSlotPatchJson(i, slots[i].name || "Untitled", true, moduleChanged);
+    if (!patchJson) return;
+
+    /* Wrap with name, version, modified flag */
+    const wrapper = {
+        name: slots[i].name || "Untitled",
+        version: 1,
+        modified: slotDirtyCache[i],
+        chain: JSON.parse(patchJson)
+    };
+
+    const slotPath = activeSlotStateDir + "/slot_" + i + ".json";
+    const payload = JSON.stringify(wrapper, null, 2) + "\n";
+
+    /*
+     * Skip the write when the bytes are identical to what we last wrote.
+     *
+     * Measured on device: an autosave tick spent 187ms of which only 66ms was
+     * IPC — the other ~120ms was this host_write_file. eMMC on this device is
+     * slow enough that writing a few KB of JSON is comfortably the most
+     * expensive thing the UI thread does all second, and on an idle set it was
+     * rewriting byte-for-byte identical files every five seconds forever.
+     *
+     * Comparing against the last payload we wrote (not against the file — that
+     * would be a read, and reads are what we are trying to avoid) makes the
+     * idle case free. `lastWrittenSlotJson` is per-process, so the first pass
+     * after a restart still writes, which is what we want: it re-establishes
+     * the file even if something else changed it underneath us.
+     */
+    if (lastWrittenSlotJson[i] === payload) {
+        lastSavedSlotSignature[i] = currentSig;
+        return;
+    }
+
+    if (host_write_file(slotPath, payload)) {
+        lastSavedSlotSignature[i] = currentSig;
+        lastWrittenSlotJson[i] = payload;
+    } else {
+        lastWrittenSlotJson[i] = null;   /* force a retry next pass */
+        debugLog("autosave: failed to write slot_" + i + ".json — " +
+                 "keeping stale signature so the next autosave retries");
+    }
+}
+
+/* Every slot, right now. Used by the explicit save paths (shutdown, set
+ * switch, overtake suspend) where the whole set must land before we
+ * proceed. The periodic timer uses autosaveOneSlot per tick instead. */
+function autosaveAllSlots() {
+    for (let i = 0; i < SHADOW_UI_SLOTS; i++) autosaveOneSlot(i);
 }
 
 /* Actually save the preset */
@@ -14277,6 +14369,7 @@ globalThis.init = function() {
                 const setDir = "/data/UserData/schwung/set_state/" + uuid;
                 if (host_file_exists(setDir + "/slot_0.json") || host_file_exists(setDir + "/shadow_chain_config.json")) {
                     activeSlotStateDir = setDir;
+                    invalidateAutosaveWriteCache();
                     debugLog("Init: using per-set state dir " + setDir);
                 }
             }
@@ -14875,6 +14968,10 @@ globalThis.tick = function() {
             /* 5. Switch directory and load chain config (volumes/channels/mute/solo) */
             const oldDir = activeSlotStateDir;
             activeSlotStateDir = newDir;
+            /* Different directory — what we last wrote says nothing about
+             * what is in THIS set's files, so never skip a write on its
+             * behalf. */
+            invalidateAutosaveWriteCache();
             debugLog("SET_CHANGED: " + oldDir + " -> " + newDir);
             loadChainConfigFromDir(newDir);
 
@@ -15102,8 +15199,39 @@ globalThis.tick = function() {
         autosaveCounter++;
         if (!isOvertakeActive && autosaveCounter >= AUTOSAVE_INTERVAL) {
             autosaveCounter = 0;
-            autosaveAllSlots();
-            saveMasterFxChainConfig();
+            autosaveJob = 0;   /* arm; drained one step per tick below */
+        }
+    }
+
+    /*
+     * Autosave, ONE SLOT PER TICK.
+     *
+     * It used to do all four slots and the master FX chain in a single tick.
+     * Measured on device that was ~70 sequential IPC reads landing on one
+     * frame — ~200ms, i.e. about eleven dropped frames, every five seconds.
+     * It is the visible hitch while nothing is being touched, and the read
+     * histogram showed it plainly: 758 ticks doing 3 reads, and a handful
+     * doing 68-72.
+     *
+     * Nothing about autosave is latency-sensitive — it is background
+     * persistence on a five-second timer — so it has no business being
+     * atomic with respect to the frame. Spread over five ticks (~83ms) it
+     * finishes just as promptly in wall-clock terms while no single frame
+     * carries more than a slot's worth of reads.
+     *
+     * Deliberately NOT restructured below slot granularity: buildSlotPatchJson
+     * has a history of silently dropping saves, and a resumable version of it
+     * would risk persisting a half-read slot. A slot is the unit that is
+     * already all-or-nothing.
+     */
+    if (autosaveJob !== null) {
+        if (isOvertakeActive) {
+            autosaveJob = null;          /* overtake owns the surface; abandon */
+        } else {
+            if (autosaveJob < SHADOW_UI_SLOTS) autosaveOneSlot(autosaveJob);
+            else saveMasterFxChainConfig();
+            autosaveJob++;
+            if (autosaveJob > SHADOW_UI_SLOTS) autosaveJob = null;
         }
     }
     /* Refresh dirty cache frequently for responsive UI */

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2772,9 +2772,43 @@ function isLineInConsumerModule(moduleId) {
     return v;
 }
 
+/* Rotates the no-risk scan over the slots; see reconcileFeedbackHolds. */
+let _feedbackScanCursor = 0;
+
 function reconcileFeedbackHolds() {
     const risk = bootFeedbackRisk();
-    for (let slot = 0; slot < SHADOW_UI_SLOTS; slot++) {
+
+    /*
+     * Which slots to examine THIS pass.
+     *
+     * Every slot needs `synth_module`, and that is a synchronous IPC round
+     * trip at ~2.8ms. Four of them landed on one tick, six times a second:
+     * ~11ms of blocking on top of the ~7ms the knob grid already spends, over
+     * the 16.67ms period, six times a second. Measured on device via the
+     * js.feedback_guard span — mean 10.84ms, and 34% of ALL js.tick time —
+     * which is the whole of the unexplained "60 should be 60, is 54-56".
+     * Nothing else here costs anything: bootFeedbackRisk() is two plain SHM
+     * reads and isLineInConsumerModule() is memoised by module id.
+     *
+     * So when there is no risk, scan ONE slot per pass and rotate: same total
+     * coverage, a quarter of the reads, and no tick ever takes more than one
+     * of them. Each slot is still visited about every 670ms, which is well
+     * inside the FEEDBACK_SAFE_DEBOUNCE_MS the safe path waits out anyway.
+     *
+     * Under risk, scan ALL of them, every pass. The protective direction is
+     * never rate-limited — that is the same rule the bypass path itself
+     * follows, and risk is a rare, transient state (someone unplugged the
+     * headphones), so its cost does not sit on the steady-state frame rate.
+     */
+    const scan = [];
+    if (risk) {
+        for (let i = 0; i < SHADOW_UI_SLOTS; i++) scan.push(i);
+    } else {
+        scan.push(_feedbackScanCursor % SHADOW_UI_SLOTS);
+        _feedbackScanCursor = (_feedbackScanCursor + 1) % SHADOW_UI_SLOTS;
+    }
+
+    for (const slot of scan) {
         const moduleId = getSlotParam(slot, "synth_module");
         if (!isLineInConsumerModule(moduleId)) {
             /* Not a line-in slot — drop any stale guard state. */

--- a/tests/shadow/test_save_preset_error_feedback.sh
+++ b/tests/shadow/test_save_preset_error_feedback.sh
@@ -26,9 +26,16 @@ fi
 
 # Autosave must not record a slot as saved when the write failed, or the
 # retry is suppressed until the next module change.
-auto_body=$(awk '/^function autosaveAllSlots\(/,/^}/' "$file")
+# The per-slot write lives in autosaveOneSlot; autosaveAllSlots is now just a
+# loop over it, because the periodic pass spends one slot per tick rather than
+# landing every slot's IPC reads on a single frame.
+auto_body=$(awk '/^function autosaveOneSlot\(/,/^}/' "$file")
+if [ -z "$auto_body" ]; then
+  echo "FAIL: autosaveOneSlot not found (did the autosave split get renamed?)" >&2
+  exit 1
+fi
 if ! grep -Eq 'if \(host_write_file\(|= host_write_file\(' <<<"$auto_body"; then
-  echo "FAIL: autosaveAllSlots ignores host_write_file result" >&2
+  echo "FAIL: autosaveOneSlot ignores host_write_file result" >&2
   exit 1
 fi
 


### PR DESCRIPTION
The knob grid was jagged, hierarchy edits were jagged, and values visibly flashed. All three were **one bug** in the `/schwung-param` protocol.

## The bug: a published response had no owner

`shadow_param_publish_response` sets `response_ready = 1` and clears `request_type` **in the same publish**. The next claimer CAS'd on `request_type` alone, then zeroed `response_ready` while filling in its own request. So a response could be **destroyed before the client that asked for it ever polled** — and nothing would republish it. That client blocked for its full 100ms deadline and returned `null`.

There was no acknowledgement step.

## How the evidence read

| observation | what it meant |
|---|---|
| `claim=0ms` at failure | there was never any contention |
| `rt=0 rr=1` + foreign `response_id` | our answer was binned; the other process's sat there |
| always a *full timeout*, never a slow read | destroyed, not delayed |
| pausing schwung-manager fixed it | one client = nobody to destroy the response |
| ~0.5% of reads, scaling with read volume | a per-read race window |
| **"values flashing"** (user-reported) | a failed read returns `null` and the UI draws it |

## The fix

Free means `request_type == 0` **and** `response_ready == 0` — both bytes of one 32-bit word, so a single compare-exchange tests and takes them together. The owner clears `response_ready` once it has copied its value out (`shadow_param_consume`, called on give-up paths too). Mirrored in the Go client, which had the identical claim.

So the new rule can't wedge anything: a 250ms bounded steal discards a response whose owner died, and the deliberate fire-and-forget paths flag the response they abandon so the next claim bins it immediately.

Also fixed: the overtake fire-and-forget SET wrote key/value/slot/request_id with **no claim at all**.

## Everything else in this branch, all measured

- **Feedback guard** read `synth_module` for all four slots every 10 ticks — **34.2% of all `js.tick` time**. Now one slot per pass, rotating; all four under risk, because the protective direction is never rate-limited.
- **Autosave** did ~70 sequential reads on one tick every 5s (~200ms). Now one slot per tick. Two multipliers removed: `getSlotModuleSignature` (4 round trips) was called **twice per slot per pass**, and `getSlotStateWithRetry` retried on any *falsy* result, so a legitimately-empty state cost 4 round trips forever.
- **Autosave rewrote byte-identical JSON to eMMC every 5s** — ~120ms per write, the most expensive thing the UI thread did. Skipped when unchanged; invalidated on set change.
- **`loop_stats`** (`touch loop_stats_on`): times the whole loop iteration by phase plus **wake-up lateness**, because `js.tick` never covered `process_shadow_midi`, `js_display_pack` or the touch-file poll. Note `late` samples only the *top* of the loop — it does not see mid-tick preemption.

## Results

| | before | after |
|---|---|---|
| slow reads (≥90ms) | ~1/sec at 109–160ms | **0 per window** |
| idle tick rate | 50–59 | **60, steady** |
| idle worst tick | ~200ms recurring | 27–62ms |
| avg tick (idle) | 2.45ms | **1.6–2.4ms** |

On hardware: "oh my god it's so smooth."

## Verification

`tests/shadow` + `tests/host` diff **identical to main**. `make -C tests/host test` passes. schwung-manager builds, vets and tests clean. Verified on device across idle, the knob grid and hierarchy edits; manager and web UI confirmed healthy after each deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56