### PR TITLE
docs: the author-facing rules MODULES.md never stated

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1026,7 +1026,50 @@ Modules expose a navigable parameter hierarchy to the Shadow UI via `ui_hierarch
 | `list_param` / `count_param` / `name_param` | For preset browser levels |
 | `items_param` / `select_param` | For dynamic item selection levels |
 | `child_prefix` / `child_count` / `child_label` | For repeated elements (see below) |
+| `navigate_to` | Where to land after choosing from this level's list (see below) |
 | `visible_if` | Optional conditional visibility rule for this level |
+
+#### Selector keys must not appear in `knobs`
+
+The keys named by `list_param`, `count_param`, `name_param`, `items_param` and
+`select_param` get their own page — a preset browser or an items list — which is
+a better control than a knob and is where the host expects you to choose from.
+**Listing one in `knobs` as well is now ignored.**
+
+Two modules did it (`impressive-chords` `preset_index`, `breakbeat` `preset`) and
+in both the `knobs` array was byte-identical to `params` — everything listed
+rather than eight chosen — so the selector happened to land on knob 1. It could
+not have worked anyway: `impressive-chords` declares `preset_index` as
+`int 0..500` against 52 presets, so ~90% of that knob was dead travel landing on
+nothing.
+
+You lose nothing by leaving it out. Reported from the device as *"why is preset a
+knob on impressive chords?"*.
+
+#### `navigate_to` — where choosing leaves you
+
+A level with `items_param` may declare `navigate_to: "<level>"`, meaning *"having
+chosen from this list, the user wants to be there"*. Without it, choosing lands
+on the first grid page.
+
+Two behaviours worth knowing, both of which changed in 2026-08:
+
+- **If the named level plans BOTH a preset browser and a knob grid, you get the
+  browser.** `obxd` declares `banks -> navigate_to: "root"`, and its `root`
+  carries `list_param`/`count_param` *and* `knobs`. Naming the level never said
+  which, and the lookup used to filter to knob pages only — so choosing a bank
+  landed on the sliders instead of in that bank's presets. A chooser that filters
+  a list means "now show me the list".
+- **You arrive with the page already open.** The jog is normally inert on a
+  preset browser or items list until you click in (so that *paging past* one
+  cannot audition every preset it goes by). A page you were **sent** to opens:
+  you did not page there, you chose your way there, and one deliberate gesture
+  should not need a second to take effect. Naming a level that plans no preset
+  page still lands on its grid, as before.
+
+There is deliberately no `navigate_to: {level, kind}` form. Only three modules in
+the fleet declare `navigate_to` at all, and new vocabulary nobody adopts is how
+`options_as_string` sat documented and unused for months.
 
 ### Parameter Item Types
 
@@ -2142,6 +2185,28 @@ Modules that already support per-slot autosave get module presets for free. A mo
 doesn't expose a self-contained `state` (or that returns a referential blob) won't produce a
 usable preset, so make `state` round-trip-complete. (User-facing usage is covered in the
 manual.)
+
+#### If you implement no `state` at all
+
+Your parameters do not survive a reboot. That is the expected cost and it is
+yours alone to pay — **but until 2026-08 it was not.** The host asked for
+`state`, could not tell `""` ("this module declares none") apart from `null`
+("the read did not complete"), and took the second reading: it then skipped the
+save to avoid clobbering a good file with defaults, and skipped it for the
+**whole slot**, including the other components in it.
+
+So a slot containing `denis` or `branchage` never autosaved *anything*, ever —
+not the synth, not the FX behind it — and silently, because the thing that fires
+is a guard designed to leave your file alone. Fixed; the two answers are kept
+apart now.
+
+The obligation this leaves you: **answer the `state` query one way or the
+other.** Return your blob, or return `-1` / an empty buffer to say you have
+none. What you must not do is fail to answer — a read that times out is still
+indistinguishable from a module that is simply slow, and the host will (rightly)
+protect the existing file rather than overwrite it with defaults. If your
+`get_param` can block — see the threading section; several modules read files
+from it — that is the same bug wearing a different hat.
 
 ### Testing Shadow Mode
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1349,6 +1349,53 @@ int get_param(void *instance, const char *key, char *buf, int buf_len) {
 }
 ```
 
+#### Pattern: a knob whose options depend on another selection
+
+*"Select a folder, then turn a pot through the wavetables in it."* This works
+today; nothing needs adding to the host. Reported as impossible by a module
+author, so it is written down here.
+
+**Why a `filepath` cannot do it.** `type: "filepath"` is **opaque**: the grid can
+*open* it but never *turn* it, on purpose — turning would write nonsense into a
+path. A knob asking to drive a filepath is asking for a control the host has
+classified as un-turnable. That is usually the whole reason this looks impossible.
+
+**The shape that works:**
+
+1. Declare the dependent control as `type: "enum"` with an `options` array
+   holding the current folder's entries. It becomes turnable *and* divable —
+   hold the knob and click opens a scrolling picker, which is what you want past
+   a handful of entries.
+2. Serve `chain_params` from `get_param` (dynamic, above) rather than a static
+   string, so the option list can change.
+3. Offer the folder as its own level with `items_param` / `select_param`.
+
+**The host re-reads your contract when the user chooses.** Committing an items
+selection arms a settle deadline; once your answer stops changing, the host
+re-reads `chain_params` / `ui_hierarchy` and re-plans the pages, so the knob
+steps the new folder's list. It is throttled — the deadline re-arms per detent
+and two agreeing readings are required — so spinning a folder list costs about
+five contract reads in total, not one per step.
+
+**The obligation: do not scan the filesystem to answer.** `get_param` and
+`set_param` are the SPI audio callback (see the threading section). Scan on your
+own `SCHED_OTHER` worker when the folder changes, publish the result by pointer
+swap, and let `get_param` only *format* an already-cached list. A module that
+scans a directory inside `get_param` pays that cost **once per repaint**.
+
+**Limits to design against:**
+
+| Limit | Value | What happens past it |
+|---|---|---|
+| `MAX_ENUM_OPTIONS` (`chain_internal.h`) | 128 | The knob grid still lists them (JS parses the JSON itself), but the chain host's C-side knob-mapping and modulation tables truncate — the picker works while CC mapping quietly does not |
+| `chain_params` string | 64 KB (`SHADOW_PARAM_VALUE_LEN`) | The read fails; see the three-answers rule |
+
+Keep a folder under 128 entries, or paginate it into sub-levels.
+
+And the enum wire rule still applies: index in, index out — or names both ways
+with `options_as_string: true`. A module that already resolves an index into its
+scan list should report the index and declare nothing.
+
 ### Parameter Types
 
 Use the canonical type list in `Shadow UI Parameter Hierarchy -> Parameter Types`.


### PR DESCRIPTION
Docs-only follow-up to #229. Everything here is something a module author **declares**, so leaving it undocumented is how the fleet ends up declaring it wrong.

**1. Selector keys must not appear in `knobs`.** `list_param`/`count_param`/`name_param`/`items_param`/`select_param` already get their own page; listing one as a knob is now ignored (#226). Two modules did it, both with `knobs[]` byte-identical to `params[]`, and it couldn't have worked anyway — `impressive-chords` declares `preset_index` as `int 0..500` against 52 presets.

**2. `navigate_to` had ZERO mentions in this file** despite three modules declaring it and two changes landing on it today: a named level that plans both a browser and a grid now means the **browser** (obxd's `banks -> root`), and a page you were *sent* to arrives already open while paging onto one still does not. Also records why there's deliberately no `navigate_to: {level, kind}` form.

**3. What happens if you implement no `state`.** Losing persistence is fair; until today it also cost the **whole slot's** autosave, including the other components in it, silently. Now that the host keeps `""` and `null` apart, the remaining obligation is the honest one: *answer the query, either way*.

**4. Pattern: a knob whose options depend on another selection.** A module author reported "select a folder, then turn a pot through the wavetables in it" as impossible. It works today and needs nothing added to the host. The trap is that the obvious declaration is `type: "filepath"`, which is **opaque** — openable, never turnable — so the knob is asking to drive a control the host has classified as un-turnable.

The working shape is an enum with a runtime `options` array, `chain_params` served from `get_param`, and the folder as its own `items_param` level. Committing that selection already arms a contract re-read (`commitItem` → `armContractSettle`) — the machinery the airwindows fix added this morning, throttled to ~5 reads per settle rather than one per detent.

Includes the obligation that makes it safe (scan on a worker; `get_param` only *formats* a cached list, because a directory scan there costs once per **repaint**) and the two limits: `MAX_ENUM_OPTIONS` 128, past which the JS grid still lists them while the C-side knob-mapping and modulation tables truncate; and the 64 KB `chain_params` cap.

Local suite at the 32-failure `rg` baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56