### PR TITLE
catalog: add Tape Echo 2 (audio_fx)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1267,6 +1267,17 @@
       "asset_name": "chord-finder-module.tar.gz",
       "min_host_version": "0.11.6",
       "requires": "Ableton Move 1.8 or newer; Move/USB-C audition requires matching Move track MIDI routing"
+    },
+    {
+      "id": "tape-echo2",
+      "name": "Tape Echo 2",
+      "description": "Component-modeled vintage three-head tape echo with spring reverb: 12 head/reverb modes, in-loop tape saturation, wow & flutter, tape age, and tempo sync with the reference machine's leading-head note tables.",
+      "author": "Tape Echo 2 by Dusk Audio (GPL-3.0) \u00b7 port: athousanddetails",
+      "component_type": "audio_fx",
+      "github_repo": "athousanddetails/schwung-tape-echo2",
+      "default_branch": "main",
+      "asset_name": "tape-echo2-module.tar.gz",
+      "min_host_version": "0.7.13"
     }
   ]
 }


### PR DESCRIPTION
Adds **Tape Echo 2** as an `audio_fx` entry.

A component-modeled vintage three-head tape echo with a three-spring reverb tank — port of [Tape Echo 2 by Dusk Audio](https://github.com/dusk-audio/dusk-audio-plugins/tree/main/plugins/tape-echo) (GPL-3.0). The DSP core is vendored **unmodified**; the port is the Schwung shell around it.

- **Repo:** https://github.com/athousanddetails/schwung-tape-echo2
- **Release:** [v1.0.0](https://github.com/athousanddetails/schwung-tape-echo2/releases/tag/v1.0.0) — `tape-echo2-module.tar.gz` (built by CI, aarch64, glibc ≤ 2.34, libc/libm only)
- **License:** GPL-3.0, inherited from upstream and attributed in the module `author`, README and `help.json`

### What it ships

- 14 parameters over 2 Movy pages; the `ui_hierarchy` root assigns 8 encoders
- 12 head/reverb modes, Galaxy-style tempo sync (leading-head note tables, measured motor clamp, no octave folding)
- in-loop record EQ + tape saturation, wow & flutter, New/Used/Old tape age, dub-style input send
- `ui_chain.js` chain editor with a record VU, `help.json`, and a browser panel

### `min_host_version: 0.7.13`

That is the first tag containing `host_api_v1.get_bpm`, which tempo sync reads. Everything else it uses (`audio_fx_api_v2`, `chain_params` in `module.json`) is older. The call is guarded, so it loads on earlier hosts — tempo sync would just assume 120 BPM there.

### Verification

Tested on hardware (Move, Schwung 0.12.x). An on-device loadtest dlopens the module exactly as the chain host does and checks the API surface, enum round-trips, state save/restore, an audible echo tail, click-free bypass, and the realtime factor:

```
ALL PASS — 0.407 ms per 128-frame block (budget 2.902 ms, 14.0% of one core)
```

worst case (all three heads plus the spring tank). The repo's build gate also cross-checks `movy_config.json`, `chain_params`, the C parameter table and the chain UI against each other before every cross-compile.

Note the browser panel is deliberately standalone rather than an iframe: `remote_ui.go` only offers a custom `web_ui.html` for the `synth` component, so an audio FX cannot get one. It uses `schwungRemote` when embedded and the remote-ui WebSocket otherwise, so it works on stock Schwung today. Happy to drop that file from the entry if you'd rather FX modules not ship one.
