### PR TITLE
param_pages: make a two-state switch actually switch

### DIFF
--- a/src/shared/param_pages/movy_knob.mjs
+++ b/src/shared/param_pages/movy_knob.mjs
@@ -20,6 +20,8 @@
  * kind of "ported but currently inert" note.
  */
 
+import { BOOL_OPTION } from "./viz.mjs";
+
 /** Physical clicks per value step for a narrow int range, and for every enum. */
 export const ENUM_DELTA_DIV = 4;
 /** Sensitivity multiplier for a continuous arc-rendered knob — every knob in
@@ -64,6 +66,29 @@ function wideStepCount(state, direction, nowMs) {
     return direction * multiplier;
 }
 
+/**
+ * A two-state boolean, i.e. exactly what viz.mjs `detectSwitch` draws as a
+ * switch. Kept on the same BOOL_OPTION test so a control cannot be drawn as a
+ * switch but turned like a list (or the reverse).
+ */
+function isSwitchMeta(meta) {
+    const opts = Array.isArray(meta.options) ? meta.options : null;
+    return !!opts && opts.length === 2
+        && opts.every((o) => BOOL_OPTION.test(String(o).trim()));
+}
+
+/**
+ * Reversing direction drops whatever partial turn was banked the other way.
+ * Without it the residue is spent cancelling the new direction first, so a
+ * reversal costs up to div + (div - 1) detents — 7 at ENUM_DELTA_DIV 4 — and
+ * how many depends on where the previous turn happened to stop, which is why
+ * the same knob feels inconsistent from one reversal to the next.
+ */
+function clearOnReversal(state, delta) {
+    if (state.detentAccum !== 0 && Math.sign(state.detentAccum) !== Math.sign(delta))
+        state.detentAccum = 0;
+}
+
 export function movyKnobInit(initialValue) {
     return { value: initialValue, detentAccum: 0, lastTurnMs: 0, lastDirection: 0 };
 }
@@ -87,7 +112,17 @@ export function movyKnobTick(state, meta, delta, nowMs, fine = false) {
     if (delta === 0) return state.value;
 
     if (meta.kind === "enum" || meta.type === "enum") {
+        /* A switch has two states and no travel, so it flips on ONE detent, in
+         * the direction turned. Running it through the click gate below cost 4
+         * detents to move at all (and up to 7 to come back), which reads as a
+         * dead control: the drawn knob simply does not move when you turn it. */
+        if (isSwitchMeta(meta)) {
+            state.detentAccum = 0;
+            state.value = delta > 0 ? 1 : 0;
+            return state.value;
+        }
         const div = fine ? 1 : ENUM_DELTA_DIV;
+        clearOnReversal(state, delta);
         state.detentAccum += delta;
         const steps = Math.trunc(state.detentAccum / div);
         if (steps === 0) return state.value;
@@ -111,6 +146,7 @@ export function movyKnobTick(state, meta, delta, nowMs, fine = false) {
     const div = fine ? 1 : detentsPerStep(meta);
     let steps = delta;
     if (div > 1) {
+        clearOnReversal(state, delta);
         state.detentAccum += delta;
         steps = Math.trunc(state.detentAccum / div);
         if (steps === 0) return state.value;

--- a/src/shared/param_pages/viz.mjs
+++ b/src/shared/param_pages/viz.mjs
@@ -98,7 +98,9 @@ export function isGainRange(meta) {
 }
 
 const WAVEFORM_NAMES = /\b(sine|sin|tri|triangle|saw|sawtooth|square|pulse|ramp|noise|random|s\s?&\s?h|sample\s?&?\s?hold)\b/i;
-const BOOL_OPTION = /^(off|on|no|yes|0|1|false|true|disabled|enabled)$/i;
+/* Exported so movy_knob.mjs turns exactly the controls detectSwitch draws as a
+ * switch — the feel and the picture must agree on what a boolean is. */
+export const BOOL_OPTION = /^(off|on|no|yes|0|1|false|true|disabled|enabled)$/i;
 
 /**
  * Strip the matched role word out of a key, leaving whatever names the

--- a/src/shared/param_pages/viz_draw.mjs
+++ b/src/shared/param_pages/viz_draw.mjs
@@ -812,9 +812,19 @@ const SW_IN_W = [18, 22, 22, 24, 24, 24, 22, 22, 18];
 const SW_KN_X = [3, 1, 1, 0, 0, 0, 1, 1, 3];
 const SW_KN_W = [3, 7, 7, 9, 9, 9, 7, 7, 3];
 
-export function drawSwitch(ctx, rect, key, values) {
+export function drawSwitch(ctx, rect, key, values, metaIndex) {
     const raw = values ? values[key] : undefined;
-    const on = Math.round(Number(raw)) === 1;
+    /* Resolves a name-reporting plugin's value too — see enumIndexOf.
+     *
+     * A bare Number(raw) reads NaN for the "Off"/"On" spelling (and for
+     * "No"/"Yes", "Disabled"/"Enabled" — every non-numeric pair detectSwitch
+     * accepts), so the knob stayed pinned to the OFF seat no matter what the
+     * module reported: the switch drew, but it never moved. The rest of this
+     * file already goes through enumIndexOf for exactly this reason; the
+     * metaIndex needed for it was already being passed to us and dropped. */
+    const meta = metaIndex ? metaIndex.getOrGuess(key) : null;
+    const idx = meta ? enumIndexOf(meta, raw) : Math.round(Number(raw));
+    const on = idx === 1;
     const kx = Math.round(rect.x + rect.w / 2 - 8), ky = rect.y;
 
     const x = kx - 5, y = ky + 2;


### PR DESCRIPTION
A two-state switch in the Movy-style param pages never moved and took four clicks to change anything. Two independent causes, both in the `schwung-movy` port.

### 1. The switch never moved

`viz_draw.mjs` read its state with:

```js
const on = Math.round(Number(raw)) === 1;
```

`Number("On")` is `NaN`, so for any module that reports its enum **by name** — the `Off`/`On` spelling that `detectSwitch` itself accepts, along with `No`/`Yes`, `Disabled`/`Enabled` — `on` was always `false`. The switch drew, but the knob stayed on the OFF seat no matter what the module reported.

Measured against a name-reporting module before the fix:

```
value Off -> circle x=-4 (LEFT)
value On  -> circle x=-4 (LEFT)     <- never moves
```

Every other value read in `viz_draw.mjs` already goes through `enumIndexOf` for exactly this reason (see `optionText`, which carries the comment "Resolves a name-reporting plugin's value too"), and the `metaIndex` it needs was already being passed into `drawSwitch` and dropped. After: `Off -> x=-4 (LEFT)`, `On -> x=11 (RIGHT)`, for both name-form and index-form modules.

### 2. Four clicks to move

`movyKnobTick` ran a boolean through the enum click gate, so a switch cost `ENUM_DELTA_DIV` (4) detents to change at all. A switch has two states and no travel, so it now seats at the end you turned toward, on one detent. The gate still applies to real multi-option enums.

While there: the detent accumulator was not cleared when the turn reverses, so the residue left by a partial turn was spent cancelling the new direction first. A reversal cost up to `div + (div - 1)` = 7 detents, and how many depended on where the previous turn happened to stop — the same knob felt different from one reversal to the next. This affected every enum, not just switches.

### Behaviour

| | before | after |
|---|---|---|
| switch circle | stuck LEFT for name-reporting modules | LEFT = off, RIGHT = on |
| detents to flip on | 4 | 1 |
| detents to flip back | 4–7 | 1 |
| 12-option enum reversal | 4–7 | 4 |
| 3-option enum step | 4 | 4 (unchanged) |

`BOOL_OPTION` is exported from `viz.mjs` so the knob math turns exactly the controls `detectSwitch` draws as a switch — the feel and the picture cannot drift apart.

### Testing

- `tests/host`: **103/103** shell tests plus `make -C tests/host test`, including `test_param_pages_viz.sh`, `test_param_pages_view.sh` and `test_param_pages_movy.sh` (572 page renders, 433 viz groups).
- Verified on hardware (Move, Schwung installed): switches in an audio-FX module now seat left/right and flip on a single detent. Modules with boolean switches are fixed with no module-side change — confirmed against Tablor's 8 (`lfo1_sync`, `m1_on`…`m4_on`, `legato`, …).

The same detent half of this applies upstream in schwung-movy; I'll open that separately. Movy's own renderer resolves the index correctly, so bug 1 is specific to this port.
