### PR TITLE
enums: learn the wire format, open a list, and never plan from a failed read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -397,6 +397,49 @@ byte-identical against `tests/fixtures/movy-geom-baseline.txt`
 Preview it without deploying: `node tools/param-pages/preview_knob_card.mjs
 <module-id> --knob N [--short] [--png DIR --scale 4]`.
 
+### Every enum opens a LIST
+
+Any enum that declares `options` is divable: hold its knob, click, pick from a
+scrolling list, Back cancels. The knob still steps it one detent at a time —
+the list is the other half, for a Recv Ch with seventeen options or a Braids
+model with forty-seven. `VIEWS.ENUM_PICKER`, `drawEnumPicker` in
+`src/shadow/shadow_ui.js`, hints `JOG SEL` / `CLK SET` / `BACK EXIT`
+(`enumPickerFooterHints` in `shadow_ui_param_pages.mjs` — the hint vocabulary is
+a canon, so the wording is built there and not at the draw site).
+
+**`meta.divable` and `meta.divable_mark` are separate on purpose.** The corner
+brackets key on `divable_mark`, which stays exactly where it was: the opaque
+types. ~135 enums in the fleet against ~5 opaque params — bracket them all and
+every cell on every page is marked, which is the same as marking none; and for
+an opaque cell the brackets are STRUCTURAL, because `drawOpaqueBox` draws no
+frame of its own. Net pixel change on the grid is zero. The affordance for an
+enum is the footer, which flips to `CLK OPEN` off `divable` for free. An enum
+with no declared options has no list, so it is not a door.
+
+**The picker wears the movy chrome from BOTH entry points** — the knob grid, and
+a jog-click on an enum row in the hierarchy list editor — and reuses the one
+shared `drawMenuList`. Following the caller's chrome instead would be a
+`cameFromGrid` branch inside a shared draw, which is the exact thing
+`chain_editor_chrome.mjs` records the module picker doing before ("the module
+select here is different than the module select in slots", reported from the
+device). Entry-point chrome is that branch coming back.
+
+**The list rect starts at y=9, not `MENU_LIST_Y`.** `MENU_LIST_Y` (10) leaves
+44px, which at a 9px line is FOUR options where the old chrome showed FIVE. 9 is
+safe only because this header is not inverted — the glyphs stop at row 5, so the
+selected row's highlight at row 8 still has air above it. **A menu page cannot
+do the same: its bank bar owns row 7.** `tests/host/test_enum_picker_chrome.sh`
+pins it as `CAPACITY === OLD_CAPACITY` and `clipped() === 0`, because the device
+clips silently and losing the last option to a band drawn over it is a failure
+this codebase has already had.
+
+Nothing is written on the way in or while scrolling, so Back is a real cancel
+and the draw path costs no IPC. The grid path keeps its controller alive and
+commits through `controller.commitEnum` — that is what makes the picker work on
+Slot Settings and Master FX Settings, which are synthesised contracts with no
+`ui_hierarchy` to enter, and it keeps the slot io's own mappings (Fwd's offset,
+MPE's compound write) applied rather than bypassed.
+
 ### Recording / capture
 
 Audio capture is shim-side: the Quantized Sampler (Shift+Sample) and Skipback
@@ -407,6 +450,43 @@ unreachable v1 plugin path.)
 ## Shadow Mode
 
 Shim intercepts hardware I/O to mix shadow audio with Move's output.
+
+### A param read has THREE answers, not two
+
+`shadow_get_param` (`js_shadow_get_param`, `src/shadow/shadow_ui.c`) returns:
+
+```
+JSON / text   the component answered
+""            the channel served us, the key produced nothing
+null          the read did not complete — claim refused, response timed out,
+              or the answer belonged to somebody else
+```
+
+`null` is **not news about the module.** Collapsing it into `""` cost three
+separate bugs in one day: `impressive-chords` reporting a literal `"[]"` for
+`chain_params` and being believed; missing metadata making the grid invent a
+`float 0..1 step 0.01` knob and write `0.058750` into an enum; and granny's
+knobs reordering with `sample_path` on knob 1, because a timed-out
+`ui_hierarchy` read was read as "this module has no hierarchy", paginated
+`chain_params` instead — and then **latched**, because the invented metadata
+looked complete enough to settle.
+
+**Never let a failed read produce a plan, a default, or a cached verdict.**
+Branch on the RAW value before parsing: `parse(null)` and `parse("")` both give
+`null`, so by the time it is parsed the distinction is gone and only the caller
+that saw the wire can report it. In `page_controller.mjs` that is
+`contractUnresolved` — plan nothing, keep the previous page set if it is the
+same component, retry on `CONTRACT_RETRY_INTERVAL_TICKS` up to
+`CONTRACT_RETRY_LIMIT`, and refuse to `metaSettled` while unresolved.
+`planPages({ unresolved: true })` returns no pages for any other consumer.
+
+Wrinkle: `tests/fixtures/module-contracts.json` records `ui_hierarchy: null` for
+the four modules that genuinely declare none, so at PLANNER level `null` still
+means absent. The tri-state exists only where the wire is visible.
+
+(granny's read fails because it loads a WAV synchronously inside `set_param`, on
+the SPI thread that serves param requests. That realtime violation lives in its
+own repo and is not fixed here.)
 
 ### Shortcuts
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1419,12 +1419,48 @@ will see `50` displayed as `5000%`.
 
 #### Enum wire format
 
-By default the formatter sends the option's numeric INDEX over the
-`set_param` wire. If your DSP plugin only accepts the option's STRING label
-(no `atoi` fallback in `set_param`), declare `options_as_string: true` on the
-chain_params entry. The shadow UI's enum cycle path is independent of this
-setting (it auto-detects from the plugin's `get_param` echo), so most modules
-don't need to set it.
+An enum can go over the `set_param` wire as its numeric INDEX or as its option
+NAME. The UI **auto-detects which your plugin speaks** and latches the answer
+per key: it looks at what `get_param` reports — a value that matches a declared
+option means names, a value that parses as a number means indices, anything
+else teaches nothing and leaves the question open for the next read.
+Detection only ever uses values that came from the DSP, never values the UI
+itself wrote (`learnEnumWireFormat` in `src/shared/param_format.mjs`); the
+option picker asks the same question through `enumWireValue`.
+
+`options_as_string: true` on the chain_params entry is therefore an **override,
+not a requirement** — it is checked first and never learned over. Declare it if
+you want the convention nailed down regardless of what your `get_param` says.
+
+**The one obligation: a `set_param` that accepts only NAMES must report NAMES
+from `get_param`.** That read is the only signal detection has. Report an index
+while accepting only names and every write is discarded in silence — which is
+exactly what the built-in `chord` module did: its `set_param` is a `strcmp`
+ladder over the option names with **no trailing `else`**, so the value never
+moved while the UI drew the index it had invented.
+
+Two `set_param` shapes worth avoiding, both found in the fleet, neither of which
+reports an error:
+
+- **No trailing `else`** (chord) — an unrecognised value is silently ignored.
+- **`else atof(val)`** (arp's `division`) — an unrecognised value is silently
+  *accepted*, turning index `3` into a division of `3.0`.
+
+Prefer accepting both conventions and rejecting anything else loudly enough to
+show up in a log.
+
+#### `divable` vs `divable_mark`
+
+Every enum with a non-empty `options` array is **divable**: on the knob grid,
+holding its knob and clicking opens a scrolling option list. You get this for
+free — there is nothing to declare, and nothing to declare it away.
+
+Divability is not the same as the corner-bracket **mark**, which stays on the
+opaque types only (`filepath`/`file`, `string`, `canvas`, `wav_position`, the
+two picker types). With ~135
+enums in the fleet against ~5 opaque params, bracketing every enum would erase
+what the mark means. The affordance for an enum is the footer's `CLK OPEN`.
+Module authors influence this only through `type` and `options`.
 
 ### Knob Acceleration
 

--- a/docs/REALTIME_SAFETY.md
+++ b/docs/REALTIME_SAFETY.md
@@ -109,10 +109,57 @@ load), and the current-set filesystem scan (results delivered through a
 seqlock snapshot consumed on the SPI thread). When adding RT-path work that
 needs file I/O or process spawning: post an event, add a hook.
 
-## Accepted tradeoff: patch/module load runs on the SPI thread
+## Module load blocks the SPI callback — MEASURED at 673 ms
 
-`set_param("load_patch")` and Master-FX slot loads reach dlopen/fopen/calloc
-from the SPI thread by design — the audible hiccup on load is accepted.
-A glitch-free alternative (loader thread + atomic instance swap, masked by
-the existing fade machinery) is sketched in the 2026-06-11 cleanup review.
-Don't re-investigate "why does loading glitch" — this is it.
+`set_param("<id>:module")`, `load_patch`, `load_file` and Master-FX slot loads
+reach `dlopen` / `fopen` / `calloc` and the plugin's own `create_instance` from
+the SPI thread. This was recorded here as an "accepted tradeoff" with an
+"audible hiccup". It is not a hiccup.
+
+**Measured on hardware 2026-08-21, loading minijv from the chain editor:**
+
+```
+param  = 678 / 672889 us     one param request took 672.9 ms
+total  max = 673487 us       the whole frame
+pre    max = 673004 us       essentially all of it before the transfer
+ioctl  max =   2932 us       the transfer itself was normal
+```
+
+Against a **2900 us** frame budget that is **~232 consecutive dropped frames**.
+Idle `param` max is 35-80 us, so a load is roughly four orders of magnitude
+over. Corroborated independently one line earlier in the same log by a
+different subsystem: `[link_subscriber] cbgap slot=3 674.3 ms`. The whole
+system stops, not just the slot being loaded.
+
+**Where the time goes.** Not `dlopen`, and not file I/O. minijv loads ROMs
+inside `create_instance`, and **the plugin API has no realtime contract** —
+`create_instance` may do anything, most modules ship outside this tree, and
+the cost is therefore unbounded and unknowable from here. Any budget set
+against modules in this repo is a lower bound.
+
+**The previous entry cited a design that does not exist.** It pointed at
+`docs/plans/2026-06-11-codebase-cleanup-review.md`; that file's only mention
+(line 103) is a one-line TODO to *write this section*. The citation was
+circular, and "don't re-investigate" then discouraged anyone from finding out
+the number was 673 ms.
+
+**The design does exist, in code.** `SHIM_EVT_OVERTAKE_DSP_LOAD`
+(`src/schwung_shim.c:1570-1805`) already does loader-thread + staged instance +
+detach-then-defer free for overtake modules, including a deliberate
+leak-on-timeout because "a leak is recoverable; a use-after-free in the audio
+path is not". The chain path never adopted it. See residual 2.6.
+
+**What makes the port non-trivial** (all verified, not assumed):
+- The module triple (`handle` / `plugin_v2` / `instance`) is a check-then-call
+  over three non-atomic words read from `chain_midi.c` in five places. Off
+  thread, a `dlclose` under a reader is a jump into an unmapped segment.
+- Chain instances are touched on **both** sides of the ioctl — `mix_audio` and
+  `forward_midi` before, `render_block` / `shadow_chain_process_fx` after — so a
+  worker must be excluded from two windows separated by a ~2 ms blocking call,
+  not one.
+- Four **synchronous read-backs** live inside the param handler in C
+  (`shadow_chain_mgmt.c:3341`, `:3362`, `:3388`, `:3406`). The
+  `default_forward_channel` one fails *silently* if the load is deferred: wrong
+  MIDI routing, no error, no crash.
+- The patch path is already fade-masked to silence before loading; the
+  `<id>:module` write path is not, and that is the one users hit.

--- a/docs/plans/2026-08-21-create-instance-thread-spike.md
+++ b/docs/plans/2026-08-21-create-instance-thread-spike.md
@@ -1,0 +1,154 @@
+# Spike — is `create_instance` safe to call off the SPI thread?
+
+**Verdict: yes, for the entire current fleet, and the audit found a bug that
+moving off the SPI thread would *fix* rather than introduce.** Residual 2.6
+(RT-safe module loading, design B) is not blocked. Three thread contracts have
+to be written down before code is written; none of them requires a lock.
+
+This is the gate the handoff (`docs/plans/2026-08-21-handoff.md` §2.1) said to
+run before writing any of design B: *"whether a third-party `create_instance` is
+safe to call off the SPI thread at all. If that audit comes back badly the whole
+design needs rethinking."*
+
+## Method
+
+The worry was that a plugin can call back into `host_api_v1_t` during create,
+and some of those callbacks write structures the SPI thread owns —
+`midi_inject_to_move` writes a ring the SPI thread drains, `mod_emit_value`
+touches the chain modulation bus.
+
+So: for every plugin repo in the parent directory, resolve the `.create_instance`
+member of its `plugin_api_v2_t` to the actual function name (it is almost never
+literally called `create_instance` — that is why a naive grep under-reports),
+extract that function's body by brace matching, then transitively expand every
+locally-defined function it calls within the same translation unit, and collect
+
+- every `->` access to a `host_api_v1_t` member, and
+- `pthread_create` / `dlopen` / `fopen` / `open` / `mmap` / `system` / `popen`.
+
+Script: `tools/spike/create_instance_audit.py` (see §5). 67 create paths across
+65 repos.
+
+## 1. What the fleet actually calls during create
+
+| host member | callers |
+|---|---|
+| `log` | ~50 — the overwhelming majority |
+| `sample_rate` | chordism, hush1, mrsample, mverb, sf2, sfz (both), talkbox |
+| `mapped_memory` + `audio_in_offset` / `audio_out_offset` | breath, performance-fx |
+| `get_bpm` | ambiotica |
+| `get_clock_status` | tb3po |
+
+And the number that matters:
+
+> **Zero plugins call `midi_send_internal`, `midi_send_external`,
+> `midi_inject_to_move`, `mod_emit_value` or `mod_clear_source` during create.**
+
+Not "few". None. Fleet-wide there are exactly three call sites of those
+callbacks anywhere in plugin C at all — `schwung-tb3po` (`send_midi`, reached
+only from the step sequencer in `render_block`), `schwung-fourtrack` (wrappers it
+hands *down* to the sub-plugins it hosts), and `move-anything-jupiter` (an old
+fork of the host itself, not a plugin). Everything else that greps positive is
+the vendored copy of the struct declaration in each repo's own header.
+
+**Do not take this as a permanent property.** It is a fact about today's fleet,
+not a contract the API states — §3 is about turning it into one.
+
+## 2. The finding that flips the argument
+
+Seven plugins call `pthread_create` **inside create_instance**:
+`schwung-airwindows`/`schwung-clap` (`clap_fx.cpp`), `schwung-jp8000`,
+`schwung-nam`, `schwung-sfz` (`xsynth_plugin.c`), `schwung-tb3po`,
+`schwung-virus`, `schwung-webstream`.
+
+Today create runs on the SPI callback, which is **SCHED_FIFO 90 on core 3**. A
+thread created there **inherits FIFO 90**. That is exactly the defect already
+recorded for keydetect (memory `module_threads_and_logging_in_audio_path`) and
+it is the same mechanism as the Link Audio starvation
+(`link_audio_producer_burst_dropouts`: Move's `Link Main` is FIFO 35, our DSP is
+70, and it starves).
+
+So seven modules are currently spawning FIFO-90 worker threads, and nobody
+declared it. Under design B, create runs on a plain SCHED_OTHER loader thread
+and every one of those threads is born SCHED_OTHER instead. **Moving
+`create_instance` off the SPI thread is a fix for a live priority-inheritance
+bug, not just a latency change.** (The loader thread must therefore be created
+*from* a SCHED_OTHER context, or explicitly reset — the same rule
+`shadow_process.c` already applies before exec.)
+
+Also present at create, all of which are the very cost design B exists to move:
+`fopen` (13), `open`/`mmap` (norns, breakbeat, jp8000, virus, pipewire),
+`dlopen` (chain host itself), and `system()` (schwung-rnbo).
+
+## 3. The three contracts to write down
+
+None needs a lock. Each is a sentence in `plugin_api_v1.h` plus a line in
+`docs/REALTIME_SAFETY.md`.
+
+**(a) `log` is already thread-safe, by construction.** `host->log` →
+`shadow_log` → `unified_log_v`, which opens with
+`pthread_mutex_trylock(&log_mutex)` and **returns without logging if the lock is
+held**. A loader thread and the SPI thread can call it concurrently; the only
+possible outcome is a dropped line, never a block on either side. This is the
+one callback that is safe today with no change.
+
+**(b) The scalar reads are benign races, and must be declared as such.**
+`sample_rate`, `frames_per_block`, the two offsets and `mapped_memory` are set
+once at init and never written again — not races at all. `get_bpm`
+(`shim_get_bpm` → `sampler_get_bpm`) and `get_clock_status`
+(`chain_get_clock_status`) read `int`/`uint64_t` globals the SPI thread writes.
+On ARM64 these are single-instruction naturally-aligned accesses, so no tearing;
+the worst case is a create observing a tempo one block stale, which no plugin
+can distinguish from being created one block earlier.
+
+One wrinkle worth a comment rather than a fix: `chain_get_clock_status` calls
+`chain_refresh_clock_output_enabled`, which **writes** `g_clock_output_enabled`
+and `g_clock_next_refresh_ms` and does an `access()` on a settings file. Called
+from two threads it can duplicate one settings re-read. Benign, but it means
+`get_clock_status` is not a pure read, and a future maintainer will assume it is.
+
+**(c) The MIDI/modulation callbacks must be declared create-forbidden.** Nothing
+calls them today (§1), so the rule costs nothing to adopt now and is unenforceable
+later if we wait. Proposed wording for `plugin_api_v1.h`:
+
+> During `create_instance` and `destroy_instance`, the host may call your plugin
+> from a background loader thread. You may call `log` and the scalar queries
+> (`get_bpm`, `get_clock_status`, `get_beat_position`, `slot_recv_channel`); you
+> may **not** call `midi_send_internal`, `midi_send_external`,
+> `midi_inject_to_move`, `mod_emit_value` or `mod_clear_source`, and you may not
+> write through `mapped_memory`. Defer any of those to your first `render_block`.
+
+A host-side test can pin this cheaply: build the fleet's create paths through the
+same audit script in CI-for-modules, or — better, because it does not depend on
+source access — hand plugins a **create-time host vtable** whose forbidden
+members are stubs that log loudly and return failure, and swap in the real vtable
+at commit. That converts an unwritten convention into an observable one, and it
+is five lines at the call site.
+
+## 4. What this does and does not settle
+
+Settled: the gate in §2.1 of the handoff. Design B may proceed.
+
+Not settled, and still carried from the handoff as lower-confidence: the
+SET-replay buffer sizing (by inspection, not measurement); whether making
+`<id>_module` report the *pending* name disturbs patch-save (untraced); and the
+claim that `docs/REALTIME_SAFETY.md` is wrong to treat `load_patch` as already
+safe.
+
+Newly raised here: `schwung-fourtrack`'s create path hosts **sub-plugins**, so
+its `create_instance` can transitively call another plugin's `create_instance`.
+Design B stages one position at a time; a nested create inside a staged create is
+still just work on the loader thread, so it should compose — but it is the one
+case where "one pending load at a time" is not literally true, and the pending-
+index retargeting through `map[]` should be checked against it.
+
+## 5. Reproducing
+
+```
+python3 tools/spike/create_instance_audit.py    # run from schwung-parent/
+```
+
+Prints one line per create path: repo, file, resolved entry function, the
+`host_api_v1_t` members reached transitively, and the risk calls. Re-run it
+before adopting §3(c) — the point of writing the rule down is that the fleet is
+allowed to change under us.

--- a/docs/plans/2026-08-21-handoff.md
+++ b/docs/plans/2026-08-21-handoff.md
@@ -1,0 +1,293 @@
+# Handoff — 2026-08-21
+
+Branch `fix/enum-wire-and-contract-reads`, **PR #223 open, CI green, not merged,
+nothing released.** Everything below is deployed to the device and tested by
+Charles on hardware.
+
+---
+
+## 1. What shipped today, and the one idea behind it
+
+Four fixes, all found from hardware, all the same mistake in a different place:
+
+> **A value the UI could not interpret was turned into a confident guess instead
+> of a question.**
+
+- An empty `chain_params` (`"[]"`) became a valid contract.
+- Missing metadata became an invented `float 0..1 step 0.01` knob, which wrote
+  `0.058750` into an enum.
+- A timed-out `ui_hierarchy` read became "this module declares no hierarchy",
+  and then latched.
+- A contract read taken too early became the truth about a plugin that had not
+  finished loading.
+
+Reading the four commits in order is the fastest way in:
+
+| commit | what |
+|---|---|
+| `f9cb95b7` | a knob takes its type from the level that named it |
+| `97f1ea9e` | enums: learn the wire format, open a list, never plan from a failed read |
+| `35ef1aeb` | docs |
+| `18a2209e` | contract: a selection books a deadline, not an immediate read |
+| `20c1a206` | contract: `is_loading` may spend fewer reads, never fewer confirmations |
+
+### 1.1 Enum wire format — the grid learns it, nobody declares it
+
+The knob grid held an enum as a **number** end to end and always wrote
+`String(idx)`. `chord`'s `set_param` is a `strcmp` ladder over the option NAMES
+**with no trailing `else`**, so every write was silently discarded while the
+renderer drew `options[idx]` — the value appeared to move and snapped back. It
+never moved; "always reverts to major" was simply where it started.
+
+The grid now **learns the convention from what `get_param` reports**, latching
+per key. Two properties are load-bearing:
+
+- **It cannot use its own cache.** The grid's writes populate `s.values`, so
+  inferring from it locks into index mode after one write. Detection uses only
+  values that came from the DSP.
+- **It adds no IPC.** It rides two reads that already happen — the staggered read
+  cursor, and the first-turn seeding read. A cursor-only design writes indices
+  until the cursor comes round, polluting the cache on the way. There is a test
+  for exactly that.
+
+`options_as_string: true` survives as an **explicit override**, checked first.
+Eight declarations were added to `chord` / `arp` / `velocity_scale`. **Before
+today, not one shipped module had ever set it, despite it being documented** —
+the same declaration-burden trap to avoid in future designs.
+
+Fixed in passing: enum knob state was seeded with `Number(value)`, and
+`Number("major")` is `NaN`, so every name-reporting enum seeded at option 0; and
+`short_options` / enum-driven graphics were already broken for the same reason.
+`arp`'s `division` was worse than the rest — its `else atof(val)` turned index
+`3` into a division of `3.0` rather than rejecting it.
+
+### 1.2 Every enum opens a list
+
+Every enum with declared options is now **divable** — hold the knob, click, pick
+from a list — **while the knob keeps turning it**.
+
+**`meta.divable` and `meta.divable_mark` are separate on purpose.** 135 enums in
+the fleet against 5 opaque params; marking them all would destroy what the
+bracket means, and for an opaque cell the brackets *are* `drawOpaqueBox`'s frame
+(it draws none of its own). **Net pixel change on the grid is zero.** The
+affordance is the footer's `CLK OPEN`. Mutation-checked in both directions.
+
+The picker wears the **movy chrome from both entry points** (knob grid, and
+jog-click on an enum row in the hierarchy list editor) and reuses the one shared
+list widget. This is not stylistic: `chain_editor_chrome.mjs` records the module
+picker drawing itself in whichever chrome its caller wore, Charles reported it
+from the device, and the fix comment forbids a caller test inside a shared draw.
+Entry-point chrome is that branch coming back.
+
+Row rect starts at **y=9, not `MENU_LIST_Y`** — `MENU_LIST_Y` costs a row (4 vs
+5), and 9 is only safe because this header is not inverted. `test_enum_picker_chrome.sh`
+pins `CAPACITY === OLD_CAPACITY` and `clipped() === 0`.
+
+It also **does not route through `openParamEditorFromGrid`** — it intercepts in
+param-pages and keeps the controller alive. Decisive reason: slot settings and
+Master FX settings are *synthesised* contracts with no `ui_hierarchy`, so the
+hierarchy route refuses everything but LFO Target. Their enums (Recv Ch, 17
+options; Fwd Ch, 18) are where the list earns its keep.
+
+### 1.3 A param read has THREE answers
+
+**This is the most reusable thing in the whole session.**
+
+`js_shadow_get_param` (`src/shadow/shadow_ui.c`, ~:1201) returns:
+
+- **JSON** — served, here it is
+- **`""`** — reachable, but the module declares nothing here
+- **`null`** — the read FAILED: failed claim, **timeout**, error, or stolen
+  response
+
+Collapsing `""` and `null` caused three separate bugs in one day. The rule:
+**never let a failed read produce a plan, a default, or a cached verdict**, and
+**branch on the raw value BEFORE parsing** — `parse(null)` and `parse("")` both
+give `null` and destroy the distinction.
+
+Wrinkle: `tests/fixtures/module-contracts.json` records `ui_hierarchy: null` for
+modules that genuinely have none, so at *planner* level null still means absent.
+The tri-state exists only where the wire is visible (the controller).
+
+### 1.4 The granny bug, and then the airwindows bug
+
+**granny** (reported: *"selecting a sample puts the sample file on knob 1 until I
+go into the waveform editor and back"*): granny loads a WAV **synchronously
+inside `set_param`**, on the SPI thread that serves param requests. The write
+times out at 100 ms; the grid rebuild in the same JS handler reads
+`ui_hierarchy`, gets `null`, and treats it as "no hierarchy" — so it paginates
+`chain_params`, and granny emits `sample_path` first. Then it **latched**,
+because the fallback metadata looked complete enough to settle.
+
+**airwindows** (reported: *"kCyberCity shows Headrm/A Delay/A Level; step to
+kosmos and it shows kCyberCity's controls; exit and come back and it's right"*):
+a different bug with a similar shape. Airwindows updates `selected_plugin_index`
+synchronously — so `plugin_name` is right immediately — but only *schedules* the
+load, 300 ms later on a worker thread. `chain_params` keeps reporting the old
+cache. We re-read milliseconds after the write.
+
+`commitItem` and `stepPreset` both carried comments **promising** the contract
+would be re-read. The promise was not kept: they cleared `metaSettled`, and
+`maybeResettle` re-latched it immediately, because `metaUnsettled()` only fires
+for an enum showing a placeholder — and airwindows publishes `type:"float"` for
+everything.
+
+Now a selection **arms a settle deadline**, re-armed per detent, and the re-read
+happens once the contract has stopped moving. Notes:
+
+- **Milliseconds, not ticks.** What is being waited out is another process's
+  debounce; the tick rate is neither fixed nor owned by that file.
+- **A degenerate answer means "not settled", not an answer** — airwindows emits
+  `"[]"` for its whole dlopen window, and the chain host now substitutes
+  `module.json` for `"[]"`, which for airwindows declares one `plugin_id` param.
+  The guard is phrased as *"does anything on the knob page have declared
+  metadata"* so it catches both without naming either.
+- **Deferred under a held knob** — a rebuild drops `s.values` and would blink the
+  cell under your hand back to `--`.
+- **`is_loading` may spend fewer reads, never fewer confirmations.** The first
+  version let `is_loading == "0"` stand in for the second agreeing reading — and
+  the fleet fake reports ready while still serving the previous contract, so the
+  test caught it settling on the stale answer. It is probed **once per component
+  and latched** (`""` → unsupported forever). This is what keeps correctness
+  genuinely independent of it.
+- **Cost is O(1) in jog length**: **5 contract reads per settle** — two `load()`s
+  for the two agreeing readings plus one `is_loading` probe — whether you step
+  once or spin through all 519 effects; **0 while idle**. Spread over ~1 s of wall
+  clock, so well under a frame in any single tick. (`18a2209e`'s message says 2;
+  that was true of that commit, not of the final state.)
+
+---
+
+## 2. Open items
+
+### 2.1 Residual 2.6 — RT-safe module loading (deferred, design written)
+
+**The branch was originally cut for this and it contains none of it.** Module
+loading calls `dlopen()`, `fopen()` and `malloc()` on the SCHED_FIFO 90 SPI
+callback. **Measured: 672.9 ms for minijv**, ~232 dropped frames, corroborated by
+`link_subscriber cbgap 674.3 ms`. See `617275e9` and `docs/REALTIME_SAFETY.md`.
+
+Designs A (trim the work) and C (warm the dlopen cache) are dead — 673 ms is not
+shavable to under ~900 µs, and C does not help a first load.
+
+**Design B, as designed: stage, don't swap.** The worker never touches a live
+position array; it builds the whole instance into a staging record no render path
+can reach, and the SPI thread commits by swapping pointers at the same call site
+the synchronous load uses today. So *"only the SPI thread ever mutates a chain
+instance"* survives verbatim — no lock on either side. Key details:
+
+- Nothing is freed on the SPI thread; retire records go to the loader thread.
+  Copy the overtake leak-on-doubt rule rather than draining inline.
+- **Metadata blocks are swapped, not copied** — a position's `fx_params` block is
+  ~1.1 MB; memcpy at commit would eat the frame budget. Staging owns one spare
+  pair, so the pointer multiset stays invariant and `chain_permute.h`'s never-null
+  rule holds.
+- A **replace** keeps the old module rendering for the whole load (no silence);
+  an **append** opens a genuine hole, which existing hole-skipping already covers.
+- A permutation landing mid-load retargets the pending index through the same
+  `map[]` that re-aims mod targets and LFOs; `-1` means cancel-and-reap.
+- Use a **new dedicated loader thread**, not `shim_worker` — its loop is
+  `usleep(200ms)` and every constant in it is expressed in those ticks; a 673 ms
+  load inside its serial `drain_events()` would also delay
+  `overtake_dsp_free_pending`, which has a reasoned 200 ms bound.
+
+**Do the spike first:** whether a third-party `create_instance` is safe to call
+off the SPI thread **at all**. Plugins can call back into `host_api_v1_t` during
+create — `midi_inject_to_move` writes into a ring the SPI thread drains. The
+plugin API has no realtime contract *and no thread contract*. **If that audit
+comes back badly the whole design needs rethinking**, so run it before writing
+code.
+
+Lower-confidence flags from the design: the SET-replay buffer was sized by
+inspection, not measurement; making `<id>_module` report the *pending* name turns
+it into a statement of intent, which may affect patch-save if that path reads
+through `get_param` (untraced); and the design argues `docs/REALTIME_SAFETY.md`
+is **wrong** to treat `load_patch` as already safe — fade-masking hides that
+slot's click but does nothing about 232 device-wide dropped frames.
+
+### 2.2 Jump-to-category lands on knobs, not the preset list
+
+Reported by Charles; **a design gap, not a defect, and deliberately not fixed.**
+`commitItem` (`page_controller.mjs:762`) resolves `navigate_to` only to a
+`PAGE_KNOBS` page, and the fallback `firstGrid` is a knob page too. **No module
+can currently declare "having chosen a category, land me in the preset browser."**
+Needs a decision on whether that becomes expressible, not a patch.
+
+### 2.3 Bugs in other repos
+
+- **`impressive-chords` leaks the dry note** through alongside the chord. The one
+  genuinely unexplained thing left. Confirmed NOT host leniency —
+  `v2_process_midi_fx` really does swallow input when a stage emits nothing — so
+  the root note arrives by another route. MIDI FX Pre did not help. Nobody has
+  read its `process_midi` yet. Also tell mestela it returns literal `"[]"` for
+  `chain_params`; it should ship a `chain_params.json` or return `-1`.
+- **granny** does blocking `fopen`/read/alloc on the audio callback
+  (`granny_plugin.cpp:571`), and `live_preview: true` means it reloads on **every
+  scroll**. The host now survives it; the audio stall is real and remains.
+- **`clap`/airwindows** implements no `is_loading`. Optional now — correctness
+  does not depend on it — but it would let us skip the settle deadline entirely.
+  Five lines: `inst->loading || inst->pending_load_time != 0`.
+
+### 2.4 Release, when you want it
+
+Not started deliberately. `version.txt` and `module-catalog.json` are still on
+**0.12.1**. Needs: version bump, catalog `latest_version` + download URL,
+`min_host_version` for any module depending on today's work, tag, release notes.
+`../schwung-catalog-site` has a **local, unpushed** commit (`4b83517`) describing
+the enum picker — deliberately unpushed, since the public manual should not
+describe an unreleased feature.
+
+---
+
+## 3. Things that cost time today — read this before repeating them
+
+- **Airwindows' module id is `clap`.** Grepping `airwindows` in
+  `tests/fixtures/module-contracts.json` finds nothing, so an agent concluded it
+  was uncaptured and hand-rolled a contract — twice, with a modelling error that
+  produced a confident wrong diagnosis. The real entry has genuine captured names
+  (`Headrm`, `A Delay`, `A Level`) matching the hardware report verbatim.
+- **`clap` is the module where "the module id identifies the parameter set" is
+  false.** 519 effects behind one id; a static `ui_hierarchy` of `param_0..param_7`;
+  `type:"float"` throughout. **Check every identity-keyed design against it** —
+  fingerprints, caches, retain-on-failure, "same component" tests.
+- **A hypothesis that fits is not a diagnosis.** Two confident wrong diagnoses
+  were produced before the bisect-and-reproduce discipline was applied. The
+  decisive move each time was *running the experiment* (three trees, then six),
+  not reasoning harder.
+- **"It worked this morning" was never explained.** Six commits back to yesterday
+  gave byte-identical repro output. The airwindows fix rests on a reproduced
+  mechanism, not on that memory. **If anything else shows up one-behind, do not
+  assume it is covered.**
+- **Mutation-test the guard you just added.** Across the two contract commits,
+  **three mutations survived the first test matrix** — the degeneracy guard, the
+  `is_loading` fast path, and the fingerprint carry — because the cases were not
+  reaching them. Each time the test was widened rather than the green accepted.
+  A mutation that survives is the test's failure, not the mutation's.
+- **An agent can keep working after you commit.** `18a2209e` captured a
+  work-in-progress state; the refinement landed afterwards as `20c1a206`, which
+  also corrected the read cost quoted in the earlier message. Check `git status`
+  and file mtimes before treating a hand-off as final.
+- **`rg` is a shell function here, not a binary** — ~32 host tests silently do not
+  run. Use `command grep`. A clean-worktree baseline and a byte-identical failure
+  list is the only trustworthy signal.
+- **Agents share one git index and one worktree.** Two implementers briefly
+  landed on the same files today. Nothing was lost — the second detected the
+  concurrent writes and backed off — but check `git worktree list` and file
+  mtimes before assuming a tree is quiet.
+
+---
+
+## 4. State
+
+- Branch `fix/enum-wire-and-contract-reads` @ `20c1a206`, pushed. **PR #223 open,
+  all three checks green against that head, not merged.**
+- Device has this build (`install.sh local --skip-modules --skip-confirmation`),
+  verified on device. chord, granny and airwindows all confirmed fixed on
+  hardware by Charles — **though he confirmed airwindows on `18a2209e`; the
+  `20c1a206` refinement is deployed but not yet hardware-confirmed.** The check
+  that would settle it: `touch /data/UserData/schwung/param_tally_on`, select an
+  effect, and `fx1:chain_params` should show a small burst ~500 ms after the
+  selection settles and nothing at all while jogging.
+- Working tree clean except `.serena/project.yml`, which churns on its own and
+  should never be staged.
+- Worktrees: only `menu-style-v2` (pre-existing, unrelated).

--- a/docs/plans/2026-08-21-handoff.md
+++ b/docs/plans/2026-08-21-handoff.md
@@ -160,7 +160,25 @@ happens once the contract has stopped moving. Notes:
 
 ## 2. Open items
 
+> **Update, later the same day.** §2.1's gate has been run and it passed —
+> `docs/plans/2026-08-21-create-instance-thread-spike.md`. §2.2 is fixed
+> (`c4226f42`). §2.3's impressive-chords entry has a diagnosis and an experiment
+> —`docs/plans/2026-08-21-impressive-chords-dry-note.md` — and its
+> `clap`/airwindows entry is implemented in that repo, committed, unpushed.
+> §2.4 (release) is untouched, deliberately. Details are folded in below.
+
 ### 2.1 Residual 2.6 — RT-safe module loading (deferred, design written)
+
+> **Gate cleared.** The spike this section says to run first has been run:
+> across all 67 create paths in the fleet, **no plugin calls `midi_send_*`,
+> `midi_inject_to_move`, `mod_emit_value` or `mod_clear_source` during
+> create** — the exact hazard. What they call is `log` (already thread-safe by
+> trylock-and-drop), the fixed scalars, and two benign global reads. And the
+> audit found that **seven plugins `pthread_create` inside create**, so today
+> those workers inherit SCHED_FIFO 90 from the SPI callback: moving create off
+> that thread is a *fix*, not just a latency change. Three thread contracts to
+> write down first, none needing a lock. Full result, method and the re-runnable
+> script in `docs/plans/2026-08-21-create-instance-thread-spike.md`.
 
 **The branch was originally cut for this and it contains none of it.** Module
 loading calls `dlopen()`, `fopen()` and `malloc()` on the SCHED_FIFO 90 SPI
@@ -205,28 +223,52 @@ through `get_param` (untraced); and the design argues `docs/REALTIME_SAFETY.md`
 is **wrong** to treat `load_patch` as already safe — fade-masking hides that
 slot's click but does nothing about 232 device-wide dropped frames.
 
-### 2.2 Jump-to-category lands on knobs, not the preset list
+### 2.2 Jump-to-category lands on knobs, not the preset list — FIXED (`c4226f42`)
 
-Reported by Charles; **a design gap, not a defect, and deliberately not fixed.**
-`commitItem` (`page_controller.mjs:762`) resolves `navigate_to` only to a
-`PAGE_KNOBS` page, and the fallback `firstGrid` is a knob page too. **No module
-can currently declare "having chosen a category, land me in the preset browser."**
-Needs a decision on whether that becomes expressible, not a patch.
+Reported by Charles. Written up here as *"a design gap, not a defect"* on the
+belief that no module could express "land me in the preset browser". That was
+wrong, and finding out why took one query: **obxd already declares exactly
+that.** Its `banks` level says `navigate_to: "root"`, and `root` carries
+`list_param`/`count_param` **and** `knobs`, so it plans a preset browser *and* a
+grid. Naming the level never said which; `commitItem` filtered the lookup to
+`PAGE_KNOBS`, so it could only ever find the grid.
+
+So it was a defect after all, and the lesson is the one this file already
+records in a different key: the gap was described from the code without asking
+what the fleet declares. Three modules in the whole fleet declare `navigate_to`
+(303, jv880, obxd) — a five-line query, and it names the reporter's module.
+
+Fixed by preferring the browser and falling back to the grid. Deliberately **not**
+a new `navigate_to: {level, kind}` form: 303 and jv880 both name levels with no
+preset page so nothing else moves, and new vocabulary would repeat the
+`options_as_string` lesson from §1.1 — documented for months, set by nobody. The
+test drives the real obxd fixture, and is mutated both ways.
 
 ### 2.3 Bugs in other repos
 
-- **`impressive-chords` leaks the dry note** through alongside the chord. The one
-  genuinely unexplained thing left. Confirmed NOT host leniency —
-  `v2_process_midi_fx` really does swallow input when a stage emits nothing — so
-  the root note arrives by another route. MIDI FX Pre did not help. Nobody has
-  read its `process_midi` yet. Also tell mestela it returns literal `"[]"` for
-  `chain_params`; it should ship a `chain_params.json` or return `-1`.
+- **`impressive-chords` leaks the dry note** through alongside the chord. Its
+  `process_midi` has now been read, and so has every route from a pad to a sound
+  on the Schwung side: the plugin never emits the input note, calls no host MIDI
+  callback, and the chain genuinely swallows a zero-output stage. Leading
+  explanation is that the extra note is **Move's own track playing the pad on
+  cable 0**, which the chain cannot swallow — inaudible with the built-in chord
+  FX because that one emits the played note as the chord root, glaring with
+  impressive-chords because its chord has no pitch relation to the pad.
+  **That is a hypothesis; §3's rule applies.**
+  `docs/plans/2026-08-21-impressive-chords-dry-note.md` has the 20-second
+  experiment that kills or confirms it. (The walk also found and deleted
+  `inst_send_note_to_synth`, a caller-less raw-msg-to-synth path.) Still tell
+  mestela it returns literal `"[]"` for `chain_params`; it should ship a
+  `chain_params.json` or return `-1`.
 - **granny** does blocking `fopen`/read/alloc on the audio callback
   (`granny_plugin.cpp:571`), and `live_preview: true` means it reloads on **every
   scroll**. The host now survives it; the audio stall is real and remains.
-- **`clap`/airwindows** implements no `is_loading`. Optional now — correctness
-  does not depend on it — but it would let us skip the settle deadline entirely.
-  Five lines: `inst->loading || inst->pending_load_time != 0`.
+- **`clap`/airwindows** implemented no `is_loading`. **Done** —
+  `schwung-airwindows` `9b661eb`, on `main`, **committed but NOT pushed and NOT
+  released**, since pushing that repo's main implies a release. Reports exactly
+  `"1"`/`"0"` in both states, which the host requires: any other answer latches
+  the component as not-implementing-it. Correctness never depended on it; it
+  just lets the host use a real edge instead of guessing at a 300 ms debounce.
 
 ### 2.4 Release, when you want it
 
@@ -279,8 +321,11 @@ describe an unreleased feature.
 
 ## 4. State
 
-- Branch `fix/enum-wire-and-contract-reads` @ `20c1a206`, pushed. **PR #223 open,
-  all three checks green against that head, not merged.**
+- Branch `fix/enum-wire-and-contract-reads`, pushed. Four more commits landed on
+  it after the ones tabled in §1: the docs handoff, the create-instance spike,
+  the impressive-chords write-up plus dead-code deletion, and the §2.2 fix.
+- `schwung-airwindows` `main` is **ahead 1, unpushed** (`9b661eb`, `is_loading`).
+  Pushing it is a release decision, so it was left alone.
 - Device has this build (`install.sh local --skip-modules --skip-confirmation`),
   verified on device. chord, granny and airwindows all confirmed fixed on
   hardware by Charles — **though he confirmed airwindows on `18a2209e`; the

--- a/docs/plans/2026-08-21-impressive-chords-dry-note.md
+++ b/docs/plans/2026-08-21-impressive-chords-dry-note.md
@@ -1,0 +1,112 @@
+# impressive-chords: the dry note, read at last
+
+Handoff §2.3 left this as *"the one genuinely unexplained thing"*, with the note
+that nobody had read `process_midi` yet. It has now been read, along with every
+route from a pad to a sound on the Schwung side.
+
+**The chain host is exonerated a second time, and this time exhaustively. The
+leading explanation is that the extra note is not leaking through Schwung at all
+— it is Move's own track, playing the pad, on the cable-0 path the chain never
+sees.** One 20-second experiment discriminates it (§3). Do that before writing
+any code.
+
+## 1. What `ic_process_midi` actually does
+
+`_community_clone/schwung-impressive-chords/src/dsp/impressive_chords.c:451`.
+It is a `midi_fx_api_v1_t` (`move_midi_fx_init`), so it runs through
+`v2_process_midi_fx`.
+
+For a Note On it does exactly one thing: `return trigger_chord(...)`. There is no
+path in which it copies the input note into its output. The only passthrough in
+the whole function is the final
+
+```c
+// Pass through for everything else
+memcpy(out_msgs[0], in_msg, in_len);
+```
+
+which is unreachable for note events — every note status is consumed by the two
+branches above it. Clock (`0xF8`) returns 0 or a retrigger. So **the plugin never
+emits the dry note.**
+
+Nor does it emit it indirectly. `trigger_chord` builds every voice from
+`chord->notes[idx] + transpose`, a preset table indexed by
+`chord_idx = note - base_note`; the input pitch is used only as a table index and
+as the key of `active_notes[]`. And the plugin calls no host MIDI callback at all
+— confirmed fleet-wide in `2026-08-21-create-instance-thread-spike.md`, and by
+grep here: `impressive_chords.c` contains no `midi_send_*` / `midi_inject_to_move`
+call site.
+
+Two `return 0` paths are worth knowing because they are the *opposite* of a leak
+— out-of-range notes go silent, not through:
+
+```c
+int chord_idx = note - inst->base_note;
+if (chord_idx < 0 || chord_idx >= 48) return 0;      // pad below base_note, or 48+ above
+if (!g_presets || ... ) return 0;                     // presets failed to load
+```
+
+## 2. What the host does with a zero-output stage
+
+`v2_process_midi_fx` (`src/modules/chain/dsp/chain_midi.c:363`) accumulates
+`next_count` only from what stages return, and the final copy loop is bounded by
+`current_count`. A stage that returns 0 leaves `current_count == 0` and the
+function returns 0. The caller (`:810`) then runs a loop `for (i = 0; i < 0; i++)`
+to the synth. **There is no leniency, no fallback, no "if the FX produced nothing,
+pass the original".** This is the second confirmation; the first is recorded in
+the handoff.
+
+I also checked every other route from `v2_on_midi` to the synth. There are five
+`synth_plugin_v2->on_midi` call sites in the chain host; four are the MIDI-FX
+output loop, the tick-generated loop, a mod-reset, and the CC path. The fifth,
+`inst_send_note_to_synth` (`chain_midi.c:636`), takes a raw `msg` and would be a
+perfect suspect — **but it has no callers.** It is dead code and should be deleted
+(see §4).
+
+## 3. The hypothesis, and the experiment that settles it
+
+Pressing a pad puts the note on cable 0, where **two** things happen: the chain
+slot receives it (and swallows it, per §2), and **Move's firmware receives it and
+plays the selected track's own instrument**. Schwung cannot swallow the second —
+that is the whole reason `midi_fx_pre_mode`'s inject path carries a "root-match
+skip" comment about Move's pad path already having triggered the note.
+
+Why this shows up on impressive-chords and not on the built-in `chord`: the
+built-in emits the played note as the chord's root, so a doubled pad note is
+inaudible as a separate event. impressive-chords maps the pad through
+`note - base_note` into a preset table, so its chord has **no pitch relationship
+to the pad at all** — and the pad note becomes glaringly, obviously wrong. Same
+mechanism, only one of them audible. That asymmetry is what has made this look
+like a plugin bug for weeks.
+
+**The discriminator** — takes about twenty seconds on the device:
+
+1. Play a pad with impressive-chords loaded and listen to the extra note.
+2. Does its pitch track the **pad** (chromatically, one semitone per pad) or the
+   **chord's base**? Pad ⇒ it is the cable-0 route, not the chain.
+3. Mute Move's own track (Mute + Track), or select an empty Move track, and play
+   again. If the extra note disappears while the chord remains, the diagnosis is
+   confirmed and there is nothing to fix in either repo — it becomes a
+   documentation and defaults question.
+
+If instead the extra note survives a muted Move track, the hypothesis is dead and
+the next step is instrumentation, not more reading: `spi_midi_log` on the slot's
+recv channel, which will name the route directly. **Do not accept a third
+plausible mechanism without that trace** — handoff §3 records that two confident
+wrong diagnoses were produced here before the bisect discipline was applied, and
+this document is a hypothesis, not a result.
+
+## 4. Two things to fix regardless
+
+**Report to mestela** (independent of the above, and already known):
+`ic_get_param` returns the literal string `"[]"` for `chain_params` when
+`chain_params.json` is missing from the install path
+(`impressive_chords.c:931`). A degenerate contract is worse than no contract —
+`"[]"` reads as "this module declares no parameters", which the shadow UI is now
+careful about but should not have to be. It should ship the `chain_params.json`
+or `return -1`.
+
+**Delete `inst_send_note_to_synth`** (`src/modules/chain/dsp/chain_midi.c:636`).
+It is unreferenced, and it is precisely the shape of the bug being hunted here —
+a raw-`msg`-to-synth call that bypasses the FX chain. Leaving it in the file
+costs a future investigator the same hour it cost this one.

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1571,7 +1571,7 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
             /* Try plugin's own chain_params handler first */
             if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->get_param) {
                 int result = inst->synth_plugin_v2->get_param(inst->synth_instance, subkey, buf, buf_len);
-                if (result > 0) return result;  /* Plugin provided chain_params */
+                if (chain_params_answer_is_useful(buf, result)) return result;  /* Plugin provided chain_params */
             }
             /* Fall back to parsed module.json data */
             if (inst->synth_param_count > 0) {
@@ -1645,7 +1645,7 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
             /* Try plugin's own chain_params handler first */
             if (inst->fx_is_v2[fxi] && inst->fx_plugins_v2[fxi] && inst->fx_instances[fxi] && inst->fx_plugins_v2[fxi]->get_param) {
                 int result = inst->fx_plugins_v2[fxi]->get_param(inst->fx_instances[fxi], subkey, buf, buf_len);
-                if (result > 0) return result;
+                if (chain_params_answer_is_useful(buf, result)) return result;
             }
             /* Fall back to parsed module.json data */
             if (inst->fx_param_counts[fxi] > 0) {
@@ -1719,7 +1719,7 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
             /* Try plugin's own chain_params handler first */
             if (inst->midi_fx_plugins[mfi] && inst->midi_fx_instances[mfi] && inst->midi_fx_plugins[mfi]->get_param) {
                 int result = inst->midi_fx_plugins[mfi]->get_param(inst->midi_fx_instances[mfi], subkey, buf, buf_len);
-                if (result > 0) return result;
+                if (chain_params_answer_is_useful(buf, result)) return result;
             }
             /* Fall back to parsed module.json data */
             if (inst->midi_fx_param_counts[mfi] > 0) {

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -417,6 +417,42 @@ typedef struct chain_instance {
  * answers 0, because a half-allocated instance is a null dereference in the
  * audio callback later, which is far worse than refusing to create the slot.
  */
+/*
+ * Did the plugin actually ANSWER the chain_params query?
+ *
+ * Every one of the three get_param routes (synth, audio FX, MIDI FX) asks the
+ * sub-plugin for "chain_params" first and only renders its own module.json
+ * fallback if the plugin declines. "Declined" was `result <= 0`, which is a
+ * length test, and a length test cannot tell a real table from an empty one.
+ *
+ * impressive-chords v0.1.24 reads its chain_params from a JSON file at runtime
+ * and returns the two characters "[]" when that file is not installed — which
+ * it is not, in the shipped tarball. Length 2 counted as an answer, so the
+ * host discarded the fifteen correct parameter declarations it had already
+ * parsed out of that module's own module.json and served "[]" instead. The
+ * Shadow UI's knob row then had no type for any of them and drove every one as
+ * a float 0..1: an int wrote a fraction its atoi read as 0, an enum took
+ * option 0. Reported as "i could see the values change, but when i release, it
+ * reset to the default".
+ *
+ * An empty array is therefore treated as no answer, and the fallback runs. A
+ * plugin that genuinely has no parameters loses nothing: the fallback finds no
+ * parsed params either and the caller ends up returning -1, which the UI reads
+ * exactly as it read "[]".
+ *
+ * Pure scan over a caller-owned buffer — no allocation, no I/O — because these
+ * routes are serviced from the SPI callback.
+ */
+static inline int chain_params_answer_is_useful(const char *buf, int result) {
+    if (result <= 0 || !buf) return 0;
+    for (int i = 0; i < result && buf[i]; i++) {
+        char c = buf[i];
+        if (c == '[' || c == ']' || c == ' ' || c == '\t' || c == '\n' || c == '\r') continue;
+        return 1;
+    }
+    return 0;
+}
+
 static inline void chain_free_position_storage(chain_instance_t *inst) {
     if (!inst) return;
     for (int i = 0; i < MAX_AUDIO_FX; i++) {

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -632,22 +632,13 @@ static void pre_delay_flush(chain_instance_t *inst) {
     inst->pre_delay_count = 0;
 }
 
-/* Send a note to synth with optional transposition (for chords) */
-static void inst_send_note_to_synth(chain_instance_t *inst, const uint8_t *msg, int len, int source, int interval) {
-    if (!inst || len < 3) return;
-
-    uint8_t out_msg[3] = { msg[0], msg[1], msg[2] };
-
-    if (interval != 0) {
-        int transposed = (int)msg[1] + interval;
-        if (transposed < 0 || transposed > 127) return;  /* Out of range */
-        out_msg[1] = (uint8_t)transposed;
-    }
-
-    if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->on_midi) {
-        inst->synth_plugin_v2->on_midi(inst->synth_instance, out_msg, len, source);
-    }
-}
+/* `inst_send_note_to_synth` lived here: a raw-msg-to-synth call with an optional
+ * transpose, left over from the built-in chord FX. It had no callers, and it is
+ * exactly the shape of bug that gets hunted through this file -- a route to the
+ * synth that bypasses the MIDI FX chain. Deleted 2026-08-21 while proving the
+ * impressive-chords dry note does NOT come from here; see
+ * docs/plans/2026-08-21-impressive-chords-dry-note.md. Every remaining
+ * synth->on_midi call site in this file is fed by v2_process_midi_fx output. */
 
 /* V2 on_midi handler */
 void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {

--- a/src/modules/midi_fx/arp/module.json
+++ b/src/modules/midi_fx/arp/module.json
@@ -14,6 +14,7 @@
           "params": [
             {
               "key": "mode",
+              "options_as_string": true,
               "name": "Mode",
               "type": "enum",
               "options": ["off", "up", "down", "up_down", "random"],
@@ -30,6 +31,7 @@
             },
             {
               "key": "division",
+              "options_as_string": true,
               "name": "Division",
               "type": "enum",
               "options": ["1/4.", "1/4", "1/4T", "1/8.", "1/8", "1/8T", "1/16.", "1/16", "1/16T", "1/32"],
@@ -37,6 +39,7 @@
             },
             {
               "key": "sync",
+              "options_as_string": true,
               "name": "Sync",
               "type": "enum",
               "options": ["internal", "clock"],

--- a/src/modules/midi_fx/chord/module.json
+++ b/src/modules/midi_fx/chord/module.json
@@ -14,6 +14,7 @@
           "params": [
             {
               "key": "type",
+              "options_as_string": true,
               "name": "Type",
               "type": "enum",
               "options": ["none", "major", "minor", "dim", "aug", "sus2", "sus4", "maj7", "min7", "dom7", "dim7", "power", "5th", "octave", "add9"],
@@ -21,6 +22,7 @@
             },
             {
               "key": "inversion",
+              "options_as_string": true,
               "name": "Inversion",
               "type": "enum",
               "options": ["root", "1st", "2nd", "3rd"],
@@ -28,6 +30,7 @@
             },
             {
               "key": "voicing",
+              "options_as_string": true,
               "name": "Voicing",
               "type": "enum",
               "options": ["close", "open", "drop2", "drop3"],
@@ -44,6 +47,7 @@
             },
             {
               "key": "strum_dir",
+              "options_as_string": true,
               "name": "Strum Dir",
               "type": "enum",
               "options": ["up", "down"],

--- a/src/modules/midi_fx/velocity_scale/module.json
+++ b/src/modules/midi_fx/velocity_scale/module.json
@@ -41,6 +41,7 @@
             },
             {
               "key": "curve_preset",
+              "options_as_string": true,
               "name": "Curve Preset",
               "type": "enum",
               "options": ["Linear", "Soft", "Softer", "Hard", "Harder"],

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1910,6 +1910,21 @@ function knobLevelForHierarchy(hierarchy) {
     return levelDef;
 }
 
+/*
+ * A parameter's metadata as the LEVEL declares it, or null.
+ *
+ * The level's `params` list is mixed: plain strings (a key with no metadata),
+ * `{level, label}` navigation rows, and `{key, name, type, ...}` declarations.
+ * Only the last kind carries a type, so only the last kind is answered here.
+ */
+function hierarchyLevelParamMeta(levelDef, key) {
+    if (!levelDef || !Array.isArray(levelDef.params)) return null;
+    for (const p of levelDef.params) {
+        if (p && typeof p === "object" && p.key === key) return p;
+    }
+    return null;
+}
+
 function toggleChainComponentBypass(target, componentKey, label) {
     const cur = parseInt(chainTargetGetParam(target, componentKey, "bypassed") || "0", 10);
     const next = cur ? 0 : 1;
@@ -11224,7 +11239,41 @@ function buildChainKnobContext(target, comp, knobIndex, pluginName, hasModule) {
         if (levelDef && levelDef.knobs && knobIndex < levelDef.knobs.length) {
             const key = levelDef.knobs[knobIndex];
             const chainParams = chainTargetChainParams(target, comp.key);
-            const meta = normalizeExpandedParamMeta(key, chainParams.find(p => p.key === key));
+            /*
+             * TWO SOURCES, and chain_params is only the preferred one.
+             *
+             * A module may declare a parameter's type inline in the same level
+             * that named the knob (`{key, name, type: "int", min, max}`), and
+             * many do — it is the shape the ui_hierarchy docs show. The host
+             * normally renders chain_params out of exactly those declarations,
+             * so the two agree and the merge is invisible. It stops being
+             * invisible the moment a plugin ANSWERS chain_params itself: the
+             * host takes any answer of non-zero length (`result > 0`), so a
+             * module that serves the two characters "[]" — impressive-chords
+             * does, when the chain_params.json it reads at runtime is not
+             * installed — suppresses the host's correct fallback and the knob
+             * is left with no metadata at all.
+             *
+             * knobConfigFromMeta does not fail on that; it INVENTS a float
+             * 0..1 step 0.01. So an int -24..24 is turned as a fraction, the
+             * module's atoi reads it as 0, and an enum takes option 0 — while
+             * the overlay, which runs on local arithmetic, moves normally.
+             * Reported from the device as "i could see the values change, but
+             * when i release, it reset to the default".
+             *
+             * The list editor never had this: getParamMetadata has always
+             * merged the hierarchy's own params under chain_params, which is
+             * why the same parameter was editable from the menu and not from
+             * the knob. Same precedence here — chain_params wins key by key,
+             * because a plugin serving it at runtime is serving something it
+             * computed (a live range, a dynamic options list) and the static
+             * declaration is the floor under it, never an override.
+             */
+            const declared = hierarchyLevelParamMeta(levelDef, key);
+            const served = chainParams.find(p => p && p.key === key);
+            const merged = (declared && served) ? { ...declared, ...served }
+                                                : (served || declared);
+            const meta = normalizeExpandedParamMeta(key, merged);
             return mapped(key, meta, meta && meta.name ? meta.name : key.replace(/_/g, " "));
         }
         debugLog(`buildKnobContext: no knob mapping for knobIndex=${knobIndex} on ${comp.key}`);

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -212,7 +212,7 @@ import {
     paramPagesEnabled, enterParamPages, exitParamPages, paramPagesActive,
     tickParamPages, drawParamPages, handleParamPagesMidi, currentParamPage,
     paramPagesComponent, paramPagesSlot, clearParamPagesTouch,
-    enumPickerFooterHints
+    enumPickerFooterHints, CONTRACT_SETTLE_MS
 } from './shadow_ui_param_pages.mjs';
 import { createSlotGridIo, createMasterGridIo } from './shadow_ui_slot_grid.mjs';
 import {
@@ -10749,10 +10749,15 @@ function changeHierPreset(delta) {
      * internally (e.g. ambiotica mode change rewrites all 8 knobs). The
      * cached values are now stale, so force a re-read on next knob touch. */
     invalidateKnobValueCache();
+    /* ...and book a second look for after any module-side debounce, because
+     * the refetch above may have read the contract of the preset we just
+     * LEFT. See armHierEditorContractSettle. */
+    armHierEditorContractSettle();
 }
 
 /* Exit hierarchy editor */
 function exitHierarchyEditor() {
+    hierEditorContractDueMs = 0;
     /* Clear pending knob state to prevent stale overlays */
     pendingHierKnobIndex = -1;
     pendingHierKnobDelta = 0;
@@ -13065,6 +13070,49 @@ function drawFilepathBrowser() {
  * inside changeHierPreset observes the previous preset's knob list. */
 let hierEditorPrevLoading = false;
 
+/*
+ * When the deferred contract re-read below comes due, or 0 for none pending.
+ *
+ * The refetch in changeHierPreset happens on the line after the write, and for
+ * a module that publishes its new contract synchronously that is right and
+ * stays. schwung-airwindows does not: writing the selection only SCHEDULES the
+ * plugin load, 300 ms later on a worker thread (clap_fx.cpp:806-822), and
+ * `chain_params` describes the plugin that is still LOADED until it finishes.
+ * The immediate refetch therefore wins the race and caches the previous
+ * effect — the grid and the list both sat exactly one selection behind.
+ *
+ * So the immediate refetch is kept (nothing that answers straight away should
+ * get slower) and a second one is booked for after the debounce. Re-armed on
+ * every detent, so a spin down a 519-effect list costs one extra refetch when
+ * the hand stops rather than one per step.
+ */
+let hierEditorContractDueMs = 0;
+
+function armHierEditorContractSettle() {
+    hierEditorContractDueMs = Date.now() + CONTRACT_SETTLE_MS;
+}
+
+/* Re-read the contract a selection made stale, once it has settled. */
+function serviceHierEditorContractSettle() {
+    if (!hierEditorContractDueMs || Date.now() < hierEditorContractDueMs) return;
+    hierEditorContractDueMs = 0;
+    let newHier = null;
+    if (hierEditorIsMasterFx) {
+        hierEditorChainParams = getMasterFxChainParams(hierEditorMasterFxSlot);
+        newHier = getMasterFxHierarchy(hierEditorMasterFxSlot);
+    } else {
+        hierEditorChainParams = getComponentChainParams(hierEditorSlot, hierEditorComponent);
+        newHier = getComponentHierarchy(hierEditorSlot, hierEditorComponent);
+    }
+    if (newHier) {
+        hierEditorHierarchy = newHier;
+        loadHierarchyLevel();
+    }
+    invalidateKnobContextCache();
+    invalidateKnobValueCache();
+    needsRedraw = true;
+}
+
 /* Draw the hierarchy-based parameter editor */
 function drawHierarchyEditor() {
     clear_screen();
@@ -13102,6 +13150,10 @@ function drawHierarchyEditor() {
         }
         hierEditorPrevLoading = loadingNow;
     }
+
+    /* The deferred half of a preset change. Costs nothing on any frame where
+     * nothing is pending, which is almost all of them. */
+    serviceHierEditorContractSettle();
 
     /* Get plugin info */
     const prefix = getComponentParamPrefix(hierEditorComponent);

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -48,7 +48,8 @@ import { decodeDelta } from '/data/UserData/schwung/shared/input_filter.mjs';
 /* The knob-grid chrome's footer rule row, which the chain editor's slot
  * indicator column stops above. The header/footer/list DRAWING that used to be
  * imported here went to chain_editor_chrome.mjs, so both editors do it once. */
-import { RULE_Y as MOVY_RULE_Y }
+import { RULE_Y as MOVY_RULE_Y,
+         drawHeader as drawMovyHeader, drawFooter as drawMovyFooter }
     from '/data/UserData/schwung/shared/param_pages/render_page_movy.mjs';
 /* The bands around a chain editor's row of boxes — header, label, info,
  * footer — and the module picker it opens on a position. Both shared with
@@ -210,7 +211,8 @@ import {
 import {
     paramPagesEnabled, enterParamPages, exitParamPages, paramPagesActive,
     tickParamPages, drawParamPages, handleParamPagesMidi, currentParamPage,
-    paramPagesComponent, paramPagesSlot, clearParamPagesTouch
+    paramPagesComponent, paramPagesSlot, clearParamPagesTouch,
+    enumPickerFooterHints
 } from './shadow_ui_param_pages.mjs';
 import { createSlotGridIo, createMasterGridIo } from './shadow_ui_slot_grid.mjs';
 import {
@@ -372,7 +374,8 @@ const VIEWS = {
     LFO_EDIT: "lfoedit",                      // LFO sub-menu editor
     ANALYTICS_PROMPT: "analyticsprompt",       // First-run analytics opt-out prompt
     LFO_TARGET_COMPONENT: "lfotargetcomp",    // LFO target picker step 1: component
-    LFO_TARGET_PARAM: "lfotargetparam"        // LFO target picker step 2: parameter
+    LFO_TARGET_PARAM: "lfotargetparam",       // LFO target picker step 2: parameter
+    ENUM_PICKER: "enumpick"                   // Option list for an enum param
 };
 
 /* ==== CO-RUN VIEW ADDRESSING ====
@@ -2049,6 +2052,42 @@ function openHierarchyParamEditor(selectedKey, meta, forceOpen) {
     }
     if (!hierEditorEditMode && meta && meta.type === "filepath") {
         openHierarchyFilepathBrowser(selectedKey, meta);
+        return;
+    }
+    /*
+     * An ENUM opens its option list. The jog still steps it in place from the
+     * row (adjustHierSelectedParam), so this is the other half of the same
+     * affordance the knob grid gets — one behaviour on both editors, which is
+     * the point of putting it here rather than only on the grid path.
+     *
+     * The write goes through the same auto-detect the row's own nudge uses:
+     * ask what the plugin REPORTS, answer in kind. chord's set_param is a
+     * strcmp ladder over the names with no trailing else, so an index would be
+     * discarded in silence.
+     */
+    if (!hierEditorEditMode && meta && meta.type === "enum" &&
+        Array.isArray(meta.options) && meta.options.length > 0) {
+        const fullKey = buildHierarchyParamKey(selectedKey);
+        const currentVal = getSlotParam(hierEditorSlot, fullKey);
+        const nameIdx = meta.options.indexOf(currentVal);
+        const pluginUsesIndex = (nameIdx < 0);
+        let index = nameIdx;
+        if (pluginUsesIndex) {
+            const parsed = parseInt(currentVal, 10);
+            index = (!isNaN(parsed) && parsed >= 0 && parsed < meta.options.length) ? parsed : 0;
+        }
+        const slot = hierEditorSlot;
+        openEnumPicker({
+            title: meta.name || meta.label || selectedKey,
+            options: meta.options,
+            index,
+            commit: (i) => {
+                setSlotParam(slot, fullKey, pluginUsesIndex ? String(i) : meta.options[i]);
+                if (shouldRefreshDynamicRateMeta(selectedKey)) refreshHierarchyChainParams();
+                refreshHierarchyVisibility();
+            },
+            returnToGrid: false,
+        });
         return;
     }
     /* Everything else — including wav_position, whose editor IS edit mode on a
@@ -14105,6 +14144,9 @@ function handleJog(delta, shift = isShiftHeld()) {
                 announceMenuItem(lfoTargetParams[selectedLfoTargetParam].label);
             }
             break;
+        case VIEWS.ENUM_PICKER:
+            enumPickerJog(delta);
+            break;
         case VIEWS.OVERTAKE_MODULE:
             /* Overtake module handles its own jog input */
             break;
@@ -14946,6 +14988,9 @@ function handleSelect() {
             }
             break;
         }
+        case VIEWS.ENUM_PICKER:
+            closeEnumPicker(true);
+            break;
         case VIEWS.OVERTAKE_MODULE:
             /* Overtake module handles its own select input */
             break;
@@ -15412,6 +15457,11 @@ function handleBack() {
                 announce("Target, " + lfoTargetComponents[selectedLfoTargetComp].label);
             }
             needsRedraw = true;
+            break;
+        case VIEWS.ENUM_PICKER:
+            /* Nothing was written on the way in or while scrolling, so cancel
+             * is simply not writing now. */
+            closeEnumPicker(false);
             break;
         case VIEWS.OVERTAKE_MODULE:
             /* Overtake module handles its own back input.
@@ -16314,7 +16364,12 @@ function drawHelpDetail() {
      * WAVEFORM, clicking a filepath shows the BROWSER, and Back from either
      * returns to the grid" is four states, and none of them was observable
      * from outside this file — which is why all three routing bugs shipped. */
+    /* The enum option picker. Handed the list and the index rather than a key,
+     * because the two callers (knob grid, list editor) write through different
+     * owners — see openEnumPicker. */
+    _ctx.openEnumPicker = (o) => openEnumPicker(o);
     _ctx.activeParamEditor = () => {
+        if (view === VIEWS.ENUM_PICKER) return "enum";
         if (view === VIEWS.FILEPATH_BROWSER) return "filepath";
         if (view === VIEWS.CANVAS) return "canvas";
         if (view !== VIEWS.HIERARCHY_EDITOR) return null;
@@ -16895,6 +16950,168 @@ function drawLfoTargetParam() {
         selectedIndex: selectedLfoTargetParam,
         getLabel: function(item) { return item.label; },
     });
+}
+
+/* ======================================================================== *
+ * ENUM OPTION PICKER
+ *
+ * A scrolling list of one enum param's options. Reached two ways and it is the
+ * SAME screen both times, on purpose:
+ *
+ *   the knob grid   clicking a held enum knob (footer: CLK OPEN)
+ *   the list editor jog-clicking an enum row
+ *
+ * Why it exists: an enum is turnable, so both editors let you step it one
+ * detent at a time — which is fine for Off/On and useless for a Recv Ch with
+ * seventeen options or a macro-oscillator model with forty-seven. Stepping does
+ * not go away; this is the other half.
+ *
+ * It owns NO param knowledge. The caller hands over the option list, where in
+ * it we currently are, and a `commit` closure — because the two callers write
+ * through different owners: the grid writes through its controller (so the slot
+ * contract's Fwd offset and MPE compound write still apply) and the list editor
+ * writes through setSlotParam. One screen, two owners, no second copy of the
+ * wire-format decision.
+ *
+ * Nothing is written while you scroll, so Back is a genuine cancel and there is
+ * nothing to revert. That also keeps the draw path free of IPC: every value it
+ * shows was resolved once, at open.
+ * ======================================================================== */
+let enumPickerTitle = "";
+let enumPickerOptions = [];
+let enumPickerIndex = 0;
+let enumPickerOpenIndex = 0;
+let enumPickerCommit = null;
+let enumPickerReturnToGrid = false;
+
+function openEnumPicker(o) {
+    const options = Array.isArray(o && o.options) ? o.options : [];
+    if (options.length === 0) return false;
+    enumPickerTitle = String((o && o.title) || "Options");
+    enumPickerOptions = options.map((v) => String(v));
+    const i = Math.round(Number(o && o.index));
+    enumPickerIndex = (isFinite(i) && i >= 0 && i < options.length) ? i : 0;
+    enumPickerOpenIndex = enumPickerIndex;
+    enumPickerCommit = (o && typeof o.commit === "function") ? o.commit : null;
+    enumPickerReturnToGrid = !!(o && o.returnToGrid);
+    setView(VIEWS.ENUM_PICKER);
+    needsRedraw = true;
+    announce(enumPickerTitle + ", " + enumPickerOptions[enumPickerIndex]
+             + ", " + (enumPickerIndex + 1) + " of " + enumPickerOptions.length);
+    return true;
+}
+
+/* Leave the picker. `commit` is false for Back, which must leave the value
+ * exactly where it was — nothing was written on the way in or while scrolling,
+ * so that is simply a matter of not writing now. */
+function closeEnumPicker(commit) {
+    const title = enumPickerTitle;
+    const chosen = enumPickerOptions[enumPickerIndex];
+    const write = commit ? enumPickerCommit : null;
+    const idx = enumPickerIndex;
+    const toGrid = enumPickerReturnToGrid;
+
+    enumPickerCommit = null;
+    enumPickerOptions = [];
+    enumPickerTitle = "";
+    enumPickerIndex = 0;
+    enumPickerOpenIndex = 0;
+    enumPickerReturnToGrid = false;
+
+    if (write) write(idx);
+
+    if (toGrid && paramPagesActive()) {
+        setView(VIEWS.PARAM_PAGES);
+    } else {
+        setView(VIEWS.HIERARCHY_EDITOR);
+    }
+    needsRedraw = true;
+    if (commit) announceParameter(title, chosen);
+    else announce("Cancelled, " + title);
+}
+
+function enumPickerJog(delta) {
+    if (enumPickerOptions.length === 0) return;
+    enumPickerIndex = Math.max(0, Math.min(enumPickerOptions.length - 1,
+                                           enumPickerIndex + delta));
+    needsRedraw = true;
+    announce(enumPickerOptions[enumPickerIndex] + ", "
+             + (enumPickerIndex + 1) + " of " + enumPickerOptions.length);
+}
+
+/*
+ * THE LIST RECT, and why it is nine and not ten.
+ *
+ * The movy bands cost vertical space the old chrome did not: a footer rule at
+ * 55 with an 8-row hint band under it takes the bottom of the screen, where
+ * drawMenuList's default indicator row (62) used to sit. Left at its defaults
+ * the list would have run its last row and its down-arrow straight through the
+ * footer, and the device clips silently — nothing would have said so.
+ *
+ * The obvious top is MENU_LIST_Y (10), the rect the knob grid's own menu pages
+ * use. It costs a row: 10..54 is 44px, and at a 9px line that is FOUR options
+ * where the old chrome showed FIVE. One row up is 45px and buys the fifth back,
+ * and it is free here because this header is NOT inverted — drawHeader only
+ * fills the band when told to, so under a plain header the glyphs stop at row 5
+ * and the selected row's highlight starting at row 8 still has clear air above
+ * it. (A menu page cannot do the same: its bank bar owns row 7.)
+ *
+ * Losing the last option of a list to a band drawn over it is a failure this
+ * codebase has hit before, which is why test_enum_picker_chrome.sh asserts the
+ * row COUNT and clipped() === 0 rather than just eyeballing the render.
+ */
+const ENUM_PICKER_LIST_TOP_Y = 9;
+const ENUM_PICKER_LIST_BOTTOM_Y = MOVY_RULE_Y - 1;
+
+/*
+ * The picker wears the KNOB GRID's chrome — movy header band, hint footer —
+ * unconditionally, from BOTH entry points.
+ *
+ * It is reached from the grid (holding an enum knob and clicking) and from the
+ * hierarchy list editor (jog-clicking an enum row), and the list editor still
+ * wears the older device chrome. So there was a choice: follow the caller, or
+ * be one screen. Following the caller means a `cameFromGrid` branch in the draw
+ * — which is precisely the `kind === "master"` that drawChainPicker's comment
+ * forbids, for the reason it gives: a shared function with a caller test in it
+ * drifts exactly as well as two functions did, and this screen's own header
+ * comment already promises it is the SAME screen both times. It is also the
+ * shape of the bug a user reported from the device about the module pickers
+ * ("the module select here is different than the module select in slots").
+ *
+ * So: one look. The list editor is the frame that will move to match, not this.
+ */
+function drawEnumPicker() {
+    clear_screen();
+    const ctx = { fillRect: fill_rect, print, textWidth: text_width };
+    /* SELECT on the right, the same word drawChainPicker puts there: both are
+     * "a list, pick one", and the grammar of the band is what tells you so
+     * before you have read the title. */
+    drawMovyHeader(ctx, enumPickerTitle, "SELECT", false);
+    if (enumPickerOptions.length === 0) {
+        print(LIST_LABEL_X, ENUM_PICKER_LIST_TOP_Y + 8, "No options", 1);
+        /* Still a footer. openEnumPicker refuses an empty list so this should
+         * be unreachable, but a screen with nothing on it is the one place a
+         * way out most needs naming. */
+        drawMovyFooter(ctx, [["BACK", "EXIT"]]);
+        return;
+    }
+    /* The same list every other picker on this device uses. A second list
+     * widget is how Master FX and the chain editor drifted apart. The tick
+     * marks which option is CURRENTLY set, so scrolling away from it stays
+     * legible as "you have moved off the live value". */
+    drawMenuList({
+        items: enumPickerOptions,
+        selectedIndex: enumPickerIndex,
+        listArea: { topY: ENUM_PICKER_LIST_TOP_Y, bottomY: ENUM_PICKER_LIST_BOTTOM_Y },
+        getLabel: function(item) { return String(item); },
+        /* Which option is CURRENTLY set, so scrolling away from it still reads
+         * as "you have moved off the live value" rather than as nothing. */
+        getValue: function(item, i) { return i === enumPickerOpenIndex ? "*" : ""; },
+        /* This screen announces its own, richer string ("Room, 2 of 17"), so
+         * the list must not also announce "Room: *". */
+        announce: false,
+    });
+    drawMovyFooter(ctx, enumPickerFooterHints());
 }
 
 globalThis.init = function() {
@@ -18211,6 +18428,9 @@ globalThis.tick = function() {
             break;
         case VIEWS.LFO_TARGET_PARAM:
             drawLfoTargetParam();
+            break;
+        case VIEWS.ENUM_PICKER:
+            drawEnumPicker();
             break;
         case VIEWS.OVERTAKE_MODULE:
             try {

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -596,7 +596,19 @@ export function drawParamPages() {
      */
     const drawable = page && (page.kind === PAGE_KNOBS || page.kind === PAGE_MENU
                               || page.kind === PAGE_PRESET || page.kind === PAGE_ITEMS);
-    if (!controller.pickerOpen && !drawable) return false;
+    /*
+     * A contract we could not READ has no page set, and refusing to draw ejects
+     * to the list editor — a whole view change, in response to a 100 ms timeout
+     * that is usually about to clear. So hold the screen while the controller
+     * retries (it stops claiming to be unresolved once it gives up, and the
+     * ordinary fallback runs then) rather than showing a plan built from the
+     * failure, which is what put granny's sample_path on knob 1.
+     *
+     * Only reachable on a FIRST entry: a re-entry keeps the page set it already
+     * had, so the reported granny sequence never shows this.
+     */
+    const holdForContract = !controller.pickerOpen && !drawable && controller.contractUnresolved;
+    if (!controller.pickerOpen && !drawable && !holdForContract) return false;
 
     const nowMs = Date.now();
     if (nowMs - lastDrawMs < MOVY_REDRAW_MIN_MS) return true;
@@ -617,6 +629,15 @@ export function drawParamPages() {
     }
 
     clear_screen();
+
+    /* The hold frame — see holdForContract above. Deliberately after the
+     * redraw throttle, so a screen that says one word costs one draw per
+     * MOVY_REDRAW_MIN_MS like any other. */
+    if (holdForContract) {
+        const msg = "Loading...";
+        print(Math.max(0, (128 - text_width(msg)) >> 1), 28, msg, 1);
+        return true;
+    }
 
     /* draw_line / draw_circle / fill_circle (src/host/js_display.c) do the
      * whole shape in C — one QuickJS<->native crossing regardless of length,
@@ -735,6 +756,39 @@ export function handleParamPagesMidi(data) {
         return true;
     }
     if (todo.action === 'open') {
+        /*
+         * An ENUM opens the option picker, and it does NOT go the long way
+         * round through the list editor.
+         *
+         * The other divable types hand off to a screen that only exists inside
+         * the hierarchy editor, so openParamEditor has to exit the grid, enter
+         * that editor and find the param again. An option list needs none of
+         * that — it needs the options and an index, both of which the intent is
+         * carrying — so the grid CONTROLLER STAYS ALIVE and the page and cell
+         * survive by construction, exactly as the LFO target picker does.
+         *
+         * That is also the only thing that makes this work on SLOT SETTINGS and
+         * MASTER FX SETTINGS, which are synthesised contracts with no
+         * ui_hierarchy to enter and whose enums (Recv Ch, Fwd Ch, MPE) are the
+         * ones with the longest option lists on the device. The commit goes
+         * back through the controller so the slot io's own mappings — Fwd's
+         * offset, MPE's compound write — are applied rather than bypassed.
+         */
+        if (Array.isArray(todo.options) && todo.options.length > 0 &&
+            typeof ctx.openEnumPicker === 'function') {
+            /* The note-off for the held knob will go to the PICKER, so drop the
+             * touch now or the cell stays highlighted after we come back. */
+            clearParamPagesTouch();
+            const key = todo.key;
+            ctx.openEnumPicker({
+                title: todo.meta && (todo.meta.label || todo.meta.name) || key,
+                options: todo.options,
+                index: todo.index || 0,
+                commit: (i) => { if (controller) controller.commitEnum(key, i); },
+                returnToGrid: true,
+            });
+            return true;
+        }
         /* A filepath, canvas, wav_position or string param: hand it to the
          * editor the list view already has rather than building a second one. */
         if (typeof ctx.openParamEditor === 'function') {
@@ -791,6 +845,27 @@ export function paramPagesRevealing() {
  */
 export function paramPagesFooterHints() {
     return footerHints();
+}
+
+/**
+ * The footer hints for the ENUM OPTION PICKER.
+ *
+ * Lives here, next to footerHints(), rather than at the picker's own draw site,
+ * because the hint vocabulary is a canon (FOOTER_CANON in render_page_movy.mjs)
+ * and a second place that invents wording is how a canon stops being one. The
+ * picker is drawn from shadow_ui.js, which is not importable under node, so
+ * building the list HERE is also what lets a test read the words at all — the
+ * footer is set in font4x5 and cannot be read back off the framebuffer.
+ *
+ * SEL / SET, not PAGE / OPEN: inside the picker the jog moves the highlight
+ * through one param's options and the click writes the highlighted one. BACK is
+ * EXIT by the canon, not OUT — it leaves the picker entirely and lands back on
+ * whichever editor opened it, exactly as the module picker's BACK does.
+ *
+ * Constant, so it takes no controller and works from both entry points.
+ */
+export function enumPickerFooterHints() {
+    return orderedHints({ jog: "SEL", click: "SET", extra: [["BACK", "EXIT"]] });
 }
 
 /** True while the section picker is over the grid. */

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -27,7 +27,10 @@
  */
 
 import { ctx } from './shadow_ui_ctx.mjs';
-import { createController } from '/data/UserData/schwung/shared/param_pages/page_controller.mjs';
+import { createController, CONTRACT_SETTLE_MS } from '/data/UserData/schwung/shared/param_pages/page_controller.mjs';
+/* Re-exported so the LIST editor waits out the same module-side debounce the
+ * grid does, from the same number. Two hand-written 500s would drift. */
+export { CONTRACT_SETTLE_MS };
 import { decodeInput, applyInput } from '/data/UserData/schwung/shared/param_pages/page_input.mjs';
 import { PAGE_KNOBS, PAGE_MENU, PAGE_PRESET, PAGE_ITEMS } from '/data/UserData/schwung/shared/param_pages/page_plan.mjs';
 import { LAYOUT_BAR, LAYOUT_DIAL } from '/data/UserData/schwung/shared/param_pages/render_page.mjs';

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -264,19 +264,31 @@ export function tickParamPages() {
     if (++_loadingPoll >= _loadingInterval) {
         _loadingPoll = 0;
         const raw = ctx.getSlotParam(currentSlot, `${currentPrefix}:is_loading`);
-        if (raw === null || raw === undefined) {
-            /* The module does not implement is_loading — most don't; it exists
-             * for the ones with an async ROM or sample load. Measured on
-             * device, this errored 5-7 times a SECOND, and an errored read
-             * still costs the full ~2.8ms round trip: the error is free, the
-             * round trip is not.
+        if (raw === '') {
+            /*
+             * NOBODY SERVES THIS KEY. Stop asking, for this component.
              *
-             * Backed off rather than switched off, because this poll is
-             * correctness-relevant — it is what re-plans the page tree when a
-             * module finishes loading. A module that is genuinely mid-load can
-             * error first and answer later, so giving up entirely could strand
-             * the page on a stale tree. Backing off keeps the edge, just
-             * later. Reset on entry to the view and on any successful read. */
+             * An unserved key answers "" — the shim replies with an error and
+             * a zeroed buffer, and the binding hands that back as an empty
+             * string. Only an unclaimable channel answers null. The back-off
+             * below tested for null, so for the overwhelming majority of the
+             * fleet — which does not implement is_loading at all — it never
+             * engaged: the poll fell through to the `else`, read "" as
+             * not-loading, reset the interval to full rate, and did that
+             * forever. Measured on device at 5-7 errored reads a SECOND, and
+             * an errored read still costs the whole ~2.8 ms round trip.
+             *
+             * Giving up entirely is safe now in a way it was not before,
+             * because the contract no longer depends on this edge: a selection
+             * books its own settle in the controller (armContractSettle), and
+             * that path needs no cooperation from the module.
+             */
+            _loadingInterval = Infinity;
+        } else if (raw === null || raw === undefined) {
+            /* The channel would not answer — transient, unlike "". Back off
+             * rather than give up: a module genuinely mid-load can fail a
+             * claim first and answer later, and this is what re-plans the page
+             * tree when it finishes. Reset on entry and on any real read. */
             if (_loadingInterval < LOADING_POLL_MAX_TICKS) _loadingInterval *= 2;
         } else {
             _loadingInterval = LOADING_POLL_TICKS;

--- a/src/shared/help_content.json
+++ b/src/shared/help_content.json
@@ -98,7 +98,14 @@
             "neighbours, with",
             "names and values.",
             "Let go and the",
-            "chain is back."
+            "chain is back.",
+            "",
+            "A knob that picks",
+            "from a list opens",
+            "it: hold the knob",
+            "and click. Jog to",
+            "choose, click to",
+            "set, Back cancels."
           ]
         },
         {

--- a/src/shared/param_format.mjs
+++ b/src/shared/param_format.mjs
@@ -118,6 +118,91 @@ export function formatParamValue(rawValue, meta) {
     return num.toFixed(decimals) + (unit ? " " + unit : "");
 }
 
+/* The two conventions a plugin's set_param can speak for an enum. */
+export const WIRE_NAME = "name";
+export const WIRE_INDEX = "index";
+
+/**
+ * Learn which of the two an enum's plugin speaks, from a value the PLUGIN
+ * reported, and latch it onto the metadata.
+ *
+ * The problem this solves: `chord_set_param` is a strcmp ladder over the option
+ * NAMES with no trailing else, so a numeric index is silently discarded — the
+ * value never moves while the UI renders the index it just invented, and the
+ * user watches it change and snap back. Plenty of plugins are the other way
+ * round (an atoi()) and plenty accept both. Nothing in the contract obliges an
+ * author to say which, and until now the knob grid guessed "index" for
+ * everyone unless a module declared `options_as_string`.
+ *
+ * The two enum writers in shadow_ui.js never needed a declaration — they ask
+ * what the plugin currently REPORTS and answer in kind:
+ *
+ *     const pluginUsesIndex = (ctx.meta.options.indexOf(currentVal) < 0);
+ *
+ * This is the same question, asked once per key and remembered, because the
+ * grid — unlike those two — holds the enum as a number end to end and would
+ * otherwise have to re-derive it from a value it wrote itself.
+ *
+ * TWO RULES, and both are load-bearing:
+ *
+ *   `raw` MUST have come from the device. The grid's own writes populate
+ *   `s.values`; learning from that cache means the first index write teaches
+ *   it "this plugin uses indices" for the rest of the session, which is a
+ *   verdict that makes itself true and looks right in a one-detent test.
+ *
+ *   A value that is NEITHER a declared option nor a number teaches nothing.
+ *   That is the one place this deliberately diverges from `pluginUsesIndex`,
+ *   which treats any non-name as an index: those two recompute per write and
+ *   self-correct, this one latches, so an unrecognised reading leaves the
+ *   question open for the next read rather than locking in an answer derived
+ *   from a value neither convention explains.
+ *
+ * An explicit `options_as_string: true` is an OVERRIDE and is never learned
+ * over — a module that declares its convention has said the last word.
+ *
+ * @returns {string|null} the latched convention, or null if still unknown
+ */
+export function learnEnumWireFormat(meta, raw) {
+    if (!meta || meta.type !== "enum" || !Array.isArray(meta.options)) return null;
+    if (meta.options_as_string) return WIRE_NAME;
+    if (meta.wire_format) return meta.wire_format;
+    if (raw === null || raw === undefined) return null;
+    const s = String(raw);
+    if (s === "" || s.trim() === "") return null;
+    if (meta.options.indexOf(s) >= 0 || meta.options.indexOf(s.trim()) >= 0) {
+        meta.wire_format = WIRE_NAME;
+        return WIRE_NAME;
+    }
+    if (isFinite(Number(s.trim()))) {
+        meta.wire_format = WIRE_INDEX;
+        return WIRE_INDEX;
+    }
+    return null;
+}
+
+/** True when this enum should be written as its option NAME. */
+export function enumWiresNames(meta) {
+    return !!meta && (!!meta.options_as_string || meta.wire_format === WIRE_NAME);
+}
+
+/**
+ * The wire value for picking option `index`, in whatever convention this
+ * plugin speaks — the one call an option PICKER should make.
+ *
+ * A picker is not a knob: it does not carry a running numeric state, it hands
+ * you an index straight out of a list. The temptation is therefore to write
+ * `String(index)`, which is precisely the write chord silently discards. So the
+ * detection is not optional here, and `currentRaw` — the value the PLUGIN last
+ * reported — is what settles it, exactly as learnEnumWireFormat requires.
+ *
+ * Pass `currentRaw` undefined when the format is already latched (or declared);
+ * the learn step is a no-op then.
+ */
+export function enumWireValue(meta, index, currentRaw) {
+    learnEnumWireFormat(meta, currentRaw);
+    return formatParamForSet(index, meta);
+}
+
 /* Wire-format value for set_param (no unit suffix; numeric strings only). */
 export function formatParamForSet(rawValue, meta) {
     if (!meta) {
@@ -134,7 +219,7 @@ export function formatParamForSet(rawValue, meta) {
             idx = Math.round(Number(rawValue));
         }
         if (!isFinite(idx) || idx < 0) idx = 0;
-        if (meta.options_as_string && Array.isArray(meta.options) &&
+        if (enumWiresNames(meta) && Array.isArray(meta.options) &&
             idx < meta.options.length) {
             return meta.options[idx];
         }

--- a/src/shared/param_pages/README.md
+++ b/src/shared/param_pages/README.md
@@ -51,10 +51,14 @@ import { buildMetaIndex } from "shared/param_pages/param_meta.mjs";
 import { renderPage } from "shared/param_pages/render_page.mjs";
 import { step, stepLevel, reanchor } from "shared/param_pages/page_nav.mjs";
 
-const hierarchy   = JSON.parse(getParam("synth:ui_hierarchy"));
-const chainParams = JSON.parse(getParam("synth:chain_params"));
+/* Branch on the RAW value before parsing — see "Three answers" below. */
+const rawHierarchy = getParam("synth:ui_hierarchy");
+const unresolved   = (rawHierarchy === null || rawHierarchy === undefined);
+const hierarchy    = unresolved ? null : parse(rawHierarchy);
+const chainParams  = unresolved ? null : parse(getParam("synth:chain_params"));
 
-const { pages, fingerprint } = planPages({ hierarchy, chainParams, mode, visible });
+const { pages, fingerprint } = planPages({ hierarchy, chainParams, mode, visible,
+                                           unresolved });
 const metaIndex = buildMetaIndex({ hierarchy, chainParams });
 
 renderPage(ctx, {
@@ -68,6 +72,35 @@ renderPage(ctx, {
     rect,             // defaults to the whole 128x64 screen
 });
 ```
+
+### Three answers, not two
+
+A contract read has three outcomes and only two of them say anything about the
+module:
+
+```
+JSON   the module declares this contract
+""     the module declares NONE            -> the chain_params fallback
+null   the read FAILED, we know nothing    -> planPages({ unresolved: true })
+```
+
+`unresolved` makes `planPages` return **no pages at all** (and echoes
+`unresolved: true` back), because a plan is a statement about what a module
+declares and a failed read is not one. It has to be passed in by the caller:
+`parse(null)` and `parse("")` both give `null`, so by the time the planner sees
+it the distinction is already gone — only the caller saw the wire.
+
+The symptom this prevents: granny loads a WAV synchronously on the thread that
+serves param requests, the `ui_hierarchy` read issued straight after times out,
+and paginating `chain_params` in response put granny's first declared param
+(`sample_path`) on knob 1 and shifted every other knob along — and latched,
+because the fallback metadata looked complete enough to settle.
+
+`page_controller.mjs` does this for you: it short-circuits before `planPages`,
+keeps the page set it already had when the component has not changed, retries
+on `CONTRACT_RETRY_INTERVAL_TICKS` up to `CONTRACT_RETRY_LIMIT`, and exposes
+`controller.contractUnresolved` so the host can hold the screen instead of
+ejecting. `hierarchy: null` on its own still means ABSENT.
 
 ### Graphics (`viz`)
 

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -177,6 +177,44 @@ export const META_RETRY_LIMIT = 8;
 export const META_RETRY_INTERVAL_TICKS = 344;
 
 /**
+ * Ticks between a SELECTION and the contract re-read it earns (~500 ms).
+ *
+ * A selection can republish the whole parameter set — that is what choosing a
+ * preset, a soundfont or a CLAP effect IS — but it does not republish it
+ * SYNCHRONOUSLY. schwung-airwindows updates its selected index inside
+ * set_param, so `plugin_name` is instantly right, and then schedules the
+ * actual plugin load on a worker thread 300 ms later
+ * (clap_fx.cpp:806-822, PLUGIN_LOAD_DEBOUNCE_MS). `chain_params` is generated
+ * from the LOADED plugin, so for that whole window it still describes the
+ * previous effect. Reading the instant the write lands therefore caches the
+ * wrong contract: reported from hardware as the grid sitting exactly one
+ * selection behind.
+ *
+ * So the read waits, and the deadline is RE-ARMED on every detent: a spin down
+ * a 519-effect list costs one read at the end, not 519 on the way.
+ *
+ * In MILLISECONDS, not ticks. The thing being waited out is another process
+ * debounce, which is in milliseconds, and the shadow UI tick rate is neither
+ * fixed nor owned by this file.
+ *
+ * A deadline is a guess about someone else's debounce, which is why it is
+ * backed by the bounded re-arm below rather than trusted on its own. Where a
+ * module implements `is_loading` the host uses its ready edge instead
+ * (shadow_ui_param_pages.mjs) — that is a genuine signal and a better one.
+ * This exists because most of the fleet does not implement it, and correctness
+ * cannot be a thing third-party modules have to remember to opt into.
+ */
+export const CONTRACT_SETTLE_MS = 500;
+/**
+ * How many times that deadline re-arms while the answer still looks unsettled.
+ *
+ * Bounded, and small: three reads is ~8 ms of IPC spread over a second and a
+ * half. Unbounded would mean a module whose contract legitimately never
+ * changes polls forever.
+ */
+export const CONTRACT_SETTLE_RETRIES = 3;
+
+/**
  * How many times a page will re-try a contract read that FAILED.
  *
  * Bounded for the same reason META_RETRY_LIMIT is: a component whose channel
@@ -293,6 +331,16 @@ export function createController(io = {}) {
          * has been planned from it. See load() and maybeReresolveContract. */
         contractUnresolved: false,
         contractRetries: 0,
+        /* Wall-clock ms at which a selection-driven contract re-read comes
+         * due, or 0 for none pending. Re-armed per detent — see
+         * CONTRACT_SETTLE_MS. */
+        contractDirtyAt: 0,
+        contractSettleTries: 0,
+        /* Fingerprint of the previous POST-DEADLINE reading. Two that agree is
+         * what "settled" means here; see maybeSettleContract. */
+        contractSettleLastFp: null,
+        /* null = never asked, true/false = latched. See isLoadingSays. */
+        isLoadingSupported: null,
         /* Param keys a visible_if condition reads. A condition is driven by a
          * VALUE, which moves without the declared contract moving, so the
          * fingerprint cannot see it — these are watched explicitly instead.
@@ -358,6 +406,9 @@ export function createController(io = {}) {
          * unresolved read may keep — see below. */
         const sameComponent = (s.slot === slot && s.component === component && s.prefix === nextPrefix);
         s.lastLoadOpts = { mode, visible };
+        /* A different component may well implement is_loading even if the last
+         * one did not, so the latch is per-component, not per-session. */
+        if (!sameComponent) s.isLoadingSupported = null;
         s.slot = slot;
         s.component = component;
         s.prefix = nextPrefix;
@@ -413,6 +464,7 @@ export function createController(io = {}) {
             s.cursor = 0;
             s.pageIndex = 0;
             s.metaRetries = 0;
+            s.isLoadingSupported = null;
             s.knobStates = Object.create(null);
             s.lastWriteMs = Object.create(null);
             s.pendingWrite = Object.create(null);
@@ -422,7 +474,26 @@ export function createController(io = {}) {
         s.contractRetries = 0;
 
         const hierarchy = parse(rawHierarchy);
-        const chainParams = parse(getParam(`${s.prefix}:chain_params`));
+        /*
+         * A chain_params read can fail the same way a ui_hierarchy read can,
+         * and it is the same defect one key over.
+         *
+         * null is "the channel would not answer", "" is "nobody serves this
+         * key". Collapsing them parsed a TIMEOUT as "this module declares no
+         * chain_params", rebuilt the metaIndex from the hierarchy alone, and
+         * every knob lost its name — permanently, because for a contract with
+         * no enum placeholder nothing ever reads again.
+         *
+         * The hierarchy answered, so the plan is sound; only the metadata is
+         * missing. Keep the metadata we already had, and let the settle below
+         * fetch it again.
+         */
+        const rawChain = getParam(`${s.prefix}:chain_params`);
+        const chainFailed = (rawChain === null || rawChain === undefined);
+        const chainParams = chainFailed
+            ? (sameComponent ? s.chainParams : null)
+            : parse(rawChain);
+        if (chainFailed && sameComponent) armContractSettle();
         const planned = planPages({ hierarchy, chainParams, mode, visible });
         /* Retained so a visibility re-plan costs no extra device reads. */
         s.hierarchy = hierarchy;
@@ -456,6 +527,119 @@ export function createController(io = {}) {
     /** Poll for a contract that changed underneath us (async ROM/sample loads). */
     function reloadIfChanged(opts) {
         return load({ slot: s.slot, component: s.component, prefix: s.prefix, ...opts });
+    }
+
+    /**
+     * A selection was made: the contract it publishes comes due shortly.
+     *
+     * Idempotent and re-arming, which is the whole point — every detent of a
+     * jog through a long list pushes the deadline out, so the read happens
+     * once, when the hand stops.
+     */
+    function armContractSettle() {
+        s.contractDirtyAt = now() + CONTRACT_SETTLE_MS;
+        s.contractSettleTries = 0;
+        /* Both agreeing readings must post-date THIS deadline. */
+        s.contractSettleLastFp = null;
+        /* Where a module DOES implement is_loading, its ready edge fires first
+         * and this deadline finds nothing left to change. Cheap either way. */
+        s.metaSettled = false;
+        s.metaRetries = 0;
+    }
+
+    /**
+     * Does the contract we just read still describe a module mid-load?
+     *
+     * schwung-airwindows answers "[]" for the entire dlopen window, because
+     * its param cache is filled from the plugin pointer and that pointer is
+     * NULL until the load completes (clap_fx.cpp:342-343, 914-916). The chain
+     * host now treats "[]" as no answer and substitutes the module.json
+     * fallback, which for that module is a single `plugin_id`. Both shapes
+     * mean the same thing and neither is the contract we are waiting for.
+     *
+     * Asked as "does anything on the knob page have declared metadata" rather
+     * than by naming either shape, so a third module that degrades a third way
+     * is covered without being enumerated.
+     */
+    function contractLooksUnsettled() {
+        if (!s.metaIndex) return true;
+        const p = s.pages.find((q) => q && q.kind === PAGE_KNOBS && (q.keys || []).length);
+        if (!p) return false;
+        return p.keys.every((k) => s.metaIndex.getOrGuess(k).guessed);
+    }
+
+    /**
+     * Does this component serve `is_loading`, asked at most once per component?
+     *
+     * An unserved key answers "" — the shim replies with an error and a zeroed
+     * buffer — and only an unclaimable channel answers null. So one probe
+     * settles it forever: "1"/"0" is a module that implements it, anything
+     * else is one of the many that do not, and we never ask again.
+     *
+     * Only ever consulted while a settle is already pending, so a component
+     * nobody selects anything on never spends this read at all.
+     */
+    function isLoadingSays() {
+        if (s.isLoadingSupported === false) return null;
+        const raw = getParam(`${s.prefix}:is_loading`);
+        if (raw === null || raw === undefined) return null;   /* claim failed */
+        if (raw !== "1" && raw !== "0") { s.isLoadingSupported = false; return null; }
+        s.isLoadingSupported = true;
+        return raw;
+    }
+
+    /**
+     * Re-read a contract a selection made stale, once it has settled.
+     *
+     * Returns true when it spent a read.
+     *
+     * Deciding it HAS settled takes two readings that agree, and both of them
+     * must be taken AFTER the deadline. Comparing the first reading against
+     * the fingerprint from before the write is the tempting shortcut — it
+     * settles a static module in a single probe — but it settles WRONGLY
+     * whenever the module load lands just after that first probe, which is the
+     * original bug rediscovered one layer up.
+     *
+     * `is_loading` is the fast path and never the mechanism: a module that
+     * answers it tells us exactly when to look, so one confirming read is
+     * enough and a "1" costs a re-arm with no contract read at all. The fleet
+     * that does not implement it is unaffected and still correct.
+     */
+    function maybeSettleContract(reload) {
+        if (!s.contractDirtyAt || now() < s.contractDirtyAt) return false;
+        /*
+         * Never rebuild under a hand that is on a knob. A rebuild drops
+         * s.values and resets the read cursor, so doing it mid-turn makes the
+         * cell the user is holding blink back to "--". Deferred, not dropped.
+         */
+        if (s.touchOrder.length) {
+            s.contractDirtyAt = now() + CONTRACT_SETTLE_MS;
+            return false;
+        }
+        /* A failed read has its own bounded retry, which owns this state until
+         * it lands; two loops re-reading the same key would just race. */
+        if (s.contractUnresolved) return false;
+
+        const rearm = () => { s.contractDirtyAt = now() + CONTRACT_SETTLE_MS; };
+        s.contractSettleTries++;
+        const capped = s.contractSettleTries >= CONTRACT_SETTLE_RETRIES;
+
+        const loading = isLoadingSays();
+        if (loading === "1" && !capped) { rearm(); return true; }
+
+        reload();
+        const fp = s.fingerprint;
+
+        if (capped) { s.contractDirtyAt = 0; return true; }
+        /* Still describing a module mid-load: keep probing, never plan from it. */
+        if (contractLooksUnsettled()) { rearm(); return true; }
+        /* The module said it is ready, so this reading is the answer. */
+        if (loading === "0") { s.contractDirtyAt = 0; return true; }
+        /* Otherwise: two post-deadline readings that agree. */
+        if (s.contractSettleLastFp === fp) { s.contractDirtyAt = 0; return true; }
+        s.contractSettleLastFp = fp;
+        rearm();
+        return true;
     }
 
     /**
@@ -582,6 +766,17 @@ export function createController(io = {}) {
         if (s.contractUnresolved && s.tickCount % CONTRACT_RETRY_INTERVAL_TICKS === 0) {
             triedReresolve = true;
             maybeReresolveContract(() => reloadIfChanged(s.lastLoadOpts));
+        }
+
+        /*
+         * The settle runs BEFORE the page-kind guards below, because the
+         * selection that made the contract stale is made ON the preset or
+         * items page and those return early. Waiting until the user reached a
+         * knob page would mean the read never happened while browsing, which
+         * is precisely when the labels are wrong.
+         */
+        if (!triedReresolve) {
+            triedReresolve = maybeSettleContract(() => reloadIfChanged(s.lastLoadOpts));
         }
 
         const p = page();
@@ -752,10 +947,17 @@ export function createController(io = {}) {
         const it = st.list[st.cursor];
         if (p.selectParam) setParam(fullKey(p.selectParam), String(it.index));
         st.current = it.index;
-        /* The chosen item can republish the whole contract — a different
-         * soundfont has different presets — so let it be re-read. */
-        s.metaSettled = false;
-        s.metaRetries = 0;
+        /*
+         * The chosen item can republish the whole contract — a different
+         * soundfont has different presets — so let it be re-read.
+         *
+         * Clearing metaSettled is NOT enough on its own, and that gap is the
+         * airwindows bug: maybeResettle only fires for an enum still showing a
+         * placeholder, so a float-only contract re-latched on the next tick
+         * having read nothing. armContractSettle is what actually books the
+         * read.
+         */
+        armContractSettle();
         s.menuEntered = null;
         let target = -1;
         if (p.navigateTo) {
@@ -812,9 +1014,10 @@ export function createController(io = {}) {
         st.name = (nm && nm.length) ? nm : null;
         /* The new preset can publish a different parameter set — that is what
          * a preset IS — so let the contract be re-read rather than leaving the
-         * knob pages describing the preset you just left. */
-        s.metaSettled = false;
-        s.metaRetries = 0;
+         * knob pages describing the preset you just left. Deadline, not an
+         * immediate read: the module may still be loading it, and every detent
+         * re-arms so a fast spin costs one read rather than one per step. */
+        armContractSettle();
         /* Throttled exactly as a turned knob is: a fast spin down a 2427-preset
          * list is hundreds of announcements a second, which no one can follow
          * and which competes with the redraw for the same tick. */
@@ -1687,6 +1890,10 @@ export function createController(io = {}) {
 
     return {
         load, reloadIfChanged, tick,
+        /* For a selection made OUTSIDE the controller — the list editor drives
+         * the same modules through its own preset browser and has the same
+         * race. Books the settle; costs nothing until it comes due. */
+        selectionChanged: armContractSettle,
         onJog, goToPage, onKnobTurn, onKnobTouch, onClick, takePending, commitEnum,
         openPicker, closePicker, pickerSelect, showHint, dismissHint,
         menuEntry, menuIndex: () => menuIndex(page()),

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -28,7 +28,7 @@
  */
 
 import { planPages, PAGE_KNOBS, PAGE_MENU, PAGE_PRESET, PAGE_ITEMS } from "./page_plan.mjs";
-import { buildMetaIndex, inferFromValue, isTurnable, KIND_ENUM, KIND_OPAQUE } from "./param_meta.mjs";
+import { buildMetaIndex, inferFromValue, isTurnable, enumIndexOf, KIND_ENUM, KIND_OPAQUE } from "./param_meta.mjs";
 import { renderPage, renderPicker, renderHint, LAYOUT_DIAL } from "./render_page.mjs";
 import { renderPageMovy, drawFooter, drawHeader as drawHeaderMovy, drawBankBar,
          drawBrackets, drawPresetBody, RULE_Y, LAYOUT_MOVY } from "./render_page_movy.mjs";
@@ -86,7 +86,7 @@ const MENU_FRAME_BOTTOM_INSET = 1;
 const MENU_BRACKET_LEN = 7;
 import { knobInit, knobTick, knobConfigFromMeta } from "../knob_engine.mjs";
 import { movyKnobInit, movyKnobTick } from "./movy_knob.mjs";
-import { formatParamForSet } from "../param_format.mjs";
+import { formatParamForSet, learnEnumWireFormat, enumWireValue } from "../param_format.mjs";
 import { announcePage, announceTouch, announceTurn, announcePageContents } from "./announce_page.mjs";
 
 /** Ticks a key ignores incoming reads after being turned (~200 ms at 44 Hz). */
@@ -175,6 +175,24 @@ export const META_RETRY_LIMIT = 8;
  *  9 ticks, which would burn the whole retry budget in under two seconds —
  *  long before a module that loads a ROM has finished. */
 export const META_RETRY_INTERVAL_TICKS = 344;
+
+/**
+ * How many times a page will re-try a contract read that FAILED.
+ *
+ * Bounded for the same reason META_RETRY_LIMIT is: a component whose channel
+ * never answers must cost a fixed number of reads, not one per interval for
+ * the rest of the session.
+ */
+export const CONTRACT_RETRY_LIMIT = 40;
+/**
+ * Ticks between those attempts. Much tighter than META_RETRY_INTERVAL_TICKS —
+ * a failed claim is transient (the param channel unblocks as soon as whatever
+ * was hogging it returns), and until it clears the grid is showing the
+ * PREVIOUS page set, or none at all on a first load. One read per interval
+ * while unresolved and zero once resolved, so the read budget is unaffected in
+ * the normal case.
+ */
+export const CONTRACT_RETRY_INTERVAL_TICKS = 30;
 
 export function createController(io = {}) {
     const getParam = io.getParam || (() => null);
@@ -270,6 +288,11 @@ export function createController(io = {}) {
          * the session. Re-resolution is bounded and latching — see maybeResettle. */
         metaRetries: 0,
         metaSettled: false,
+        /* The `<prefix>:ui_hierarchy` read FAILED — the channel would not
+         * answer — so we do not know what this component declares and nothing
+         * has been planned from it. See load() and maybeReresolveContract. */
+        contractUnresolved: false,
+        contractRetries: 0,
         /* Param keys a visible_if condition reads. A condition is driven by a
          * VALUE, which moves without the declared contract moving, so the
          * fingerprint cannot see it — these are watched explicitly instead.
@@ -330,12 +353,75 @@ export function createController(io = {}) {
      * actually changed, and keeps the user's place when it does.
      */
     function load({ slot = 0, component = "synth", prefix, mode, visible } = {}) {
+        const nextPrefix = prefix || component;
+        /* Whether we are re-reading the SAME component decides what an
+         * unresolved read may keep — see below. */
+        const sameComponent = (s.slot === slot && s.component === component && s.prefix === nextPrefix);
         s.lastLoadOpts = { mode, visible };
         s.slot = slot;
         s.component = component;
-        s.prefix = prefix || component;
+        s.prefix = nextPrefix;
 
-        const hierarchy = parse(getParam(`${s.prefix}:ui_hierarchy`));
+        /*
+         * A contract read has three answers and only two of them are the same
+         * thing (see planPages): JSON is a declaration, "" is "I declare none",
+         * and null is "the channel would not answer". The last one is not news
+         * about the module, so nothing here may be derived from it.
+         *
+         * Reads fail legitimately — granny loads a WAV synchronously on the
+         * thread that serves param requests, so the read the UI issues on the
+         * way back from its file browser times out at 100 ms. What was wrong was
+         * treating that silence as "this module has no hierarchy" and
+         * paginating chain_params, which put granny's `sample_path` on knob 1.
+         */
+        const rawHierarchy = getParam(`${s.prefix}:ui_hierarchy`);
+        if (rawHierarchy === null || rawHierarchy === undefined) {
+            /* A fresh failure gets a fresh retry budget; a repeat one does not,
+             * or a channel that never answers would retry forever. */
+            if (!s.contractUnresolved) s.contractRetries = 0;
+            s.contractUnresolved = true;
+            /* Do not latch: the retry loop owns this until the read lands. */
+            s.metaSettled = false;
+            /* Deliberately NOT read: chain_params on its own cannot produce a
+             * plan we are willing to show, so asking for it would just be a
+             * second doomed round trip on a channel already refusing. */
+            if (sameComponent) {
+                /*
+                 * Keep the page set we already had.
+                 *
+                 * The component has not changed, so the plan on screen is still
+                 * the plan this component declared — it is stale by at most the
+                 * retry interval, and stale-but-right beats a page built from a
+                 * failure. The granny case is exactly this: the plan we keep is
+                 * byte-identical to the one that arrives.
+                 */
+                return false;
+            }
+            /*
+             * A DIFFERENT component, though, we know nothing about — keeping the
+             * previous one would show one module the other module knobs. Show
+             * nothing until the read lands.
+             */
+            flushDueWritesUnconditionally();
+            s.pages = [];
+            s.fingerprint = null;
+            s.hierarchy = null;
+            s.chainParams = null;
+            s.metaIndex = null;
+            s.conditionKeys = new Set();
+            s.values = Object.create(null);
+            s.cursor = 0;
+            s.pageIndex = 0;
+            s.metaRetries = 0;
+            s.knobStates = Object.create(null);
+            s.lastWriteMs = Object.create(null);
+            s.pendingWrite = Object.create(null);
+            return true;
+        }
+        s.contractUnresolved = false;
+        s.contractRetries = 0;
+
+        const hierarchy = parse(rawHierarchy);
         const chainParams = parse(getParam(`${s.prefix}:chain_params`));
         const planned = planPages({ hierarchy, chainParams, mode, visible });
         /* Retained so a visibility re-plan costs no extra device reads. */
@@ -401,9 +487,42 @@ export function createController(io = {}) {
      * enum legitimately reads "(none)" must not make us poll forever.
      */
     function maybeResettle(reload) {
+        /*
+         * Never LATCH on a contract we could not read.
+         *
+         * metaUnsettled() inspects the page we are holding, and while the read
+         * is failing that page is either the previous component or nothing at
+         * all — "looks complete" would be a verdict about the wrong data, and
+         * once it sets metaSettled nothing ever reads again. That latch is why
+         * the granny symptom survived until a full teardown of the controller
+         * rather than clearing itself a frame later. The contract retry below
+         * owns this state until the read lands.
+         */
+        if (s.contractUnresolved) return false;
         if (s.metaSettled || s.metaRetries >= META_RETRY_LIMIT) return false;
         if (!metaUnsettled()) { s.metaSettled = true; return false; }
         s.metaRetries++;
+        return reload();
+    }
+
+    /**
+     * Bounded re-try of a contract read that FAILED.
+     *
+     * One read per CONTRACT_RETRY_INTERVAL_TICKS while unresolved, capped, and
+     * nothing at all once it lands — the grid cannot recover on its own
+     * otherwise, because there is no page to hang the ordinary read cursor on.
+     */
+    function maybeReresolveContract(reload) {
+        if (!s.contractUnresolved) return false;
+        if (s.contractRetries >= CONTRACT_RETRY_LIMIT) {
+            /* Given up. Stop CLAIMING to be mid-resolve: the host holds the
+             * screen while this is true, and holding it forever on a component
+             * that will never answer is worse than running the ordinary
+             * no-drawable-page fallback. */
+            s.contractUnresolved = false;
+            return false;
+        }
+        s.contractRetries++;
         return reload();
     }
 
@@ -453,6 +572,18 @@ export function createController(io = {}) {
         s.tickCount++;
         flushDueWrites();
         expireTurnClaim();
+
+        /*
+         * Re-try an unresolved contract BEFORE the page guards below: an
+         * unresolved first load leaves no page at all, so anything hung off the
+         * read cursor would never run and the grid would stay blank forever.
+         */
+        let triedReresolve = false;
+        if (s.contractUnresolved && s.tickCount % CONTRACT_RETRY_INTERVAL_TICKS === 0) {
+            triedReresolve = true;
+            maybeReresolveContract(() => reloadIfChanged(s.lastLoadOpts));
+        }
+
         const p = page();
         if (p && p.kind === PAGE_PRESET) { tickPreset(p); return null; }
         if (p && p.kind === PAGE_ITEMS) { tickItems(p); return null; }
@@ -468,7 +599,7 @@ export function createController(io = {}) {
         s.cursor = (s.cursor + 1) % stops;
 
         /* Give late metadata a chance to arrive, on a wall-clock cadence. */
-        if (s.tickCount % META_RETRY_INTERVAL_TICKS === 0) {
+        if (!triedReresolve && s.tickCount % META_RETRY_INTERVAL_TICKS === 0) {
             maybeResettle(() => reloadIfChanged(s.lastLoadOpts));
         }
 
@@ -528,6 +659,13 @@ export function createController(io = {}) {
 
         /* First successful read repairs a guessed range, once. */
         const meta = s.metaIndex.getOrGuess(key);
+        /*
+         * ...and teaches an enum which wire format its plugin speaks. This is
+         * THE read detection is allowed to use: it comes from the device, it is
+         * already being made, and it keeps arriving, so a verdict is never
+         * derived from a value the grid itself wrote. See learnEnumWireFormat.
+         */
+        learnEnumWireFormat(meta, raw);
         if (meta.guessed) {
             const patch = inferFromValue(meta, raw);
             if (patch) Object.assign(meta, patch);
@@ -978,8 +1116,29 @@ export function createController(io = {}) {
         const useMovy = s.layout === LAYOUT_MOVY;
         let st = s.knobStates[key];
         if (!st) {
-            const current = s.values[key] !== undefined ? Number(s.values[key]) : Number(getParam(fullKey(key)));
-            const start = isFinite(current) ? current : 0;
+            /* Turning a knob the read cursor has not reached yet is the one
+             * case that reads here — and since that read IS from the device,
+             * it is also allowed to settle the enum wire format, for a page
+             * whose first gesture beats its first read. */
+            let raw = s.values[key];
+            if (raw === undefined) {
+                raw = getParam(fullKey(key));
+                learnEnumWireFormat(meta, raw);
+            }
+            /* An enum reported as a NAME is still an index to the engine —
+             * Number("major") is NaN, which used to seed every such knob at
+             * option 0 and jump the value on the first detent. */
+            let start;
+            if (meta.kind === KIND_ENUM) {
+                const idx = enumIndexOf(meta, raw);
+                start = idx >= 0 ? idx : 0;
+            } else {
+                /* A plain number keeps its sign — clamping to >= 0 here would
+                 * seed a bipolar param (transpose, pan) at 0 instead of where
+                 * it is. */
+                const num = Number(raw);
+                start = isFinite(num) ? num : 0;
+            }
             st = s.knobStates[key] = useMovy ? movyKnobInit(start) : knobInit(start);
         }
 
@@ -1023,6 +1182,47 @@ export function createController(io = {}) {
             s.lastAnnounceMs[key] = t;
             announce(announceTurn(meta, wire));
         }
+        return wire;
+    }
+
+    /**
+     * Set an enum to a chosen OPTION INDEX, as an option picker does.
+     *
+     * The same tail as onKnobTurn — format, cache, settle, write, re-plan —
+     * minus the knob engine, because a picker has no running numeric state to
+     * carry: it hands over an index straight out of a list.
+     *
+     * Two details that are not decoration:
+     *
+     *   the write goes through enumWireValue, so a plugin that only accepts
+     *   option NAMES gets a name. Writing String(index) here is exactly the
+     *   chord bug, and a picker is where it is most tempting.
+     *
+     *   the knob state for this key is DROPPED. It was seeded from the value
+     *   before the picker ran, so the first detent afterwards would step from
+     *   there and snap the value back to where the user had just moved it away
+     *   from. It is re-seeded from s.values on the next turn.
+     *
+     * The wire format is NOT learned here: `s.values` holds writes the grid
+     * made as well as reads from the device, and learning from our own write
+     * is a verdict that makes itself true. Detection belongs on the read
+     * cursor and on the picker-open read (see onClick).
+     */
+    function commitEnum(key, index) {
+        const meta = key ? s.metaIndex.getOrGuess(key) : null;
+        if (!meta || meta.kind !== KIND_ENUM) return null;
+        let i = Math.round(Number(index));
+        if (!isFinite(i)) return null;
+        const n = Array.isArray(meta.options) ? meta.options.length : 0;
+        if (n > 0) i = Math.max(0, Math.min(n - 1, i));
+        const wire = enumWireValue(meta, i);
+        s.values[key] = wire;
+        s.settleUntil[key] = s.tickCount + SETTLE_TICKS;
+        s.lastWriteMs[key] = now();
+        delete s.pendingWrite[key];
+        delete s.knobStates[key];
+        setParam(fullKey(key), wire);
+        replanIfCondition(key);
         return wire;
     }
 
@@ -1178,6 +1378,26 @@ export function createController(io = {}) {
         const meta = metaAt(slot);
         if (!key || !meta || !meta.divable) return null;
         s.pending = { action: "open", key, fullKey: fullKey(key), meta };
+        /*
+         * An enum opens a list of its OPTIONS, so the intent carries the list
+         * and where in it we currently are — the host should not have to spend
+         * an IPC read to find out what the cursor already knows.
+         *
+         * The read below is the exception, and it is also the only honest place
+         * left to settle the wire format for a page whose first gesture beats
+         * its first read: it comes from the DEVICE. Learning from s.values
+         * would risk learning from a value the grid itself wrote.
+         */
+        if (meta.kind === KIND_ENUM && Array.isArray(meta.options)) {
+            let raw = s.values[key];
+            if (raw === undefined) {
+                raw = getParam(fullKey(key));
+                learnEnumWireFormat(meta, raw);
+            }
+            const idx = enumIndexOf(meta, raw);
+            s.pending.options = meta.options.slice();
+            s.pending.index = idx >= 0 ? idx : 0;
+        }
         return s.pending;
     }
 
@@ -1467,7 +1687,7 @@ export function createController(io = {}) {
 
     return {
         load, reloadIfChanged, tick,
-        onJog, goToPage, onKnobTurn, onKnobTouch, onClick, takePending,
+        onJog, goToPage, onKnobTurn, onKnobTouch, onClick, takePending, commitEnum,
         openPicker, closePicker, pickerSelect, showHint, dismissHint,
         menuEntry, menuIndex: () => menuIndex(page()),
         menuEntered, enterMenu, exitMenu, clearTouch,
@@ -1486,6 +1706,10 @@ export function createController(io = {}) {
          *  isModulated is deliberately NOT called during a draw. */
         isModulatedCached: (key) => !!s.modCache[key],
         get metaIndex() { return s.metaIndex; },
+        /** True while `<prefix>:ui_hierarchy` could not be READ. The page set,
+         *  if any, is the previous one — nothing here was planned from the
+         *  failure. */
+        get contractUnresolved() { return s.contractUnresolved; },
         keyAt, metaAt,
         jumpIndex: () => jumpIndex(s.pages),
         groupIndex: () => groupIndex(s.pages),

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -600,10 +600,9 @@ export function createController(io = {}) {
      * whenever the module load lands just after that first probe, which is the
      * original bug rediscovered one layer up.
      *
-     * `is_loading` is the fast path and never the mechanism: a module that
-     * answers it tells us exactly when to look, so one confirming read is
-     * enough and a "1" costs a re-arm with no contract read at all. The fleet
-     * that does not implement it is unaffected and still correct.
+     * `is_loading` is the fast path and never the mechanism: while it says "1"
+     * a probe costs one cheap read and no contract read at all. It is not
+     * allowed to shorten the confirmation — see the note at the bottom.
      */
     function maybeSettleContract(reload) {
         if (!s.contractDirtyAt || now() < s.contractDirtyAt) return false;
@@ -633,9 +632,17 @@ export function createController(io = {}) {
         if (capped) { s.contractDirtyAt = 0; return true; }
         /* Still describing a module mid-load: keep probing, never plan from it. */
         if (contractLooksUnsettled()) { rearm(); return true; }
-        /* The module said it is ready, so this reading is the answer. */
-        if (loading === "0") { s.contractDirtyAt = 0; return true; }
-        /* Otherwise: two post-deadline readings that agree. */
+        /*
+         * Two post-deadline readings that agree — including when is_loading
+         * just said "0".
+         *
+         * Letting a "0" stand in for the second reading was tried and is
+         * wrong: a module can report ready while its contract is still the
+         * previous one (the fleet fake does exactly this), and then the fast
+         * path settles on the stale answer — the original bug, restored by the
+         * thing meant to avoid it. is_loading may spend FEWER reads; it may
+         * never remove a confirmation.
+         */
         if (s.contractSettleLastFp === fp) { s.contractDirtyAt = 0; return true; }
         s.contractSettleLastFp = fp;
         rearm();

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -945,7 +945,8 @@ export function createController(io = {}) {
      *
      * Where to leave TO is the declaration's business: a level with navigate_to
      * is saying "having chosen, you want to be here". Without one, the first
-     * grid page, same as the preset browser.
+     * grid page, same as the preset browser. A named level that plans both a
+     * preset browser and a grid means the browser — see below.
      */
     function commitItem() {
         const p = page();
@@ -968,7 +969,28 @@ export function createController(io = {}) {
         s.menuEntered = null;
         let target = -1;
         if (p.navigateTo) {
-            target = s.pages.findIndex((q) => q.level === p.navigateTo && q.kind === PAGE_KNOBS);
+            /*
+             * A level can produce TWO pages -- a preset browser and a knob
+             * grid -- and naming it did not say which. Prefer the browser.
+             *
+             * This is obxd, reported from the device as "jump to category
+             * lands on knobs, not the preset list": its `banks` level declares
+             * navigate_to `root`, and root carries list_param/count_param AND
+             * knobs. Filtering to PAGE_KNOBS could only ever find the grid, so
+             * choosing a bank landed you on the sliders rather than in that
+             * bank's presets. A chooser that filters a list means "now show me
+             * the list" -- that is the whole reason it exists.
+             *
+             * Preferring rather than adding a `navigate_to: {level, kind}`
+             * form is deliberate. Only three modules in the fleet declare
+             * navigate_to at all, and the other two (303, jv880) name levels
+             * with no preset page, so they are untouched -- while a new
+             * declaration would repeat today's `options_as_string` lesson,
+             * which was documented for months and set by nobody.
+             */
+            const at = (kind) => s.pages.findIndex((q) => q.level === p.navigateTo && q.kind === kind);
+            target = at(PAGE_PRESET);
+            if (target < 0) target = at(PAGE_KNOBS);
         }
         if (target < 0) target = firstGrid(s.pages);
         announce(it.label);

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -137,8 +137,11 @@ function balancedChunk(arr, size) {
 
 /**
  * @param {object}   o
- * @param {object}   o.hierarchy    parsed ui_hierarchy (may be null)
+ * @param {object}   o.hierarchy    parsed ui_hierarchy (null = the module
+ *                                  declares none)
  * @param {Array}    o.chainParams  parsed chain_params (may be null/empty)
+ * @param {boolean}  [o.unresolved] the contract could not be READ. Plans
+ *                                  nothing at all — see the note in the body.
  * @param {string}   [o.mode]       active value of hierarchy.mode_param
  * @param {Function} [o.visible]    (condition, levelDef) => boolean. Lets the
  *                                  caller wire the shadow UI's visible_if
@@ -147,7 +150,7 @@ function balancedChunk(arr, size) {
  *                                  is what the native evaluator does too).
  * @returns {{pages: Array, fingerprint: string, warnings: string[]}}
  */
-export function planPages({ hierarchy, chainParams, mode, visible } = {}) {
+export function planPages({ hierarchy, chainParams, mode, visible, unresolved } = {}) {
     const warnings = [];
     /* Keys any visible_if condition reads. Returned so the caller can re-plan
      * when one of THEM changes — a condition is driven by a param VALUE, which
@@ -170,6 +173,38 @@ export function planPages({ hierarchy, chainParams, mode, visible } = {}) {
      * count and no level — hashing the length alone would call that unchanged
      * and leave the placeholder on screen for the rest of the session. */
     const fingerprint = fingerprintOf([hierarchy || null, chainParams || null, mode || null]);
+
+    /*
+     * "the module declares no hierarchy" and "we could not READ the hierarchy"
+     * are different answers, and collapsing them is a bug with a visible
+     * symptom. On the wire:
+     *
+     *   JSON   the module declares this hierarchy
+     *   ""     the module declares NO hierarchy       -> the fallback below
+     *   null   the read FAILED, we know NOTHING       -> `unresolved: true`
+     *
+     * Both of the first two parse to a value the planner can act on, and a
+     * failed read parses to nothing — which is indistinguishable from absence
+     * by the time it reaches here. So the caller, who is the only one that saw
+     * the wire, says so explicitly. (`hierarchy: null` on its own still means
+     * ABSENT: that is what the fleet capture records for the four modules that
+     * publish chain_params and nothing else.)
+     *
+     * Picking a sample in granny loads the WAV synchronously on the thread that
+     * serves param requests; the ui_hierarchy read issued milliseconds later
+     * times out, and paginating chain_params in response put `sample_path` —
+     * granny's first declared param — on knob 1 and shifted every other knob
+     * along, until a full teardown of the controller.
+     *
+     * A plan is a statement about what a module declares. With a failed read we
+     * have no such statement, so we make none.
+     */
+    if (unresolved) {
+        return {
+            pages: [], fingerprint, conditionKeys: new Set(), unresolved: true,
+            warnings: ["ui_hierarchy unresolved — the contract read failed"],
+        };
+    }
 
     const levels = (hierarchy && hierarchy.levels && typeof hierarchy.levels === "object")
         ? hierarchy.levels : null;

--- a/src/shared/param_pages/param_meta.mjs
+++ b/src/shared/param_pages/param_meta.mjs
@@ -24,6 +24,8 @@
  *                  narrow fallback and never infers structure.
  */
 
+import { enumWiresNames } from "../param_format.mjs";
+
 /** A knob turns it continuously — float/int. */
 export const KIND_NUMBER = "number";
 /** A knob steps through discrete options — enum/toggle. */
@@ -184,16 +186,87 @@ function normalize(key, raw) {
     const opaqueType = OPAQUE_TYPES.has(type);
     const ranged = typeof meta.min === "number" && typeof meta.max === "number"
                    && meta.max > meta.min;
-    meta.divable = opaqueType;
+    /*
+     * An ENUM is a third case, and it is why `divable` and the MARK had to come
+     * apart as well.
+     *
+     * Every enum opens a list of its options on a click, and the knob keeps
+     * stepping it — a Recv Ch with seventeen options or a Braids algorithm with
+     * forty-seven is not something you want to hunt for one detent at a time.
+     * So an enum is divable AND KIND_ENUM, exactly the pairing wav_position
+     * already needed.
+     *
+     * But it must NOT wear the corner brackets. There are ~135 enum params in
+     * the fleet against ~5 filepath/string/canvas ones: bracket them all and
+     * nearly every cell on nearly every page is marked, which is the same as
+     * marking none. Worse, the mark is STRUCTURAL for an opaque cell —
+     * drawOpaqueBox draws no frame of its own, the brackets are its frame (see
+     * render_page_movy.mjs) — so it cannot simply be made rarer either.
+     *
+     * Hence `divable_mark`, which is what the renderer keys on, and which stays
+     * exactly where it was: the opaque types, wav_position included. The
+     * affordance for an enum is the footer, which flips to CLK OPEN off
+     * `divable` for free.
+     *
+     * An enum that declares NO options is index-addressed and has no list to
+     * show, so it is not a door.
+     */
+    const listableEnum = type === "enum"
+                       && Array.isArray(meta.options) && meta.options.length > 0;
+    meta.divable_mark = opaqueType;
+    meta.divable = opaqueType || listableEnum;
     meta.kind = (opaqueType && !(type === "wav_position" && ranged)) ? KIND_OPAQUE
               : type === "enum" ? KIND_ENUM
               : KIND_NUMBER;
     return meta;
 }
 
+/**
+ * An enum's raw value as an INDEX, whichever convention it arrived in.
+ *
+ * The grid holds enums as numbers end to end, but a plugin is equally entitled
+ * to report `"major"` as `"1"` (see learnEnumWireFormat in param_format.mjs),
+ * and `Number("major")` is NaN — which seeds a knob at option 0 instead of
+ * where the value actually is, and makes a widget fall back to printing the
+ * raw string instead of consulting `short_options`.
+ *
+ * @returns {number} the index, or -1 when the value resolves to neither
+ */
+export function enumIndexOf(meta, raw) {
+    if (!meta || raw === null || raw === undefined) return -1;
+    const s = String(raw);
+    if (s.trim() === "") return -1;
+    const byName = Array.isArray(meta.options)
+        ? (meta.options.indexOf(s) >= 0 ? meta.options.indexOf(s) : meta.options.indexOf(s.trim()))
+        : -1;
+    const num = Number(s.trim());
+    const byNumber = isFinite(num) ? Math.round(num) : -1;
+    /*
+     * An enum whose OPTIONS are themselves numerals ("1", "2", "4", "8") makes
+     * the two readings disagree — "4" is the name of option 2 — and nothing in
+     * the value can settle it. The known convention can: ask the name first
+     * for a plugin that speaks names, and the number first for one that does
+     * not. Same precedence as shadow_ui.js's `pluginUsesIndex`, which checks
+     * `options.indexOf(currentVal)` before parsing an int.
+     */
+    if (enumWiresNames(meta)) return byName >= 0 ? byName : byNumber;
+    return byNumber >= 0 ? byNumber : byName;
+}
+
 /** True when clicking this param should open an editor the grid does not own. */
 export function isDivable(meta) {
     return !!meta && !!meta.divable;
+}
+
+/**
+ * True when the cell should WEAR the corner brackets.
+ *
+ * Deliberately not the same question as isDivable — see normalize(). Every
+ * enum is divable and none of them is marked, because a mark on 135 of 140
+ * params is not a mark.
+ */
+export function isDivableMarked(meta) {
+    return !!meta && !!meta.divable_mark;
 }
 
 /** True when a knob can drive this param at all. */

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -26,7 +26,7 @@
  * device's own print(), same as the dial/bar grid.
  */
 
-import { KIND_ENUM, KIND_OPAQUE } from "./param_meta.mjs";
+import { KIND_ENUM, KIND_OPAQUE, enumIndexOf } from "./param_meta.mjs";
 import { formatParamValue } from "../param_format.mjs";
 import { asciiFold, fitText, shortenLabel, line } from "./render_page.mjs";
 import { drawVizGroup } from "./viz_draw.mjs";
@@ -652,10 +652,17 @@ function drawOpaqueBox(ctx, kx, ky, value, override) {
  * ~8px of clear corner a 32px cell has, it does not resolve into a box and an
  * arrow, it resolves into a smudge.
  *
- * Keyed on meta.divable, NOT on kind === OPAQUE. They are different questions:
- * granny's wav_position is a ranged number a knob turns perfectly well AND has a
- * waveform editor worth opening, so it draws as a KNOB wearing brackets. Keying
- * the mark on opaqueness made that knob dead.
+ * Keyed on meta.divable_mark, which is NOT kind === OPAQUE and is no longer
+ * meta.divable either. Three different questions:
+ *
+ *   kind === OPAQUE   a knob cannot turn it. granny's wav_position is a ranged
+ *                     number a knob turns perfectly well AND has a waveform
+ *                     editor worth opening, so it draws as a KNOB wearing
+ *                     brackets; keying the mark on opaqueness made it dead.
+ *   divable           a click opens something. Every enum does now.
+ *   divable_mark      it wears these brackets. Opaque types only — bracketing
+ *                     135 enums would erase the mark's meaning, and the footer
+ *                     already says CLK OPEN while such a knob is held.
  *
  * MUST stay inside rowY..rowY+BOX_H-1. One row of overflow lands on LBL0_Y and
  * the brackets merge into the label below.
@@ -696,7 +703,11 @@ function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, cellText)
     const shown = (liveRaw === null || liveRaw === undefined) ? raw : liveRaw;
     if (meta.kind === KIND_OPAQUE) { drawOpaqueBox(ctx, kx, ky, shown, cellText); return; }
     if (meta.kind === KIND_ENUM) {
-        const idx = Math.round(Number(shown));
+        /* A plugin may report an enum as its option NAME rather than as an
+         * index (see learnEnumWireFormat) — resolve either to the index, or
+         * `short_options` is skipped for exactly the modules whose values are
+         * words and therefore need shortening most. */
+        const idx = enumIndexOf(meta, shown);
         /*
          * `short_options` is for the SQUARE only.
          *
@@ -905,7 +916,10 @@ export function drawKnobRow(ctx, o, row, rowY, lblY, geom) {
         /* AFTER the widget and OUTSIDE the `covered` test: a viz group that
          * spans the cell (mrsample's SMP waveform) is still divable, and the
          * mark is the only thing that says so. */
-        if (meta.divable) drawDivableMark(ctx, g, col, rowY);
+        /* `divable_mark`, NOT `divable` — an enum opens a picker but is not
+         * bracketed. See param_meta.mjs normalize() for why the mark cannot
+         * simply follow divability. */
+        if (meta.divable_mark) drawDivableMark(ctx, g, col, rowY);
 
 
         const labelWidth = Math.min(g.cellW - 2, fontWidth4x5("M".repeat(LABEL_CHARS)));

--- a/src/shared/param_pages/viz_draw.mjs
+++ b/src/shared/param_pages/viz_draw.mjs
@@ -29,6 +29,7 @@ import { clamp01, fractionOf, line } from "./render_page.mjs";
 import {
     VIZ_ENVELOPE, VIZ_FILTER, VIZ_LFO, VIZ_WAVEFORM, VIZ_FADER, VIZ_SWITCH, VIZ_EQ, VIZ_SAMPLE,
 } from "./viz.mjs";
+import { enumIndexOf } from "./param_meta.mjs";
 
 /* -------------------------------------------------------------- primitives */
 
@@ -310,7 +311,8 @@ function optionText(metaIndex, key, values) {
     const meta = metaIndex.getOrGuess(key);
     const raw = values ? values[key] : undefined;
     if (!meta || !Array.isArray(meta.options)) return "";
-    const idx = Math.round(Number(raw));
+    /* Resolves a name-reporting plugin's value too — see enumIndexOf. */
+    const idx = enumIndexOf(meta, raw);
     return (idx >= 0 && idx < meta.options.length) ? String(meta.options[idx]) : "";
 }
 

--- a/tests/host/test_chain_knob_meta_hierarchy_fallback.sh
+++ b/tests/host/test_chain_knob_meta_hierarchy_fallback.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Where a knob gets a parameter's TYPE from, when chain_params does not have it.
+#
+# Reported from the device 2026-08-21, against `impressive-chords`: "i could see
+# the values change, but when i release, it reset to the default". The turn was
+# real -- the overlay moves by local JS arithmetic -- and the write was real
+# too. What was wrong was the NUMBER being written.
+#
+# The module declares all fifteen of its parameters inline in its
+# ui_hierarchy's root level (`{key, name, type: "int", min: -24, max: 24}`) and
+# ships no chain_params.json, so its DSP answers `<prefix>:chain_params` with
+# the two characters "[]" -- and the chain host's fallback, which renders the
+# CORRECT metadata parsed out of module.json, is skipped because the plugin
+# "answered" (`result > 0`).
+#
+# So chain_params is empty. buildChainKnobContext resolved meta from
+# chain_params ALONE, `find` returned undefined, and knobConfigFromMeta(meta)
+# invents a float 0..1 step 0.01 for anything it is not told about. Turning
+# `transpose` (int, -24..24) then wrote "0.058750", which the module's atoi
+# reads as 0; turning `retrig` (enum) wrote the same string, whose first
+# character is '0', selecting option 0 -- the default. The screen moved, the
+# DSP did not, and the next read snapped it back.
+#
+# The hierarchy is the same object that NAMED the knob, and it is carrying the
+# metadata one level up from where the knob row was read. The list editor has
+# always merged it (getParamMetadata: `{...hierarchyMeta, ...chainMeta}`); the
+# knob path did not, which is exactly why the same parameter is editable from
+# the menu and not from the knob. This pins the merge, on both chains.
+#
+# PRE-EXISTING, not a regression: the pre-merge builder at 5e0a7537 did the
+# same chain_params-only lookup.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the knob metadata fallback test" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/chain_model.mjs"),
+  import("./src/shared/knob_engine.mjs"),
+  import("node:fs"),
+]).then(([CM, KE, fs]) => {
+  const src = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+  let failures = 0;
+  const fail = (m) => { console.log("FAIL: " + m); failures++; };
+
+  function lift(name, deps) {
+    const at = src.indexOf("function " + name + "(");
+    const end = at >= 0 ? src.indexOf("\n}\n", at) : -1;
+    if (end < 0) { fail(name + " is gone from shadow_ui.js"); process.exit(1); }
+    return new Function(...deps, src.slice(at, end + 2) + "\nreturn " + name + ";");
+  }
+
+  /* ---------------------------------------------------------------- world */
+
+  /* A module shaped like the ones that hit this: every parameter declared
+     INLINE in the hierarchy level that also names the knob row, and a DSP that
+     answers chain_params with an empty array rather than declining. */
+  const LEVEL_PARAMS = [
+    { key: "transpose", name: "Transpose", type: "int", min: -24, max: 24, step: 1 },
+    { key: "base_note", name: "Base Note", type: "int", min: 0, max: 127, step: 1 },
+    { key: "timing", name: "Timing", type: "enum", options: ["Straight", "Dotted", "Triplet"] },
+  ];
+  const HIER = JSON.stringify({
+    levels: { root: { name: "Inline", params: LEVEL_PARAMS,
+                      knobs: ["transpose", "base_note", "timing"] } }
+  });
+
+  /* `answer` decides what the position serves for chain_params. */
+  function world(prefix, answer) {
+    const STATE = {};
+    STATE[prefix + ":ui_hierarchy"] = HIER;
+    STATE[prefix + ":chain_params"] = answer;
+    return (slot, key) => (key in STATE ? STATE[key] : "");
+  }
+
+  function builder(getSlotParam) {
+    const chainComponentId = lift("chainComponentId", [])();
+    const isChainModuleKey = lift("isChainModuleKey",
+      ["chainComponentId", "parseChainId"])(chainComponentId, CM.parseId);
+    const chainComponentParamKey = lift("chainComponentParamKey",
+      ["isChainModuleKey", "chainComponentId"])(isChainModuleKey, chainComponentId);
+    const chainTargetGetParam = lift("chainTargetGetParam", ["getSlotParam"])(getSlotParam);
+    const chainTargetChainParams = lift("chainTargetChainParams",
+      ["chainTargetGetParam"])(chainTargetGetParam);
+    const chainTargetHierarchy = lift("chainTargetHierarchy",
+      ["chainTargetGetParam"])(chainTargetGetParam);
+    const knobLevelForHierarchy = lift("knobLevelForHierarchy", [])();
+    const hierarchyLevelParamMeta = lift("hierarchyLevelParamMeta", [])();
+    /* normalizeExpandedParamMeta is identity here: it resolves dynamic pickers
+       and note/rate/canvas shapes, none of which this is about, and stubbing it
+       keeps the assertion on WHICH object was chosen. */
+    return lift("buildChainKnobContext",
+      ["chainTargetHierarchy", "knobLevelForHierarchy", "chainTargetChainParams",
+       "hierarchyLevelParamMeta", "normalizeExpandedParamMeta", "debugLog"])(
+      chainTargetHierarchy, knobLevelForHierarchy, chainTargetChainParams,
+      hierarchyLevelParamMeta, (key, meta) => meta, () => {});
+    }
+
+  const TARGETS = {
+    slot: { prefix: "midi_fx1", comp: { key: "midiFx", label: "MIDI FX" },
+            target: (get) => ({ slot: 0, label: "S1",
+              key: (c, s) => keyer(c, s) }) },
+    master: { prefix: "master_fx:fx1", comp: { key: "fx1", label: "FX 1" },
+              target: () => ({ slot: 0, label: "MFX",
+                key: (c, s) => (CM.parseId(c) ? "master_fx:" + c + ":" + s : null) }) },
+  };
+  /* The slot chain spells its keys through the real chainComponentParamKey. */
+  let keyer = null;
+  {
+    const chainComponentId = lift("chainComponentId", [])();
+    const isChainModuleKey = lift("isChainModuleKey",
+      ["chainComponentId", "parseChainId"])(chainComponentId, CM.parseId);
+    keyer = lift("chainComponentParamKey",
+      ["isChainModuleKey", "chainComponentId"])(isChainModuleKey, chainComponentId);
+  }
+
+  /* ================================================================ cases */
+
+  for (const kind of ["slot", "master"]) {
+    const T = TARGETS[kind];
+    const at = kind + ": ";
+
+    /* ---- 1. chain_params empty: the hierarchy is the metadata ---- */
+    for (const answer of ["[]", "", "   "]) {
+      const get = world(T.prefix, answer);
+      const build = builder(get);
+      const target = T.target(get);
+
+      const c0 = build(target, T.comp, 0, "mod", true);
+      if (!c0.meta || c0.meta.type !== "int")
+        fail(at + "with chain_params " + JSON.stringify(answer) + ", knob 1 got meta " +
+             JSON.stringify(c0.meta) + " for an int declared in the hierarchy level " +
+             "that named the knob. knobConfigFromMeta turns that into a float 0..1 " +
+             "step 0.01, so the turn writes a fraction and the module reads it as 0");
+      if (c0.meta && (c0.meta.min !== -24 || c0.meta.max !== 24))
+        fail(at + "knob 1 range is " + c0.meta.min + ".." + c0.meta.max + ", not -24..24");
+      if (c0.displayName !== "Transpose")
+        fail(at + "knob 1 is labelled " + JSON.stringify(c0.displayName) +
+             ", not the declared name");
+
+      const c2 = build(target, T.comp, 2, "mod", true);
+      if (!c2.meta || c2.meta.type !== "enum" || !Array.isArray(c2.meta.options) ||
+          c2.meta.options.length !== 3)
+        fail(at + "with chain_params " + JSON.stringify(answer) + ", knob 3 got meta " +
+             JSON.stringify(c2.meta) + " for an enum declared in the hierarchy. " +
+             "Without options the knob drives it as a float and the written string " +
+             "selects option 0 -- the default the user sees it snap back to");
+    }
+
+    /* ---- 2. chain_params still WINS where it has an answer ---- */
+    /* The host renders chain_params from the same module.json in the ordinary
+       case, but a plugin that serves its own is serving something it computed
+       at runtime (a dynamic max, a live options list). The hierarchy is a
+       fallback underneath it, never an override. */
+    {
+      const dynamic = JSON.stringify([
+        { key: "transpose", name: "Transpose", type: "int", min: -7, max: 7, step: 1 },
+      ]);
+      const build = builder(world(T.prefix, dynamic));
+      const c0 = build(T.target(), T.comp, 0, "mod", true);
+      if (!c0.meta || c0.meta.min !== -7 || c0.meta.max !== 7)
+        fail(at + "chain_params lost to the hierarchy: knob 1 range is " +
+             (c0.meta && c0.meta.min) + ".." + (c0.meta && c0.meta.max) + ", not -7..7");
+      /* and a key chain_params does not carry still falls through */
+      const c2 = build(T.target(), T.comp, 2, "mod", true);
+      if (!c2.meta || c2.meta.type !== "enum")
+        fail(at + "a partial chain_params suppressed the hierarchy fallback for the " +
+             "keys it does not mention");
+    }
+  }
+
+  /* ---- 3. the consequence, stated in the units the user saw ---- */
+  /* Not a restatement of case 1: this runs the real knob engine and shows what
+     the missing metadata actually WRITES, which is the thing that was reported
+     and the thing a future "simplification" of the merge would break. */
+  {
+    const build = builder(world("midi_fx1", "[]"));
+    const target = { slot: 0, label: "S1", key: (c, s) => keyer(c, s) };
+    const ctx = build(target, TARGETS.slot.comp, 0, "mod", true);
+    const cfg = KE.knobConfigFromMeta(ctx.meta);
+    const st = KE.knobInit(0);
+    let v = 0;
+    for (let i = 0; i < 40; i++) v = KE.knobTick(st, cfg, 1, Date.now() + i * 100);
+    if (parseInt(String(v), 10) === 0 && v !== 0)
+      fail("40 detents on transpose produced " + v + ", which atoi() reads as 0 -- " +
+           "the knob moves on screen and the DSP never changes. cfg was " +
+           JSON.stringify(cfg));
+    if (cfg.max === 1 && cfg.min === 0)
+      fail("transpose is being driven as a 0..1 float; the metadata merge is not " +
+           "reaching knobConfigFromMeta");
+  }
+
+  if (failures) process.exit(1);
+  console.log("PASS: a knob takes its type from the hierarchy level that named it when " +
+              "chain_params has nothing to say, on BOTH chains, and chain_params still wins");
+}).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'

--- a/tests/host/test_chain_params_answer.c
+++ b/tests/host/test_chain_params_answer.c
@@ -1,0 +1,60 @@
+/*
+ * Does an empty array count as a plugin ANSWERING the chain_params query?
+ *
+ * All three get_param routes (synth, audio FX, MIDI FX) ask the sub-plugin
+ * first and render the module.json fallback only if it declines. "Declined"
+ * used to be `result <= 0` — a length test — so a plugin returning the two
+ * characters "[]" suppressed the correct metadata the host had already parsed.
+ * That is what impressive-chords v0.1.24 does when the chain_params.json it
+ * reads at runtime is not installed, and it is why its knobs drove every
+ * parameter as a float 0..1: an int wrote a fraction its atoi read as 0, an
+ * enum took option 0. Reported from the device 2026-08-21.
+ *
+ * The predicate is the whole fix, so it is what is pinned. It is `static
+ * inline` in chain_internal.h precisely so it can be RUN here rather than
+ * grepped for.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "chain_internal.h"
+
+static int failures = 0;
+
+static void check(const char *what, const char *buf, int result, int want) {
+    int got = chain_params_answer_is_useful(buf, result);
+    if (got != want) {
+        fprintf(stderr, "FAIL: %s -> %d, wanted %d\n", what, got, want);
+        failures++;
+    }
+}
+
+int main(void) {
+    /* ---- the reported case, and its neighbours ---- */
+    check("\"[]\" (impressive-chords with no chain_params.json)", "[]", 2, 0);
+    check("\"[ ]\"", "[ ]", 3, 0);
+    check("\"[\\n]\"", "[\n]", 3, 0);
+    check("empty string with length 0", "", 0, 0);
+    check("declined (-1)", "", -1, 0);
+    check("NULL buffer", NULL, 4, 0);
+
+    /* ---- a real table is still an answer ---- */
+    const char *real = "[{\"key\":\"cutoff\",\"type\":\"float\"}]";
+    check("a one-param table", real, (int)strlen(real), 1);
+    check("a table with leading whitespace", "  [{\"key\":\"a\"}]", 15, 1);
+
+    /* ---- result is the LENGTH, and it bounds the scan ---- */
+    /* A plugin reports how much it wrote; anything past that is not ours to
+     * read. A scan that ran to the NUL instead would read a stale tail out of
+     * a 64KB buffer the caller reuses. */
+    {
+        char buf[64];
+        memcpy(buf, "[]", 3);
+        memcpy(buf + 3, "{\"key\":\"stale\"}", 16);   /* left over, past result */
+        check("stale bytes past result are not read", buf, 2, 0);
+    }
+
+    if (failures) return 1;
+    printf("PASS: an empty chain_params array is not an answer, a real table is\n");
+    return 0;
+}

--- a/tests/host/test_chain_params_answer.sh
+++ b/tests/host/test_chain_params_answer.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# See the header comment in test_chain_params_answer.c.
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/schwung-chain-params-answer.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# chain_internal.h includes <malloc.h>, which is glibc-only. One shim header so
+# the file compiles on macOS as well as Linux; it changes nothing about the
+# code under test. (Same shim as test_chain_midi_fx_slot.sh.)
+mkdir -p "$work/shim"
+cat > "$work/shim/malloc.h" <<'EOF'
+#include <stdlib.h>
+EOF
+
+bin="build/tests/test_chain_params_answer"
+mkdir -p "$(dirname "$bin")"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
+  -I"$work/shim" -Isrc -Isrc/modules/chain/dsp -Isrc/host \
+  tests/host/test_chain_params_answer.c -o "$bin"
+
+"$bin"

--- a/tests/host/test_enum_picker.sh
+++ b/tests/host/test_enum_picker.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Every enum in the knob grid is a DOOR as well as a knob.
+#
+# Clicking a held enum knob opens a scrolling list of that param's options; the
+# knob itself keeps stepping the value exactly as it did. Two abilities, one
+# param, and the codebase already knows they are separate questions -- see the
+# long comment at param_meta.mjs `normalize`, where conflating `divable` with
+# `opaque` made granny's Position knob dead.
+#
+# THE MARK IS THE PART THAT MUST NOT MOVE.
+#
+# render_page_movy draws corner brackets on a cell to say "you can go into
+# this". There are 135 enum params in the fleet against 5 filepath/string/canvas
+# ones, so bracketing every enum would put the mark on almost every cell on
+# almost every page and it would stop meaning anything. Worse, the brackets are
+# STRUCTURAL for an opaque cell: drawOpaqueBox draws no frame of its own (see
+# render_page_movy.mjs:626), so the brackets ARE its frame.
+#
+# So `divable` (does clicking open something) and the MARK are decoupled, and
+# this pins BOTH DIRECTIONS on the actual pixel buffer:
+#
+#   - an enum cell draws NO brackets
+#   - a filepath / canvas / string / wav_position cell still DOES
+#
+# A test that only checked "no mark on an enum" would pass trivially if the
+# mark were broken everywhere, which is the failure mode this file exists for.
+#
+# Part 3 checks that what the picker COMMITS is a value the plugin accepts,
+# against chord -- whose set_param is a strcmp ladder over the option names
+# with no trailing else, so an index on the wire is silently discarded. The
+# accepted set is parsed out of chord.c, the same way
+# test_enum_wire_format_contract.sh does it, so the test and the DSP cannot
+# drift.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the enum picker tests" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+const [PM, PF, RM, H, fs] = await Promise.all([
+  import("./src/shared/param_pages/param_meta.mjs"),
+  import("./src/shared/param_format.mjs"),
+  import("./src/shared/param_pages/render_page_movy.mjs"),
+  import("./tools/param-pages/harness.mjs"),
+  import("node:fs"),
+]);
+
+let failures = 0;
+const fail = (m) => { console.log("FAIL: " + m); failures++; };
+
+/* ======================================================================= 1 ==
+ * An enum is DIVABLE and still TURNABLE.
+ */
+const CHAIN_PARAMS = [
+  { key: "mode",   name: "Mode",  type: "enum", options: ["Hall", "Room", "Plate", "Cave"] },
+  { key: "bare",   name: "Bare",  type: "enum" },                       /* no options */
+  { key: "sw",     name: "Sw",    type: "toggle" },                     /* two-option enum */
+  { key: "file",   name: "File",  type: "filepath" },
+  { key: "view",   name: "View",  type: "canvas" },
+  { key: "name",   name: "Name",  type: "string" },
+  { key: "pos",    name: "Pos",   type: "wav_position", min: 0, max: 1, step: 0.01 },
+  { key: "gain",   name: "Gain",  type: "float", min: 0, max: 1, step: 0.01 },
+];
+const mi = PM.buildMetaIndex({ hierarchy: null, chainParams: CHAIN_PARAMS });
+const m = (k) => mi.getOrGuess(k);
+
+if (!PM.isDivable(m("mode")))
+  fail("an enum with declared options must be divable -- clicking a held enum " +
+       "knob is how you get its option list");
+if (m("mode").kind !== PM.KIND_ENUM)
+  fail("an enum must stay KIND_ENUM so the knob keeps stepping it; got " + m("mode").kind);
+if (!PM.isTurnable(m("mode")))
+  fail("making an enum divable must not make it opaque -- divable and turnable " +
+       "are independent, and conflating them is the bug param_meta.mjs already " +
+       "documents for wav_position");
+if (!PM.isDivable(m("sw")))
+  fail("a `toggle` normalises to a two-option enum, so it is divable too");
+if (PM.isDivable(m("bare")))
+  fail("an enum that declares NO options has no list to show -- it must not " +
+       "advertise a door that opens on nothing");
+if (PM.isDivable(m("gain")))
+  fail("a plain float is not divable");
+for (const k of ["file", "view", "name", "pos"])
+  if (!PM.isDivable(m(k))) fail(k + " must still be divable");
+
+/* The knob still moves it. Drive the real turn through the controller. */
+{
+  const { createController } = await import("./src/shared/param_pages/page_controller.mjs");
+  const hierarchy = { modes: null, levels: { root: { label: "T",
+    knobs: ["mode", "gain", "file", "pos"],
+    params: CHAIN_PARAMS.map((p) => ({ key: p.key })) } } };
+  const store = { mode: "0", gain: "0.5", file: "", pos: "0.25" };
+  const ctl = createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return JSON.stringify(hierarchy);
+      if (b === "chain_params") return JSON.stringify(CHAIN_PARAMS);
+      return b in store ? store[b] : "";
+    },
+    setParam: (k, v) => { store[String(k).replace(/^[^:]+:/, "")] = String(v); },
+    announce: () => {},
+  });
+  ctl.load({ prefix: "synth" });
+  const slot = (ctl.page.keys || []).indexOf("mode");
+  if (slot < 0) fail("mode never reached the page");
+  else {
+    const before = store.mode;
+    const t0 = Date.now();
+    for (let i = 0; i < 24; i++) ctl.onKnobTurn(slot, 1, false, t0 + i * 60);
+    ctl.tick();
+    if (store.mode === before)
+      fail("turning a divable enum knob wrote nothing -- it must still step the " +
+           "value; got " + JSON.stringify(store.mode));
+  }
+
+  /* ...and clicking it while held asks the HOST to open something. */
+  if (slot >= 0) {
+    ctl.onKnobTouch(slot, true);
+    const todo = ctl.onClick(slot);
+    if (!todo || todo.action !== "open")
+      fail("clicking a held enum knob returned " + JSON.stringify(todo) +
+           ", expected an {action:\"open\"} intent for the host");
+    if (todo && todo.key !== "mode") fail("the open intent names the wrong key: " + todo.key);
+    ctl.onKnobTouch(slot, false);
+  }
+}
+
+/* ======================================================================= 2 ==
+ * THE MARK, on the pixels, in both directions.
+ */
+{
+  /* One row of four cells: enum, filepath, canvas, wav_position. */
+  const page = { kind: "knobs", keys: ["mode", "file", "view", "pos",
+                                       null, null, null, null] };
+  const values = { mode: "1", file: "/x/kick.wav", view: "", pos: "0.25" };
+  const fb = H.createFramebuffer();
+  RM.drawKnobRow(H.drawContext(fb), { page, metaIndex: mi, values, touched: -1 },
+                 0, RM.ROW0_Y, RM.LBL0_Y);
+  if (fb.clipped() !== 0) fail("the row drew outside the display");
+
+  const at = (x, y) => fb.pixels[y * fb.width + x];
+  /* drawDivableMark: cellLeft + 1, rowY, cellW - 2, BOX_H */
+  function corners(col) {
+    const x0 = col * RM.CELL_W + 1, y0 = RM.ROW0_Y;
+    const w = RM.CELL_W - 2, h = RM.BOX_H;
+    return [[x0, y0, "top left"], [x0 + w - 1, y0, "top right"],
+            [x0, y0 + h - 1, "bottom left"], [x0 + w - 1, y0 + h - 1, "bottom right"]];
+  }
+  function marked(col) {
+    return corners(col).every(([x, y]) => at(x, y));
+  }
+  function unmarked(col) {
+    return corners(col).every(([x, y]) => !at(x, y));
+  }
+
+  /* The enum: NO mark. */
+  if (!unmarked(0)) {
+    const lit = corners(0).filter(([x, y]) => at(x, y)).map((c) => c[2]);
+    fail("the ENUM cell drew divable brackets (" + lit.join(", ") + "). 135 of the " +
+         "fleet`s params are enums against 5 opaque ones, so bracketing them all " +
+         "makes the mark mean nothing. The affordance is the footer`s CLK OPEN.");
+  }
+  /* Everything that was marked before still is. Asserted per type, because a
+   * single representative would not notice the mark being lost for one kind. */
+  for (const [col, what] of [[1, "filepath"], [2, "canvas"], [3, "wav_position"]]) {
+    if (!marked(col)) {
+      const dark = corners(col).filter(([x, y]) => !at(x, y)).map((c) => c[2]);
+      fail("the " + what + " cell has lost its divable brackets (" + dark.join(", ") +
+           "). For an opaque cell those brackets are its ONLY frame -- " +
+           "drawOpaqueBox draws none of its own -- so the value floats loose.");
+    }
+  }
+
+  /* And a `string`, which is opaque too but is what an LFO Target declares. */
+  {
+    const fb2 = H.createFramebuffer();
+    RM.drawKnobRow(H.drawContext(fb2),
+      { page: { kind: "knobs", keys: ["name", null, null, null, null, null, null, null] },
+        metaIndex: mi, values: { name: "fx1" }, touched: -1 },
+      0, RM.ROW0_Y, RM.LBL0_Y);
+    const at2 = (x, y) => fb2.pixels[y * fb2.width + x];
+    for (const [x, y, which] of corners(0))
+      if (!at2(x, y)) fail("a `string` cell lost its " + which + " bracket");
+  }
+  if (failures === 0) console.log("PASS: the mark is on the opaque types and off the enums");
+}
+
+/* ======================================================================= 3 ==
+ * What the picker COMMITS has to be a value the plugin accepts.
+ */
+{
+  const mj = JSON.parse(fs.readFileSync("src/modules/midi_fx/chord/module.json", "utf8"));
+  const declared = mj.capabilities.ui_hierarchy.levels.root.params.find((p) => p.key === "type");
+  const csrc = fs.readFileSync("src/modules/midi_fx/chord/dsp/chord.c", "utf8");
+  const at = csrc.indexOf("(key, \"type\")");
+  const next = csrc.indexOf("strcmp(key,", at + 1);
+  const branch = csrc.slice(at, next < 0 ? csrc.length : next);
+  const accepted = new Set();
+  for (const mm of branch.matchAll(/strcmp\(val,\s*"([^"]+)"\)/g)) accepted.add(mm[1]);
+  if (accepted.size === 0) fail("parsed no accepted names out of chord.c");
+
+  /* Through the same pipeline the grid uses: hierarchy + the chain_params the
+     chain host renders (which does NOT emit options_as_string). */
+  const idx = PM.buildMetaIndex({
+    hierarchy: mj.capabilities.ui_hierarchy,
+    chainParams: [{ key: "type", name: "Type", type: "enum", options: declared.options }],
+  });
+  const meta = idx.getOrGuess("type");
+
+  if (typeof PF.enumWireValue !== "function")
+    fail("param_format.mjs exports no enumWireValue -- the picker and the knob " +
+         "must decide the wire format the same way, in one place, or the picker " +
+         "will write String(index) into a plugin that only accepts names");
+  else {
+    /* Every option, not one: a single pick passes on `major` by luck. */
+    const bad = [];
+    for (let i = 0; i < declared.options.length; i++) {
+      /* `currentRaw` is what the plugin REPORTED, which is how the format is
+         detected -- chord reports names. */
+      const wire = PF.enumWireValue(meta, i, "major");
+      if (!accepted.has(wire)) bad.push([i, wire]);
+    }
+    if (bad.length)
+      fail("chord would silently discard " + bad.length + " of " +
+           declared.options.length + " picks -- e.g. " + JSON.stringify(bad.slice(0, 3)) +
+           ". chord_set_param is a strcmp ladder over the NAMES with no trailing " +
+           "else, so those leave `type` where it was while the UI shows it moved.");
+
+    /* ...and an index-speaking plugin still gets an index. */
+    const im = PM.buildMetaIndex({ hierarchy: null, chainParams: [
+      { key: "shape", name: "Shape", type: "enum", options: ["Sine", "Saw", "Sqr"] },
+    ] }).getOrGuess("shape");
+    const w = PF.enumWireValue(im, 2, "0");   /* plugin reported the index "0" */
+    if (w !== "2")
+      fail("a plugin that reports indices must receive an index, got " + JSON.stringify(w));
+  }
+  if (failures === 0) console.log("PASS: the picker commits values chord actually accepts");
+}
+
+if (failures) process.exit(1);
+console.log("PASS: enums are divable and turnable, unmarked, and commit a wire " +
+            "value the plugin accepts");
+'

--- a/tests/host/test_enum_picker_chrome.sh
+++ b/tests/host/test_enum_picker_chrome.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# THE ENUM OPTION PICKER WEARS THE KNOB GRID'S CHROME.
+#
+# The picker is reached by holding an enum knob in the movy grid and clicking.
+# It shipped drawing the generic device list chrome instead -- drawHeader's big
+# 5x7 title plus a rule, and NO footer at all -- so the screen you land on from
+# the grid looked like it belonged to a different product, and the two gestures
+# it does have (jog scrolls, click sets) were named nowhere. A user looking at it
+# on hardware asked why.
+#
+# WHY THIS IS PINNED ON PIXELS AND NOT ON CODE.
+#
+# The footer is set in font4x5, which draws every glyph as fillRect pixels: a
+# recording print() sees nothing at all, so "does this screen have a footer" is
+# not a question the source can answer. The header is the same. The header and
+# footer bands are therefore compared against a REFERENCE render of
+# render_page_movy's own drawHeader/drawFooter -- byte for byte, not "has some
+# lit pixels" -- so the assertion is "it is the movy band", not "it is a band".
+#
+# THE ROW COUNT IS THE PART THAT SILENTLY BREAKS.
+#
+# The movy bands take the top and the bottom of a 64px screen. drawMenuList's
+# DEFAULTS (top 15, indicator row 62) would put the last row and the down-arrow
+# straight through the footer, and the device clips silently -- the picker would
+# simply lose its last option with nothing to say it had. So this asserts the
+# visible row COUNT (5, unchanged from the old chrome) and clipped() === 0, over
+# a range of list lengths and scroll positions, not just one render.
+#
+# It also pins the things this change was NOT allowed to touch: the list is
+# still menu_layout's drawMenuList (one list widget, which is what Master FX and
+# the chain editor drifted apart for want of), the `*` still marks the option
+# currently SET, the draw path still announces nothing of its own (the screen
+# emits its own richer TTS from openEnumPicker/enumPickerJog), and the draw path
+# still performs NO parameter reads.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the enum picker chrome tests" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { readFileSync } from "node:fs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
+import * as RM from "./src/shared/param_pages/render_page_movy.mjs";
+import { LIST_LABEL_X, LIST_VALUE_X, LIST_LINE_HEIGHT, drawMenuList }
+  from "./src/shared/menu_layout.mjs";
+
+let failures = 0;
+const fail = (m) => { console.log("FAIL: " + m); failures++; };
+
+/* ------------------------------------------------------------------ lifting */
+/* Same lift as test_chain_editor_snapshot.sh / test_chain_edit_read_budget.sh:
+   pull the top-level function out of shadow_ui.js -- which cannot be imported,
+   being full of host globals and device-absolute import paths -- and hand it
+   its dependencies as parameters, so what runs is the REAL body.
+
+   The dependency list is EXPLICIT and the trap is documented in
+   test_chain_edit_read_budget.sh: a free identifier under the lift is a
+   ReferenceError, and the tempting fix -- a typeof guard -- makes a whole block
+   silently unreachable, leaving the test measuring a screen with the feature
+   switched off. Nothing is guarded here; a missing name throws. */
+const uiSrc = readFileSync("src/shadow/shadow_ui.js", "utf8");
+const ppSrc = readFileSync("src/shadow/shadow_ui_param_pages.mjs", "utf8");
+function liftFrom(src, what, name, deps) {
+  const at = src.indexOf("function " + name + "(");
+  if (at < 0) { fail(name + " is gone from " + what); return () => () => {}; }
+  const end = src.indexOf("\n}\n", at);
+  if (end < 0) { fail("could not find the end of " + name + " in " + what); return () => () => {}; }
+  return new Function(...deps, src.slice(at, end + 2) + "\nreturn " + name + ";");
+}
+const lift = (name, deps) => liftFrom(uiSrc, "shadow_ui.js", name, deps);
+
+/* The hints are built in shadow_ui_param_pages.mjs, next to footerHints(), so
+   the wording stays in one place -- but that file imports through the DEVICE
+   absolute paths (/data/UserData/schwung/...) and cannot be imported under
+   node either. Lifted the same way, with the REAL orderedHints under it, so
+   what is asserted is the ordering rule the grid`s own footer obeys. */
+const orderedHints = liftFrom(ppSrc, "shadow_ui_param_pages.mjs", "orderedHints", [])();
+const enumPickerFooterHints = liftFrom(ppSrc, "shadow_ui_param_pages.mjs",
+  "enumPickerFooterHints", ["orderedHints"])(orderedHints);
+
+/* The two rect constants are read out of the source rather than restated, so a
+   future change to them moves this test`s expectations with it instead of
+   quietly disagreeing. */
+function constOf(name) {
+  const m = uiSrc.match(new RegExp("const\\s+" + name + "\\s*=\\s*([^;]+);"));
+  if (!m) { fail("shadow_ui.js no longer defines " + name); return null; }
+  return m[1].trim();
+}
+const TOP_Y = Number(constOf("ENUM_PICKER_LIST_TOP_Y"));
+if (!isFinite(TOP_Y)) fail("ENUM_PICKER_LIST_TOP_Y is not a literal any more");
+if (constOf("ENUM_PICKER_LIST_BOTTOM_Y") !== "MOVY_RULE_Y - 1")
+  fail("the list bottom must be DERIVED from the footer rule, not restated -- " +
+       "a second copy of 54 is how the list comes to overrun the footer again");
+const BOTTOM_Y = RM.RULE_Y - 1;
+
+const DRAW_DEPS = ["clear_screen", "fill_rect", "print", "text_width",
+  "drawMovyHeader", "drawMovyFooter", "drawMenuList",
+  "LIST_LABEL_X", "ENUM_PICKER_LIST_TOP_Y", "ENUM_PICKER_LIST_BOTTOM_Y",
+  "enumPickerFooterHints", "enumPickerTitle", "enumPickerOptions",
+  "enumPickerIndex", "enumPickerOpenIndex"];
+const mkDraw = lift("drawEnumPicker", DRAW_DEPS);
+
+/* ----------------------------------------------------------------- rendering */
+
+const GLOBAL_NAMES = ["print", "fill_rect", "set_pixel", "text_width",
+  "shadow_get_param", "shadow_get_display_mode", "host_send_screenreader"];
+
+/* menu_layout.mjs reaches for print / fill_rect / set_pixel by NAME, exactly as
+   it does on the device, so they have to be real globals rather than deps. */
+function render(c) {
+  const fb = createFramebuffer();
+  const reads = [], spoken = [];
+  const g = {
+    print: fb.print,
+    fill_rect: fb.fillRect,
+    set_pixel: fb.setPixel,
+    text_width: fb.textWidth,
+    /* A read here is a bug, not a value to supply: the picker resolved
+       everything it shows once, at open, precisely so the draw path is free of
+       IPC. Recorded rather than thrown so the message names the key. */
+    shadow_get_param: (k) => { reads.push(String(k)); return ""; },
+    shadow_get_display_mode: () => 1,
+    host_send_screenreader: (t) => { spoken.push(String(t)); },
+  };
+  for (const k of GLOBAL_NAMES) globalThis[k] = g[k];
+  try {
+    mkDraw(() => fb.clearScreen(), fb.fillRect, fb.print, fb.textWidth,
+      RM.drawHeader, RM.drawFooter, drawMenuList,
+      LIST_LABEL_X, TOP_Y, BOTTOM_Y, enumPickerFooterHints,
+      c.title, c.options, c.index, c.openIndex)();
+  } finally {
+    for (const k of GLOBAL_NAMES) delete globalThis[k];
+  }
+  return { fb, reads, spoken };
+}
+
+const at = (fb, x, y) => fb.pixels[y * fb.width + x];
+function band(fb, y0, y1) {
+  const out = [];
+  for (let y = y0; y <= y1; y++)
+    for (let x = 0; x < fb.width; x++) out.push(at(fb, x, y));
+  return out.join("");
+}
+function litIn(fb, x0, x1, y0, y1) {
+  let n = 0;
+  for (let y = y0; y <= y1; y++) for (let x = x0; x <= x1; x++) if (at(fb, x, y)) n++;
+  return n;
+}
+
+const OPTS = ["Hall", "Room", "Plate", "Cave", "Chamber", "Spring",
+              "Shimmer", "Gated", "Reverse", "Ambience", "Church", "Tunnel"];
+const TITLE = "Reverb Mode";
+
+/* ======================================================================= 1 ==
+ * THE HEADER IS THE MOVY BAND -- compared against the movy band itself.
+ */
+{
+  const { fb } = render({ title: TITLE, options: OPTS, index: 0, openIndex: 3 });
+
+  const ref = createFramebuffer();
+  RM.drawHeader(drawContext(ref), TITLE, "SELECT", false);
+
+  /* Rows 0..7: the 7-row band plus the clear row under it, everything above the
+     first list row`s highlight. */
+  if (band(fb, 0, 7) !== band(ref, 0, 7))
+    fail("the picker`s top band is not render_page_movy`s drawHeader. It drew " +
+         "the generic device chrome (drawHeader`s 5x7 title + a rule at y=12), " +
+         "which is what made the screen you reach from the knob grid look like " +
+         "a different product.");
+
+  /* And the OLD chrome is gone, named explicitly: a full-width rule at
+     TITLE_RULE_Y is its signature. Rendered with the selection on the THIRD
+     row, because a selected first row inverts a full-width band across rows
+     8..16 and would light row 12 whether the old rule were there or not. */
+  const { fb: fb2 } = render({ title: TITLE, options: OPTS, index: 2, openIndex: 3 });
+  let ruleRow12 = 0;
+  for (let x = 0; x < 128; x++) if (at(fb2, x, 12)) ruleRow12++;
+  if (ruleRow12 > 100)
+    fail("row 12 is still a full-width rule -- the old drawHeader title rule is " +
+         "being drawn under the movy band");
+}
+
+/* ======================================================================= 2 ==
+ * THE FOOTER EXISTS, IS THE MOVY FOOTER, AND SAYS WHAT THE CONTROLS DO.
+ */
+{
+  const hints = enumPickerFooterHints();
+  /* Words first: they cannot be read back off the framebuffer (font4x5 draws
+     glyphs as fillRect pixels), so the wording is asserted on the list and the
+     PIXELS are asserted against a render of that same list. */
+  const keys = hints.map((h) => h[0]);
+  if (keys[0] !== "JOG" || keys[1] !== "CLK")
+    fail("hints must be ordered jog first, click second, like every other " +
+         "movy footer; got " + JSON.stringify(keys));
+  for (const [k] of hints)
+    if (!RM.FOOTER_CANON.keys.includes(k))
+      fail(k + " is not a key in FOOTER_CANON -- the keys name physical " +
+           "controls and are fixed by the hardware, not by taste");
+  const back = hints.find((h) => h[0] === "BACK");
+  if (!back) fail("no BACK hint: the picker`s only cancel is unnamed");
+  else if (!RM.FOOTER_CANON.backActions.includes(back[1]))
+    fail("BACK says " + JSON.stringify(back[1]) + "; the canon is EXIT (leaves " +
+         "the view) or OUT (rises a level). The picker leaves the view.");
+  else if (back[1] !== "EXIT")
+    fail("BACK should be EXIT here -- it leaves the picker entirely and lands " +
+         "back on the editor, the same as the module picker`s BACK");
+  /* Three pairs only fit while every word is <= 4 characters; drawFooter drops
+     what does not fit rather than squeezing, so a 5-letter action silently
+     costs a hint. */
+  for (const [k, a] of hints)
+    if (a.length > 4) fail("hint action " + JSON.stringify(a) + " is over 4 " +
+      "characters; drawFooter would drop a pair rather than squeeze it");
+
+  const { fb } = render({ title: TITLE, options: OPTS, index: 0, openIndex: 3 });
+  const ref = createFramebuffer();
+  RM.drawFooter(drawContext(ref), hints);
+  if (band(fb, RM.RULE_Y, 63) !== band(ref, RM.RULE_Y, 63))
+    fail("rows " + RM.RULE_Y + "..63 are not render_page_movy`s drawFooter of " +
+         "the declared hints. Before this change the picker had NO footer at " +
+         "all, so its two gestures were named nowhere.");
+
+  /* All three pairs actually landed. drawFooter returns how many it drew, but
+     from the pixels: the reference is the authority and it matched above, so
+     assert the reference itself did not silently drop one. */
+  const drawn = RM.drawFooter(drawContext(createFramebuffer()), hints);
+  if (drawn !== hints.length)
+    fail("drawFooter drew " + drawn + " of " + hints.length + " hints -- the " +
+         "row is too wide and a pair was dropped");
+}
+
+/* ======================================================================= 3 ==
+ * NOTHING CLIPS, AND THE LIST STILL SHOWS FIVE OPTIONS.
+ *
+ * This is the assertion the change was most likely to break silently. The
+ * bands take the top and bottom of the screen; left on drawMenuList`s defaults
+ * the last row and the down-arrow run through the footer and the device
+ * discards those pixels without a word.
+ */
+{
+  /* A row is "visible" if anything is lit in the label column across its 7
+     glyph rows. Derived from the rect the source declares, so the count and the
+     geometry cannot disagree. */
+  function visibleRows(fb) {
+    let n = 0;
+    for (let k = 0; k < 8; k++) {
+      const y = TOP_Y + k * LIST_LINE_HEIGHT;
+      /* Stop at the list rect, not at the screen. Past it lies the footer,
+         whose hints sit in the same label column -- counting those as options
+         is how a footer that ate a row would still look like five. */
+      if (y + 6 > BOTTOM_Y) break;
+      if (litIn(fb, LIST_LABEL_X, LIST_LABEL_X + 60, y, y + 6)) n++;
+    }
+    return n;
+  }
+
+  /* CAPACITY is what the chrome change could take away: how many rows fit
+     between the header and the footer rule. drawMenuList computes it exactly
+     this way from the rect it is given. Five is what the old chrome (top 15,
+     indicator row 62) held, and five is the bar. */
+  const CAPACITY = Math.max(1, Math.floor((BOTTOM_Y - TOP_Y) / LIST_LINE_HEIGHT));
+  const OLD_CAPACITY = Math.max(1, Math.floor((62 - 15) / LIST_LINE_HEIGHT));
+  if (CAPACITY !== OLD_CAPACITY)
+    fail("the movy bands cost the list a row: " + OLD_CAPACITY + " options fit " +
+         "under the old chrome, " + CAPACITY + " fit now. The rect is " + TOP_Y +
+         ".." + BOTTOM_Y + ". MENU_LIST_Y (10) is one row too low here -- this " +
+         "header is not inverted, so the list can start at 9.");
+
+  const cases = [
+    { what: "top of a long list",    index: 0,  openIndex: 3,  options: OPTS },
+    { what: "scrolled mid-list",     index: 6,  openIndex: 0,  options: OPTS },
+    { what: "last option selected",  index: 11, openIndex: 11, options: OPTS },
+    { what: "exactly five options",  index: 4,  openIndex: 1,  options: OPTS.slice(0, 5) },
+    { what: "two options",           index: 1,  openIndex: 0,  options: ["Off", "On"] },
+    { what: "one option",            index: 0,  openIndex: 0,  options: ["Only"] },
+    { what: "very long option names", index: 2, openIndex: 2,
+      options: OPTS.map((o) => o + " Extra Long Name That Overruns") },
+    { what: "very long title",       index: 0,  openIndex: 0,  options: OPTS,
+      title: "An Absurdly Long Parameter Name For The Header Band" },
+  ];
+
+  let anyFail = false;
+  for (const c of cases) {
+    const { fb } = render({ title: c.title || TITLE, options: c.options,
+                            index: c.index, openIndex: c.openIndex });
+    if (fb.clipped() !== 0) {
+      fail("[" + c.what + "] drew " + fb.clipped() + " pixels off the 128x64 " +
+           "display. The device discards them silently, so an overrun here is " +
+           "invisible on hardware until an option goes missing.");
+      anyFail = true;
+    }
+    /* drawMenuList`s own windowing rule, restated so the expectation is not
+       "5" -- at the END of a list it legitimately shows four, because
+       keepOffLastRow holds the selection one row off the bottom. That is
+       unchanged from the old chrome and is not what this test is hunting. The
+       CAPACITY assertion above is what pins the row the bands could have
+       eaten. */
+    const start = Math.max(0, c.index - (CAPACITY - 2));
+    const want = Math.min(start + CAPACITY, c.options.length) - start;
+    const got = visibleRows(fb);
+    if (got !== want) {
+      fail("[" + c.what + "] shows " + got + " option rows, expected " + want +
+           ". The old chrome showed five; a movy band that eats one is the " +
+           "regression this file exists for.");
+      anyFail = true;
+    }
+    /* Nothing may be drawn INTO the footer band by the list -- that is how the
+       fifth row would be "visible" and still unreadable. */
+    if (litIn(fb, 0, 127, RM.RULE_Y - 1, RM.RULE_Y - 1) > 100) {
+      fail("[" + c.what + "] the list drew a full-width run on row " +
+           (RM.RULE_Y - 1) + ", immediately above the footer rule");
+      anyFail = true;
+    }
+  }
+  if (!anyFail) console.log("PASS: five options, no clipping, across 8 list states");
+}
+
+/* ======================================================================= 4 ==
+ * THE LIST BODY IS UNCHANGED: still drawMenuList, still marking what is SET.
+ */
+{
+  /* The source still calls the shared widget. One list widget is a hard
+     requirement -- a second one is exactly how Master FX and the chain editor
+     came to look like different products. */
+  const at0 = uiSrc.indexOf("function drawEnumPicker(");
+  const body = uiSrc.slice(at0, uiSrc.indexOf("\n}\n", at0));
+  if (!/drawMenuList\(/.test(body))
+    fail("drawEnumPicker no longer calls drawMenuList -- this change was chrome " +
+         "only, and a second list widget is the drift it must not cause");
+  if (!/announce:\s*false/.test(body))
+    fail("drawEnumPicker stopped passing announce:false -- the screen emits its " +
+         "own richer TTS (\"Room, 2 of 17\"), so the list must not also say " +
+         "\"Room: *\"");
+
+  /* The `*`, on the pixels. Chosen so the marked row is NOT the selected one:
+     a selected row is inverted full-width, which would light the value column
+     whether the mark were drawn or not. */
+  const { fb } = render({ title: TITLE, options: OPTS, index: 0, openIndex: 3 });
+  const rowY = (k) => TOP_Y + k * LIST_LINE_HEIGHT;
+  const markLit = (k) => litIn(fb, LIST_VALUE_X, LIST_VALUE_X + 8, rowY(k), rowY(k) + 6);
+
+  if (!markLit(3))
+    fail("the option currently SET (row 3) has no `*` in the value column. " +
+         "Without it, scrolling away from the live value reads as nothing.");
+  for (const k of [1, 2, 4])
+    if (markLit(k)) fail("row " + k + " drew a mark and is not the set option");
+}
+
+/* ======================================================================= 5 ==
+ * THE DRAW PATH READS NO PARAMETERS AND ANNOUNCES NOTHING.
+ */
+{
+  const { reads, spoken } = render({ title: TITLE, options: OPTS, index: 2, openIndex: 3 });
+  if (reads.length)
+    fail("the draw path performed " + reads.length + " parameter read(s) (" +
+         reads.slice(0, 3).join(", ") + "). A read is ~2.8ms against a 1.68ms " +
+         "whole-page render; everything this screen shows was resolved once, at " +
+         "open, on purpose.");
+  if (spoken.length)
+    fail("the draw path announced " + JSON.stringify(spoken.slice(0, 2)) + ". " +
+         "The picker announces from openEnumPicker/enumPickerJog, where it can " +
+         "say \"Room, 2 of 17\"; a draw-path announcement would double it.");
+  if (failures === 0) console.log("PASS: no IPC and no TTS on the draw path");
+}
+
+if (failures) process.exit(1);
+console.log("PASS: the enum picker wears the movy header and footer, from both " +
+            "entry points, without losing a row");
+'

--- a/tests/host/test_enum_wire_autodetect.sh
+++ b/tests/host/test_enum_wire_autodetect.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The knob grid must LEARN which enum wire format a plugin speaks, the way the
+# other two enum writers already do, instead of requiring a declaration.
+#
+# Background: `formatParamForSet` used to write `String(index)` for every enum
+# unless the metadata declared `options_as_string: true`. A plugin whose
+# set_param is a strcmp ladder over the option NAMES with no trailing else --
+# `chord_set_param` is exactly that -- silently discards every one of those
+# writes, so the value never moves while the grid renders the index it just
+# invented. The user watches it change and snap back.
+#
+# Declaring the flag on the three built-in MIDI FX fixed those three modules.
+# It does nothing for a third-party module, and nothing tells its author. The
+# other two writers in shadow_ui.js never needed a declaration:
+#
+#     const pluginUsesIndex = (ctx.meta.options.indexOf(currentVal) < 0);
+#
+# -- they ask what the PLUGIN currently reports and answer in kind. This pins
+# the same behaviour for the grid.
+#
+# THE TRAP, and the reason a naive version of this fix fails: the grid caches
+# values in `s.values`, and its OWN WRITES populate that cache. Detect from
+# there and the first index write teaches it "this plugin uses indices" for the
+# rest of the session -- a self-fulfilling verdict that looks right in a
+# one-detent test. Detection may only consider a value that came back from the
+# DSP.
+#
+# So every case below runs MANY consecutive detents with the read cursor
+# turning between them, and checks the DSP's own state, not the UI's.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the enum wire autodetect test" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_pages/page_controller.mjs"),
+  import("./src/shared/param_pages/render_page_movy.mjs"),
+  import("node:fs"),
+]).then(([C, RM, fs]) => {
+  let failures = 0;
+  const fail = (m) => { console.log("FAIL: " + m); failures++; };
+
+  const PREFIX = "midi_fx1";
+
+  /* -------------------------------------------------------------- DSPs --
+   * Two plugins, both real conventions found in the fleet.
+   */
+
+  /* chord.c: a strcmp ladder over the NAMES, no trailing else, and get_param
+     answers with the name. An unrecognised write is silently dropped. */
+  function nameOnlyDsp(options, initial) {
+    const st = { value: options[initial], rejected: 0 };
+    return {
+      st,
+      get: () => st.value,
+      set: (val) => {
+        if (options.indexOf(val) >= 0) st.value = val;
+        else st.rejected++;
+      },
+      index: () => options.indexOf(st.value),
+    };
+  }
+
+  /* The other half of the fleet: an atoi()-style set_param that only
+     understands a numeric index, and reports one back. */
+  function indexOnlyDsp(options, initial) {
+    const st = { value: initial, rejected: 0 };
+    return {
+      st,
+      get: () => String(st.value),
+      set: (val) => {
+        const n = Number(val);
+        if (isFinite(n) && String(Math.round(n)) === String(val).trim() &&
+            n >= 0 && n < options.length) st.value = Math.round(n);
+        else st.rejected++;
+      },
+      index: () => st.value,
+    };
+  }
+
+  /* ------------------------------------------------------------ harness --
+   * The real controller, wired to a fake device that serves the contract and
+   * routes one enum key to a simulated DSP. Reads and writes are counted so
+   * this test also pins that autodetection costs no extra IPC.
+   */
+  function harness({ hierarchy, chainParams, key, dsp, others = {} }) {
+    const stats = { reads: 0, writes: 0, readKeys: [] };
+    const store = Object.assign({
+      [PREFIX + ":ui_hierarchy"]: JSON.stringify(hierarchy),
+      [PREFIX + ":chain_params"]: JSON.stringify(chainParams),
+    }, others);
+    const io = {
+      getParam: (k) => {
+        stats.reads++; stats.readKeys.push(k);
+        if (k === PREFIX + ":" + key) return dsp.get();
+        return store[k] !== undefined ? store[k] : null;
+      },
+      setParam: (k, v) => {
+        stats.writes++;
+        if (k === PREFIX + ":" + key) { dsp.set(v); return; }
+        store[k] = v;
+      },
+      now: () => tms,
+    };
+    let tms = 1000;
+    const ctl = C.createController(io);
+    ctl.setLayout(RM.LAYOUT_MOVY);      /* what the device actually draws */
+    ctl.load({ slot: 0, component: "midi_fx1", prefix: PREFIX });
+
+    /* Find the grid page and knob slot carrying `key`. */
+    let pageIdx = -1, slot = -1;
+    ctl.pages.forEach((p, i) => {
+      if (p.kind !== "knobs") return;
+      const at = (p.keys || []).indexOf(key);
+      if (at >= 0 && pageIdx < 0) { pageIdx = i; slot = at; }
+    });
+    if (pageIdx < 0) throw new Error("no grid page carries " + key);
+    ctl.goToPage(pageIdx);
+
+    return {
+      ctl, stats, slot,
+      advance: (ms) => { tms += ms; },
+      /* Let the staggered read cursor sweep the whole page once. */
+      settle: (n) => { for (let i = 0; i < n; i++) { tms += 25; ctl.tick(); } },
+      /* One physical detent, then a tick -- exactly the interleaving on the
+         device, and the interleaving that exposes the cache trap. */
+      detent: (dir) => {
+        tms += 25;
+        ctl.onKnobTurn(slot, dir === undefined ? 1 : dir, tms);
+        ctl.tick();
+      },
+    };
+  }
+
+  /* chord`s real declaration, with the override deliberately STRIPPED -- this
+     is what a third-party module that never heard of the flag looks like. */
+  const chordJson = JSON.parse(fs.readFileSync("src/modules/midi_fx/chord/module.json", "utf8"));
+  function chordContract({ withOverride }) {
+    const h = JSON.parse(JSON.stringify(chordJson.capabilities.ui_hierarchy));
+    for (const lvl of Object.values(h.levels)) {
+      for (const p of (lvl.params || [])) {
+        if (p && typeof p === "object" && "options_as_string" in p) {
+          if (withOverride) p.options_as_string = true;
+          else delete p.options_as_string;
+        }
+      }
+    }
+    const declared = h.levels.root.params.find((p) => p.key === "type");
+    /* chain_params exactly as chain_host.c renders it: it never emits the
+       flag, so the hierarchy is the only carrier. */
+    const chainParams = [{ key: "type", name: "Type", type: "enum", options: declared.options }];
+    return { hierarchy: h, chainParams, options: declared.options };
+  }
+
+  /* ================================================== 1. name-only, no flag */
+  {
+    const { hierarchy, chainParams, options } = chordContract({ withOverride: false });
+    const dsp = nameOnlyDsp(options, options.indexOf("major"));
+    const h = harness({ hierarchy, chainParams, key: "type", dsp });
+    h.settle(hierarchy.levels.root.knobs.length + 2);   /* cursor reads `type` */
+
+    const before = dsp.index();
+    for (let i = 0; i < 120; i++) h.detent(1);
+
+    if (dsp.st.rejected)
+      fail("a name-only plugin with NO options_as_string declaration rejected " +
+           dsp.st.rejected + " of the grid`s writes -- the grid is still " +
+           "writing String(index) into a strcmp ladder over the names, so the " +
+           "value stays at " + JSON.stringify(dsp.st.value) + " while the grid " +
+           "renders the index it invented");
+    if (dsp.index() <= before)
+      fail("after 120 detents the undeclared name-only plugin sits at " +
+           JSON.stringify(dsp.st.value) + ", where it started");
+  }
+
+  /* ============================================ 2. index-only, no regression */
+  {
+    const { hierarchy, chainParams, options } = chordContract({ withOverride: false });
+    const dsp = indexOnlyDsp(options, 1);
+    const h = harness({ hierarchy, chainParams, key: "type", dsp });
+    h.settle(hierarchy.levels.root.knobs.length + 2);
+
+    const before = dsp.index();
+    for (let i = 0; i < 120; i++) h.detent(1);
+
+    if (dsp.st.rejected)
+      fail("an index-taking plugin rejected " + dsp.st.rejected + " writes -- " +
+           "autodetection has flipped the whole fleet onto names");
+    if (dsp.index() <= before)
+      fail("after 120 detents the index-taking plugin never moved off " + before);
+  }
+
+  /* ================================= 3. options_as_string is still an OVERRIDE
+   * A plugin that reports an INDEX but declares the flag must still be written
+   * to by NAME. The declaration outranks anything inferred; deleting it, or
+   * letting detection beat it, breaks the eight shipped declarations.
+   */
+  {
+    const { hierarchy, chainParams, options } = chordContract({ withOverride: true });
+    const dsp = indexOnlyDsp(options, 1);
+    const seen = [];
+    const wrapped = { st: dsp.st, get: dsp.get, index: dsp.index,
+                      set: (v) => { seen.push(v); dsp.set(v); } };
+    const h = harness({ hierarchy, chainParams, key: "type", dsp: wrapped });
+    h.settle(hierarchy.levels.root.knobs.length + 2);
+    for (let i = 0; i < 40; i++) h.detent(1);
+
+    if (!seen.length) fail("the override case wrote nothing at all");
+    const numeric = seen.filter((v) => options.indexOf(v) < 0);
+    if (numeric.length)
+      fail("options_as_string: true no longer forces names -- " + numeric.length +
+           " of " + seen.length + " writes were indices, e.g. " +
+           JSON.stringify(numeric.slice(0, 3)));
+  }
+
+  /* ============================================== 4. THE CACHE-POLLUTION TRAP
+   * Detection must still hold after the grid has written many times, and
+   * across a page-away-and-back rebuild of the knob state. The grid`s own
+   * writes land in s.values; a verdict derived from that cache flips to
+   * "index" the moment the grid writes an index once, and never recovers.
+   */
+  {
+    const { hierarchy, chainParams, options } = chordContract({ withOverride: false });
+    const dsp = nameOnlyDsp(options, options.indexOf("major"));
+    const h = harness({ hierarchy, chainParams, key: "type", dsp });
+    h.settle(hierarchy.levels.root.knobs.length + 2);
+
+    /* Five separate gestures, each several detents, with the read cursor
+       sweeping in between -- the cache is thoroughly polluted by the end. */
+    const marks = [];
+    for (let g = 0; g < 5; g++) {
+      for (let i = 0; i < 24; i++) h.detent(g % 2 ? -1 : 1);
+      h.settle(hierarchy.levels.root.knobs.length + 2);
+      marks.push(dsp.st.rejected);
+    }
+    if (marks[marks.length - 1] !== 0)
+      fail("detection survived the first gesture but not the rest: rejects after " +
+           "each gesture were " + JSON.stringify(marks) + ". The grid`s own write " +
+           "is in s.values, so a verdict taken from that cache locks to `index` " +
+           "as soon as the grid writes one");
+
+    /* And the value the grid holds still reads as its option name, not as a
+       stray index -- what the cell and the screen reader show. */
+    const shown = h.ctl.state.values.type;
+    if (options.indexOf(String(shown)) < 0)
+      fail("after five gestures the grid holds " + JSON.stringify(shown) +
+           " for an enum whose plugin speaks names");
+  }
+
+  /* ============================ 4b. THE FIRST GESTURE BEATS THE FIRST READ
+   * The read cursor takes `keys + 1` ticks to come round, so a hand already on
+   * the knob when the page opens turns it before any value has been read. An
+   * implementation that only learns on the cursor writes indices until then --
+   * and each of those indices lands in s.values, which is exactly the value a
+   * cache-derived verdict would go on to read. This is the ordering that turns
+   * "detected late" into "detected wrong, permanently".
+   */
+  {
+    const { hierarchy, chainParams, options } = chordContract({ withOverride: false });
+    const dsp = nameOnlyDsp(options, options.indexOf("major"));
+    const h = harness({ hierarchy, chainParams, key: "type", dsp });
+    /* No settle: straight from load to the knob. */
+    for (let i = 0; i < 60; i++) h.detent(1);
+
+    if (dsp.st.rejected)
+      fail("turning before the read cursor arrives cost " + dsp.st.rejected +
+           " rejected writes. Detection has to have an answer by the FIRST " +
+           "write -- onKnobTurn already reads the value when it seeds the knob " +
+           "state, and that read is from the device");
+    if (dsp.index() <= options.indexOf("major"))
+      fail("60 detents from a cold page left the value at " +
+           JSON.stringify(dsp.st.value));
+    /* And it kept the answer once the cursor started reporting too. */
+    h.settle(hierarchy.levels.root.knobs.length + 2);
+    const after = dsp.st.rejected;
+    for (let i = 0; i < 60; i++) h.detent(-1);
+    if (dsp.st.rejected !== after)
+      fail("the verdict flipped once the read cursor caught up: " +
+           (dsp.st.rejected - after) + " writes rejected afterwards");
+  }
+
+  /* ================================================= 5. no extra IPC per tick
+   * The read that detection uses must be one the grid ALREADY makes. A param
+   * round trip is ~2.8ms against a 1.68ms whole-page render; a per-frame or
+   * per-detent read added here would be more expensive than the bug.
+   */
+  {
+    const { hierarchy, chainParams, options } = chordContract({ withOverride: false });
+    const dsp = nameOnlyDsp(options, options.indexOf("major"));
+    const h = harness({ hierarchy, chainParams, key: "type", dsp });
+    h.settle(hierarchy.levels.root.knobs.length + 2);
+
+    h.stats.reads = 0;
+    for (let i = 0; i < 20; i++) { h.advance(25); h.ctl.tick(); }
+    if (h.stats.reads > 20)
+      fail("20 ticks issued " + h.stats.reads + " reads -- the cursor budget is " +
+           "one per tick and detection must not add another");
+
+    h.stats.reads = 0;
+    for (let i = 0; i < 40; i++) { h.advance(25); h.ctl.onKnobTurn(h.slot, 1, undefined); }
+    if (h.stats.reads > 1)
+      fail("40 detents issued " + h.stats.reads + " reads -- detection is reading " +
+           "per detent. It must use the value the read cursor already fetched");
+  }
+
+  if (failures) process.exit(1);
+  console.log("PASS: the knob grid learns an enum`s wire format from the plugin, " +
+              "survives its own write cache, keeps index plugins on indices, and " +
+              "adds no reads");
+}).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'

--- a/tests/host/test_enum_wire_format_contract.sh
+++ b/tests/host/test_enum_wire_format_contract.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# What a knob puts ON THE WIRE for an enum, against what the DSP will accept.
+#
+# Reported from the device 2026-08-21, against the built-in `chord`: "when i
+# turn the knob for key i see it go through and then falls back to major no
+# matter what i pick."
+#
+# Nothing "falls back". `chord_set_param` (chord.c:420) is a strcmp ladder over
+# the option NAMES with no trailing else, so a value it does not recognise
+# leaves inst->type exactly where it was -- and where it was is the declared
+# default, index 1, "major". Every write was being REJECTED, silently, and the
+# read-back kept returning the untouched value.
+#
+# What was being written was the numeric INDEX. There are two enum writers and
+# they do not agree:
+#
+#   shadow_ui.js   (chain editor knob, jog) -- AUTO-DETECTS, by asking whether
+#                  the value the plugin currently reports is one of the option
+#                  names (`pluginUsesIndex`). chord reports "major", so this
+#                  path writes names and works.
+#   param_pages    (the knob grid) -- holds the enum as a number end to end
+#                  (page_controller.mjs onKnobTurn) and formats it with
+#                  formatParamForSet, which returns String(idx) UNLESS the
+#                  metadata declares `options_as_string: true`.
+#
+# That declared convention already exists and is already documented
+# (docs/MODULES.md, "Enum wire format"). Not one shipped module declares it --
+# which is fine for a module whose set_param has an atoi fallback, and fatal
+# for one whose does not.
+#
+# So this pins the CONTRACT rather than the symptom, in two halves:
+#
+#   1. Mechanically, over every built-in module: an enum whose set_param branch
+#      compares `val` against strings must declare options_as_string. Derived
+#      from the shipped module.json and the DSP source, so a module added later
+#      is covered without editing this file.
+#   2. Behaviourally: drive the REAL knob engine and the REAL formatParamForSet
+#      with chord's REAL metadata across several consecutive detents, and check
+#      every wire value against chord's actual ladder. Several detents, not one
+#      -- a single-detent test passes on the first option by luck.
+#
+# PRE-EXISTING, not a regression: chord has never declared it.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the enum wire format test" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_format.mjs"),
+  import("./src/shared/knob_engine.mjs"),
+  import("node:fs"),
+  import("node:path"),
+]).then(([PF, KE, fs, path]) => {
+  let failures = 0;
+  const fail = (m) => { console.log("FAIL: " + m); failures++; };
+
+  /* ============================================================ part 1 ====
+   * The contract, over every built-in module that declares an enum.
+   */
+
+  /* Every enum param declared anywhere in a module.json ui_hierarchy. */
+  function declaredEnums(moduleJsonPath) {
+    let d;
+    try { d = JSON.parse(fs.readFileSync(moduleJsonPath, "utf8")); }
+    catch (e) { return []; }
+    const h = d.capabilities && d.capabilities.ui_hierarchy;
+    if (!h || !h.levels) return [];
+    const out = [];
+    for (const levelName of Object.keys(h.levels)) {
+      const params = h.levels[levelName].params;
+      if (!Array.isArray(params)) continue;
+      for (const p of params) {
+        if (p && typeof p === "object" && p.type === "enum" && Array.isArray(p.options)) {
+          out.push({ level: levelName, key: p.key, options: p.options,
+                     asString: !!p.options_as_string });
+        }
+      }
+    }
+    return out;
+  }
+
+  /*
+   * The body of the `strcmp(key, "<name>")` branch inside set_param.
+   *
+   * Deliberately crude -- it slices from this key’s test to the next
+   * `strcmp(key,` -- because the question it has to answer is crude too: does
+   * this branch look at the STRING the UI sends. The "state" restore branch is
+   * not it; that parses a JSON blob and never sees a knob write.
+   */
+  function setParamBranch(csrc, key) {
+    const at = csrc.indexOf("(key, \"" + key + "\")");
+    if (at < 0) return null;
+    const next = csrc.indexOf("strcmp(key,", at + 1);
+    return csrc.slice(at, next < 0 ? csrc.length : next);
+  }
+
+  function dspSources(moduleDir) {
+    const dsp = path.join(moduleDir, "dsp");
+    if (!fs.existsSync(dsp)) return "";
+    return fs.readdirSync(dsp).filter((f) => f.endsWith(".c"))
+      .map((f) => fs.readFileSync(path.join(dsp, f), "utf8")).join("\n");
+  }
+
+  const moduleDirs = [];
+  for (const kind of fs.readdirSync("src/modules")) {
+    const kdir = path.join("src/modules", kind);
+    if (!fs.statSync(kdir).isDirectory()) continue;
+    for (const id of fs.readdirSync(kdir)) {
+      const mdir = path.join(kdir, id);
+      if (fs.existsSync(path.join(mdir, "module.json"))) moduleDirs.push(mdir);
+    }
+  }
+  if (moduleDirs.length === 0) { fail("found no built-in modules to check"); }
+
+  let checked = 0;
+  for (const mdir of moduleDirs) {
+    const csrc = dspSources(mdir);
+    if (!csrc) continue;
+    for (const e of declaredEnums(path.join(mdir, "module.json"))) {
+      const branch = setParamBranch(csrc, e.key);
+      if (branch === null) continue;   /* served some other way */
+      /* Does the branch compare the VALUE against strings? If it does, an
+         index on the wire can only be right by accident. */
+      if (!/strcmp\(\s*val\b/.test(branch)) continue;
+      checked++;
+      if (!e.asString)
+        fail(mdir + " enum \"" + e.key + "\" is matched by NAME in set_param " +
+             "(strcmp on val) but module.json does not declare " +
+             "options_as_string. The knob grid writes String(index), the ladder " +
+             "matches nothing, and the value silently stays where it was -- " +
+             "which the user reads as \"it snaps back to the default\"");
+    }
+  }
+  if (checked === 0)
+    fail("the detector matched no name-compared enum in any built-in module -- " +
+         "it has stopped looking at whatever it used to look at, and would now " +
+         "pass no matter what the modules declare");
+
+  /* ============================================================ part 2 ====
+   * chord specifically, end to end, through the real code.
+   */
+  {
+    const mj = JSON.parse(fs.readFileSync("src/modules/midi_fx/chord/module.json", "utf8"));
+    const root = mj.capabilities.ui_hierarchy.levels.root;
+    const meta = root.params.find((p) => p.key === "type");
+    const csrc = fs.readFileSync("src/modules/midi_fx/chord/dsp/chord.c", "utf8");
+    const branch = setParamBranch(csrc, "type");
+
+    /* chord_set_param, as the ladder actually behaves: an unrecognised value
+       leaves the field alone. Built from the SOURCE, so it cannot drift into
+       agreeing with the test by hand. */
+    const accepted = new Set();
+    for (const m of branch.matchAll(/strcmp\(val,\s*"([^"]+)"\)/g)) accepted.add(m[1]);
+    if (accepted.size !== meta.options.length)
+      fail("chord.c accepts " + accepted.size + " names for `type` but module.json " +
+           "declares " + meta.options.length + " options -- the two have drifted");
+
+    /* Several consecutive detents through the real engine, exactly as the knob
+       grid drives it: the state is seeded from the CURRENT value and carried,
+       and each wire value is formatted by the real formatter. */
+    let current = "major";
+    const st = KE.knobInit(meta.options.indexOf(current));
+    const cfg = KE.knobConfigFromMeta(meta);
+    const wires = [];
+    let moved = 0;
+    const t0 = Date.now();
+    for (let i = 0; i < 120; i++) {
+      const v = KE.knobTick(st, cfg, 1, t0 + i * 40);
+      const wire = PF.formatParamForSet(v, meta);
+      if (wires[wires.length - 1] === wire) continue;
+      wires.push(wire);
+      /* the DSP ladder */
+      if (accepted.has(wire)) { current = wire; moved++; }
+    }
+    if (wires.length < 3)
+      fail("the knob only produced " + wires.length + " distinct wire values over 120 " +
+           "detents; this case is meant to cross several options");
+    const rejected = wires.filter((w) => !accepted.has(w));
+    if (rejected.length)
+      fail("chord rejects " + rejected.length + " of " + wires.length + " wire values " +
+           "the knob grid sends -- e.g. " + JSON.stringify(rejected.slice(0, 4)) +
+           ". chord_set_param is a strcmp ladder over the option names with no " +
+           "trailing else, so each of those leaves `type` untouched at " +
+           JSON.stringify(current) + " while the grid renders options[idx] and " +
+           "shows the user it moved");
+    if (moved === 0)
+      fail("after 120 detents chord`s `type` never changed: still " + JSON.stringify(current));
+  }
+
+  /* ============================================================ part 3 ====
+   * The declaration has to SURVIVE the pipeline the device actually uses.
+   *
+   * Part 2 hands formatParamForSet the module.json entry directly, which the
+   * grid never does: it goes through buildMetaIndex, merging the hierarchy
+   * with the chain_params the chain host RENDERS. That renderer emits key,
+   * name, type, options, unit and display_format -- and NOT
+   * options_as_string. So the flag survives only because chain_params
+   * overrides key by key and has no key to override with. Nothing said that
+   * out loud, and a merge that rebuilt the object field by field instead
+   * would drop it and make every declaration above inert while both other
+   * parts kept passing.
+   */
+  {
+    const mj = JSON.parse(fs.readFileSync("src/modules/midi_fx/chord/module.json", "utf8"));
+    const hierarchy = mj.capabilities.ui_hierarchy;
+    const declared = hierarchy.levels.root.params.find((p) => p.key === "type");
+
+    /* chain_params exactly as chain_host.c renders it for a MIDI FX: the
+       fields that serializer writes, and nothing else. */
+    const hostRendered = [{
+      key: "type", name: "Type", type: "enum", options: declared.options,
+    }];
+
+    return import("./src/shared/param_pages/param_meta.mjs").then((PM) => {
+      const idx = PM.buildMetaIndex({ hierarchy, chainParams: hostRendered });
+      const meta = idx.getOrGuess("type");
+      if (!meta || meta.options_as_string !== true)
+        fail("options_as_string did not survive buildMetaIndex: the grid formats " +
+             "with " + JSON.stringify(meta) + ", so the declaration in " +
+             "chord/module.json has no effect. chain_host.c`s chain_params " +
+             "renderer does not emit the flag, so the hierarchy is the only " +
+             "thing carrying it");
+      const wire = PF.formatParamForSet(3, meta);
+      if (wire !== declared.options[3])
+        fail("through the real metadata pipeline the grid still writes " +
+             JSON.stringify(wire) + " for option 3, not " +
+             JSON.stringify(declared.options[3]));
+
+      if (failures) process.exit(1);
+      console.log("PASS: every name-matched enum declares options_as_string, chord " +
+                  "accepts every value the knob grid puts on the wire, and the flag " +
+                  "survives buildMetaIndex");
+    });
+  }
+  /* eslint-disable no-unreachable */
+  if (failures) process.exit(1);
+}).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'

--- a/tests/host/test_param_pages_contract_read_failure.sh
+++ b/tests/host/test_param_pages_contract_read_failure.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A contract read that FAILED must never produce a page plan.
+#
+# Reported from hardware: "in granny when I select a sample, it reorders the
+# knobs and puts the sample file in knob position 1 - until I go into the
+# waveform position editor and back."
+#
+# The chain:
+#   1. picking a sample writes synth:sample_path, and granny loads the WAV
+#      SYNCHRONOUSLY inside set_param, on the SPI callback thread that also
+#      serves param requests. The write times out at 100 ms.
+#   2. closing the file browser re-enters the knob grid in the SAME JS handler,
+#      milliseconds later, and controller.load() reads synth:ui_hierarchy while
+#      the channel is still busy. The read returns null.
+#   3. null parsed to nothing, which looked exactly like "this module declares
+#      no hierarchy", so the planner paginated chain_params 8 at a time - and
+#      granny declares sample_path FIRST, so the sample file landed on knob 1
+#      and shifted every other knob along.
+#   4. it latched: the cached failure was re-planned from, and metaSettled was
+#      set because the chain_params-derived metadata looked complete, so the
+#      contract was never read again. Only a full teardown healed it.
+#
+# The distinction the fix rests on is already on the wire:
+#   null  the binding could not claim the param channel  -> retry, know nothing
+#   ""    an unserved but reachable key, zeroed buffer   -> genuinely absent
+#
+# Both halves below are required. The first alone would be passed by a fix that
+# simply never plans anything.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the contract-read-failure tests" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_pages/page_controller.mjs"),
+  import("./tools/param-pages/fake_device.mjs"),
+]).then(([C, D]) => {
+  const fail = (msg) => { console.log("FAIL: " + msg); process.exit(1); };
+  const keys1 = (ctl) => ((ctl.pages[0] || {}).keys || []);
+  /* Enough ticks to cover CONTRACT_RETRY_INTERVAL_TICKS a few times over. */
+  const RECOVER_TICKS = C.CONTRACT_RETRY_INTERVAL_TICKS * 3 + 2;
+  const tickFor = (ctl, n) => { for (let i = 0; i < n; i++) ctl.tick(); };
+
+  /* ---- 0. the fixture still reproduces the reported bug ----------------- */
+  {
+    const dev = D.createFakeDevice({ id: "granny" });
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    if (keys1(ctl)[0] !== "position")
+      fail("granny knob 1 should be position, got " + keys1(ctl)[0]);
+    const cp = JSON.parse(dev.getParam("synth:chain_params"));
+    if (cp[0].key !== "sample_path")
+      fail("granny fixture changed: chain_params[0] is no longer sample_path, " +
+           "so a chain_params fallback would no longer misplace it");
+  }
+
+  /* ---- 1. a failed contract read plans NOTHING -------------------------- */
+  {
+    const dev = D.createFakeDevice({ id: "granny" });
+    dev.failParam("ui_hierarchy", 1);
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+
+    if (keys1(ctl)[0] === "sample_path")
+      fail("THE BUG: a failed ui_hierarchy read put sample_path on knob 1 - " +
+           JSON.stringify(keys1(ctl)));
+    if (ctl.pages.length !== 0)
+      fail("a failed contract read produced a page plan: " + JSON.stringify(keys1(ctl)));
+    if (!ctl.contractUnresolved)
+      fail("a null ui_hierarchy read was not recorded as unresolved");
+
+    /* ...and it must not have burned a second doomed round trip asking for
+     * chain_params it could not use. */
+    if (dev.readsFor("chain_params") !== 0)
+      fail("chain_params was read despite the hierarchy read failing");
+
+    /* ---- 2. ...and it RECOVERS, on its own, from the read cursor -------- */
+    tickFor(ctl, RECOVER_TICKS);
+    if (ctl.contractUnresolved) fail("the contract never re-resolved");
+    if (keys1(ctl)[0] !== "position")
+      fail("after recovery granny knob 1 is " + keys1(ctl)[0] + ", expected position");
+    if (ctl.page.name !== "Main")
+      fail("after recovery the page is named " + ctl.page.name + ", expected Main");
+  }
+
+  /* ---- 3. a re-entry that fails KEEPS the plan it already had ----------- */
+  {
+    /* The reported sequence: the grid is already up for this component, the
+     * user dives into the sample browser and comes back, and the load() on the
+     * way back gets nothing. The plan on screen is still this component plan -
+     * stale by at most one retry interval, and right. */
+    const dev = D.createFakeDevice({ id: "granny" });
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    const before = keys1(ctl).join();
+
+    dev.failParam("ui_hierarchy", 1);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    if (!ctl.contractUnresolved) fail("re-entry: the failed read was not recorded");
+    if (keys1(ctl).join() !== before)
+      fail("re-entry: the page set changed under a failed read, from [" + before +
+           "] to [" + keys1(ctl).join() + "]");
+
+    tickFor(ctl, RECOVER_TICKS);
+    if (ctl.contractUnresolved) fail("re-entry: the contract never re-resolved");
+    if (keys1(ctl).join() !== before) fail("re-entry: recovery changed the page set");
+  }
+
+  /* ---- 4. a DIFFERENT component is not shown the old one knobs ---------- */
+  {
+    const dev = D.createFakeDevice({ id: "granny" });
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    if (!ctl.pages.length) fail("granny planned no pages");
+
+    /* The fake device serves one prefix, so fx1 reads answer null - which is
+     * exactly the shape of an unservable request. */
+    ctl.load({ slot: 0, component: "fx1", prefix: "fx1" });
+    if (!ctl.contractUnresolved) fail("an unservable fx1 contract was not recorded as unresolved");
+    if (ctl.pages.length !== 0)
+      fail("a different component under a failed read kept the previous page set: " +
+           JSON.stringify(keys1(ctl)));
+  }
+
+  /* ---- 5. the latch is gone -------------------------------------------- */
+  {
+    /* A single failed read used to be permanent: the wrong plan was re-planned
+     * from the cached failure, and metaSettled stopped the contract ever being
+     * re-read. Hold the read down for longer than one retry interval to prove
+     * the recovery is a real loop and not one lucky attempt. */
+    const dev = D.createFakeDevice({ id: "granny" });
+    dev.failParam("ui_hierarchy", 4);
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    tickFor(ctl, C.CONTRACT_RETRY_INTERVAL_TICKS * 8 + 2);
+    if (ctl.contractUnresolved)
+      fail("a contract that failed 4 times never re-resolved");
+    if (keys1(ctl)[0] !== "position")
+      fail("after 4 failed reads knob 1 is " + keys1(ctl)[0] + ", expected position");
+  }
+
+  /* ---- 6. the retry is BOUNDED ----------------------------------------- */
+  {
+    /* A component whose channel never answers must cost a fixed number of
+     * reads, not one per interval for the rest of the session. */
+    const dev = D.createFakeDevice({ id: "granny" });
+    dev.failParam("ui_hierarchy", 1e9);
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    dev.resetCounters();
+    tickFor(ctl, C.CONTRACT_RETRY_INTERVAL_TICKS * (C.CONTRACT_RETRY_LIMIT + 20));
+    const n = dev.readsFor("ui_hierarchy");
+    if (n > C.CONTRACT_RETRY_LIMIT)
+      fail("unbounded contract retries: " + n + " reads, limit is " + C.CONTRACT_RETRY_LIMIT);
+    if (n < 2) fail("the contract retry loop is not running at all (" + n + " reads)");
+  }
+
+  /* ---- 7. genuine absence still paginates chain_params ------------------ */
+  {
+    /* Four fleet modules publish chain_params and no hierarchy at all. They
+     * answer "" - an unserved but reachable key - and that fallback is not
+     * what was broken. Do not fix a timeout by breaking it. */
+    for (const id of ["branchage", "belt-in", "po32-drum", "smack-in"]) {
+      const dev = D.createFakeDevice({ id });
+      if (dev.getParam("synth:ui_hierarchy") !== "")
+        fail(id + ": the fake device must answer \"\" for a genuinely absent hierarchy");
+      dev.resetCounters();
+      const ctl = C.createController(dev);
+      ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+      if (ctl.contractUnresolved) fail(id + ": genuine absence was treated as a failed read");
+      if (!ctl.pages.length) fail(id + ": the chain_params pagination fallback stopped working");
+      if (ctl.page.name !== "Params") fail(id + ": fallback page 1 is named " + ctl.page.name);
+      const cp = JSON.parse(dev.getParam("synth:chain_params"));
+      if (keys1(ctl)[0] !== cp[0].key)
+        fail(id + ": the fallback no longer paginates in declaration order");
+    }
+  }
+
+  /* ---- 8. no new per-frame reads on the healthy path -------------------- */
+  {
+    /* The read budget is the hard constraint here: a param round trip is
+     * ~2.8 ms against a 1.68 ms whole-page render. A resolved contract must
+     * cost the same one read per tick it always did. */
+    const dev = D.createFakeDevice({ id: "granny" });
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    dev.resetCounters();
+    const N = 60;
+    tickFor(ctl, N);
+    if (dev.reads.length > N)
+      fail("a resolved contract cost " + dev.reads.length + " reads over " + N +
+           " ticks - more than one per tick");
+    if (dev.readsFor("ui_hierarchy") !== 0)
+      fail("a resolved contract is being re-read every tick");
+  }
+
+  console.log("PASS: a failed contract read plans nothing, recovers on its own, " +
+              "and genuine absence still paginates chain_params");
+}).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'

--- a/tests/host/test_param_pages_contract_settle.sh
+++ b/tests/host/test_param_pages_contract_settle.sh
@@ -150,10 +150,12 @@ Promise.all([
     const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
     dev.setServesIsLoading(false);
     const ctl = openGrid(dev);
-    /* The degenerate window must OUTLAST the settle deadline, or the first
-       re-read lands after it and the guard is never asked anything. */
+    /* The degenerate window must outlast TWO probes, or the two-agree rule
+       absorbs it on its own and the guard is never asked anything. A real
+       module load blocks the callback for ~673 ms (docs/), so a window this
+       wide is not a contrivance. */
     dev.stagePlugin(contractFor("kosmos"),
-                    { debounceMs: C.CONTRACT_SETTLE_MS + 200, during: [] });
+                    { debounceMs: C.CONTRACT_SETTLE_MS * 2 + 200, during: [] });
     ctl.selectionChanged();
     settle(ctl, dev, SETTLED_MS);
     if (labels(ctl) !== want("kosmos"))
@@ -276,20 +278,25 @@ Promise.all([
            "the support latch is not holding");
   }
 
-  /* ---- 9. a module that DOES serve it settles on its ready edge --------- */
+  /* ---- 9. a module that DOES serve it is not probed while it says 1 ----- */
   {
     const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
     const ctl = openGrid(dev);            /* serves is_loading by default */
-    const before = dev.readsFor("chain_params");
+    dev.setLoading(true);
     dev.stagePlugin(contractFor("kosmos"), { debounceMs: DEBOUNCE_MS });
     ctl.selectionChanged();
+    const before = dev.readsFor("chain_params");
+    /* While the module says it is loading, probing the contract is pointless
+       and must cost nothing but the cheap flag read. */
+    settle(ctl, dev, C.CONTRACT_SETTLE_MS * 2);
+    if (dev.readsFor("chain_params") !== before)
+      fail("a module reporting is_loading=1 was still probed for its " +
+           "contract " + (dev.readsFor("chain_params") - before) + " times");
+    /* ...and the moment it reports ready, the ordinary settle takes over. */
+    dev.setLoading(false);
     settle(ctl, dev, SETTLED_MS);
     if (labels(ctl) !== want("kosmos"))
       fail("an is_loading-serving module did not settle: " + labels(ctl));
-    /* One confirming contract read, because the module said when to look. */
-    if (dev.readsFor("chain_params") - before > 1)
-      fail("is_loading bought no read back: " +
-           (dev.readsFor("chain_params") - before) + " contract reads");
   }
 
   /* ---- 10. a load landing AFTER the first probe is still picked up ------ */
@@ -311,6 +318,77 @@ Promise.all([
       fail("THE TRAP: settled on the intermediate contract " + labels(ctl));
     if (labels(ctl) !== want("kosmos"))
       fail("did not reach the final contract: " + labels(ctl));
+  }
+
+
+  /* ---- 11. the agreement is not carried across selections -------------- */
+  {
+    /* A completed settle leaves the last reading fingerprint equal to the
+       contract now on screen. If that survives into the NEXT selection, the
+       first probe of that selection agrees with it immediately and settles on
+       the contract being replaced — the original bug, laundered through the
+       confirmation. The agreement has to start empty on every arm. */
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    const SLOW = C.CONTRACT_SETTLE_MS + 200;   /* outlasts the first probe */
+
+    dev.stagePlugin(contractFor("Ensemble"), { debounceMs: SLOW });
+    ctl.selectionChanged();
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) !== want("Ensemble"))
+      fail("first slow selection did not settle: " + labels(ctl));
+
+    dev.stagePlugin(contractFor("kosmos"), { debounceMs: SLOW });
+    ctl.selectionChanged();
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) === want("Ensemble"))
+      fail("THE BUG: the second selection settled on the contract it was " +
+           "replacing, " + labels(ctl));
+    if (labels(ctl) !== want("kosmos"))
+      fail("second slow selection did not settle: " + labels(ctl));
+  }
+
+  /* ---- 12. the is_loading verdict is per COMPONENT, not per session ----- */
+  {
+    /* Latching "this module does not implement it" forever would mean the
+       first component you happen to open decides it for every module you open
+       afterwards. */
+    const serves = { fx1: false, fx2: true };
+    const asked = { fx1: 0, fx2: 0 };
+    const contract = JSON.stringify([
+      { key: "param_0", name: "P", type: "float", min: 0, max: 1 },
+    ]);
+    const hierarchy = JSON.stringify({
+      modes: null,
+      levels: { root: { knobs: ["param_0"], params: ["param_0"] } },
+    });
+    let clock = 0;
+    const io = {
+      getParam(key) {
+        const [pfx, bare] = [key.split(":")[0], key.split(":").slice(1).join(":")];
+        if (bare === "ui_hierarchy") return hierarchy;
+        if (bare === "chain_params") return contract;
+        if (bare === "is_loading") { asked[pfx]++; return serves[pfx] ? "0" : ""; }
+        return "0.5";
+      },
+      setParam() {}, announce() {}, now: () => clock,
+    };
+    const ctl = C.createController(io);
+    ctl.load({ slot: 0, component: "fx1", prefix: "fx1" });
+    for (let i = 0; i < 4; i++) {
+      ctl.selectionChanged();
+      for (let t = 0; t < C.CONTRACT_SETTLE_MS * 4; t += 10) { clock += 10; ctl.tick(); }
+    }
+    if (asked.fx1 > 1)
+      fail("is_loading asked " + asked.fx1 + " times on a component that answers empty");
+
+    ctl.load({ slot: 0, component: "fx2", prefix: "fx2" });
+    ctl.selectionChanged();
+    for (let t = 0; t < C.CONTRACT_SETTLE_MS * 4; t += 10) { clock += 10; ctl.tick(); }
+    if (asked.fx2 === 0)
+      fail("THE BUG: a component that DOES implement is_loading was never " +
+           "asked, because the previous one latched unsupported");
   }
 
   console.log("PASS: contract settle");

--- a/tests/host/test_param_pages_contract_settle.sh
+++ b/tests/host/test_param_pages_contract_settle.sh
@@ -1,0 +1,318 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A contract that changes UNDER an unchanged component must be re-read once it
+# has SETTLED — not the instant the selection is written.
+#
+# Reported from hardware, on schwung-airwindows:
+#
+#   "I've got kCyberCity and it shows head, a delay, a lev. And when I changed
+#    to kosmos then I see rege, posi, dry (the kCyberCity controls)."
+#   "If I exit the module and come back to it, it shows the right ones."
+#
+# Strictly one behind, and eventually correct — which places the fault in the
+# TIMING of the re-read, not in whether one happens:
+#
+#   1. writing the selection updates the module's selected index synchronously,
+#      so `plugin_name` is immediately right, but only SCHEDULES the plugin
+#      load on a worker thread 300 ms later (clap_fx.cpp:806-822).
+#   2. `chain_params` is generated from `cached_param_names`, rewritten only at
+#      the END of that load (clap_fx.cpp:651). For the whole debounce it
+#      reports the plugin still loaded — the PREVIOUS one.
+#   3. our re-read fires milliseconds after the write, so it wins the race and
+#      caches the previous effect's labels. Leaving and re-entering reads long
+#      after the debounce, which is why that heals it.
+#
+# The fix must not depend on the module volunteering `is_loading`: nothing in
+# the fleet is obliged to implement it, and correctness that rests on a flag
+# third-party modules must remember to set is not correctness. The fingerprint
+# already hashes chain_params CONTENT, so "has it changed" is answerable here.
+#
+# Cost matters as much as correctness. A param read is ~2.8 ms against a
+# 1.68 ms whole-page render, and the effect list is 519 long: a fast jog must
+# cost O(1) contract reads, not one per detent.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the contract-settle tests" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_pages/page_controller.mjs"),
+  import("./tools/param-pages/fake_device.mjs"),
+]).then(([C, D]) => {
+  const fail = (msg) => { console.log("FAIL: " + msg); process.exit(1); };
+  const tickFor = (ctl, n) => { for (let i = 0; i < n; i++) ctl.tick(); };
+  /* The device debounce, from clap_fx.cpp PLUGIN_LOAD_DEBOUNCE_MS. */
+  const DEBOUNCE_MS = 300;
+  /* Walk the clock forward in small steps while ticking, the way real time
+     passes: a settle that only worked when the clock jumped in one bound
+     would not be a settle. */
+  const settle = (ctl, dev, ms) => {
+    for (let t = 0; t < ms; t += 10) { dev.advance(10); ctl.tick(); }
+  };
+  /* Comfortably past the deadline and every one of its bounded retries. */
+  const SETTLED_MS = C.CONTRACT_SETTLE_MS * (C.CONTRACT_SETTLE_RETRIES + 2);
+
+  /* The three effects from the report, with their real Airwindows param
+   * names and their real (differing) param counts. */
+  /* The names are the ones the hardware report actually types, not expansions
+     invented here: the repo ships no Airwindows parameter table (only
+     airwindows_category_map.inc), so the full spellings are not verifiable
+     from source and are not claimed. What the cases below assert is that the
+     contract CHANGES and the grid follows it, which does not depend on the
+     spelling being right. The captured six-param contract in the fixture is
+     the one real contract in play. */
+  const FX = {
+    kCyberCity: ["rege", "posi", "dry"],
+    kosmos:     ["kos1", "kos2", "kos3", "kos4"],
+    Ensemble:   ["head", "a delay", "a lev"],
+  };
+  const contractFor = (name) => FX[name].map((n, i) => ({
+    key: `param_${i}`, name: n, type: "float", min: 0, max: 1,
+  }));
+
+  const grid = (ctl) => (ctl.pages || []).find((p) => p.kind === "knobs");
+  const labels = (ctl) => {
+    const p = grid(ctl);
+    if (!p) return "<no knobs page>";
+    const mi = ctl.state.metaIndex;
+    /* Only the cells a real effect declares; the hierarchy always names eight
+     * knobs, so the tail is legitimately undeclared. */
+    return p.keys.slice(0, 4).map((k) => mi.getOrGuess(k).label).join(",");
+  };
+  const want = (name) => FX[name].concat(["param 3"]).slice(0, 4).join(",");
+  /* Whatever effect the CAPTURE was taken with. Read from the fixture rather
+     than written out, so a re-capture does not turn every case below into a
+     spurious failure. */
+  const captured = (dev) => {
+    const cp = JSON.parse(dev.getParam("fx1:chain_params"));
+    return cp.map((p) => p.name).concat(["param 3"]).slice(0, 4).join(",");
+  };
+
+  const openGrid = (dev) => {
+    const ctl = C.createController({ ...dev, now: dev.now });
+    ctl.load({ slot: 0, component: "fx1", prefix: "fx1" });
+    return ctl;
+  };
+
+  /* ---- 0. the fixture is the real airwindows contract ------------------- */
+  {
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    const g = grid(ctl);
+    if (!g) fail("clap planned no knobs page");
+    if (g.keys[0] !== "param_0")
+      fail("fixture changed: knob 1 is no longer param_0, got " + g.keys[0]);
+    const cp = JSON.parse(dev.getParam("fx1:chain_params"));
+    if (!cp.length || cp[0].type !== "float")
+      fail("fixture changed: clap chain_params is no longer float-typed, " +
+           "so metaUnsettled() may now fire and this bug would not reproduce");
+    /* The whole diagnosis rests on this: nothing in the contract is an enum,
+     * so the existing placeholder-driven re-resolve can never fire for it. */
+    const before = dev.readsFor("chain_params");
+    tickFor(ctl, C.META_RETRY_INTERVAL_TICKS * 2 + 2);
+    if (dev.readsFor("chain_params") !== before)
+      fail("maybeResettle re-read a float-only contract; the premise of this " +
+           "test (that nothing else re-reads) no longer holds");
+  }
+
+  /* ---- 1. THE BUG: three consecutive selections, none one-behind -------- */
+  {
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    if (labels(ctl) !== captured(dev))
+      fail("expected the captured fixture contract at load, got " + labels(ctl));
+
+    /* One step is passed by luck — a stale read that happens to be right
+     * once. Three consecutive selections is the assertion. */
+    const order = ["kosmos", "Ensemble", "kCyberCity"];
+    for (const name of order) {
+      dev.stagePlugin(contractFor(name), { debounceMs: DEBOUNCE_MS });
+      ctl.selectionChanged();
+      settle(ctl, dev, SETTLED_MS);
+      if (labels(ctl) !== want(name))
+        fail(`THE BUG: after selecting ${name} the grid shows ` +
+             `"${labels(ctl)}", want "${want(name)}"`);
+    }
+  }
+
+  /* ---- 2. a contract that is still degenerate is not an answer ---------- */
+  {
+    /* While the plugin pointer is NULL the module answers "[]"
+     * (clap_fx.cpp:914-916). Taking that as the settled contract would blank
+     * every label — so it must keep waiting, not latch. */
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    /* The degenerate window must OUTLAST the settle deadline, or the first
+       re-read lands after it and the guard is never asked anything. */
+    dev.stagePlugin(contractFor("kosmos"),
+                    { debounceMs: C.CONTRACT_SETTLE_MS + 200, during: [] });
+    ctl.selectionChanged();
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) !== want("kosmos"))
+      fail("an empty mid-load contract was taken as settled: " + labels(ctl));
+  }
+
+  /* ---- 3. a fast jog costs O(1) contract reads, not one per detent ------ */
+  {
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    const before = dev.readsFor("chain_params");
+    /* 40 detents inside one settle window, as a spin down a 519-effect list. */
+    for (let i = 0; i < 40; i++) {
+      ctl.selectionChanged();
+      dev.advance(30);          /* a brisk 33 detents a second */
+      ctl.tick();
+    }
+    dev.stagePlugin(contractFor("kosmos"), { debounceMs: DEBOUNCE_MS });
+    settle(ctl, dev, SETTLED_MS);
+    const spent = dev.readsFor("chain_params") - before;
+    if (spent > 4)
+      fail(`a 40-detent jog cost ${spent} contract reads; the deadline is not ` +
+           "being re-armed per detent");
+    if (labels(ctl) !== want("kosmos"))
+      fail("the settle after a fast jog did not land: " + labels(ctl));
+  }
+
+  /* ---- 4. the browse is not yanked out from under the user ------------- */
+  {
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    const pages = ctl.pages.map((p) => p.name);
+    const presetIdx = ctl.pages.findIndex((p) => p.kind === "preset");
+    if (presetIdx < 0) fail("clap planned no preset page");
+    ctl.goToPage(presetIdx);
+    const wasOn = ctl.pages[ctl.state.pageIndex].name;
+    dev.stagePlugin(contractFor("kosmos"), { debounceMs: DEBOUNCE_MS });
+    ctl.selectionChanged();
+    settle(ctl, dev, SETTLED_MS);
+    if (ctl.pages[ctl.state.pageIndex].name !== wasOn)
+      fail("the settle moved the user off " + wasOn + " to " +
+           ctl.pages[ctl.state.pageIndex].name);
+    if (ctl.pages.map((p) => p.name).join() !== pages.join())
+      fail("the settle changed the page set: " + ctl.pages.map((p) => p.name).join());
+  }
+
+  /* ---- 5. a knob being TURNED is not rebuilt underneath ----------------- */
+  {
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    const start = labels(ctl);
+    dev.stagePlugin(contractFor("kosmos"), { debounceMs: DEBOUNCE_MS });
+    ctl.selectionChanged();
+    ctl.onKnobTouch(0, true);
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) !== start)
+      fail("a held knob was rebuilt underneath the hand: " + labels(ctl));
+    ctl.onKnobTouch(0, false);
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) !== want("kosmos"))
+      fail("the deferred settle never ran after the knob was released: " + labels(ctl));
+  }
+
+  /* ---- 6. granny must not regress: retain-on-failed-read still holds ---- */
+  {
+    const dev = D.createFakeDevice({ id: "granny" });
+    const ctl = C.createController(dev);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    const keys = (ctl.pages[0] || {}).keys || [];
+    if (keys[0] !== "position") fail("granny knob 1 should be position, got " + keys[0]);
+
+    /* Same component, contract read fails: keep the plan we had. */
+    dev.failParam("ui_hierarchy", 1);
+    ctl.load({ slot: 0, component: "synth", prefix: "synth" });
+    if (((ctl.pages[0] || {}).keys || [])[0] !== "position")
+      fail("a failed re-read stopped retaining the granny plan: " +
+           JSON.stringify((ctl.pages[0] || {}).keys));
+    if (!ctl.contractUnresolved)
+      fail("a failed ui_hierarchy read is no longer recorded as unresolved");
+  }
+
+  /* ---- 7. a FAILED chain_params read must not blank every label --------- */
+  {
+    /* The sibling of the granny defect, one key over. ui_hierarchy answers,
+     * chain_params times out; parsing null as "declares nothing" rebuilt the
+     * metaIndex from the hierarchy alone and every knob lost its name, for
+     * the rest of the session, because nothing re-reads. */
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    if (labels(ctl) !== captured(dev)) fail("bad start: " + labels(ctl));
+
+    dev.failParam("chain_params", 1);
+    ctl.load({ slot: 0, component: "fx1", prefix: "fx1" });
+    if (/^param 0/.test(labels(ctl)))
+      fail("THE BUG: a failed chain_params read blanked the labels: " + labels(ctl));
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) !== captured(dev))
+      fail("a failed chain_params read did not recover: " + labels(ctl));
+  }
+
+
+  /* ---- 8. is_loading is asked ONCE by a module that does not serve it ---- */
+  {
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    const before = dev.readsFor("is_loading");
+    for (let i = 0; i < 3; i++) {
+      dev.stagePlugin(contractFor("kosmos"), { debounceMs: DEBOUNCE_MS });
+      ctl.selectionChanged();
+      settle(ctl, dev, SETTLED_MS);
+    }
+    const asked = dev.readsFor("is_loading") - before;
+    if (asked > 1)
+      fail(`is_loading was asked ${asked} times by a module that answers ""; ` +
+           "the support latch is not holding");
+  }
+
+  /* ---- 9. a module that DOES serve it settles on its ready edge --------- */
+  {
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    const ctl = openGrid(dev);            /* serves is_loading by default */
+    const before = dev.readsFor("chain_params");
+    dev.stagePlugin(contractFor("kosmos"), { debounceMs: DEBOUNCE_MS });
+    ctl.selectionChanged();
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) !== want("kosmos"))
+      fail("an is_loading-serving module did not settle: " + labels(ctl));
+    /* One confirming contract read, because the module said when to look. */
+    if (dev.readsFor("chain_params") - before > 1)
+      fail("is_loading bought no read back: " +
+           (dev.readsFor("chain_params") - before) + " contract reads");
+  }
+
+  /* ---- 10. a load landing AFTER the first probe is still picked up ------ */
+  {
+    /* The trap in comparing the first reading against the PRE-WRITE
+       fingerprint: an intermediate contract differs from it, so that
+       comparison calls it settled and stops — the original bug, one layer up.
+       Both agreeing readings have to post-date the deadline. */
+    const dev = D.createFakeDevice({ id: "clap", prefix: "fx1" });
+    dev.setServesIsLoading(false);
+    const ctl = openGrid(dev);
+    dev.stagePlugin(contractFor("kosmos"), {
+      debounceMs: C.CONTRACT_SETTLE_MS + 200,
+      during: contractFor("Ensemble"),     /* real, declared, NOT degenerate */
+    });
+    ctl.selectionChanged();
+    settle(ctl, dev, SETTLED_MS);
+    if (labels(ctl) === want("Ensemble"))
+      fail("THE TRAP: settled on the intermediate contract " + labels(ctl));
+    if (labels(ctl) !== want("kosmos"))
+      fail("did not reach the final contract: " + labels(ctl));
+  }
+
+  console.log("PASS: contract settle");
+}).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'

--- a/tests/host/test_param_pages_controller.sh
+++ b/tests/host/test_param_pages_controller.sh
@@ -926,6 +926,55 @@ Promise.all([
         fail("navigate_to should land on the level it names, got page " + ctl2.pageIndex);
     }
 
+    /* ---- ...and when that level is BOTH pages, it means the list --------
+     *
+     * Reported from the device as "jump to category lands on knobs, not the
+     * preset list". This is obxd: `banks` declares navigate_to `root`, and
+     * root carries list_param/count_param AND knobs, so it plans a preset
+     * browser AND a grid. Naming the level did not say which, and the lookup
+     * filtered to PAGE_KNOBS, so it could only ever find the grid.
+     *
+     * Driven off the real fleet fixture rather than a hand-written hierarchy:
+     * the whole reason this went unnoticed is that no invented contract has
+     * a level wearing both hats, and hand-rolling one here would pin the fix
+     * without pinning the case that motivated it.
+     *
+     * (No apostrophes anywhere in this file: the whole suite is one
+     * single-quoted node -e argument, and one would end it.)
+     */
+    {
+      const dev3 = D.createFakeDevice({ id: "obxd" });
+      const banks = [{ index: 0, label: "Factory" }, { index: 1, label: "Vintage" }];
+      const ctl3 = C.createController({
+        ...dev3,
+        getParam: (k) => {
+          const b = String(k).replace(/^[^:]+:/, "");
+          if (b === "fxb_bank_list") return JSON.stringify(banks);
+          if (b === "bank_index") return "0";
+          return dev3.getParam(k);
+        },
+      });
+      ctl3.load({ slot: 0, component: "synth" });
+
+      const banksAt = ctl3.pages.findIndex((p) => p.kind === "items" && p.level === "banks");
+      const rootPreset = ctl3.pages.findIndex((p) => p.level === "root" && p.kind === "preset");
+      const rootGrid = ctl3.pages.findIndex((p) => p.level === "root" && p.kind === "knobs");
+      if (banksAt < 0) fail("obxd fixture should plan a banks items page");
+      if (rootPreset < 0 || rootGrid < 0)
+        fail("obxd root should plan BOTH a preset browser and a grid - the whole point of this case");
+
+      ctl3.goToPage(banksAt, { remember: false });
+      for (let i = 0; i < 8; i++) ctl3.tick();
+      ctl3.onClick(-1);   /* enter the list */
+      ctl3.onClick(-1);   /* choose the highlighted bank */
+
+      if (ctl3.pageIndex === rootGrid)
+        fail("choosing a bank landed on the root knob grid - the reported bug");
+      if (ctl3.pageIndex !== rootPreset)
+        fail("choosing a bank should land on the root preset browser, got page " +
+             ctl3.pageIndex + " (" + (ctl3.page && ctl3.page.kind) + ")");
+    }
+
     /* ---- shift still escapes from inside -------------------------------- */
     ctl.goToPage(itemsAt, { remember: false });
     for (let i = 0; i < 6; i++) ctl.tick();

--- a/tests/host/test_param_pages_plan.sh
+++ b/tests/host/test_param_pages_plan.sh
@@ -223,6 +223,72 @@ import("./src/shared/param_pages/page_plan.mjs").then(async (m) => {
     if (kNone.size >= kAll.size) fail("visible_if evaluator had no effect");
   }
 
+  /* ---- 11. a FAILED contract read must not produce a page plan ---------- */
+  {
+    /*
+     * The wire has three answers for `<prefix>:ui_hierarchy` and only two of
+     * them are the same thing:
+     *
+     *   JSON      the module declares this hierarchy
+     *   ""        the module declares NO hierarchy      -> paginate chain_params
+     *   null      the READ FAILED (param channel busy)  -> we know nothing
+     *
+     * The first two both parse to something the planner can act on; a failed
+     * read parses to nothing, which is indistinguishable from absence by the
+     * time it gets here — the fleet capture itself records `ui_hierarchy: null`
+     * for the four modules that genuinely have none. So the caller, the only
+     * one that saw the wire, passes `unresolved`.
+     *
+     * Collapsing the two is the granny bug: pick a sample, granny loads the WAV
+     * synchronously on the param-serving thread, the ui_hierarchy read times
+     * out at 100 ms, and the planner happily paginates chain_params instead —
+     * whose first entry is `sample_path`, so the sample file lands on knob 1
+     * and every other knob shifts.
+     */
+    const g = fx.modules.find((x) => x.id === "granny");
+    if (!g) fail("fixture has no module \"granny\"");
+    if (g.chain_params[0].key !== "sample_path")
+      fail("granny fixture changed: chain_params[0] is no longer sample_path, " +
+           "so this test no longer reproduces the reported bug");
+
+    const good = planPages({ hierarchy: g.ui_hierarchy, chainParams: g.chain_params });
+    if (good.pages[0].keys[0] !== "position")
+      fail("granny page 1 knob 1 should be position, got " + good.pages[0].keys[0]);
+    if (good.unresolved) fail("a good contract was reported unresolved");
+
+    /* What the bug looked like: chain_params paginated as though the module had
+     * declared no hierarchy at all. Pinned so the symptom stays legible. */
+    const asAbsent = planPages({ hierarchy: null, chainParams: g.chain_params });
+    if (asAbsent.pages[0].keys[0] !== "sample_path")
+      fail("the granny chain_params fallback no longer starts with sample_path — " +
+           "this test no longer describes the reported symptom");
+
+    /* ...and that is exactly what an unresolved read must NOT produce. */
+    for (const h of [null, g.ui_hierarchy]) {
+      const r = planPages({ hierarchy: h, chainParams: g.chain_params, unresolved: true });
+      if (!r.unresolved) fail("planPages did not report unresolved back to the caller");
+      if (r.pages.length !== 0)
+        fail("an unresolved contract produced " + r.pages.length + " page(s): " +
+             JSON.stringify((r.pages[0] || {}).keys));
+      if ((r.pages[0] || { keys: [] }).keys[0] === "sample_path")
+        fail("an unresolved contract put sample_path on knob 1");
+    }
+
+    /* ...and the fallback that legitimately exists must be untouched: four
+     * fleet modules publish chain_params and no hierarchy at all. */
+    for (const id of ["branchage", "belt-in", "po32-drum", "smack-in"]) {
+      const m = fx.modules.find((x) => x.id === id);
+      if (!m) continue;
+      if (m.ui_hierarchy) fail(id + " grew a ui_hierarchy; pick another no-hierarchy module");
+      const r = planPages({ hierarchy: m.ui_hierarchy, chainParams: m.chain_params });
+      if (r.unresolved) fail(id + ": genuine absence was reported as unresolved");
+      if (!r.pages.length) fail(id + ": chain_params pagination fallback stopped working");
+      if (r.pages[0].name !== "Params") fail(id + ": fallback page 1 is named " + r.pages[0].name);
+      if (r.pages[0].keys[0] !== m.chain_params[0].key)
+        fail(id + ": fallback no longer paginates in declaration order");
+    }
+  }
+
   console.log("PASS: param-page planner — " + fx.modules.length + " modules, " + totalPages +
               " pages, every declared key reachable, no duplicate page names");
 });

--- a/tests/host/test_shadow_param_editor_routing.sh
+++ b/tests/host/test_shadow_param_editor_routing.sh
@@ -90,6 +90,10 @@ const CHAIN_PARAMS = [
     filepath_param: "sample_path", min: 0, max: 1, step: 0.01 },
   { key: "sample_path", name: "Sample File", type: "filepath",
     root: "/tmp", filter: ".wav" },
+  /* An enum, reported by NAME — the chord case. Divable now (clicking a held
+   * enum knob opens its option list) while the knob still steps it. */
+  { key: "mode", name: "Mode", type: "enum",
+    options: ["Hall", "Room", "Plate", "Cave"] },
 ];
 /*
  * Shaped like granny ON PURPOSE: root puts the params on KNOBS but its params[]
@@ -116,11 +120,11 @@ const HIERARCHY = {
       label: "Main",
       knobs: ["gain", ...FILLER],
       params: [{ key: "gain" }, ...FILLER.map((k) => ({ key: k })),
-               { key: "position" }, { key: "sample_path" }],
+               { key: "position" }, { key: "sample_path" }, { key: "mode" }],
     },
   },
 };
-const values = { gain: "0.5", position: "0.25", sample_path: "" };
+const values = { gain: "0.5", position: "0.25", sample_path: "", mode: "Hall" };
 for (const k of FILLER) values[k] = "0.5";
 function getParam(key) {
   const bare = String(key).replace(/^[^:]+:/, "");
@@ -343,6 +347,142 @@ function gotoSlotFor(name) {
   }
 }
 
+/* ---- 7. an ENUM opens the OPTION PICKER, and the knob still turns it ----
+ *
+ * Every enum is a door now. The knob keeps stepping the value -- that is what
+ * makes this different from the opaque types, which a knob cannot drive at all
+ * -- so both abilities are asserted on the same param.
+ *
+ * There is deliberately NO bracket mark on an enum cell (see
+ * test_enum_picker.sh); the whole affordance is the footer flipping to
+ * CLK OPEN, which is why that is checked here rather than left implicit.
+ */
+{
+  openGrid();
+  const slot = gotoSlotFor("mode");
+  if (slot < 0) {
+    fail("mode never reached the grid");
+  } else {
+    const pageName = (V.currentParamPage() || {}).name;
+    feed(noteOn(slot));
+
+    const held = V.paramPagesFooterHints() || [];
+    if (!held.length || held[1] === undefined || held[1][1] !== "OPEN") {
+      fail("holding an ENUM knob must say CLK OPEN, got " +
+           JSON.stringify((held || []).map((p) => p.join(" ")).join(" / ")) +
+           " -- the footer is the ONLY affordance an enum gets, because the " +
+           "bracket mark is deliberately withheld from enums");
+    }
+
+    feed(click());
+    if (ctx.activeParamEditor() !== "enum") {
+      fail("clicking a held enum opened " + JSON.stringify(ctx.activeParamEditor()) +
+           ", expected the option picker. A \"value\" here is the inline nudge " +
+           "editor openHierarchyParamEditor falls through to, which is the gap " +
+           "this fills");
+    }
+    /*
+     * The grid CONTROLLER must survive. An enum picker does not go the long way
+     * round through the list editor the way a filepath does — it has the
+     * options and the index already — so the grid is not torn down and rebuilt,
+     * and the commit closure it handed over is still pointing at a live
+     * controller. If this is null the hand-off has gone through
+     * openParamEditorFromGrid, which calls exitParamPages(), and the commit
+     * below would write through a corpse.
+     */
+    if (!V.currentParamPage()) {
+      fail("the grid was torn down to open the option picker -- the enum path " +
+           "must keep the controller alive, the way the LFO target picker does");
+    }
+
+    /* Scroll one and commit. The value must go out as a NAME: this fixtures
+     * plugin reports "Hall", so an index would be silently discarded by a
+     * strcmp ladder (the chord bug). */
+    feed([0xb0, 14, 1]);
+    feed(click());
+    if (values.mode !== "Room") {
+      fail("committing the picker wrote " + JSON.stringify(values.mode) +
+           ", expected \"Room\" -- the wire format must be auto-detected from " +
+           "what the plugin reports, not hardcoded to String(index)");
+    }
+    if (ctx.view !== ctx.VIEWS.PARAM_PAGES) {
+      fail("committing the picker landed on view " + ctx.view + ", expected the grid");
+    } else {
+      const b = V.currentParamPage();
+      if (!b || b.name !== pageName) {
+        fail("committing the picker landed on page " + JSON.stringify(b && b.name) +
+             ", expected " + JSON.stringify(pageName));
+      }
+      /*
+       * The note-off for the held knob went to the PICKER, so the grid never
+       * saw it. Unless the hand-off drops the touch, that cell stays
+       * highlighted for good -- which is exactly what clearParamPagesTouch
+       * exists for. Observed through the footer, which says CLK OPEN only
+       * while a divable knob is held.
+       */
+      const after = V.paramPagesFooterHints() || [];
+      if (after[1] && after[1][1] === "OPEN") {
+        fail("the grid still thinks the enum knob is held after the picker " +
+             "returned -- the note-off went to the picker, so the hand-off " +
+             "must clear the touch");
+      }
+    }
+    feed(noteOff(slot));
+  }
+}
+
+/* ---- 8. Back out of the picker leaves the value ALONE ------------------- */
+{
+  openGrid();
+  const slot = gotoSlotFor("mode");
+  if (slot < 0) {
+    fail("mode never reached the grid for the cancel case");
+  } else {
+    const before = values.mode;
+    feed(noteOn(slot));
+    feed(click());
+    if (ctx.activeParamEditor() !== "enum") fail("the picker did not open for the cancel case");
+    feed([0xb0, 14, 1]);
+    feed([0xb0, 14, 1]);
+    if (values.mode !== before) {
+      fail("scrolling the picker wrote " + JSON.stringify(values.mode) +
+           " -- scrolling must not commit, or Back has nothing to cancel");
+    }
+    feed(back());
+    if (values.mode !== before) {
+      fail("Back out of the picker changed the value to " + JSON.stringify(values.mode) +
+           ", expected it untouched at " + JSON.stringify(before));
+    }
+    if (ctx.view !== ctx.VIEWS.PARAM_PAGES) {
+      fail("Back out of the picker landed on view " + ctx.view + ", expected the grid");
+    }
+    feed(noteOff(slot));
+  }
+}
+
+/* ---- 8b. the knob still STEPS the enum -------------------------------- */
+{
+  openGrid();
+  const slot = gotoSlotFor("mode");
+  if (slot < 0) {
+    fail("mode never reached the grid for the turn case");
+  } else {
+    const before = values.mode;
+    feed(noteOn(slot));
+    for (let i = 0; i < 24; i++) feed([0xb0, 71 + slot, 1]);
+    for (let i = 0; i < 8; i++) V.tickParamPages();
+    feed(noteOff(slot));
+    for (let i = 0; i < 4; i++) V.tickParamPages();
+    if (values.mode === before) {
+      fail("turning the enum knob no longer moves it (still " + JSON.stringify(before) +
+           ") -- making it divable must not make it opaque");
+    }
+    if (ctx.view !== ctx.VIEWS.PARAM_PAGES) {
+      fail("turning the enum knob left the grid, view=" + ctx.view);
+    }
+  }
+}
+
 /* ---- 9. SLOT SETTINGS opens as a grid and its menu runs the real actions -- */
 {
   const slotStore = {
@@ -372,6 +512,50 @@ function gotoSlotFor(name) {
 
     /* The io must be reaching the real store, not a component. */
     if (V.paramPagesComponent() !== "slot") fail("the grid is not pointed at the slot");
+
+    /* ---- 9a. the enum picker on a SYNTHESISED contract --------------------
+     *
+     * Slot settings is where the picker earns its keep — Fwd Ch has eighteen
+     * options — and it is also the case that cannot go through the list
+     * editor at all: "slot" has no ui_hierarchy, so openParamEditorFromGrid
+     * refuses everything but the LFO target. The enum path therefore must NOT
+     * be routed through there.
+     *
+     * And the commit must go back through the CONTROLLER, not straight to
+     * setSlotParam: Fwd is stored offset (Thru = -2, Auto = -1) by the slot
+     * io, so a picker that wrote the raw index would move every channel two
+     * places. Index 3 is "Ch 2", which the io stores as 1.
+     */
+    {
+      const fwd = ((V.currentParamPage() || {}).keys || []).indexOf("forward_channel");
+      if (fwd < 0) {
+        fail("forward_channel is not on the slot grid page");
+      } else {
+        feed(noteOn(fwd));
+        feed(click());
+        if (ctx.activeParamEditor() !== "enum") {
+          fail("clicking Fwd Ch on slot settings opened " +
+               JSON.stringify(ctx.activeParamEditor()) + " — a synthesised " +
+               "contract has no hierarchy to fall back to, so this must not be " +
+               "routed through the list editor");
+        } else {
+          feed([0xb0, 14, 1]);   /* Auto -> Ch 1 */
+          feed([0xb0, 14, 1]);   /* Ch 1  -> Ch 2 */
+          feed(click());
+          if (slotStore["slot:forward_channel"] !== "1") {
+            fail("the picker stored forward_channel as " +
+                 JSON.stringify(slotStore["slot:forward_channel"]) +
+                 ", expected \"1\" (Ch 2) — the commit must go through the slot " +
+                 "io, which offsets Thru/Auto, not straight to setSlotParam");
+          }
+          if (ctx.view !== ctx.VIEWS.PARAM_PAGES) {
+            fail("committing on slot settings landed on view " + ctx.view);
+          }
+        }
+        feed(noteOff(fwd));
+        for (let i = 0; i < 4; i++) V.tickParamPages();
+      }
+    }
 
     /* A slot has no module to abbreviate, so the header read "S1 > ---". */
     const titles = [];

--- a/tools/param-pages/fake_device.mjs
+++ b/tools/param-pages/fake_device.mjs
@@ -54,6 +54,19 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
     let loading = false;
     const lag = Object.create(null);      /* key -> { remaining, value } */
     const failing = Object.create(null);  /* key -> reads still to fail */
+    let staged = null;                    /* see stagePlugin */
+    /*
+     * A clock the test drives.
+     *
+     * A debounce is measured in MILLISECONDS, not in reads — the whole defect
+     * is that the UI re-reads too SOON, and a read-counted debounce cannot
+     * express "too soon" because it is the reads themselves that move it along.
+     * Pass this as `io.now` and advance it explicitly.
+     */
+    let clock = 0;
+    /** Whether this device answers `is_loading` at all. Almost no module does,
+     *  and a fix that depends on it would be a fix for a fleet of one. */
+    let servesIsLoading = true;
 
     const seed = () => {
         for (const p of (mod.chain_params || [])) {
@@ -80,8 +93,25 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
          * buffer, and the JS binding hands that back as an empty string. Only
          * an unservable request is null. */
         if (bare === "ui_hierarchy") return mod.ui_hierarchy ? JSON.stringify(mod.ui_hierarchy) : "";
-        if (bare === "chain_params") return mod.chain_params ? JSON.stringify(mod.chain_params) : "";
-        if (bare === "is_loading") return loading ? "1" : "0";
+        if (bare === "chain_params") {
+            /*
+             * A staged contract is not visible until its debounce has run out
+             * — see stagePlugin. Until then this answers with what is still
+             * LOADED, which is the previous selection's contract, and that is
+             * the whole of the airwindows one-behind bug.
+             */
+            if (staged) {
+                const pending = staged.reads > 0 || clock < staged.untilMs;
+                if (pending) { if (staged.reads > 0) staged.reads--; return JSON.stringify(staged.during); }
+                mod = { ...mod, chain_params: staged.after };
+                staged = null;
+            }
+            return mod.chain_params ? JSON.stringify(mod.chain_params) : "";
+        }
+        /* An unserved key answers "", not null — see the header. Almost nothing
+         * in the fleet implements is_loading, so a test can turn it off and
+         * prove the behaviour under test does not secretly depend on it. */
+        if (bare === "is_loading") return servesIsLoading ? (loading ? "1" : "0") : "";
 
         /* A lagging param serves its stale value for a few reads — this is the
          * race that makes write-back suppression necessary rather than tidy. */
@@ -110,6 +140,11 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
 
         /* device behaviours a test can provoke */
         setLoading: (on) => { loading = !!on; },
+        /** The injectable clock. Pass as `io.now`; move it with `advance`. */
+        now: () => clock,
+        advance: (ms) => { clock += ms; return clock; },
+        /** Stop answering `is_loading` at all — what the fleet actually does. */
+        setServesIsLoading: (on) => { servesIsLoading = !!on; },
         /** Swap the loaded module, as an async load finishing with a bigger tree. */
         becomeModule: (newId) => { mod = moduleById(newId); seed(); },
         /** Rewrite the loaded module's chain_params, as a DSP does when it
@@ -127,6 +162,39 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
          * contract read the UI issues milliseconds later gets nothing back.
          */
         failParam: (bare, n) => { failing[bare] = { remaining: n }; },
+        /**
+         * Select something whose contract only arrives after a debounce.
+         *
+         * schwung-airwindows is the case this exists for. Writing
+         * `plugin_index` updates `selected_plugin_index` synchronously — so
+         * `plugin_name` is immediately right — but only SCHEDULES the plugin
+         * load on a worker thread, 300 ms later
+         * (clap_fx.cpp:806-822, PLUGIN_LOAD_DEBOUNCE_MS). `chain_params` is
+         * generated from `cached_param_names`, which is not rewritten until
+         * that load finishes, so for the whole debounce it reports the
+         * PREVIOUS effect.
+         *
+         * @param {Array}  after         the contract once the load lands
+         * @param {object} [o]
+         * @param {number} [o.debounceReads]  reads served stale first
+         * @param {number} [o.debounceMs]     ms of CLOCK the load takes. The
+         *                                    honest unit: 300 ms of debounce
+         *                                    plus the dlopen. Reads do not
+         *                                    move it along, which is the point.
+         * @param {Array}  [o.during]         what is served meanwhile;
+         *                                    defaults to the current contract,
+         *                                    which is what the module does.
+         *                                    Pass [] for the window in which
+         *                                    the plugin pointer is NULL.
+         */
+        stagePlugin: (after, { debounceReads = 0, debounceMs = 0, during } = {}) => {
+            staged = {
+                reads: debounceReads,
+                untilMs: clock + debounceMs,
+                during: during !== undefined ? during : (mod.chain_params || []),
+                after,
+            };
+        },
         get moduleId() { return mod.id; },
     };
 }

--- a/tools/param-pages/fake_device.mjs
+++ b/tools/param-pages/fake_device.mjs
@@ -52,7 +52,8 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
     const writes = [];
     const announcements = [];
     let loading = false;
-    const lag = Object.create(null);     /* key -> { remaining, value } */
+    const lag = Object.create(null);      /* key -> { remaining, value } */
+    const failing = Object.create(null);  /* key -> reads still to fail */
 
     const seed = () => {
         for (const p of (mod.chain_params || [])) {
@@ -69,8 +70,17 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
         if (!key.startsWith(prefix + ":")) return null;
         const bare = key.slice(prefix.length + 1);
 
-        if (bare === "ui_hierarchy") return mod.ui_hierarchy ? JSON.stringify(mod.ui_hierarchy) : null;
-        if (bare === "chain_params") return mod.chain_params ? JSON.stringify(mod.chain_params) : null;
+        /* A read the param channel could not SERVE answers null, and it is not
+         * the same answer as "" — see failParam. Checked first, because the
+         * contract keys below are exactly the ones worth failing. */
+        const f = failing[bare];
+        if (f && f.remaining > 0) { f.remaining--; return null; }
+
+        /* Genuine absence is "": the shim replies with an error and a zeroed
+         * buffer, and the JS binding hands that back as an empty string. Only
+         * an unservable request is null. */
+        if (bare === "ui_hierarchy") return mod.ui_hierarchy ? JSON.stringify(mod.ui_hierarchy) : "";
+        if (bare === "chain_params") return mod.chain_params ? JSON.stringify(mod.chain_params) : "";
         if (bare === "is_loading") return loading ? "1" : "0";
 
         /* A lagging param serves its stale value for a few reads — this is the
@@ -107,6 +117,16 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
         patchChainParams: (fn) => { mod = { ...mod, chain_params: fn(JSON.parse(JSON.stringify(mod.chain_params || []))) }; },
         /** Make a key serve a stale value for the next `n` reads. */
         lagParam: (bare, staleValue, n) => { lag[bare] = { remaining: n, value: String(staleValue) }; },
+        /**
+         * Make a key FAIL for the next `n` reads — null, the way the binding
+         * answers when it cannot claim the param channel within its 100 ms
+         * timeout. Distinct from an absent key, which answers "".
+         *
+         * This is the granny sequence: picking a sample makes the module load a
+         * WAV synchronously on the thread that serves param requests, and the
+         * contract read the UI issues milliseconds later gets nothing back.
+         */
+        failParam: (bare, n) => { failing[bare] = { remaining: n }; },
         get moduleId() { return mod.id; },
     };
 }

--- a/tools/spike/create_instance_audit.py
+++ b/tools/spike/create_instance_audit.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Audit what every plugin's create_instance reaches.
+
+Run from schwung-parent/ (the directory holding all the module repos):
+
+    python3 schwung/tools/spike/create_instance_audit.py
+
+For each repo, resolve `.create_instance = <fn>` to the real function (it is
+almost never literally named create_instance, which is why a naive grep
+under-reports), brace-match its body, transitively expand every locally defined
+function it calls in the same translation unit, and report the host_api_v1_t
+members reached plus any thread/IO calls.
+
+Findings and what they mean for residual 2.6 are in
+docs/plans/2026-08-21-create-instance-thread-spike.md. Re-run before relying on
+that document: the fleet is allowed to change under us.
+"""
+import re,os,glob
+roots=[d for d in glob.glob('schwung-*')+glob.glob('move-anything-*') if os.path.isdir(d+'/.git') and 'backup' not in d]
+HOSTCALL=re.compile(r'->\s*(log|midi_send_internal|midi_send_external|midi_inject_to_move|mod_emit_value|mod_clear_source|get_clock_status|get_bpm|get_beat_position|slot_recv_channel|mapped_memory|sample_rate|frames_per_block|audio_in_offset|audio_out_offset)\b')
+RISK=re.compile(r'\b(pthread_create|dlopen|fopen|open\s*\(|system\s*\(|popen|curl_easy_perform|mmap|shm_open)\b')
+def fnbody(src,name):
+    for m in re.finditer(r'(?<![\w.])'+re.escape(name)+r'\s*\(',src):
+        i=m.end()-1;d=0;j=i
+        while j<len(src):
+            if src[j]=='(':d+=1
+            elif src[j]==')':
+                d-=1
+                if d==0:break
+            j+=1
+        k=j+1
+        while k<len(src) and src[k] in ' \t\r\n':k+=1
+        if k<len(src) and src[k]=='{':
+            d=0;e=k
+            while e<len(src):
+                if src[e]=='{':d+=1
+                elif src[e]=='}':
+                    d-=1
+                    if d==0:break
+                e+=1
+            return src[k:e+1]
+    return None
+CALL=re.compile(r'(?<![\w.>])([a-zA-Z_]\w{2,})\s*\(')
+KW={'if','for','while','switch','return','sizeof','snprintf','memset','memcpy','calloc','malloc','free','strcmp','strncmp','strcpy','strncpy','atoi','atof','strdup','printf','fprintf','sprintf','strlen','realloc','static_cast','reinterpret_cast','const_cast','dynamic_cast','new','delete','catch','strstr','strchr','sscanf'}
+for r in sorted(roots):
+    files=[f for f in glob.glob(r+'/src/**/*',recursive=True) if f.endswith(('.c','.cpp','.cc'))]
+    for f in files:
+        try:s=open(f,errors='ignore').read()
+        except:continue
+        m=re.search(r'\.create_instance\s*=\s*([A-Za-z_]\w*)',s)
+        if not m:continue
+        fn=m.group(1)
+        seen=set();stack=[fn];host=set();risk=set()
+        while stack:
+            n=stack.pop()
+            if n in seen or len(seen)>60:continue
+            seen.add(n)
+            b=fnbody(s,n)
+            if b is None:continue
+            host|=set(HOSTCALL.findall(b))
+            risk|=set(x.strip('( ') for x in RISK.findall(b))
+            for c in CALL.findall(b):
+                if c not in KW and c not in seen: stack.append(c)
+        print(f"{r:26s} {os.path.basename(f):24s} entry={fn:22s} host={sorted(host)} risk={sorted(risk)}")


### PR DESCRIPTION
Three defects found from hardware in one session. One root: **a value the UI could not interpret was turned into a confident guess instead of a question.**

## 1. Enum writes were index-only, so name-only plugins silently ignored them

The knob grid held an enum as a number end to end and always wrote `String(idx)`. `chord`'s `set_param` is a `strcmp` ladder over the option **names** with no trailing `else`, so every write was discarded while the renderer drew `options[idx]` — the value appeared to move and snapped back. It never moved: "always reverts to major" was simply where it started.

The grid now **learns the convention** from what `get_param` reports, latching per key.

- **It cannot use its own cache.** The grid's writes populate `s.values`, so inferring from it locks into index mode after one write. Detection uses only values that came from the DSP.
- **It adds no IPC.** It rides two reads that already happen — the staggered read cursor, and the first-turn seeding read. A cursor-only design would write indices until the cursor came round, polluting the cache on the way; there is a test for exactly that.
- `options_as_string: true` remains an explicit override and is checked first. The 8 declarations here are the built-ins whose DSP accepts names only.

Two bugs fixed in passing: enum knob state was seeded with `Number(value)`, and `Number("major")` is `NaN`, so every name-reporting enum seeded at option 0; and `short_options` / enum-driven graphics were already broken for the same reason. `arp`'s `division` was worse than the rest — its `else atof(val)` turned index `3` into a division of `3.0` rather than rejecting it.

## 2. Enums had no list

Every enum with declared options is now divable — hold the knob, click, pick from a list — **while the knob keeps turning it**.

`meta.divable` and `meta.divable_mark` are now separate questions. There are **135 enums in the fleet against 5 opaque params**; marking them all would destroy what the bracket means, and for an opaque cell the brackets *are* `drawOpaqueBox`'s frame. **Net pixel change on the grid is zero.** The affordance is the footer's `CLK OPEN`. Mutation-checked in both directions, so neither "brackets everywhere" nor "brackets nowhere" can pass.

The picker wears the movy chrome from **both** entry points and reuses the one shared list widget — a caller test inside a shared draw is how the module picker drifted before. Row capacity is 5 before and after (the obvious `MENU_LIST_Y` would have silently eaten one, so it is asserted as `CAPACITY === OLD_CAPACITY`). It also fixes an unnoticed clip: the old chrome passed the raw title through untruncated, drawing 332 pixels off-screen for a long name.

## 3. A failed contract read produced a page plan

Reported as: *"in granny when I select a sample it reorders the knobs and puts the sample file in knob position 1, until I go into the waveform editor and back."*

granny loads a WAV **synchronously inside `set_param`**, on the SPI thread that serves param requests. The write times out at 100 ms, and the grid rebuild in the same JS handler reads `ui_hierarchy` and gets nothing. `null` (claim failed) and `""` (unserved) both collapsed to "this module has no hierarchy", so the grid paginated `chain_params` instead — and granny emits `sample_path` first. It then **latched**, because the fallback metadata looked complete enough to settle.

Reproduced headlessly against the repo's own 76-module fixture:

```
GOOD page 1 "Main":   position, size_ms, density, spray, jitter, scan, grain_gain, quality
BAD  page 1 "Params": sample_path, position, size_ms, density, spray, jitter, scan, pitch_semi
```

The controller now branches on the raw value **before** parsing, plans nothing on a failure, retries on the existing cadence (zero reads once resolved), and cannot settle while unresolved. Genuine absence still paginates.

## Testing

Five new test files. Every fix has a test that was **verified to fail first**, several against a clean worktree at HEAD. Full suite failure list is byte-identical to the pre-change baseline. Read-budget tests (`test_chain_edit_read_budget.sh`, `test_chain_knob_card_reads.sh`) stay green — no new per-frame IPC anywhere.

## Not fixed here

granny's blocking `fopen`/read on the audio callback is a real realtime violation in its own repo and the underlying cause of the timeout — `live_preview: true` means it reloads on **every scroll**. The host now survives it; the audio stall remains. Same class as the 673 ms module-load measurement in `docs/REALTIME_SAFETY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56