### PR TITLE
catalog: add Tape Echo 2 (audio_fx)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1267,6 +1267,17 @@
       "asset_name": "chord-finder-module.tar.gz",
       "min_host_version": "0.11.6",
       "requires": "Ableton Move 1.8 or newer; Move/USB-C audition requires matching Move track MIDI routing"
+    },
+    {
+      "id": "tape-echo2",
+      "name": "Tape Echo 2",
+      "description": "Component-modeled vintage three-head tape echo with spring reverb: 12 head/reverb modes, in-loop tape saturation, wow & flutter, tape age, and tempo sync with the reference machine's leading-head note tables.",
+      "author": "Tape Echo 2 by Dusk Audio (GPL-3.0) \u00b7 port: athousanddetails",
+      "component_type": "audio_fx",
+      "github_repo": "athousanddetails/schwung-tape-echo2",
+      "default_branch": "main",
+      "asset_name": "tape-echo2-module.tar.gz",
+      "min_host_version": "0.7.13"
     }
   ]
 }


### PR DESCRIPTION
Adds **Tape Echo 2** as an `audio_fx` entry.

A component-modelled vintage three-head tape echo with a three-spring reverb tank — port of [Tape Echo 2 by Dusk Audio](https://github.com/dusk-audio/dusk-audio-plugins/tree/main/plugins/tape-echo) (GPL-3.0). The DSP core is vendored **unmodified**; this is only the Schwung shell around it.

- **Repo:** https://github.com/athousanddetails/schwung-tape-echo2
- **Release:** [v1.0.1](https://github.com/athousanddetails/schwung-tape-echo2/releases/tag/v1.0.1) — `tape-echo2-module.tar.gz`, built by CI (aarch64, glibc ≤ 2.34, links only libc/libm)
- **License:** GPL-3.0, inherited from upstream and credited in `module.json`, the README and `help.json`

### What it ships

- 14 parameters over 2 pages; the `ui_hierarchy` root assigns the 8 encoders
- 12 head/reverb combinations, tempo sync using the reference machine's leading-head note tables and its measured motor clamp (out-of-range notes pin rather than octave-fold)
- record EQ and tape saturation inside the feedback loop, wow and flutter, New/Used/Old tape age, dub-style input send
- `ui_chain.js` chain editor with a record VU, `help.json`, and a browser panel

### `min_host_version: 0.7.13`

First tag containing `host_api_v1.get_bpm`, which tempo sync reads. Everything else it uses (`audio_fx_api_v2`, `chain_params` in `module.json`) is older, and the call is guarded — it loads on earlier hosts, tempo sync just assumes 120 BPM there.

### Verification

Tested on hardware (Move, Schwung 0.12.x). An on-device loadtest dlopens the module exactly as the chain host does and checks the API surface, enum round-trips, state save/restore, an audible echo tail, click-free bypass and the realtime factor:

```
ALL PASS — 0.407 ms per 128-frame block (budget 2.902 ms, 14.0% of one core)
```

worst case, all three heads plus the spring tank. The repo's build gate also cross-checks `movy_config.json`, `chain_params`, the C parameter table and the chain UI against each other before every cross-compile.

One note: the module ships a `web_ui.html`, but since `remote_ui.go` only offers a custom UI for the `synth` component it is opened directly rather than embedded, so it changes nothing about how the manager renders FX slots. Happy to drop it if you would rather FX modules not carry one.

(Reopened from #232, which I closed while tidying the module's README.)
