### PR TITLE
param_helper: declare viz beside the param, not in a parallel table

### DIFF
--- a/src/host/param_helper.h
+++ b/src/host/param_helper.h
@@ -23,6 +23,13 @@ typedef enum {
     PARAM_TYPE_INT = 1
 } param_type_t;
 
+/*
+ * Sentinel for viz_kind meaning "never draw a graphic for this param, whatever
+ * a detector thinks" — the `viz: false` of docs/MODULES.md. Not a real kind, so
+ * it cannot collide with one.
+ */
+#define PARAM_VIZ_NONE "false"
+
 /* Parameter definition */
 typedef struct {
     const char *key;      /* Parameter key (used in get/set) */
@@ -31,6 +38,28 @@ typedef struct {
     int index;            /* Index into values array */
     float min_val;        /* Minimum value */
     float max_val;        /* Maximum value */
+
+    /*
+     * Optional parameter visualisation — see docs/MODULES.md, "Parameter
+     * visualisations (viz)". Leave all three NULL (the default for any entry
+     * that does not mention them) and the param is simply not declared: the
+     * host's detectors get a look, and a plain knob dial is the honest
+     * fallback when none of them fire.
+     *
+     * Declared here, beside the param itself, ON PURPOSE. A module that keeps
+     * its viz in a separate key-string lookup has two tables to hold in sync,
+     * and renaming a key there silently detaches the graphic — no compile
+     * error, the picture just stops appearing.
+     */
+    const char *viz_group;  /* Group id shared by one graphic's members;
+                             * NULL for a single-param kind. Scoped to the
+                             * module, never shown on screen. */
+    const char *viz_role;   /* This param's part in the group ("attack",
+                             * "cutoff", …). Required when viz_group is set. */
+    const char *viz_kind;   /* Graphic type. Usually NULL — the host derives it
+                             * from the roles present. Set it for a
+                             * single-param graphic ("fader", "waveform",
+                             * "switch"), or to PARAM_VIZ_NONE to suppress. */
 } param_def_t;
 
 /*
@@ -82,6 +111,69 @@ static inline int param_helper_set(
 }
 
 /*
+ * Headroom the entry loops keep in reserve so a param is never written half
+ * way. It has to exceed the longest single entry any module can emit — key,
+ * name, type, range, and now a viz object, which alone can run past 80 chars.
+ * The old value of 100 predated viz and no longer covers one.
+ */
+#define PARAM_HELPER_ENTRY_MARGIN 256
+
+/*
+ * Emit the optional ",\"viz\":{…}" field for one param definition.
+ *
+ * Written as its own function because not every module can use the generator
+ * below — several hand-assemble chain_params to express something param_def_t
+ * has no room for (an enum's options list, a unit, a display format). Those
+ * modules should still call this rather than hand-rolling the JSON, so there
+ * stays exactly one place that knows the field's shape.
+ *
+ * The leading comma is included: this always appends to an object that already
+ * has at least a "key".
+ *
+ * Returns: chars written (0 when the param declares no viz), or -1 if the
+ * buffer is too small to hold the field.
+ */
+static inline int param_helper_viz_json(
+    const param_def_t *def,
+    char *buf,
+    int buf_len
+) {
+    if (!def || !buf || buf_len <= 0) return 0;
+    if (!def->viz_group && !def->viz_kind) return 0;   /* nothing declared */
+
+    /* viz: false — suppress any detector guess. */
+    if (def->viz_kind && strcmp(def->viz_kind, PARAM_VIZ_NONE) == 0) {
+        int n = snprintf(buf, buf_len, ",\"viz\":false");
+        return (n < 0 || n >= buf_len) ? -1 : n;
+    }
+
+    int offset = snprintf(buf, buf_len, ",\"viz\":{");
+    if (offset < 0 || offset >= buf_len) return -1;
+
+    int wrote = 0;
+    if (def->viz_group) {
+        offset += snprintf(buf + offset, buf_len - offset,
+                           "\"group\":\"%s\"", def->viz_group);
+        if (offset >= buf_len) return -1;
+        wrote = 1;
+        if (def->viz_role) {
+            offset += snprintf(buf + offset, buf_len - offset,
+                               ",\"role\":\"%s\"", def->viz_role);
+            if (offset >= buf_len) return -1;
+        }
+    }
+    if (def->viz_kind) {
+        offset += snprintf(buf + offset, buf_len - offset,
+                           "%s\"kind\":\"%s\"", wrote ? "," : "", def->viz_kind);
+        if (offset >= buf_len) return -1;
+    }
+
+    offset += snprintf(buf + offset, buf_len - offset, "}");
+    if (offset >= buf_len) return -1;
+    return offset;
+}
+
+/*
  * Generate chain_params JSON from parameter definitions.
  * Returns: length written to buf, or -1 if buffer too small
  */
@@ -92,22 +184,34 @@ static inline int param_helper_chain_params_json(
     int buf_len
 ) {
     int offset = 0;
+    int emitted = 0;
     offset += snprintf(buf + offset, buf_len - offset, "[");
 
-    for (int i = 0; i < def_count && offset < buf_len - 100; i++) {
+    for (int i = 0; i < def_count && offset < buf_len - PARAM_HELPER_ENTRY_MARGIN; i++, emitted++) {
         if (i > 0) offset += snprintf(buf + offset, buf_len - offset, ",");
         offset += snprintf(buf + offset, buf_len - offset,
-            "{\"key\":\"%s\",\"name\":\"%s\",\"type\":\"%s\",\"min\":%g,\"max\":%g}",
+            "{\"key\":\"%s\",\"name\":\"%s\",\"type\":\"%s\",\"min\":%g,\"max\":%g",
             defs[i].key,
             defs[i].name[0] ? defs[i].name : defs[i].key,
             defs[i].type == PARAM_TYPE_INT ? "int" : "float",
             defs[i].min_val,
             defs[i].max_val);
+        int vn = param_helper_viz_json(&defs[i], buf + offset, buf_len - offset);
+        if (vn < 0) return -1;
+        offset += vn;
+        offset += snprintf(buf + offset, buf_len - offset, "}");
     }
 
     offset += snprintf(buf + offset, buf_len - offset, "]");
 
     if (offset >= buf_len) return -1;
+    /*
+     * Running out of room used to return a short but well-formed list, which
+     * reaches the host as a module that simply has fewer params — no error
+     * anywhere, the missing ones just never appear. Say -1 instead and let the
+     * caller find out.
+     */
+    if (emitted < def_count) return -1;
     return offset;
 }
 

--- a/tests/host/test_param_helper_viz.c
+++ b/tests/host/test_param_helper_viz.c
@@ -1,0 +1,127 @@
+/*
+ * Tests for param_helper.h's viz emission — the `viz` field of
+ * docs/MODULES.md, "Parameter visualisations".
+ *
+ * A module declares a graphic by filling in viz_group/viz_role/viz_kind beside
+ * the param itself. What is being pinned here is mostly that the JSON comes out
+ * the shape the host's resolver expects (src/shared/param_pages/viz.mjs reads
+ * `group`/`role`/`kind`, and treats `viz: false` as a suppression), because
+ * nothing else in the build would notice if it drifted: a malformed viz field
+ * does not fail to compile, it just silently stops drawing a picture.
+ */
+#include <stdio.h>
+#include <string.h>
+#include "param_helper.h"
+
+static int failures = 0;
+
+static void expect_str(const char *what, const char *got, const char *want) {
+    if (strcmp(got, want) != 0) {
+        fprintf(stderr, "FAIL %s\n  got:  %s\n  want: %s\n", what, got, want);
+        failures++;
+    }
+}
+
+static void expect_int(const char *what, int got, int want) {
+    if (got != want) {
+        fprintf(stderr, "FAIL %s: got %d, want %d\n", what, got, want);
+        failures++;
+    }
+}
+
+enum { IDX_A, IDX_B, IDX_C, IDX_D };
+
+int main(void) {
+    char buf[512];
+
+    /* A group member: group + role, kind left for the host to derive. */
+    {
+        param_def_t d = {"attack", "Attack", PARAM_TYPE_FLOAT, IDX_A, 0.0f, 1.0f,
+                         "amp", "attack", NULL};
+        int n = param_helper_viz_json(&d, buf, sizeof(buf));
+        expect_str("group+role", buf, ",\"viz\":{\"group\":\"amp\",\"role\":\"attack\"}");
+        expect_int("group+role length", n, (int)strlen(buf));
+    }
+
+    /* A single-param graphic: kind alone, no group. */
+    {
+        param_def_t d = {"volume", "Volume", PARAM_TYPE_FLOAT, IDX_B, 0.0f, 1.0f,
+                         NULL, NULL, "fader"};
+        param_helper_viz_json(&d, buf, sizeof(buf));
+        expect_str("kind only", buf, ",\"viz\":{\"kind\":\"fader\"}");
+    }
+
+    /* Group with an explicit kind — both appear, group first. */
+    {
+        param_def_t d = {"lfo_rate", "Rate", PARAM_TYPE_FLOAT, IDX_C, 0.0f, 1.0f,
+                         "osc1_lfo", "rate", "lfo"};
+        param_helper_viz_json(&d, buf, sizeof(buf));
+        expect_str("group+role+kind", buf,
+                   ",\"viz\":{\"group\":\"osc1_lfo\",\"role\":\"rate\",\"kind\":\"lfo\"}");
+    }
+
+    /* PARAM_VIZ_NONE is `viz: false` — stop a detector guessing, never an
+     * object with kind "false". */
+    {
+        param_def_t d = {"low_xo", "Low XO", PARAM_TYPE_INT, IDX_D, 0.0f, 400.0f,
+                         NULL, NULL, PARAM_VIZ_NONE};
+        param_helper_viz_json(&d, buf, sizeof(buf));
+        expect_str("viz false", buf, ",\"viz\":false");
+    }
+
+    /* Undeclared: writes nothing at all, so the param falls through to the
+     * host's detectors and then to a plain dial. Most params are this. */
+    {
+        param_def_t d = {"timbre", "Timbre", PARAM_TYPE_FLOAT, IDX_A, 0.0f, 1.0f,
+                         NULL, NULL, NULL};
+        buf[0] = 'x'; buf[1] = '\0';
+        int n = param_helper_viz_json(&d, buf, sizeof(buf));
+        expect_int("undeclared writes nothing", n, 0);
+        expect_str("undeclared leaves buffer alone", buf, "x");
+    }
+
+    /* Too small a buffer reports -1 rather than emitting half an object. */
+    {
+        param_def_t d = {"attack", "Attack", PARAM_TYPE_FLOAT, IDX_A, 0.0f, 1.0f,
+                         "amp", "attack", NULL};
+        char tiny[12];
+        expect_int("tiny buffer", param_helper_viz_json(&d, tiny, sizeof(tiny)), -1);
+    }
+
+    /* The generator threads viz through, and a param that declares none adds
+     * no field. */
+    {
+        static const param_def_t defs[] = {
+            {"attack", "Attack", PARAM_TYPE_FLOAT, IDX_A, 0.0f, 1.0f, "amp", "attack", NULL},
+            {"timbre", "Timbre", PARAM_TYPE_FLOAT, IDX_B, 0.0f, 1.0f, NULL, NULL, NULL},
+        };
+        int n = param_helper_chain_params_json(defs, PARAM_DEF_COUNT(defs), buf, sizeof(buf));
+        expect_str("chain_params", buf,
+            "[{\"key\":\"attack\",\"name\":\"Attack\",\"type\":\"float\",\"min\":0,\"max\":1,"
+            "\"viz\":{\"group\":\"amp\",\"role\":\"attack\"}},"
+            "{\"key\":\"timbre\",\"name\":\"Timbre\",\"type\":\"float\",\"min\":0,\"max\":1}]");
+        expect_int("chain_params length", n, (int)strlen(buf));
+    }
+
+    /*
+     * A buffer too small for every param must fail, not return a short list.
+     * Silently dropping params reaches the host as a module that simply has
+     * fewer of them — the exact failure the viz migration guide warns about.
+     */
+    {
+        static const param_def_t defs[] = {
+            {"attack",  "Attack",  PARAM_TYPE_FLOAT, IDX_A, 0.0f, 1.0f, "amp", "attack",  NULL},
+            {"release", "Release", PARAM_TYPE_FLOAT, IDX_B, 0.0f, 1.0f, "amp", "release", NULL},
+        };
+        char small[64];
+        expect_int("truncation is an error",
+                   param_helper_chain_params_json(defs, PARAM_DEF_COUNT(defs), small, sizeof(small)), -1);
+    }
+
+    if (failures) {
+        fprintf(stderr, "%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("PASS test_param_helper_viz\n");
+    return 0;
+}

--- a/tests/host/test_param_helper_viz.sh
+++ b/tests/host/test_param_helper_viz.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+bin="build/tests/test_param_helper_viz"
+mkdir -p "$(dirname "$bin")"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Isrc -Isrc/host \
+  tests/host/test_param_helper_viz.c \
+  -o "$bin"
+
+"$bin"


### PR DESCRIPTION
Follow-up to #214. Makes the `viz` declaration path something the remaining ~45 modules can copy, instead of the workaround braids currently models.

## The problem

Braids declares its viz groups through a standalone `viz_json_for()` `strcmp` chain sitting ~200 lines away from `g_shadow_params[]`:

```c
if (!strcmp(key, "attack")) return ",\"viz\":{\"group\":\"amp\",\"role\":\"attack\"}";
```

So the module has two tables keyed by the same strings with nothing tying them together. Rename a key in one and the graphic silently detaches — no compile error, the picture just stops appearing. `docs/plans/2026-08-16-viz-migration-guide.md` asks for the opposite:

> adding `viz` means extending `param_def_t` and the generator — do it once in that module's `param_helper.h`, then fill in the table

Braids is the only migrated module so far, so the shape it set is the shape the next 45 would copy.

## The change

- `param_def_t` grows `viz_group` / `viz_role` / `viz_kind`. All default to `NULL`, so every existing entry compiles untouched and stays undeclared — still the right answer for most params.
- `PARAM_VIZ_NONE` expresses `viz: false`.
- `param_helper_viz_json()` is a separate function, not folded into the generator, because several modules hand-assemble `chain_params` to express what `param_def_t` has no room for (an enum's options list, a unit, a display format) and so cannot call `param_helper_chain_params_json()` at all. They can still call this one, keeping a single place that knows the field's shape.

Two fixes while here:

- **Entry margin was 100 chars.** That predates viz and no longer covers one entry — braids' longest is now 151. Latent rather than live (callers pass a 64 KB buffer, so the guard never fired), but wrong. Now `PARAM_HELPER_ENTRY_MARGIN` = 256.
- **Truncation was silent.** Running out of room returned a short but well-formed list, which reaches the host as a module that simply has fewer params. Now returns -1. Safe to change: there are currently no callers of the generator anywhere in the fleet.

## Tests

`param_helper.h` had no coverage at all, and a malformed viz field is invisible to the compiler — it just stops drawing. Adds `tests/host/test_param_helper_viz.{c,sh}` covering group+role, single-param kind, explicit kind, `viz: false`, undeclared-writes-nothing, small-buffer -1, generator threading, and truncation-is-an-error.

Verified non-vacuous: mutating the emitted `"role"` key to `"ROLE"` makes it fail as expected.

Local run: all C tests pass (`make -C tests/host test`) plus the new one. 32 of the `.sh` tests fail locally with `rg: command not found` — environmental, `rg` is a shell function my non-interactive shell can't see; CI has the real binary.

## Companion change

`schwung-braids` gets the identical header (the two files are byte-identical today, and 6 module repos carry copies) plus its table filled in and `viz_json_for()` deleted. Differential-tested: old and new emit byte-identical `chain_params` (1949 chars), and the module cross-compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1c1uu1486Nw1myHT97KAH