### PR TITLE
fix(shadow): persist the master FX chain from the shim, not the in-file mirror

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -8945,6 +8945,23 @@ function loadMasterFxChainConfig() {
     }
 }
 
+/* Read one of the shim's own master-slot facts ("name" = module id, "module" =
+ * DSP path).
+ *
+ * Distinct from getMasterFxSlotModule, which collapses a failed read into "".
+ * The saver has to tell "this slot is empty" from "the shim did not answer",
+ * because acting on the second as if it were the first erases a loaded slot.
+ * Returns null when there is no answer. */
+function masterFxShimValue(slotIndex, field) {
+    if (typeof shadow_get_param !== "function") return null;
+    try {
+        const v = shadow_get_param(0, `master_fx:fx${slotIndex + 1}:${field}`);
+        return (v === null || v === undefined) ? null : v;
+    } catch (e) {
+        return null;
+    }
+}
+
 /* Get a parameter from a master FX slot (0..MASTER_FX_SLOTS-1).
  * Index-taking wrapper over the shared chain-target accessor. The "" rather
  * than null is this caller's convention and is preserved here. */
@@ -9144,6 +9161,27 @@ function saveMasterFxChainConfig() {
         for (let i = 1; i <= MASTER_FX_SLOTS; i++) {
             const key = `fx${i}`;
             const slotIdx = i - 1;
+            /* The SHIM decides what is loaded, not this mirror.
+             *
+             * masterFxConfig only learns about a slot when something in this
+             * file puts it there, so anything that loads a master module by
+             * writing `master_fx:fxN:module` to the shim directly — an overtake
+             * tool, most visibly Movy — was invisible here. The mirror still
+             * read empty, the empty-slot branch below wrote "{}" over a slot
+             * the shim genuinely had loaded, and the whole master chain was
+             * gone on the next boot. It drifted the other way too: a slot
+             * cleared through the shim was written back from the stale mirror.
+             *
+             * A null answer means the read failed (timeout), which is NOT the
+             * same as an empty slot — adopting it would erase a good slot on a
+             * busy device, the failure the snapshot guard below exists to
+             * prevent. Only a real answer is adopted. */
+            const shimId = masterFxShimValue(slotIdx, "name");
+            if (shimId !== null && shimId !== (masterFxConfig[key]?.module || "")) {
+                debugLog(`MFX save: ${key} adopting shim state "${shimId}" ` +
+                         `(mirror had "${masterFxConfig[key]?.module || ""}")`);
+                masterFxConfig[key].module = shimId;
+            }
             const moduleId = masterFxConfig[key]?.module || "";
             const stateFilePath = activeSlotStateDir + "/master_fx_" + slotIdx + ".json";
 
@@ -9157,8 +9195,13 @@ function saveMasterFxChainConfig() {
                 continue;
             }
 
+            /* Prefer the path the shim actually dlopen'd. MASTER_FX_OPTIONS is
+             * scanned at startup, so a module installed since then is missing
+             * from it and resolved to "" — a state file that looks saved and
+             * restores nothing, because the boot loader needs the path. Falls
+             * back to the scan when the shim does not answer. */
             const opt = MASTER_FX_OPTIONS.find(o => o.id === moduleId);
-            const dspPath = opt?.dspPath || "";
+            const dspPath = masterFxShimValue(slotIdx, "module") || opt?.dspPath || "";
             const slotConfig = {
                 id: moduleId,
                 path: dspPath

--- a/tests/shadow/test_master_fx_save_reads_shim.sh
+++ b/tests/shadow/test_master_fx_save_reads_shim.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# The master FX saver must take what the SHIM has loaded, not what its own
+# in-file mirror happens to remember.
+#
+# masterFxConfig only learns about a slot when something in shadow_ui.js puts it
+# there, so a module loaded by writing `master_fx:fxN:module` to the shim
+# directly — which is what an overtake tool does — was invisible to the saver.
+# It wrote "{}" over a loaded slot and the master chain was gone on the next
+# boot. Regression guard for that.
+set -euo pipefail
+
+file="src/shadow/shadow_ui.js"
+
+if ! rg -q 'function masterFxShimValue\(slotIndex, field\)' "$file"; then
+  echo "FAIL: no helper that reads a master slot's state from the shim" >&2
+  exit 1
+fi
+
+# A failed read must be distinguishable from an empty slot, or a timeout on a
+# busy device erases a loaded slot.
+if ! rg -q 'return \(v === null \|\| v === undefined\) \? null : v;' "$file"; then
+  echo "FAIL: shim read collapses a failed read into an empty answer" >&2
+  exit 1
+fi
+
+if ! rg -q 'const shimId = masterFxShimValue\(slotIdx, "name"\);' "$file"; then
+  echo "FAIL: save flow does not consult the shim for the loaded module" >&2
+  exit 1
+fi
+
+if ! rg -q 'if \(shimId !== null && shimId !== \(masterFxConfig\[key\]\?\.module \|\| ""\)\)' "$file"; then
+  echo "FAIL: save flow does not adopt the shim's answer over its mirror" >&2
+  exit 1
+fi
+
+# The boot loader restores by PATH, so an id saved without one restores nothing.
+# MASTER_FX_OPTIONS is scanned at startup and misses later installs.
+if ! rg -q 'const dspPath = masterFxShimValue\(slotIdx, "module"\) \|\| opt\?\.dspPath \|\| "";' "$file"; then
+  echo "FAIL: save flow does not prefer the shim's own DSP path" >&2
+  exit 1
+fi
+
+echo "PASS: master FX save flow reads the shim, not just its mirror"


### PR DESCRIPTION
## The bug

`saveMasterFxChainConfig()` is the only thing that ever writes a `module_id` into a set's `master_fx_<N>.json` — the C side only seeds `{}` (`shadow_set_pages.c:124`), and the shim's boot loader (`shadow_chain_mgmt.c:1189`) restores from that file. But the saver reads `masterFxConfig`, an in-file mirror that only learns about a slot when something inside `shadow_ui.js` puts it there (the master FX menu, a preset load, `loadMasterFxChainConfig()` on entering the settings page).

Anything that loads a master module by writing `master_fx:fxN:module` straight to the shim is invisible to it. That's how an overtake tool loads one — [Movy](https://github.com/DimaDake/schwung-movy) is the visible case — and there's no notification path back: `on_param_changed` (`shadow_chain_mgmt.c:1776`) goes to `web_param_notify_push`, the web UI only, never into the QuickJS context.

So the mirror still read empty, and the save took its empty-slot branch:

```js
const moduleId = masterFxConfig[key]?.module || "";   // "" — never saw the shim-side load
if (!moduleId) {
    host_write_file(stateFilePath, "{}\n");            // erases a slot the shim HAS loaded
    continue;
}
```

and the user's whole master chain was gone on the next boot. Worth noting the loaded branch has a deliberate `snapshotOk` guard against clobbering a good file; this branch has no equivalent.

It drifted the other way too: a slot **cleared** through the shim left the mirror holding the old module, which the save wrote back — silently reverting the change.

Reported by two users on Discord, tracked downstream as DimaDake/schwung-movy#9.

## The change

Ask the shim what's loaded and adopt that answer, since the shim is what actually renders audio.

A `null` read means the shim didn't answer, which is **not** the same as an empty slot — adopting it would erase a loaded slot on a busy device, the exact failure `snapshotOk` guards against elsewhere. Only a real answer is adopted, which is why `masterFxShimValue` exists rather than reusing `getMasterFxSlotModule` (that one collapses both into `""`).

Second, smaller fix in the same path: prefer the shim's own DSP path over `MASTER_FX_OPTIONS`. That list is scanned once at startup, so a module installed since then resolved to `""` and produced a state file that looks saved but restores nothing — the boot loader restores by path.

Cost is four param reads on the existing ~10 s autosave timer.

## Testing

- `tests/shadow/test_master_fx_save_reads_shim.sh` — new, matching the house hook style.
- All 57 CI-gated `tests/host/*.sh` pass. The two failing `tests/shadow` master-FX tests (`test_native_resample_bridge_mfx_gain.sh`, `test_master_fx_resample_bridge_setting.sh`) fail identically on `origin/main` — part of the known stale set noted in `CLAUDE.md`.

**On hardware**, honestly scoped: the two halves this change depends on are both verified on a real Move, but assembled through Movy rather than through this patch — I didn't want to hand-patch someone's installed 0.12.0.

1. Reading `master_fx:fxN:name` after a tool-side load returns the right id (logged `shimName=clap`).
2. With the mirror correct at save time, the slot persists and restores — `MFX boot: slot 0 loaded clap (with state)` after a real reboot, from an empty seeded state file.

Happy to run the patched build on device if you'd like that before merging.

## Downstream

Movy currently carries a workaround that reaches into `shadow_ui.js`'s published `ctx` and calls `loadMasterFxChainConfig()` after a master-slot write. It's marked for deletion the moment this lands — once the saver reads the shim, that call is a redundant no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MxKRaGRGN7JFW9D1dwK4fE
