### PR TITLE
param pages: a door you were SENT to opens

### DIFF
--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -994,7 +994,31 @@ export function createController(io = {}) {
         }
         if (target < 0) target = firstGrid(s.pages);
         announce(it.label);
-        if (target >= 0 && target !== s.pageIndex) goToPage(target, { remember: false });
+        /*
+         * Arriving by CHOOSING is not the same as arriving by paging.
+         *
+         * The jog is inert on a door until you click in — that rule exists so
+         * paging past a preset browser cannot audition every preset it passes.
+         * But you did not page here, you chose your way here, and reported from
+         * the device: "factory does dump me to presets, but shouldn't presets
+         * be already active? I have to click into it." One deliberate gesture
+         * should not need a second one to take effect.
+         *
+         * So a door you were SENT to opens. Landing on a grid is unchanged —
+         * there is nothing to enter — and paging in afterwards still has to
+         * click, because that is the case the rule was written for.
+         *
+         * Entering writes nothing. A preset browser auditions on TURN, not on
+         * entry, so this hands you the jog without loading anything.
+         */
+        if (target >= 0 && target !== s.pageIndex) {
+            const willEnter = isDoor(s.pages[target]);
+            goToPage(target, { remember: false, silent: willEnter });
+            /* enterMenu refuses an empty list — then nobody has spoken yet. */
+            if (willEnter && !enterMenu()) announcePageChange();
+        } else if (isDoor(page())) {
+            enterMenu();
+        }
         return true;
     }
 
@@ -1290,8 +1314,15 @@ export function createController(io = {}) {
         return s.pageIndex;
     }
 
-    /** Jump straight to a page (from the index or group picker). */
-    function goToPage(index, { remember = true } = {}) {
+    /**
+     * Jump straight to a page (from the index or group picker).
+     *
+     * `silent` is for the one caller that is going to say something better in
+     * the same breath — commitItem, which lands on a door and immediately
+     * enters it. Without it the screen reader utters the item you chose, then
+     * the page name, then the entered list, and only the third is news.
+     */
+    function goToPage(index, { remember = true, silent = false } = {}) {
         /* Paging away cannot leave a menu entered — returning later would
          * silently hand the jog back to the list. (Page names are unique, so
          * this and "any index change" are the same rule; onJog carries the
@@ -1306,7 +1337,7 @@ export function createController(io = {}) {
         s.cursor = 0;
         s.touched = -1;
         s.turnClaimMs = 0;
-        announcePageChange();
+        if (!silent) announcePageChange();
         return s.pageIndex;
     }
 

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -995,30 +995,12 @@ export function createController(io = {}) {
         if (target < 0) target = firstGrid(s.pages);
         announce(it.label);
         /*
-         * Arriving by CHOOSING is not the same as arriving by paging.
-         *
-         * The jog is inert on a door until you click in — that rule exists so
-         * paging past a preset browser cannot audition every preset it passes.
-         * But you did not page here, you chose your way here, and reported from
-         * the device: "factory does dump me to presets, but shouldn't presets
-         * be already active? I have to click into it." One deliberate gesture
-         * should not need a second one to take effect.
-         *
-         * So a door you were SENT to opens. Landing on a grid is unchanged —
-         * there is nothing to enter — and paging in afterwards still has to
-         * click, because that is the case the rule was written for.
-         *
-         * Entering writes nothing. A preset browser auditions on TURN, not on
-         * entry, so this hands you the jog without loading anything.
+         * A door you were SENT to opens — see goToPage. Reported from the
+         * device: "factory does dump me to presets, but shouldn't presets be
+         * already active? I have to click into it." Entering writes nothing; a
+         * browser auditions on TURN, so this hands you the jog without loading.
          */
-        if (target >= 0 && target !== s.pageIndex) {
-            const willEnter = isDoor(s.pages[target]);
-            goToPage(target, { remember: false, silent: willEnter });
-            /* enterMenu refuses an empty list — then nobody has spoken yet. */
-            if (willEnter && !enterMenu()) announcePageChange();
-        } else if (isDoor(page())) {
-            enterMenu();
-        }
+        if (target >= 0) goToPage(target, { remember: false, enterIfDoor: true });
         return true;
     }
 
@@ -1221,7 +1203,10 @@ export function createController(io = {}) {
         if (!s.pickerOpen) return false;
         const entry = s.pickerEntries[s.pickerIndex];
         s.pickerOpen = false;
-        if (entry) goToPage(entry.index);
+        /* Naming a section in the picker is choosing it, not paging past it —
+         * reported for airwindows, where Presets and Jump To Category are both
+         * sections and both arrived shut. Same rule as navigate_to. */
+        if (entry) goToPage(entry.index, { enterIfDoor: true });
         return true;
     }
 
@@ -1317,12 +1302,24 @@ export function createController(io = {}) {
     /**
      * Jump straight to a page (from the index or group picker).
      *
-     * `silent` is for the one caller that is going to say something better in
-     * the same breath — commitItem, which lands on a door and immediately
-     * enters it. Without it the screen reader utters the item you chose, then
-     * the page name, then the entered list, and only the third is news.
+     * `enterIfDoor` is the difference between arriving by PAGING and arriving
+     * by CHOOSING. The jog is inert on a door until you click in, so that
+     * paging past a preset browser cannot audition every preset it passes —
+     * but a page you named, from a picker or by following a navigate_to, was
+     * not passed, it was asked for. Needing a second gesture to make the first
+     * one take effect is the bug; both of those callers opt in, and everything
+     * that pages keeps the old rule.
+     *
+     * Deciding it HERE rather than at the call site is not tidiness: with
+     * `remember` on, restoreSection can land you on a different page of the
+     * section than the index you passed, so only this function knows what you
+     * actually arrived at.
+     *
+     * The enter does the announcing when it happens — otherwise the reader
+     * utters the item you chose, then the page name, then the entered list,
+     * and only the last is news.
      */
-    function goToPage(index, { remember = true, silent = false } = {}) {
+    function goToPage(index, { remember = true, enterIfDoor = false } = {}) {
         /* Paging away cannot leave a menu entered — returning later would
          * silently hand the jog back to the list. (Page names are unique, so
          * this and "any index change" are the same rule; onJog carries the
@@ -1330,14 +1327,19 @@ export function createController(io = {}) {
         if (s.menuEntered && s.pages[index] && s.pages[index].name !== s.menuEntered) {
             s.menuEntered = null;
         }
-        if (index === s.pageIndex) return s.pageIndex;
+        if (index === s.pageIndex) {
+            /* Naming the page you are already on still means "open it". */
+            if (enterIfDoor && isDoor(page()) && !menuEntered()) enterMenu();
+            return s.pageIndex;
+        }
         rememberSection();
         const target = Math.max(0, Math.min(s.pages.length - 1, index));
         s.pageIndex = remember ? restoreSection(target) : target;
         s.cursor = 0;
         s.touched = -1;
         s.turnClaimMs = 0;
-        if (!silent) announcePageChange();
+        /* enterMenu refuses an empty list, and then nobody has spoken yet. */
+        if (!(enterIfDoor && isDoor(page()) && enterMenu())) announcePageChange();
         return s.pageIndex;
     }
 

--- a/tests/host/test_param_pages_controller.sh
+++ b/tests/host/test_param_pages_controller.sh
@@ -973,6 +973,18 @@ Promise.all([
       if (ctl3.pageIndex !== rootPreset)
         fail("choosing a bank should land on the root preset browser, got page " +
              ctl3.pageIndex + " (" + (ctl3.page && ctl3.page.kind) + ")");
+
+      /* ...and it arrives ENTERED. Reported from the device once the landing
+       * was right: "shouldnt presets be already active? i have to click into
+       * it." The jog is inert on a door you PAGED to, so that browsing past
+       * one cannot audition every preset it passes — but this one was chosen,
+       * and one deliberate gesture should not need a second to take effect. */
+      if (!ctl3.menuEntered())
+        fail("a preset browser you were SENT to should arrive entered, not need a click");
+      /* Entering must not have written: a browser auditions on turn, not on
+       * arrival, so being handed the jog cannot load a preset by itself. */
+      if (dev3.writes.some(([k]) => /:preset$/.test(String(k))))
+        fail("arriving on the preset browser loaded a preset: " + JSON.stringify(dev3.writes));
     }
 
     /* ---- shift still escapes from inside -------------------------------- */

--- a/tests/host/test_param_pages_controller.sh
+++ b/tests/host/test_param_pages_controller.sh
@@ -275,6 +275,53 @@ Promise.all([
     if (ctl.pickerOpen) fail("touching a knob should dismiss the picker");
   }
 
+  /* ---- 9c-2. a section you NAME in the picker opens ----------------------
+   *
+   * Reported from the device for airwindows, whose whole picker is three
+   * sections -- Presets, Main, Jump to Category -- two of them doors: "if i
+   * choose presets (or jump to category) in airwindows, it is kind of weird
+   * that they are not already active". Same argument as navigate_to: the jog
+   * is inert on a door you PAGED past, so browsing cannot audition every
+   * preset it goes by, but naming a section is choosing it.
+   *
+   * Driven on clap deliberately -- it is the module reported, and the one
+   * where "the module id identifies the parameter set" is false, so it is
+   * worth keeping in the exercised set.
+   *
+   * (No apostrophes anywhere in this file: the whole suite is one
+   * single-quoted node -e argument, and one would end it.)
+   */
+  {
+    const { dev, ctl } = setup("clap");
+    ctl.dismissHint();
+    const presetAt = ctl.pages.findIndex((p) => p.kind === "preset");
+    if (presetAt < 0) fail("clap should plan a preset browser");
+    if (!ctl.openPicker()) fail("clap should offer a section picker");
+    /* Walk to the top of the picker, then forward to the browser. */
+    for (let i = 0; i < 16 && ctl.pickerIndex > 0; i++) ctl.onJog(-1);
+    for (let i = 0; i < 16 && ctl.pickerEntries[ctl.pickerIndex].index !== presetAt; i++) ctl.onJog(1);
+    if (ctl.pickerEntries[ctl.pickerIndex].index !== presetAt)
+      fail("the preset browser is not reachable as its own section");
+
+    dev.resetCounters();
+    ctl.pickerSelect();
+    if (ctl.pageIndex !== presetAt) fail("selecting did not land on the browser");
+    if (!ctl.menuEntered())
+      fail("a section you named in the picker should arrive entered, not need a click");
+    if (dev.writes.length)
+      fail("arriving on the browser wrote to the device: " + JSON.stringify(dev.writes));
+
+    /* The old rule survives where it was earned: PAGING onto a door leaves it
+     * shut, so browsing past a browser still cannot audition it. */
+    const ctl2 = setup("clap").ctl;
+    ctl2.dismissHint();
+    ctl2.goToPage(presetAt + 1, { remember: false });
+    if (ctl2.pageIndex !== presetAt + 1) fail("could not set up a page next to the browser");
+    ctl2.onJog(-1);
+    if (ctl2.pageIndex !== presetAt) fail("could not page onto the browser");
+    if (ctl2.menuEntered()) fail("PAGING onto a door must still leave it shut");
+  }
+
   /* ---- 9d. Elektron patterns: fine adjust, reset, section memory -------- */
   {
     /* Find a float with a declared default — 744 params across 39 modules


### PR DESCRIPTION
Follow-up to #223 (`c4226f42`), reported from the device:

> factory does dump me to presets, but shouldnt presets be already active? i have to click into it.

Choosing a bank now lands on the preset browser **entered**, so the jog is yours immediately.

### Why the old rule did not apply here

The jog is inert on a door until you click in. That rule is load-bearing — it is what stops paging past a preset browser from auditioning every preset it passes. But it was being applied to arrivals it was never about: you did not *page* here, you *chose* your way here, from inside another list. Needing a second gesture to make the first one take effect is the bug.

So a door you were **sent** to opens. Landing on a grid is unchanged (nothing to enter), and paging in afterwards still has to click — the case the rule was written for.

### Notes

- **Entering writes nothing.** A browser auditions on *turn*, not on entry, so this hands over the jog without loading a preset. Asserted, and probed for vacuity: writes *are* recorded at that point, so the no-write assertion is live.
- `goToPage` grows a `silent` flag for this one caller. Otherwise the screen reader utters the item you chose, then the page name, then the entered list, and only the last is news.
- Mutation-checked: removing the enter fails the test with the reported symptom.
- Local suite at the 32-failure `rg` baseline; compiled host units pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56