### PR TITLE
Param-channel steal fix, no IPC in draw paths, and the Link Audio instrumentation that found two module bugs

### DIFF
--- a/src/host/link_subscriber.cpp
+++ b/src/host/link_subscriber.cpp
@@ -87,6 +87,15 @@ static std::atomic<uint32_t> g_cb_run[LINK_AUDIO_IN_SLOT_COUNT];
 static std::atomic<uint32_t> g_cb_max_run[LINK_AUDIO_IN_SLOT_COUNT];
 static std::atomic<uint32_t> g_cb_count[LINK_AUDIO_IN_SLOT_COUNT];
 
+/* Latch for individual large gaps, so the interval BETWEEN stalls is
+ * measurable — the 5 s summary only reports a maximum and cannot show
+ * periodicity. Rare (~1 per 5 s), so a single-entry latch per slot with a
+ * sequence counter is enough; the main loop drains and logs it with a wall
+ * clock, keeping all logging off the callback thread. */
+#define LINK_CB_GAP_REPORT_US 50000  /* report gaps over 50 ms */
+static std::atomic<uint32_t> g_cb_gap_seq[LINK_AUDIO_IN_SLOT_COUNT];
+static std::atomic<uint32_t> g_cb_gap_us[LINK_AUDIO_IN_SLOT_COUNT];
+
 static inline void link_cb_note_delivery(int slot)
 {
     struct timespec ts;
@@ -105,6 +114,11 @@ static inline void link_cb_note_delivery(int slot)
     uint32_t prev_max = g_cb_max_gap_us[slot].load(std::memory_order_relaxed);
     if (gap_us > prev_max) {
         g_cb_max_gap_us[slot].store(gap_us, std::memory_order_relaxed);
+    }
+
+    if (gap_us >= LINK_CB_GAP_REPORT_US) {
+        g_cb_gap_us[slot].store(gap_us, std::memory_order_relaxed);
+        g_cb_gap_seq[slot].fetch_add(1, std::memory_order_release);
     }
 
     if (gap_us < LINK_CB_BURST_GAP_US) {
@@ -637,6 +651,23 @@ int main()
                 }
 
                 slots[i].last_read_pos = rp;
+            }
+        }
+
+        /* Drain individual large-gap events promptly (main loop runs every
+         * 10 ms) so the log carries a wall-clock timestamp per stall. The
+         * interval between these lines is the number that matters: 5 s apart
+         * implicates the channel-request renewal, irregular does not. */
+        {
+            static uint32_t last_seq[LINK_AUDIO_IN_SLOT_COUNT];
+            for (int i = 0; i < LINK_AUDIO_IN_SLOT_COUNT; i++) {
+                uint32_t seq = g_cb_gap_seq[i].load(std::memory_order_acquire);
+                if (seq != last_seq[i]) {
+                    last_seq[i] = seq;
+                    LOG_INFO(LINK_SUB_LOG_SOURCE, "cbgap slot=%d %.1f ms",
+                             i, g_cb_gap_us[i].load(std::memory_order_relaxed)
+                                / 1000.0);
+                }
             }
         }
 

--- a/src/host/link_subscriber.cpp
+++ b/src/host/link_subscriber.cpp
@@ -60,6 +60,64 @@ static std::atomic<bool> g_channels_changed{false};
 static std::atomic<uint64_t> g_buffers_received{0};
 static std::atomic<uint64_t> g_buffers_published{0};
 
+/* ============================================================================
+ * Source-callback delivery timing (2026-08-19 dropout investigation)
+ * ============================================================================
+ * The shim reads /schwung-link-in every SPI frame — measured n=1722 reads per
+ * 5 s window, i.e. not one frame skipped — yet `avail` still jumps to ~17,900
+ * samples (~200 ms, 4.4x the whole 4096-sample ring) between two consecutive
+ * reads 2.9 ms apart. Meanwhile the kernel UDP receive queue stays at zero
+ * across 600 samples and reports no drops. Both of those together say the
+ * audio is not arriving late off the wire and is not sitting unread in the
+ * socket — it is handed to us in a burst.
+ *
+ * The SDK dispatches source buffers from MainProcessor's 1 ms process timer
+ * on the single Link io thread, with internal queues between the socket and
+ * that dispatch, so a stalled timer would produce exactly this shape. Measure
+ * it at our own boundary rather than inferring: per slot, the longest gap
+ * between successive callbacks and the longest run delivered back-to-back.
+ *
+ * Realtime-safe: a vDSO clock read plus relaxed atomics. No allocation, no
+ * locks, no logging on the callback thread.
+ */
+#define LINK_CB_BURST_GAP_US 500  /* gaps under this count as one burst */
+static std::atomic<uint64_t> g_cb_last_ns[LINK_AUDIO_IN_SLOT_COUNT];
+static std::atomic<uint32_t> g_cb_max_gap_us[LINK_AUDIO_IN_SLOT_COUNT];
+static std::atomic<uint32_t> g_cb_run[LINK_AUDIO_IN_SLOT_COUNT];
+static std::atomic<uint32_t> g_cb_max_run[LINK_AUDIO_IN_SLOT_COUNT];
+static std::atomic<uint32_t> g_cb_count[LINK_AUDIO_IN_SLOT_COUNT];
+
+static inline void link_cb_note_delivery(int slot)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    const uint64_t now =
+        (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+
+    g_cb_count[slot].fetch_add(1, std::memory_order_relaxed);
+
+    const uint64_t prev =
+        g_cb_last_ns[slot].exchange(now, std::memory_order_relaxed);
+    if (prev == 0) return;  /* first callback: no gap to report yet */
+
+    const uint32_t gap_us = (uint32_t)((now - prev) / 1000ull);
+
+    uint32_t prev_max = g_cb_max_gap_us[slot].load(std::memory_order_relaxed);
+    if (gap_us > prev_max) {
+        g_cb_max_gap_us[slot].store(gap_us, std::memory_order_relaxed);
+    }
+
+    if (gap_us < LINK_CB_BURST_GAP_US) {
+        const uint32_t run =
+            g_cb_run[slot].fetch_add(1, std::memory_order_relaxed) + 1;
+        if (run > g_cb_max_run[slot].load(std::memory_order_relaxed)) {
+            g_cb_max_run[slot].store(run, std::memory_order_relaxed);
+        }
+    } else {
+        g_cb_run[slot].store(1, std::memory_order_relaxed);
+    }
+}
+
 static void signal_handler(int sig)
 {
     /* Use write() — async-signal-safe, unlike printf() */
@@ -402,6 +460,7 @@ int main()
                         sources.emplace_back(link, pc.id,
                             [slot_idx_cap, in_shm_cap](ableton::LinkAudioSource::BufferHandle h) {
                                 g_buffers_received.fetch_add(1, std::memory_order_relaxed);
+                                link_cb_note_delivery(slot_idx_cap);
 
                                 const size_t num_frames   = h.info.numFrames;
                                 const size_t num_channels = h.info.numChannels;
@@ -578,6 +637,24 @@ int main()
                 }
 
                 slots[i].last_read_pos = rp;
+            }
+        }
+
+        /* Source-callback delivery timing, every 5 s to line up with the
+         * shim's link_audio window so the two logs can be read side by side.
+         * Expected steady state is gap≈2830us / run=1 (one 125-frame packet
+         * per 2.83 ms). A gap of ~200 ms followed by run≈70 is the burst the
+         * shim's catch-up is discarding. Only logged when a slot has actually
+         * delivered something this window. */
+        if (tick % 500 == 0) {
+            for (int i = 0; i < LINK_AUDIO_IN_SLOT_COUNT; i++) {
+                uint32_t n = g_cb_count[i].exchange(0, std::memory_order_relaxed);
+                if (n == 0) continue;
+                uint32_t max_gap = g_cb_max_gap_us[i].exchange(0, std::memory_order_relaxed);
+                uint32_t max_run = g_cb_max_run[i].exchange(0, std::memory_order_relaxed);
+                LOG_INFO(LINK_SUB_LOG_SOURCE,
+                         "cb slot=%d n=%u max_gap=%u us (%.1f ms) max_burst_run=%u",
+                         i, n, max_gap, (double)max_gap / 1000.0, max_run);
             }
         }
 

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -783,19 +783,61 @@ static inline volatile uint32_t *shadow_param_head_word(void) {
  */
 static int shadow_param_orphan_pending = 0;
 
+/*
+ * When we first saw the channel idle-but-unread, or 0 if it is not in that
+ * state. Monotonic microseconds.
+ *
+ * This has to live ACROSS calls. It used to be a per-call local, which made
+ * the steal above unreachable: the deadline that bounds this loop is 100 ms
+ * and the steal threshold is 250 ms, so the counter was reset to 0 on entry
+ * and the loop always exited long before it could get there. An orphaned
+ * response therefore wedged the channel until something happened to set
+ * shadow_param_orphan_pending — and nothing outside overtake mode's
+ * fire-and-forget SET ever does. "Longer than the request deadline" is the
+ * right design; it just has to be measured against the channel's history
+ * rather than one caller's attempt.
+ */
+static uint64_t shadow_param_blocked_since_us = 0;
+
+/* State of the channel head word the last time a claim gave up (see the
+ * give-up reporter below). */
+static uint8_t  param_claim_fail_rt = 0;
+static uint8_t  param_claim_fail_rr = 0;
+static uint32_t param_claim_fail_blocked_ms = 0;
+
+static uint64_t shadow_param_now_us(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000ull + (uint64_t)(ts.tv_nsec / 1000);
+}
+
 static int shadow_param_claim(int timeout_ms) {
     long waited_us = 0;
     const long limit_us =
         (long)(timeout_ms > 0 ? timeout_ms : SHADOW_PARAM_DEFAULT_TIMEOUT_MS) * 1000L;
-    long blocked_us = 0;
 
     while (waited_us < limit_us) {
         uint32_t w = __atomic_load_n(shadow_param_head_word(), __ATOMIC_ACQUIRE);
         int idle   = (w & SHADOW_PARAM_RT_MASK) == 0;
         int unread = (w & SHADOW_PARAM_RR_MASK) != 0;
 
+        /* Track how long the channel has been sitting on an answer nobody is
+         * collecting. Any other state means somebody is legitimately mid-flight,
+         * so the clock restarts. */
+        uint64_t blocked_us = 0;
+        if (idle && unread) {
+            uint64_t now = shadow_param_now_us();
+            if (shadow_param_blocked_since_us == 0) {
+                shadow_param_blocked_since_us = now;
+            } else {
+                blocked_us = now - shadow_param_blocked_since_us;
+            }
+        } else {
+            shadow_param_blocked_since_us = 0;
+        }
+
         if (idle && (!unread || shadow_param_orphan_pending
-                     || blocked_us >= SHADOW_PARAM_STEAL_AFTER_US)) {
+                     || blocked_us >= (uint64_t)SHADOW_PARAM_STEAL_AFTER_US)) {
             /* Take it, and clear any stale response in the same step so the
              * next waiter cannot mistake it for its own. */
             uint32_t nw = (w & ~(SHADOW_PARAM_RT_MASK | SHADOW_PARAM_RR_MASK))
@@ -804,6 +846,7 @@ static int shadow_param_claim(int timeout_ms) {
                                             0 /* strong */,
                                             __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)) {
                 shadow_param_orphan_pending = 0;
+                shadow_param_blocked_since_us = 0;
                 return 1;
             }
             continue;   /* word moved under us — re-read, do not burn the deadline */
@@ -812,7 +855,23 @@ static int shadow_param_claim(int timeout_ms) {
         long step = (waited_us < 1000) ? SHADOW_PARAM_POLL_US : 1000;
         usleep((useconds_t)step);
         waited_us += step;
-        if (idle && unread) blocked_us += step; else blocked_us = 0;
+    }
+
+    /* Record WHICH wedge beat us, so the give-up line can say so. The two look
+     * identical in the counters but have opposite causes: request_type != 0 is
+     * somebody else's request still in flight (or a requester that died holding
+     * the channel), while request_type == 0 with response_ready == 1 is an
+     * answer nobody collected. Without this the claim-stage give-up prints
+     * "where=-" and the two are indistinguishable after the fact. */
+    {
+        uint32_t w = __atomic_load_n(shadow_param_head_word(), __ATOMIC_ACQUIRE);
+        param_claim_fail_rt = (uint8_t)(w & SHADOW_PARAM_RT_MASK);
+        param_claim_fail_rr = (uint8_t)((w & SHADOW_PARAM_RR_MASK) >> 16);
+        param_claim_fail_blocked_ms =
+            (shadow_param_blocked_since_us == 0)
+                ? 0u
+                : (uint32_t)((shadow_param_now_us()
+                              - shadow_param_blocked_since_us) / 1000ull);
     }
     return 0;
 }
@@ -879,11 +938,14 @@ static void shadow_param_note_slow(const char *stage, const char *key) {
     if (now == last_report) return;
     last_report = now;
     if (!(n_claim | n_resp | n_err | param_slow_n)) return;
-    char line[320];
+    char line[400];
     snprintf(line, sizeof(line),
              "param_giveup: claim=%u response=%u error=%u last_key=%s"
+             " | claimwedge: rt=%u rr=%u blocked=%ums"
              " | slow>=90ms: n=%u worst=%ums key=%s where=%s",
              n_claim, n_resp, n_err, last_key,
+             param_claim_fail_rt, param_claim_fail_rr,
+             param_claim_fail_blocked_ms,
              param_slow_n, param_slow_max_ms,
              param_slow_key[0] ? param_slow_key : "-",
              param_slow_why[0] ? param_slow_why : "-");
@@ -891,6 +953,10 @@ static void shadow_param_note_slow(const char *stage, const char *key) {
     n_claim = n_resp = n_err = 0;
     param_slow_n = param_slow_max_ms = 0;
     param_slow_key[0] = param_slow_why[0] = '\0';
+    /* Clear too, so a window with no claim failures reports 0/0 rather than
+     * the previous window's wedge. */
+    param_claim_fail_rt = param_claim_fail_rr = 0;
+    param_claim_fail_blocked_ms = 0;
 }
 
 static int shadow_param_wait_response(uint32_t req_id, int timeout_ms) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -608,6 +608,45 @@ function pollFxDisplayName(slot, key, cacheKey) {
     return name;
 }
 
+/*
+ * Cache for the chain-edit info line (module display name + preset).
+ *
+ * drawChainEdit() read `<prefix>:name`, `<prefix>:preset_name` and
+ * `<prefix>:preset` on EVERY FRAME — three IPC round-trips per frame in a
+ * draw function, ~8.4ms of a 16.67ms budget. Measured on hardware
+ * 2026-08-19: ~50 errored reads/sec on `fx2:name` alone, because an FX that
+ * does not implement the key still costs the full round trip to say so. That
+ * load is served inside the SPI callback, where `param` was spiking to 700us.
+ *
+ * None of these values can change without a module swap or a preset load, so
+ * a frame is the wrong cadence. Re-read when the module id changes (caught
+ * immediately) or when the entry is older than the refresh interval (catches
+ * a preset loaded underneath us). ~165 reads/sec becomes ~6.
+ */
+const SLOT_PARAM_CACHE_TTL_MS = 500;
+let slotParamCache = {};   /* "slot:key" -> {module, value, ts} */
+
+/*
+ * Cached slot-param read for DRAW paths only. Returns the same value a bare
+ * getSlotParam would, including null.
+ *
+ * Pass the loaded module id so a swap invalidates immediately; the TTL is
+ * what catches a value changing underneath us (a preset loaded, a bank
+ * switched). Do NOT use this where the value must be exact right now — use
+ * getSlotParam directly on entry/commit paths.
+ */
+function getSlotParamCached(slot, key, moduleId) {
+    const ck = `${slot}:${key}`;
+    const hit = slotParamCache[ck];
+    const now = Date.now();
+    if (hit && hit.module === moduleId && (now - hit.ts) < SLOT_PARAM_CACHE_TTL_MS) {
+        return hit.value;
+    }
+    const value = getSlotParam(slot, key);
+    slotParamCache[ck] = { module: moduleId, value, ts: now };
+    return value;
+}
+
 /* Helper to change view and announce it */
 function setView(newView, customLabel) {
     if (view === newView) return;  /* No change */
@@ -10715,15 +10754,16 @@ function drawHierarchyEditor() {
     const abbrev = moduleData ? getModuleAbbrev(moduleData.module) : hierEditorComponent.toUpperCase();
 
     /* Get bank or preset name for header depending on view */
+    const hierMid = moduleData ? moduleData.module : hierEditorComponent;
     let headerName;
     if (hierEditorIsPresetLevel && !hierEditorPresetEditMode) {
         /* Preset browser: show bank/soundfont name */
-        headerName = getSlotParam(hierEditorSlot, `${prefix}:bank_name`) ||
-                     getSlotParam(hierEditorSlot, `${prefix}:name`) || "";
+        headerName = getSlotParamCached(hierEditorSlot, `${prefix}:bank_name`, hierMid) ||
+                     getSlotParamCached(hierEditorSlot, `${prefix}:name`, hierMid) || "";
     } else {
         /* Edit mode: show preset name */
-        headerName = getSlotParam(hierEditorSlot, `${prefix}:preset_name`) ||
-                     getSlotParam(hierEditorSlot, `${prefix}:name`) || "";
+        headerName = getSlotParamCached(hierEditorSlot, `${prefix}:preset_name`, hierMid) ||
+                     getSlotParamCached(hierEditorSlot, `${prefix}:name`, hierMid) || "";
     }
 
     /* Check for mode indicator - show * for performance mode */
@@ -13306,14 +13346,16 @@ function drawChainEdit() {
         if (moduleData) {
             /* Get display name from DSP if available */
             const prefix = selectedComp.key === "midiFx" ? "midi_fx1" : selectedComp.key;
-            let displayName = getSlotParam(selectedSlot, `${prefix}:name`) || moduleData.module;
+            /* Cached: these were three IPC round-trips per frame. */
+            const mid = moduleData.module;
+            let displayName = getSlotParamCached(selectedSlot, `${prefix}:name`, mid) || mid;
             /* Friendly name for RNBO pack entries */
             if (displayName === moduleData.module) {
                 if (displayName.startsWith("rnbo-synth-")) displayName = displayName.substring(11) + " (RNBO)";
                 else if (displayName.startsWith("rnbo-fx-")) displayName = displayName.substring(8) + " (RNBO)";
             }
-            const preset = getSlotParam(selectedSlot, `${prefix}:preset_name`) ||
-                          getSlotParam(selectedSlot, `${prefix}:preset`) || "";
+            const preset = getSlotParamCached(selectedSlot, `${prefix}:preset_name`, mid) ||
+                           getSlotParamCached(selectedSlot, `${prefix}:preset`, mid) || "";
             infoLine = preset ? `${displayName} (${truncateText(preset, 8)})` : displayName;
         } else {
             infoLine = "(empty)";
@@ -13388,11 +13430,12 @@ function drawComponentEdit() {
 
     /* Get display name from DSP if available */
     const prefix = editingComponentKey === "midiFx" ? "midi_fx1" : editingComponentKey;
-    const displayName = getSlotParam(selectedSlot, `${prefix}:name`) || moduleName;
+    const cmpMid = moduleData ? moduleData.module : moduleName;
+    const displayName = getSlotParamCached(selectedSlot, `${prefix}:name`, cmpMid) || moduleName;
 
     /* Build header: S#: Module: Bank (preset selection shows bank/soundfont) */
     const abbrev = moduleData ? getModuleAbbrev(moduleData.module) : moduleName;
-    const bankName = getSlotParam(selectedSlot, `${prefix}:bank_name`) || displayName;
+    const bankName = getSlotParamCached(selectedSlot, `${prefix}:bank_name`, cmpMid) || displayName;
     const headerText = truncateText(`S${selectedSlot + 1}: ${abbrev}: ${bankName}`, 24);
     drawHeader(headerText);
 


### PR DESCRIPTION
Four commits from one debugging session: two correctness/perf fixes and two pieces of instrumentation that earned their place by locating bugs in *other* repos.

## 1. The param-channel steal could never fire

`shadow_param_claim` takes the channel anyway if a response goes uncollected for `SHADOW_PARAM_STEAL_AFTER_US` (250 ms). It could never get there:

```c
#define SHADOW_PARAM_STEAL_AFTER_US 250000L   // steal at 250ms
#define SHADOW_PARAM_DEFAULT_TIMEOUT_MS 100   // ...in a loop that quits at 100ms

while (waited_us < limit_us) {                // limit_us = 100,000
    if (idle && unread) blocked_us += step; else blocked_us = 0;
}
```

`blocked_us` was a local, reset on entry, accumulating in a loop bounded at 100 ms — structurally incapable of reaching 250 ms. Now tracked against the **channel's** history rather than one caller's attempt.

**Impact:** once any response went unconsumed, every subsequent claim burned its full 100 ms and failed. The only escape was `shadow_param_orphan_pending`, which nothing outside overtake mode's fire-and-forget SET ever sets — so outside overtake it was an indefinite wedge.

Also adds `claimwedge: rt= rr= blocked=` to the give-up line, so the two wedge modes (`rt != 0` = someone else's request in flight; `rt == 0 && rr == 1` = an answer nobody collected) stop being indistinguishable.

> Scope note: this is **not** tied to a specific observed fault. A blank-slot episode prompted it, but `claim=9/sec` turned out to be the pre-existing baseline, not that episode's signature.

## 2. No IPC parameter reads inside draw functions

Three renderers read slot params **every frame**:

| Function | Keys |
|---|---|
| `drawChainEdit()` | `:name`, `:preset_name`, `:preset` |
| `drawHierarchyEditor()` | `:bank_name`, `:preset_name`, `:name` |
| `drawComponentEdit()` | `:name`, `:bank_name` |

At ~2.8 ms per round-trip, `drawChainEdit` alone spent ~8.4 ms of a 16.67 ms budget — and an IPC read already costs more than redrawing the whole screen (1.68 ms). Worse, they mostly **failed**: measured `error=51` per second on `fx2:name`, because an FX that doesn't implement a key still costs the full trip to say so. That load is served inside the SPI callback, where `param` was spiking to **700 µs**.

`getSlotParamCached()` keys on slot+key, carries the module id so a swap invalidates immediately, and uses a 500 ms TTL for preset/bank changes. Entry and commit paths keep using `getSlotParam` directly — the cache is documented as draw-only.

```
                    BEFORE       AFTER
param errors/sec    51           1        (fx1:display_name — the 1 Hz poll
param= in SPI cb    13/700 µs    2/22 µs   that already has its own backoff)
```

Same class as the `display_name` backoff in #217; that covered a 1 Hz poll, these were per-frame.

## 3–4. Link Audio delivery instrumentation

Per-slot callback timing in the sidecar (`max_gap`, `max_burst_run`, and a timestamped line per stall >50 ms), logged on the same 5 s window as the shim's `link_audio` output so the two read side by side.

**This is what found the actual cause of the dropouts, in two other repos:**

- **keydetect** (fixed, v0.1.2): its analysis thread inherited `SCHED_FIFO` 70 from Move's audio thread — `nice(10)` is a no-op on FIFO threads, and `std::thread` inherits policy. A ~200 ms FFT ran above Move's `Link Main` (`SCHED_FIFO` **35**), starving Move's Link Audio publisher every 4.0 s. The tell was the stall period fitting **4.004 s** over 128 intervals = a 2.0 s window with `skip_windows == 1`.
- **schwung-airwindows** (fixed, v0.4.3): logged on the parameter hot path, which runs at modulation rate — a `write()` syscall per audio block, and an *unconditional* `fprintf(stderr)` that fired even with logging disabled.

Kept in the tree because the interval between stalls is the number that matters and nothing else exposes it.

> Correcting the earlier description of this PR: it claimed the evidence pointed at Move's firmware. **That was wrong.** A three-point bisect (stock firmware = 0 stalls, Schwung with empty slots = 0 stalls, Schwung with modules = ~1 per 4–40 s) showed the cause was ours all along.

## Testing

- `./scripts/build.sh` — clean, zero warnings
- `make -C tests/host test` — all pass
- `tests/host/test_param_pages_*.sh` — 15/15 pass
- `tests/host/*.sh` — 24 pass / 32 fail, **identical set to `main`** (known-local `rg`-is-a-shell-function failures; CI has real ripgrep)
- Deployed to hardware; both fixes verified live

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56