### PR TITLE
Stop polling param keys the loaded modules don't implement

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -577,6 +577,36 @@ let overlayState = null;
 
 /* FX display_name cache for change-based announcements (e.g. key detection) */
 let fxDisplayNameCache = {};  /* key: "slot:component" -> last display_name string */
+/*
+ * Per-component backoff for the display_name poll.
+ *
+ * Almost no FX implements display_name — it exists for the handful that report
+ * something live, like key detection. Every other loaded FX was asked once a
+ * second forever and errored, and an errored read still costs the full ~2.8ms
+ * round trip. The error is free; the round trip is not.
+ *
+ * Backed off rather than switched off: a module could in principle start
+ * answering later. Reset wherever fxDisplayNameCache is reset (module swap),
+ * since that is exactly when support can change.
+ */
+let fxDisplayNameSkip = {};   /* key -> polls still to skip */
+let fxDisplayNameBackoff = {};/* key -> current skip length */
+const FX_NAME_BACKOFF_MAX = 32;   /* ~32s at one poll/sec */
+
+/* Returns the name, or null when the poll was skipped or unsupported. */
+function pollFxDisplayName(slot, key, cacheKey) {
+    if (fxDisplayNameSkip[cacheKey] > 0) { fxDisplayNameSkip[cacheKey]--; return null; }
+    const name = getSlotParam(slot, key);
+    if (name === null || name === undefined) {
+        const next = Math.min((fxDisplayNameBackoff[cacheKey] || 1) * 2, FX_NAME_BACKOFF_MAX);
+        fxDisplayNameBackoff[cacheKey] = next;
+        fxDisplayNameSkip[cacheKey] = next;
+        return null;
+    }
+    fxDisplayNameBackoff[cacheKey] = 0;
+    fxDisplayNameSkip[cacheKey] = 0;
+    return name;
+}
 
 /* Helper to change view and announce it */
 function setView(newView, customLabel) {
@@ -2618,8 +2648,15 @@ function loadChainConfigFromSlot(slotIndex) {
     /* Clear display_name cache when FX modules change (prevents stale announcement on swap) */
     const newFx1 = cfg.fx1 ? cfg.fx1.module : null;
     const newFx2 = cfg.fx2 ? cfg.fx2.module : null;
-    if (newFx1 !== oldFx1) delete fxDisplayNameCache[`${slotIndex}:fx1`];
-    if (newFx2 !== oldFx2) delete fxDisplayNameCache[`${slotIndex}:fx2`];
+    /* Also drop the poll backoff: a different module may well implement
+     * display_name even though the last one didn't. */
+    const forgetFxName = (ck) => {
+        delete fxDisplayNameCache[ck];
+        delete fxDisplayNameSkip[ck];
+        delete fxDisplayNameBackoff[ck];
+    };
+    if (newFx1 !== oldFx1) forgetFxName(`${slotIndex}:fx1`);
+    if (newFx2 !== oldFx2) forgetFxName(`${slotIndex}:fx2`);
 
     chainConfigs[slotIndex] = cfg;
     return cfg;
@@ -4949,6 +4986,11 @@ function clearMasterFx() {
     for (let i = 0; i < 4; i++) {
         setMasterFxSlotModule(i, "");
         masterFxConfig[`fx${i + 1}`].module = "";
+        /* Different module — it may implement display_name even if the
+         * last one didn't, so poll it at full rate again. */
+        delete fxDisplayNameCache[`master:fx${i + 1}`];
+        delete fxDisplayNameSkip[`master:fx${i + 1}`];
+        delete fxDisplayNameBackoff[`master:fx${i + 1}`];
     }
     saveMasterFxChainConfig();
     currentMasterPresetName = "";
@@ -4974,6 +5016,11 @@ function loadMasterPreset(index, presetName) {
                 if (opt) {
                     setMasterFxSlotModule(i, opt.dspPath || "");
                     masterFxConfig[key].module = opt.id;
+                    /* Different module — it may implement display_name even if the
+                     * last one didn't, so poll it at full rate again. */
+                    delete fxDisplayNameCache[`master:${key}`];
+                    delete fxDisplayNameSkip[`master:${key}`];
+                    delete fxDisplayNameBackoff[`master:${key}`];
 
                     /* Restore plugin_id first (CLAP sub-plugin selection) */
                     if (fxConfig.params && typeof shadow_set_param === "function") {
@@ -4991,10 +5038,20 @@ function loadMasterPreset(index, presetName) {
                     /* Module not found - clear slot */
                     setMasterFxSlotModule(i, "");
                     masterFxConfig[key].module = "";
+                    /* Different module — it may implement display_name even if the
+                     * last one didn't, so poll it at full rate again. */
+                    delete fxDisplayNameCache[`master:${key}`];
+                    delete fxDisplayNameSkip[`master:${key}`];
+                    delete fxDisplayNameBackoff[`master:${key}`];
                 }
             } else {
                 setMasterFxSlotModule(i, "");
                 masterFxConfig[key].module = "";
+                /* Different module — it may implement display_name even if the
+                 * last one didn't, so poll it at full rate again. */
+                delete fxDisplayNameCache[`master:${key}`];
+                delete fxDisplayNameSkip[`master:${key}`];
+                delete fxDisplayNameBackoff[`master:${key}`];
             }
         }
 
@@ -6221,6 +6278,11 @@ function loadMasterFxChainConfig() {
         const key = `fx${i}`;
         const moduleId = getMasterFxSlotModule(i - 1);
         masterFxConfig[key].module = moduleId || "";
+        /* Different module — it may implement display_name even if the
+         * last one didn't, so poll it at full rate again. */
+        delete fxDisplayNameCache[`master:${key}`];
+        delete fxDisplayNameSkip[`master:${key}`];
+        delete fxDisplayNameBackoff[`master:${key}`];
     }
 }
 
@@ -6706,6 +6768,11 @@ function loadMasterFxChainFromConfig() {
                     const stateFile = JSON.parse(raw);
                     if (stateFile.module_id) {
                         masterFxConfig[key].module = stateFile.module_id;
+                        /* Different module — it may implement display_name even if the
+                         * last one didn't, so poll it at full rate again. */
+                        delete fxDisplayNameCache[`master:${key}`];
+                        delete fxDisplayNameSkip[`master:${key}`];
+                        delete fxDisplayNameBackoff[`master:${key}`];
                         debugLog(`MFX sync ${key}: module=${stateFile.module_id} (loaded by shim)`);
                     }
                     /* Restore bypass via setSlotParam — the shim doesn't carry
@@ -15044,6 +15111,11 @@ globalThis.tick = function() {
                 setMasterFxSlotModule(mfxi, mfxDspPath);
                 const key = `fx${mfxi + 1}`;
                 masterFxConfig[key].module = mfxModuleId;
+                /* Different module — it may implement display_name even if the
+                 * last one didn't, so poll it at full rate again. */
+                delete fxDisplayNameCache[`master:${key}`];
+                delete fxDisplayNameSkip[`master:${key}`];
+                delete fxDisplayNameBackoff[`master:${key}`];
 
                 /* Restore plugin state/params if available */
                 if (mfxData) {
@@ -15257,7 +15329,7 @@ globalThis.tick = function() {
             for (const comp of fxComponents) {
                 if (!cfg[comp] || !cfg[comp].module) continue;
                 const cacheKey = `${i}:${comp}`;
-                const name = getSlotParam(i, `${comp}:display_name`);
+                const name = pollFxDisplayName(i, `${comp}:display_name`, cacheKey);
                 if (name && name !== fxDisplayNameCache[cacheKey]) {
                     const prev = fxDisplayNameCache[cacheKey];
                     fxDisplayNameCache[cacheKey] = name;
@@ -15273,7 +15345,7 @@ globalThis.tick = function() {
         for (const key of masterFxKeys) {
             if (!masterFxConfig[key] || !masterFxConfig[key].module) continue;
             const cacheKey = `master:${key}`;
-            const name = getSlotParam(0, `master_fx:${key}:display_name`);
+            const name = pollFxDisplayName(0, `master_fx:${key}:display_name`, cacheKey);
             if (name && name !== fxDisplayNameCache[cacheKey]) {
                 const prev = fxDisplayNameCache[cacheKey];
                 fxDisplayNameCache[cacheKey] = name;

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -109,6 +109,10 @@ export function enterParamPages(slot, component, prefix) {
     /* Entering the view is the only way the module behind it can have changed,
      * so this is where the cached abbreviation is dropped. */
     _abbrevCache = null;
+    /* New module behind the view — it may well implement is_loading even if
+     * the last one didn't, so start asking at full rate again. */
+    _loadingInterval = LOADING_POLL_TICKS;
+    _loadingPoll = 0;
     controller.load({ slot, component, prefix: prefix || component, visible: ctx.evaluateVisibilityCondition });
     /* "Knobs" IS schwung-movy's own knob-page layout now, not Schwung's
      * earlier dial/bar grid — see render_page_movy.mjs. The setting stays a
@@ -171,11 +175,29 @@ export function tickParamPages() {
      * a module finishes loading. Checking it ~8x less often delays the re-plan
      * by at most LOADING_POLL_TICKS, which is invisible next to the module
      * load it is waiting on. */
-    _loadingPoll = (_loadingPoll + 1) % LOADING_POLL_TICKS;
-    if (_loadingPoll === 0) {
-        const loading = ctx.getSlotParam(currentSlot, `${currentComponent}:is_loading`) === '1';
-        if (!loading && wasLoading) controller.reloadIfChanged({ visible: ctx.evaluateVisibilityCondition });
-        wasLoading = loading;
+    if (++_loadingPoll >= _loadingInterval) {
+        _loadingPoll = 0;
+        const raw = ctx.getSlotParam(currentSlot, `${currentComponent}:is_loading`);
+        if (raw === null || raw === undefined) {
+            /* The module does not implement is_loading — most don't; it exists
+             * for the ones with an async ROM or sample load. Measured on
+             * device, this errored 5-7 times a SECOND, and an errored read
+             * still costs the full ~2.8ms round trip: the error is free, the
+             * round trip is not.
+             *
+             * Backed off rather than switched off, because this poll is
+             * correctness-relevant — it is what re-plans the page tree when a
+             * module finishes loading. A module that is genuinely mid-load can
+             * error first and answer later, so giving up entirely could strand
+             * the page on a stale tree. Backing off keeps the edge, just
+             * later. Reset on entry to the view and on any successful read. */
+            if (_loadingInterval < LOADING_POLL_MAX_TICKS) _loadingInterval *= 2;
+        } else {
+            _loadingInterval = LOADING_POLL_TICKS;
+            const loading = raw === '1';
+            if (!loading && wasLoading) controller.reloadIfChanged({ visible: ctx.evaluateVisibilityCondition });
+            wasLoading = loading;
+        }
     }
 
     /* The grid paces its own redraws (MOVY_REDRAW_MIN_MS), so it does not want
@@ -196,7 +218,12 @@ let wasLoading = false;
 /* is_loading is an edge that fires once per module load; polling it every tick
  * cost a full IPC round trip per frame. See tickParamPages. */
 const LOADING_POLL_TICKS = 8;
+/* Ceiling for the backoff when the module does not implement the key at all
+ * (~2.7s at 60Hz) — rare enough to be free, frequent enough that a late-
+ * appearing answer is still noticed. */
+const LOADING_POLL_MAX_TICKS = 160;
 let _loadingPoll = 0;
+let _loadingInterval = LOADING_POLL_TICKS;
 /* Module id per (slot, component), read once instead of on every draw — it
  * changes only on a module swap, which goes through openParamPages. */
 let _abbrevCache = null;


### PR DESCRIPTION
Follow-up to #215. Two polls were asking for keys most modules have no answer for, and being told so several times a second.

Measured on device: `synth:is_loading` errored **5–7 times a second**, `master_fx:fx1:display_name` about twice. The error is free — the **~2.8ms round trip it rides on is not**, and against a 16.67ms frame each one is a sixth of a frame spent learning nothing.

## Backed off, not switched off

Both polls are correctness-relevant, so neither is disabled:

- **`is_loading`** is what re-plans the page tree when a module finishes an async ROM/sample load. A module that is genuinely mid-load can error first and answer later, so giving up entirely could strand the grid on a stale tree. The interval doubles per unanswered poll up to ~2.7s, resetting on any answer and on entering the view.
- **`display_name`** exists for the few FX that report something live (key detection). Same doubling backoff per component, capped at ~32s, reset wherever the display-name cache is already cleared on a module swap — plus the seven master-FX assignment sites that had no such reset.

## Results (idle)

| | before | after |
|---|---|---|
| param give-ups / 40s | 41 (all errors) | **0** |
| worst tick | 27ms | **24.6ms** |
| avg tick | 1.65ms | **1.51ms** |
| tick rate | 60 | 60, steady |

`tests/shadow` + `tests/host` diff identical to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56