### PR TITLE
Audit follow-ups: the threading contract, max_param, and a slot-wide autosave loss

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,21 @@ SPI callback runs SCHED_FIFO 90 on core 3. Budget ~900µs/frame after the ~2ms t
 
 **CPU pinning:** Keep core 3 free for SPI. Pin compute-heavy procs (RNBO) to cores 0–2 (`taskset 0x7`). See `docs/REALTIME_SAFETY.md`.
 
+**Module entry points ARE the SPI callback — and the ecosystem does not know
+it.** `create_instance`, `destroy_instance`, `set_param`, `get_param`,
+`on_midi`/`process_midi` and `render_block`/`tick` all run there. A 2026-08
+audit of all 113 catalogued modules found ~150 confirmed violations, several
+carrying comments asserting the opposite in so many words ("control-thread
+only", "NEVER from process_block — so this malloc is realtime-safe"). Authors
+infer a control thread because nothing contradicted them. The contract now
+lives at the top of `src/host/plugin_api_v1.h`, in `docs/MODULES.md`, and as
+rule 4 of `docs/REALTIME_SAFETY.md` — **keep all three in sync.**
+
+Two consequences worth remembering: `pthread_create` from those entry points
+inherits **FIFO 90** (at least 14 modules do this; Move's own `Link Main` is
+FIFO 35, so it starves), and a **`get_param` that scans a directory is served
+once per repaint**, which makes it worse than the equivalent `set_param`.
+
 ## Deployment Layout
 
 ```

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1452,6 +1452,44 @@ These map to knobs 1-8 in the Shadow UI for quick access.
 }
 ```
 
+### `max_param` is NOT supported — publish a real `max`
+
+Eight modules declare `"max_param": "preset_count"` (or similar) hoping the host
+will resolve the bound at runtime. **Nothing has ever consumed it.** It is
+parsed and then read by no one, in C or in JS.
+
+Until 2026-08 it also *damaged* the parameter it decorated: the parser set an
+internal `max_val = -1` marker that the chain host serialised literally, so sf2
+shipped `{"min":0,"max":-1}` — an inverted range — and every other user lost its
+declared bound. That marker is gone; a `max_param` declaration is now recorded
+and otherwise inert, and your declared `max` survives.
+
+It is deliberately not implemented, because the two real uses disagree about
+what the referenced key means:
+
+```
+preset        max_param="preset_count"   wants count - 1   (7 modules)
+laneN_pulses  max_param="laneN_steps"    wants the value   (eucalypso)
+```
+
+Picking one convention would silently be wrong for the other, which is the exact
+failure this field already caused once.
+
+**Do this instead:** emit a real `max`. Every module using `max_param` builds its
+`chain_params` string at runtime from `get_param`, so it already knows the number
+at the moment it serialises:
+
+```c
+/* not: "min":0,"max_param":"preset_count"   */
+offset += snprintf(buf + offset, buf_len - offset,
+    "{\"key\":\"preset\",\"type\":\"int\",\"min\":0,\"max\":%d}",
+    preset_count > 0 ? preset_count - 1 : 0);
+```
+
+A knob declared `0..9999` against 27 real presets is ~99.7% dead travel, and
+that shape is currently in `hera`, `surge`, `moog`, `minijv`, `helm`, `nusaw`,
+`rex` and `obxd`.
+
 ### Recognized Units
 
 The shared shadow-UI formatter (`src/shared/param_format.mjs`) renders any

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -768,6 +768,74 @@ const path = stack.getPath();  // ['Main', 'Settings']
 
 For audio synthesis/processing, create a native plugin implementing the C API.
 
+### Threading: there is no control thread
+
+**Read this before writing a line of DSP.** Every plugin entry point runs on the
+SPI audio callback — SCHED_FIFO 90, core 3, ~900 µs of budget per block:
+
+| Entry point | Runs on the SPI callback? |
+|---|---|
+| `create_instance` / `destroy_instance` | **yes** |
+| `set_param` | **yes** |
+| `get_param` | **yes** |
+| `on_midi` / `process_midi` | **yes** |
+| `render_block` / `process_block` / `tick` | **yes** |
+
+There is no separate control thread, no UI thread, and no "MIDI thread". A
+2026-08 audit of all 113 catalogued modules found ~150 confirmed realtime
+violations, and several came with comments asserting the opposite — *"control
+thread only (blocking dir + file I/O)"*, *"run on the control thread, NEVER from
+process_block — so this malloc is realtime-safe"*, *"safe because it runs in the
+MIDI callback (not the RT render thread)"*. Each of those produced a
+multi-megabyte blocking operation on the audio thread.
+
+**Never, in any of the calls above:**
+
+- file I/O — `fopen`/`fread`/`fwrite`/`open`/`stat`/`opendir`/`readdir`/`mkdir`
+- allocation or free — `malloc`/`calloc`/`realloc`/`free`/`new`/`delete`
+- locks held by a non-realtime thread
+- `fork`/`exec`/`system`/`popen`/`dlopen`
+- logging, including `host->log` **and a bare `fprintf(stderr, …)`** — stderr is
+  unbuffered, so that is a `write()` syscall even when your debug flag is off
+- unbounded work: an FFT, a whole-buffer `memset`, a directory sort
+
+The symptom is not a glitch in your module: it is a **device-wide** audio
+dropout, because you are holding the thread that services every other module's
+audio and Move's own.
+
+#### Threads inherit SCHED_FIFO 90
+
+`pthread_create()` from any of those entry points gives your worker the audio
+callback's realtime priority. Move's own `Link Main` publisher runs at **FIFO
+35**, so an inherited-priority worker starves Move's audio and causes the very
+dropouts you went off-thread to avoid. Demote as the worker's first action:
+
+```c
+static void *worker(void *arg) {
+    struct sched_param sp = { .sched_priority = 0 };
+    sched_setscheduler(0, SCHED_OTHER, &sp);      /* MUST be first */
+
+    cpu_set_t set; CPU_ZERO(&set);                 /* keep core 3 free for SPI */
+    CPU_SET(0, &set); CPU_SET(1, &set); CPU_SET(2, &set);
+    sched_setaffinity(0, sizeof(set), &set);
+    ...
+}
+```
+
+References that do this correctly: `schwung-keydetect`
+(`keyfinder_wrapper.cpp`) and `schwung-airwindows` (`clap_fx.cpp`,
+`loader_thread_fn`). The audit found at least 14 modules that do not.
+
+#### What to do instead
+
+Load files, allocate buffers and build lists on your own `SCHED_OTHER` worker,
+and publish the result to the audio path as a pointer swap. Keep `get_param`
+cheap in particular — a `get_param` that rescans a directory is served on the
+audio thread **once per repaint**, not once per click, so it is worse than the
+equivalent `set_param`. Seven modules in the audit had exactly that bug.
+
+See `docs/REALTIME_SAFETY.md` for the measurements.
+
 ### Plugin API v2 (Recommended)
 
 V2 supports multiple instances and is **required for Signal Chain integration**:

--- a/docs/REALTIME_SAFETY.md
+++ b/docs/REALTIME_SAFETY.md
@@ -40,7 +40,43 @@ SPI runs at FIFO 90 on core 3. Other threads landing there cause cache/memory co
 
 **Fix:** Pin compute-heavy processes to cores 0-2 with `taskset 0x7`. For RNBO, this is done in `rnbo-runner/ui.js` at launch and re-applied at frame 50.
 
-### 4. Guard against thread accumulation
+### 4. Module entry points ARE the SPI callback
+
+This rule is about third-party modules, and it is the one the ecosystem gets
+wrong. `create_instance`, `destroy_instance`, `set_param`, `get_param`,
+`on_midi`/`process_midi` and `render_block`/`process_block`/`tick` all run on
+the SPI callback. There is no control thread.
+
+A 2026-08 audit of all 113 catalogued modules found ~150 confirmed violations.
+The instructive part is not the count, it is that several modules **document the
+opposite**:
+
+| module | comment | what it actually does |
+|---|---|---|
+| `magneto.c:572,838` | "Control-thread only (blocking dir + file I/O)"; "not the audio thread" | 10.6 MB `fwrite` from `on_midi`, and from a knob detent |
+| `war_bells params.c:294` | "run on the control thread, NEVER from process_block — so this malloc is realtime-safe" | 21 MB `calloc` from `set_param`, reachable by MIDI CC |
+| `breakbeat.c:431` | "safe because it runs in the MIDI callback (not the RT render thread)" | `open`+`mmap` of a WAV inside `render_block` |
+| `dj_plugin.cpp:2501` | "outside the hot render path" | `free()` inside `render_block` |
+
+So the failure mode is not carelessness — authors infer a plausible
+architecture and nothing contradicts them. The contract is now stated at the
+top of `src/host/plugin_api_v1.h` and in `docs/MODULES.md`; keep all three in
+sync.
+
+**Worst shapes seen, worth grepping any new module for:**
+
+- `fork`/`exec` from `render_block` (`webstream`, `radiogarden`, `streamrtsp`)
+- a synchronous sample/preset/ROM load inside `set_param` (`sf2`, `nam`,
+  `granny`, `mrsample`, `slicer`, `surge`, `helm`, `hush1`, `mrdrums`)
+- **`get_param` that rescans a directory** — served once per repaint, so it
+  recurs per frame rather than per click (`dexed`, `sf2`, `sfz`, `obxd`,
+  `midiverb`, `nam`, `noisemaker`)
+- `pthread_create` with no `SCHED_OTHER` demotion — at least 14 modules
+- unconditional `fprintf(stderr, …)` or `host->log` on a parameter path
+- writing to **`/tmp`** on the device (`streamrtsp`, `airplay`); Move's rootfs is
+  ~463 MB and usually full. Use `/data/UserData/`.
+
+### 5. Guard against thread accumulation
 
 Background processes launched from tick (like jack_midi_connect) can accumulate if they hang.
 

--- a/src/host/plugin_api_v1.h
+++ b/src/host/plugin_api_v1.h
@@ -3,6 +3,75 @@
  *
  * Stable ABI for DSP modules loaded by the host runtime.
  * Modules are .so files loaded via dlopen() and must export move_plugin_init_v1().
+ *
+ * ===========================================================================
+ * THREADING CONTRACT — READ THIS FIRST
+ * ===========================================================================
+ *
+ * THERE IS NO CONTROL THREAD. Every entry point below runs on the SPI audio
+ * callback: SCHED_FIFO 90, pinned to core 3, with roughly 900 microseconds of
+ * budget per 128-frame block after the ~2 ms transfer.
+ *
+ *      create_instance     <- yes, this one too
+ *      destroy_instance
+ *      set_param           <- yes, this one too
+ *      get_param           <- yes, this one too
+ *      on_midi / process_midi
+ *      render_block / process_block / tick
+ *
+ * This is the single most misunderstood thing about writing a Schwung module.
+ * A 2026-08 audit of all 113 catalogued modules found ~150 confirmed realtime
+ * violations, and several carried comments asserting the opposite in so many
+ * words — "control-thread only (blocking dir + file I/O)", "run on the control
+ * thread, NEVER from process_block, so this malloc is realtime-safe", "safe
+ * because it runs in the MIDI callback (not the RT render thread)". Every one
+ * of those premises is false, and each produced a multi-megabyte blocking
+ * operation on the audio thread. If you take one thing from this header, take
+ * this paragraph.
+ *
+ * FORBIDDEN in all of the calls listed above:
+ *
+ *   - file I/O: fopen/fread/fwrite/open/read/stat/opendir/readdir/mkdir/unlink
+ *   - allocation or free: malloc/calloc/realloc/free/new/delete
+ *   - locks held by any non-RT thread (and any lock without PRIO_INHERIT)
+ *   - fork/exec/system/popen, dlopen
+ *   - logging of any kind, including host->log and a bare fprintf(stderr, ...)
+ *     -- stderr is unbuffered, so that is a write() syscall even when your
+ *     debug flag is off
+ *   - unbounded work: an FFT, a full-buffer memset, a directory sort
+ *
+ * The symptom is not a glitch in your module. It is a device-wide audio
+ * dropout, because you are holding the thread that services every other
+ * module's audio and Move's own.
+ *
+ * THREADS INHERIT SCHED_FIFO 90. pthread_create() called from any of the
+ * above hands your worker the callback's realtime priority. Move's own
+ * `Link Main` thread runs at SCHED_FIFO 35, so an inherited-priority worker
+ * starves Move's audio publisher and produces exactly the dropouts you were
+ * trying to avoid by going off-thread. Every worker must demote itself as its
+ * FIRST action:
+ *
+ *      struct sched_param sp = { .sched_priority = 0 };
+ *      sched_setscheduler(0, SCHED_OTHER, &sp);
+ *      // and keep core 3 free for SPI:
+ *      cpu_set_t set; CPU_ZERO(&set);
+ *      CPU_SET(0, &set); CPU_SET(1, &set); CPU_SET(2, &set);
+ *      sched_setaffinity(0, sizeof(set), &set);
+ *
+ * Reference implementations that get this right: schwung-keydetect
+ * (keyfinder_wrapper.cpp -- demotes and pins) and schwung-airwindows
+ * (clap_fx.cpp loader_thread_fn -- demotes, with a comment naming the
+ * inheritance problem). The audit found at least 14 modules that do not.
+ *
+ * WHAT TO DO INSTEAD. Load files, allocate buffers and build lists on your own
+ * SCHED_OTHER worker thread, and have the audio path pick up the result by
+ * publishing a pointer. Keep get_param cheap: a `get_param` that rescans a
+ * directory is served on this thread once per repaint, not once per click.
+ * If you must do work at create time, prefer doing it lazily on the worker and
+ * rendering silence until it lands.
+ *
+ * See docs/REALTIME_SAFETY.md for the measurements behind all of this.
+ * ===========================================================================
  */
 
 #ifndef MOVE_PLUGIN_API_V1_H

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -332,7 +332,29 @@ static int parse_param_object(const char *param_json, chain_param_info_t *param)
         }
     }
 
-    /* Extract max_param (dynamic max reference) */
+    /*
+     * Extract max_param — RECORDED BUT NOT IMPLEMENTED, deliberately.
+     *
+     * Eight modules declare it (sf2, hush1, hera, surge, moog, minijv, helm,
+     * eucalypso) and NOTHING has ever consumed it: it is parsed into the struct
+     * here and read by no one, in C or in JS. Its only effect was the marker
+     * below, `max_val = -1`, which chain_host serialises literally — so sf2
+     * shipped `{"min":0,"max":-1}`, an inverted range, and the rest lost their
+     * declared bound. A field that silently corrupts what it decorates is worse
+     * than one that does nothing, so the marker is gone and the declared max
+     * (or the type default) now stands.
+     *
+     * It is NOT implemented because the two real uses disagree about what the
+     * referenced key means, and picking one would be guessing at someone else's
+     * intent:
+     *
+     *   preset       max_param="preset_count"  -> wants count - 1  (7 modules)
+     *   laneN_pulses max_param="laneN_steps"   -> wants the value  (eucalypso)
+     *
+     * Modules should publish a real `max` instead. Every one of these builds
+     * its chain_params string at runtime, so it already knows the number at the
+     * moment it serialises — see docs/MODULES.md.
+     */
     const char *max_param_start = bounded_strstr(param_json, param_obj_end, "\"max_param\"");
     if (max_param_start) {
         max_param_start = strchr(max_param_start, ':');
@@ -346,7 +368,20 @@ static int parse_param_object(const char *param_json, chain_param_info_t *param)
                     if (len >= sizeof(param->max_param)) len = sizeof(param->max_param) - 1;
                     memcpy(param->max_param, max_param_start, len);
                     param->max_param[len] = '\0';
-                    param->max_val = -1; /* Marker for dynamic max */
+                    /*
+                     * These declarations pair max_param with NO literal "max"
+                     * (sf2, hush1), so dropping the marker would leave max_val
+                     * at its memset 0 — a 0..0 knob that cannot move, which is
+                     * no better than the inverted range we are removing. Fall
+                     * back to the same default a max-less int already gets in
+                     * parse_chain_params_array_json below, so the param behaves
+                     * like every other unbounded int rather than like a bug.
+                     * Only reached when max_param is declared; nothing else
+                     * changes.
+                     */
+                    if (!bounded_strstr(param_json, param_obj_end, "\"max\"")) {
+                        param->max_val = (param->type == KNOB_TYPE_FLOAT) ? 1.0f : 9999.0f;
+                    }
                 }
             }
         }
@@ -721,7 +756,8 @@ int parse_chain_params(const char *module_path, chain_param_info_t *params, int 
             }
         }
 
-        /* Parse max_param (dynamic max) */
+        /* Parse max_param. UNIMPLEMENTED — see the note at the other parse
+         * site; recorded for diagnostics only, and it must NOT touch max_val. */
         const char *max_param_pos = strstr(obj_start, "\"max_param\":");
         if (max_param_pos && max_param_pos < obj_end) {
             const char *q1 = strchr(max_param_pos + 12, '"');
@@ -732,7 +768,6 @@ int parse_chain_params(const char *module_path, chain_param_info_t *params, int 
                     int len = (int)(q2 - q1);
                     if (len > 31) len = 31;
                     strncpy(p->max_param, q1, len);
-                    p->max_val = -1.0f;  /* Marker for dynamic max */
                 }
             }
         }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -6317,10 +6317,30 @@ function generateSlotPresetName(slotIndex) {
  * slot_N.json, and the next pass is five seconds away. So it takes one extra
  * attempt, not three.
  */
+/*
+ * A state read has THREE answers, and only retrying is right for one of them.
+ *
+ *   JSON/text  the component serialised its state
+ *   ""         the channel served us and the module declares no `state` key
+ *   null       the read did not complete (claim refused, timeout, stolen)
+ *
+ * `if (state)` collapsed the last two, so a module that legitimately
+ * implements no `state` looked identical to a shim round-trip that timed out —
+ * and the caller's bail-to-protect-a-good-file then abandoned the WHOLE slot's
+ * autosave, including the other components in it. `denis` and `branchage`
+ * implement no `state`; a slot containing either never autosaved anything,
+ * ever, and neither did the FX behind it. Found in the 2026-08 fleet audit.
+ *
+ * This is the same rule as the contract reads in page_controller.mjs, one
+ * layer up: branch on the RAW value before testing it for truthiness, because
+ * `""` and `null` are both falsy and by then the distinction is gone.
+ */
 function getSlotStateWithRetry(slotIndex, key, retries) {
     const limit = (typeof retries === "number") ? retries : 3;
     let state = getSlotParam(slotIndex, key);
     if (state) return state;
+    /* Served, and the module has nothing here. Retrying cannot change that. */
+    if (state === "") return "";
     for (let attempt = 1; attempt <= limit; attempt++) {
         state = getSlotParam(slotIndex, key);
         if (state) {
@@ -6328,6 +6348,7 @@ function getSlotStateWithRetry(slotIndex, key, retries) {
                      key + " succeeded on retry " + attempt);
             return state;
         }
+        if (state === "") return "";
     }
     return null;
 }
@@ -6377,11 +6398,17 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
                 /* State is not JSON (e.g. key=value pairs) — store as opaque string */
                 config = { state: stateJson };
             }
-        } else if (bailIfEmpty) {
-            /* State query timed out AND the module is unchanged — skip autosave
-             * to avoid clobbering a good file (it would revert to defaults). */
+        } else if (stateJson === null && bailIfEmpty) {
+            /* The read FAILED (timeout / refused claim) and the module is
+             * unchanged — skip autosave rather than clobber a good file, which
+             * would revert it to defaults.
+             *
+             * `stateJson === null` is load-bearing: `""` means the module
+             * declares no `state`, which is an answer, not a failure. Bailing
+             * on that abandoned the whole slot forever for denis and branchage
+             * — see getSlotStateWithRetry. */
             debugLog("buildSlotPatchJson: slot " + slotIndex + " " + id +
-                     ":state empty after retries — bailing (preserving existing slot_" +
+                     ":state read FAILED after retries — bailing (preserving existing slot_" +
                      slotIndex + ".json)");
             return BAIL;
         }

--- a/tests/host/test_autosave_state_tristate.sh
+++ b/tests/host/test_autosave_state_tristate.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A slot's autosave must survive a module that declares no `state`.
+#
+# getSlotStateWithRetry tested the answer with `if (state)`, which collapses
+# "" (the channel served us; the module declares no `state` key) into null
+# (the read did not complete). buildSlotPatchJson then bailed to protect a
+# good file from a timed-out read — and abandoned the WHOLE slot, including
+# the other components in it.
+#
+# denis and branchage implement no `state`. A slot containing either never
+# autosaved anything, ever, and neither did the FX behind it. Found in the
+# 2026-08 fleet audit; it is the same tri-state rule as the contract reads in
+# page_controller.mjs, one layer up.
+#
+# The retry count matters as much as the return value: retrying a served ""
+# spends three IPC round trips (~2.8 ms each) on every autosave pass to learn
+# something the first read already said.
+
+file="src/shadow/shadow_ui.js"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+# ---- 1. behaviour: lift the function and drive it against a fake channel ----
+fn=$(awk '/^function getSlotStateWithRetry\(/,/^}/' "$file")
+if [ -z "$fn" ]; then
+  echo "FAIL: getSlotStateWithRetry not found in $file" >&2
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync("/dev/stdin", "utf8");
+const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+/* Lift it with an explicit dependency list, the same idiom the knob-card read
+ * budget test uses: a free identifier here would silently become undefined and
+ * the assertions would measure nothing. */
+let reads = 0;
+let answer = null;
+const getSlotParam = () => { reads++; return answer; };
+const debugLog = () => {};
+const make = new Function("getSlotParam", "debugLog",
+                          src + "; return getSlotStateWithRetry;");
+const getSlotStateWithRetry = make(getSlotParam, debugLog);
+
+/* A module that declares no state: served, empty, ONE read, no retries. */
+reads = 0; answer = "";
+let got = getSlotStateWithRetry(0, "synth:state", 3);
+if (got !== "") fail("a served empty state came back as " + JSON.stringify(got) + ", expected \"\"");
+if (got === null) fail("a served empty state was reported as a failed read");
+if (reads !== 1) fail("a served empty state cost " + reads + " reads, expected 1 (retrying it is pure IPC waste)");
+
+/* A failed read: still retried, still null at the end. */
+reads = 0; answer = null;
+got = getSlotStateWithRetry(0, "synth:state", 3);
+if (got !== null) fail("a failed read came back as " + JSON.stringify(got) + ", expected null");
+if (reads !== 4) fail("a failed read cost " + reads + " reads, expected 1 + 3 retries");
+
+/* A real answer passes straight through. */
+reads = 0; answer = "{\"a\":1}";
+got = getSlotStateWithRetry(0, "synth:state", 3);
+if (got !== "{\"a\":1}") fail("a real state was not returned verbatim: " + JSON.stringify(got));
+if (reads !== 1) fail("a real state cost " + reads + " reads, expected 1");
+
+/* A read that fails once then is served empty must stop there, not spin. */
+reads = 0;
+const seq = [null, ""];
+const getSlotParam2 = () => { reads++; return seq[Math.min(reads - 1, seq.length - 1)]; };
+const g2 = new Function("getSlotParam", "debugLog",
+                        src + "; return getSlotStateWithRetry;")(getSlotParam2, debugLog);
+got = g2(0, "synth:state", 3);
+if (got !== "") fail("null-then-empty came back as " + JSON.stringify(got) + ", expected \"\"");
+if (reads !== 2) fail("null-then-empty cost " + reads + " reads, expected 2");
+
+console.log("  ok  getSlotStateWithRetry keeps \"\" and null apart");
+' <<< "$fn"
+
+# ---- 2. the caller must branch on the RAW value, not on truthiness ---------
+# componentEntry is a closure inside buildSlotPatchJson, so this half is a
+# source pin. `else if (bailIfEmpty)` alone is the bug: it fires for "" too.
+entry=$(awk '/const componentEntry = /,/^    };/' "$file")
+if [ -z "$entry" ]; then
+  echo "FAIL: componentEntry not found in $file" >&2
+  exit 1
+fi
+if ! grep -Eq 'stateJson === null[[:space:]]*&&[[:space:]]*bailIfEmpty' <<<"$entry"; then
+  echo "FAIL: componentEntry does not require a NULL state before bailing." >&2
+  echo "      Bailing on \"\" abandons the whole slot for any module that" >&2
+  echo "      declares no state key (denis, branchage)." >&2
+  exit 1
+fi
+echo "  ok  componentEntry bails only on a FAILED read"
+
+echo "PASS: a module with no state key no longer kills its slot's autosave"

--- a/tests/host/test_chain_params_max_param.c
+++ b/tests/host/test_chain_params_max_param.c
@@ -1,0 +1,132 @@
+/*
+ * max_param must never corrupt the range it decorates.
+ *
+ * Eight modules declare `max_param` (sf2, hush1, hera, surge, moog, minijv,
+ * helm, eucalypso) and NOTHING has ever consumed it — it is parsed into
+ * chain_param_info_t and read by no one, in C or in JS. Its only effect was a
+ * marker, `max_val = -1`, which chain_host serialises literally into the
+ * chain_params it hands the UI. sf2 therefore shipped {"min":0,"max":-1}: the
+ * only inverted range in the 2026-08 fleet capture.
+ *
+ * It is deliberately still NOT implemented, because the two real uses disagree
+ * about what the referenced key means and choosing one would be guessing at
+ * someone else's intent:
+ *
+ *     preset       max_param="preset_count"  -> wants count - 1  (7 modules)
+ *     laneN_pulses max_param="laneN_steps"   -> wants the value  (eucalypso)
+ *
+ * So what is pinned here is the INVARIANT, not the feature: whatever the host
+ * does with max_param, a parsed parameter must come out with max >= min. That
+ * is the property the bug violated, and it is the one that stays true if
+ * somebody implements the field properly later.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "chain_internal.h"
+
+/* The parser pulls in two collaborators it does not need for this test.
+ * Stubbing them keeps the unit to chain_params.c + chain_json.c rather than
+ * linking the whole chain host. */
+void chain_log(const char *msg) { (void)msg; }
+int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *target) {
+    (void)inst; (void)target; return 0;
+}
+
+static int failures = 0;
+
+static void check_range(const char *what, const char *param_json) {
+    chain_param_info_t p;
+    /* parse_chain_param_object is static; go through the array parser, which
+     * is the same code path chain_host uses for a plugin's live answer. */
+    char arr[1024];
+    snprintf(arr, sizeof(arr), "[%s]", param_json);
+    chain_param_info_t params[4];
+    int n = parse_chain_params_array_json(arr, params, 4);
+    if (n < 1) {
+        fprintf(stderr, "FAIL: %s -> parser returned %d, expected >= 1\n", what, n);
+        failures++;
+        return;
+    }
+    p = params[0];
+    if (!(p.max_val >= p.min_val)) {
+        fprintf(stderr, "FAIL: %s -> min %g, max %g (inverted)\n",
+                what, (double)p.min_val, (double)p.max_val);
+        failures++;
+        return;
+    }
+    if (p.max_val == p.min_val) {
+        fprintf(stderr, "FAIL: %s -> min %g == max %g (knob cannot move)\n",
+                what, (double)p.min_val, (double)p.max_val);
+        failures++;
+        return;
+    }
+    printf("  ok  %-46s min %g max %g\n", what, (double)p.min_val, (double)p.max_val);
+}
+
+int main(void) {
+    printf("max_param never corrupts a range:\n");
+
+    /* The reported case, verbatim in shape: max_param and NO literal max. */
+    check_range("sf2 preset (max_param, no max)",
+                "{\"key\":\"preset\",\"name\":\"Preset\",\"type\":\"int\","
+                "\"min\":0,\"max_param\":\"preset_count\"}");
+
+    /* eucalypso's shape: max_param alongside a real max. The declared max must
+     * survive — this is the one that silently lost its bound before. */
+    {
+        chain_param_info_t params[4];
+        const char *arr =
+            "[{\"key\":\"lane1_pulses\",\"name\":\"Pulses\",\"type\":\"int\","
+            "\"min\":0,\"max\":128,\"max_param\":\"lane1_steps\"}]";
+        int n = parse_chain_params_array_json(arr, params, 4);
+        if (n < 1) {
+            fprintf(stderr, "FAIL: eucalypso pulses -> parser returned %d\n", n);
+            failures++;
+        } else if (params[0].max_val != 128.0f) {
+            fprintf(stderr, "FAIL: eucalypso pulses -> declared max 128 became %g\n",
+                    (double)params[0].max_val);
+            failures++;
+        } else {
+            printf("  ok  %-46s min %g max %g\n", "eucalypso pulses (max_param + max)",
+                   (double)params[0].min_val, (double)params[0].max_val);
+        }
+    }
+
+    /* A float with max_param, for the other branch of the fallback. */
+    check_range("float with max_param and no max",
+                "{\"key\":\"depth\",\"name\":\"Depth\",\"type\":\"float\","
+                "\"min\":0,\"max_param\":\"depth_max\"}");
+
+    /* And the ordinary cases must be untouched by any of this. */
+    check_range("plain int, declared max",
+                "{\"key\":\"voices\",\"name\":\"Voices\",\"type\":\"int\","
+                "\"min\":1,\"max\":16}");
+    check_range("plain float, declared max",
+                "{\"key\":\"cutoff\",\"name\":\"Cutoff\",\"type\":\"float\","
+                "\"min\":0,\"max\":1}");
+
+    /* max_param is still recorded, so a future implementation has it. */
+    {
+        chain_param_info_t params[4];
+        const char *arr =
+            "[{\"key\":\"preset\",\"type\":\"int\",\"min\":0,"
+            "\"max_param\":\"preset_count\"}]";
+        int n = parse_chain_params_array_json(arr, params, 4);
+        if (n < 1 || strcmp(params[0].max_param, "preset_count") != 0) {
+            fprintf(stderr, "FAIL: max_param no longer recorded (got \"%s\")\n",
+                    n >= 1 ? params[0].max_param : "<no param>");
+            failures++;
+        } else {
+            printf("  ok  %-46s \"%s\"\n", "max_param still recorded for later",
+                   params[0].max_param);
+        }
+    }
+
+    if (failures) {
+        fprintf(stderr, "FAIL: %d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("test_chain_params_max_param: all checks passed\n");
+    return 0;
+}

--- a/tests/host/test_chain_params_max_param.sh
+++ b/tests/host/test_chain_params_max_param.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# See the header comment in test_chain_params_max_param.c.
+
+work="$(mktemp -d "${TMPDIR:-/tmp}/schwung-chain-params-answer.XXXXXX")"
+trap 'rm -rf "$work"' EXIT
+
+# chain_internal.h includes <malloc.h>, which is glibc-only. One shim header so
+# the file compiles on macOS as well as Linux; it changes nothing about the
+# code under test. (Same shim as test_chain_midi_fx_slot.sh.)
+mkdir -p "$work/shim"
+cat > "$work/shim/malloc.h" <<'EOF'
+#include <stdlib.h>
+EOF
+
+bin="build/tests/test_chain_params_max_param"
+mkdir -p "$(dirname "$bin")"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
+  -I"$work/shim" -Isrc -Isrc/modules/chain/dsp -Isrc/host \
+  tests/host/test_chain_params_max_param.c src/modules/chain/dsp/chain_params.c src/modules/chain/dsp/chain_json.c -o "$bin"
+
+"$bin"


### PR DESCRIPTION
Three independent host-side fixes from the 113-module fleet audit. Each commit stands alone.

---

### 1. Say which thread module code runs on

Auditing every catalogued module turned up ~150 confirmed realtime violations, and the instructive part isn't the count — several modules **document the opposite of the truth**:

```
magneto.c:572    "Control-thread only (blocking dir + file I/O)"
war_bells:294    "run on the control thread, NEVER from process_block --
                  so this malloc is realtime-safe"
breakbeat.c:431  "safe because it runs in the MIDI callback (not the RT render thread)"
dj_plugin:2501   "outside the hot render path"    (a free() inside render_block)
```

Each produced a multi-megabyte blocking operation on the SPI callback. This isn't carelessness — authors infer a plausible architecture and `plugin_api_v1.h` never said otherwise.

It does now, at the top, before the structs. Same content in `docs/MODULES.md` and as rule 4 of `REALTIME_SAFETY.md`, with those four quotes as the evidence. Two specifics called out: `pthread_create` from those entry points **inherits FIFO 90** (at least 14 modules do it; Move's `Link Main` is FIFO 35, so it starves) with the demote-and-pin snippet inline and `keydetect`/`clap` named as references; and **a `get_param` that rescans a directory is served once per repaint**, which makes it worse than the equivalent `set_param` — seven modules have that one.

Docs only.

### 2. `max_param` stops corrupting the range it decorates

Eight modules declare it. **Nothing has ever consumed it** — parsed into the struct, read by no one, in C or JS. Its one effect was a marker `max_val = -1` that `chain_host` serialises literally, so **sf2 shipped `{"min":0,"max":-1}`**, the only inverted range in the fleet capture, and everyone who paired `max_param` with a real `max` silently lost it.

Still deliberately **not implemented**, because the two real uses disagree about what the referenced key means:

```
preset       max_param="preset_count"  -> wants count - 1  (7 modules)
laneN_pulses max_param="laneN_steps"   -> wants the value  (eucalypso)
```

Guessing would be the same class of error as the field itself. Documented as unsupported instead, with the one-line fix authors should make.

The test pins the **invariant** (`max >= min`, and a range you can traverse) rather than the feature, so it survives someone implementing `max_param` properly later. Restoring the marker fails it in three places.

### 3. A module with no `state` no longer kills its slot's autosave

`getSlotStateWithRetry` tested with `if (state)`, collapsing `""` (served; the module declares no `state`) into `null` (read did not complete). `buildSlotPatchJson` then bailed — correctly for a timed-out read — and abandoned the **whole slot**, including the other components in it.

`denis` and `branchage` implement no `state`. A slot containing either **never autosaved anything, ever**, and neither did the FX behind it. Silent by construction: the protection that fires is the one designed to leave the file alone.

Same tri-state rule as the contract reads in `page_controller.mjs`, one layer up. The comment already above `bailIfEmpty` shows the author half-saw it — `moduleChanged` exists to unblock exactly this, but only helps on a *swap*; on a stable slot it's false forever.

Test lifts the function with an explicit dependency list and asserts the read **count** as well as the value — the count is what catches a half-fix. All three mutations die.

---

Local suite at the 32-failure `rg` baseline; compiled host units pass. Merged with `main` after #228 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56