### PR TITLE
param pages: define `access` — readout, trigger, or both

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1542,6 +1542,43 @@ These map to knobs 1-8 in the Shadow UI for quick access.
 }
 ```
 
+### `access` — which direction a param means something in
+
+Optional on a `chain_params` entry. Defaults to `readwrite`; declare it when
+your parameter is not both.
+
+| value | meaning | host behaviour |
+|---|---|---|
+| `readwrite` | an ordinary control (default) | turnable, divable if it has options |
+| `read` | a **readout** — the value means something, writing means nothing | never turnable, never opens a picker, still refreshed on screen |
+| `write` | a **trigger** — writing does something, the value means nothing | never turnable, a click **fires** it |
+
+```json
+{"key": "detected_key", "type": "enum", "options": ["C","C#","D"], "access": "read"}
+{"key": "rnd_preset",   "type": "enum", "options": ["—","Rnd!"],   "access": "write"}
+```
+
+**Why a readout needs saying.** `keydetect`'s `detected_key` is 25 key names
+with no `set_param` branch at all — deliberately, and documented as such back
+when an enum could only be nudged one detent at a time. Enums became divable in
+1.0, so the picker opened on it and silently discarded whatever you chose. That
+was a gap in the contract, not a bug in the module: display-only was never
+expressible.
+
+**Why a trigger needs saying, and why it is the more urgent half.** A momentary
+action modelled as a two-option enum is a live hazard. `euclidrum`'s
+`rnd_preset` declares `["—","Rnd!"]` and fires on anything that is not the
+em-dash — so an **index** write of `"0"`, which *means* the em-dash, "do
+nothing", randomises all eight lanes and destroys the kit. Declaring
+`access: "write"` makes the host fire it through your own enum wire (the
+**name**, if that is what your `get_param` reports) and never scrub it with a
+knob, so the "do nothing" option can never be written by accident.
+
+A trigger is not the same as a **switch**. `["Off","On"]` is a two-state
+*setting* — it has a value worth reading, it should be turnable, and it draws as
+a switch. Leave those as ordinary enums; roughly 150 params in the fleet are
+switches and only about ten are triggers.
+
 ### `max_param` is NOT supported — publish a real `max`
 
 Eight modules declare `"max_param": "preset_count"` (or similar) hoping the host

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -523,6 +523,16 @@ function footerHints() {
     const held = controller.state ? controller.state.touched : -1;
     if (held >= 0) {
         const meta = controller.metaAt ? controller.metaAt(held) : null;
+        /*
+         * A TRIGGER is a button: the click does the thing rather than opening
+         * anything, so it says FIRE. Without this it fell through to CLK MENU
+         * -- the footer advertised the section menu while the click ran a
+         * destructive action, which is the same promise-versus-behaviour
+         * mismatch the divable line above exists to prevent.
+         */
+        if (meta && meta.writeOnly) {
+            return orderedHints({ jog: "PAGE", click: "FIRE", extra: fine });
+        }
         if (meta && meta.divable) {
             return orderedHints({ jog: "PAGE", click: "OPEN", extra: fine });
         }

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -525,13 +525,19 @@ function footerHints() {
         const meta = controller.metaAt ? controller.metaAt(held) : null;
         /*
          * A TRIGGER is a button: the click does the thing rather than opening
-         * anything, so it says FIRE. Without this it fell through to CLK MENU
-         * -- the footer advertised the section menu while the click ran a
-         * destructive action, which is the same promise-versus-behaviour
-         * mismatch the divable line above exists to prevent.
+         * anything. Without this it fell through to CLK MENU -- the footer
+         * advertised the section menu while the click ran a destructive
+         * action, which is the same promise-versus-behaviour mismatch the
+         * divable line above exists to prevent.
+         *
+         * PUSH, not FIRE. The widget is drawn as a push button, and the hint
+         * vocabulary should name the GESTURE the picture is asking for, the
+         * way JOG SEL and CLK OPEN do. FIRE names the consequence instead,
+         * which is a second thing to learn about a control that is already
+         * self-explanatory once it looks like a button.
          */
         if (meta && meta.writeOnly) {
-            return orderedHints({ jog: "PAGE", click: "FIRE", extra: fine });
+            return orderedHints({ jog: "PAGE", click: "PUSH", extra: fine });
         }
         if (meta && meta.divable) {
             return orderedHints({ jog: "PAGE", click: "OPEN", extra: fine });

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -1872,6 +1872,16 @@ export function createController(io = {}) {
                 modValues: s.modValues,
                 pageGroups: pageGroups(),
                 viz: vizEnabled ? vizGroups() : [],
+                /*
+                 * The trigger button's press animation. Both of these have to
+                 * come from here: the renderer is pure and reads the clock off
+                 * `o`, so without them every button draws in its idle phase
+                 * forever -- which is exactly what shipped, because the test
+                 * handed the renderer both directly and so only ever proved
+                 * the renderer, never the wiring.
+                 */
+                triggerFiredAt: s.triggerFiredAt,
+                nowMs: now(),
                 footer,
             });
             if (s.hintLines) {

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -252,6 +252,12 @@ export const CONTRACT_RETRY_INTERVAL_TICKS = 30;
  */
 export const CONTRACT_RECOVER_INTERVAL_TICKS = 600;
 
+/* How long a trigger press stays interesting to the renderer (its burst is
+ * still on screen), and how many overlapping presses to keep. Both exist only
+ * to bound the list — the renderer decides what it actually draws. */
+const TRIGGER_BURST_KEEP_MS = 400;
+const TRIGGER_BURST_MAX = 4;
+
 export function createController(io = {}) {
     const getParam = io.getParam || (() => null);
     const setParam = io.setParam || (() => {});
@@ -354,6 +360,8 @@ export function createController(io = {}) {
          * looking, so an unreadable component recovers without the user
          * having to navigate away and back. */
         contractGaveUp: false,
+        /* key -> ms when a trigger last fired, for the bang flash. */
+        triggerFiredAt: Object.create(null),
         contractRetries: 0,
         /* Wall-clock ms at which a selection-driven contract re-read comes
          * due, or 0 for none pending. Re-armed per detent — see
@@ -1719,6 +1727,25 @@ export function createController(io = {}) {
                 setParam(fullKey(key), "1");
                 announce(`${meta.label}`);
             }
+            /*
+             * Stamp the fire time so the bang can flash. OVERWRITING is the
+             * point: clicking again mid-flash restarts the animation from the
+             * beginning rather than being swallowed by the one in progress, so
+             * two clicks look like two events. The renderer derives everything
+             * from this one number, so there is no animation state to clear.
+             */
+            /*
+             * APPEND, do not overwrite. A press must not cancel the bursts
+             * already travelling — a fast double-tap should throw two rings,
+             * not restart one. Trimmed to what can still be on screen, so the
+             * list cannot grow.
+             */
+            const t = now();
+            const prev = s.triggerFiredAt[key] || [];
+            s.triggerFiredAt[key] = prev
+                .filter((p) => t - p < TRIGGER_BURST_KEEP_MS)
+                .slice(-TRIGGER_BURST_MAX + 1)
+                .concat(t);
             return null;
         }
 
@@ -2060,6 +2087,7 @@ export function createController(io = {}) {
          *  if any, is the previous one — nothing here was planned from the
          *  failure. */
         get contractUnresolved() { return s.contractUnresolved; },
+        get triggerFiredAt() { return s.triggerFiredAt; },
         keyAt, metaAt,
         jumpIndex: () => jumpIndex(s.pages),
         groupIndex: () => groupIndex(s.pages),

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -1697,7 +1697,32 @@ export function createController(io = {}) {
         }
         const key = keyAt(slot);
         const meta = metaAt(slot);
-        if (!key || !meta || !meta.divable) return null;
+        if (!key || !meta) return null;
+
+        /*
+         * A TRIGGER fires. It is not a value to open or scrub — the module
+         * reports a constant and acts on the write, so a click is the whole
+         * interaction.
+         *
+         * The wire value that fires it is the module's business
+         * (["idle","trigger"], ["—","Rnd!"], ["Play","Save"] are all in the
+         * fleet), so option 1 goes out through the ordinary enum wire, which
+         * speaks whichever convention that module uses. Writing a bare "1"
+         * here is exactly the bug that makes euclidrum randomise a kit when
+         * asked to do nothing.
+         */
+        if (meta.writeOnly) {
+            if (meta.kind === KIND_ENUM && Array.isArray(meta.options) && meta.options.length > 1) {
+                setParam(fullKey(key), enumWireValue(meta, 1));
+                announce(`${meta.label}, ${meta.options[1]}`);
+            } else {
+                setParam(fullKey(key), "1");
+                announce(`${meta.label}`);
+            }
+            return null;
+        }
+
+        if (!meta.divable) return null;
         s.pending = { action: "open", key, fullKey: fullKey(key), meta };
         /*
          * An enum opens a list of its OPTIONS, so the intent carries the list

--- a/src/shared/param_pages/param_meta.mjs
+++ b/src/shared/param_pages/param_meta.mjs
@@ -211,10 +211,38 @@ function normalize(key, raw) {
      * An enum that declares NO options is index-addressed and has no list to
      * show, so it is not a door.
      */
+    /*
+     * ACCESS: which direction this parameter actually means something in.
+     *
+     *   "readwrite"  (default) an ordinary control
+     *   "read"       a READOUT. The value means something, writing means
+     *                nothing. keydetect's `detected_key` is 25 key names with
+     *                no set_param branch at all — deliberately, and documented
+     *                as such when an enum could only be nudged. Enums became
+     *                divable in 1.0, so the picker opened on it and silently
+     *                discarded the choice. That is a design gap, not a bug in
+     *                keydetect: a display-only item was never expressible.
+     *   "write"      a TRIGGER. Writing does something, the value means
+     *                nothing — the module reports a constant. This is the more
+     *                dangerous end: euclidrum's `rnd_preset` declares
+     *                ["—","Rnd!"] and fires on anything that is not the
+     *                em-dash, so an INDEX write of "0" — which MEANS the
+     *                em-dash, "do nothing" — randomises all eight lanes and
+     *                destroys the kit.
+     *
+     * One axis rather than two flags, because they are the same question asked
+     * in opposite directions, and a param cannot be both.
+     */
+    const access = lower(meta.access);
+    meta.readOnly = access === "read";
+    meta.writeOnly = access === "write";
+
     const listableEnum = type === "enum"
                        && Array.isArray(meta.options) && meta.options.length > 0;
     meta.divable_mark = opaqueType;
-    meta.divable = opaqueType || listableEnum;
+    /* Neither end of the axis opens a list. A readout has nothing to choose;
+     * a trigger's options are a spelling of "do it", not a menu. */
+    meta.divable = (opaqueType || listableEnum) && !meta.readOnly && !meta.writeOnly;
     meta.kind = (opaqueType && !(type === "wav_position" && ranged)) ? KIND_OPAQUE
               : type === "enum" ? KIND_ENUM
               : KIND_NUMBER;
@@ -271,8 +299,25 @@ export function isDivableMarked(meta) {
 
 /** True when a knob can drive this param at all. */
 export function isTurnable(meta) {
-    return !!meta && meta.kind !== KIND_OPAQUE;
+    /* A readout has nothing to set; a trigger is fired, not scrubbed — turning
+     * one would walk it through "do nothing" and "do it" as if they were
+     * values, which for euclidrum's rnd_preset means randomising a kit on the
+     * way past. */
+    return !!meta && meta.kind !== KIND_OPAQUE && !meta.readOnly && !meta.writeOnly;
 }
+
+/** A readout: the value means something, writing to it does not. */
+export function isReadOnly(meta) { return !!meta && !!meta.readOnly; }
+
+/**
+ * A trigger: writing does something, the value means nothing.
+ *
+ * The wire value that FIRES it is the module's business — ["idle","trigger"],
+ * ["—","Rnd!"], ["Play","Save"] are all in the fleet — so the host sends
+ * option 1 through the ordinary enum wire (enumWireValue), which respects
+ * whichever convention that module speaks.
+ */
+export function isTrigger(meta) { return !!meta && !!meta.writeOnly; }
 
 /**
  * One-shot repair for a param whose type/range we had to guess (`meta.guessed`).

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -28,11 +28,12 @@
 
 import { KIND_ENUM, KIND_OPAQUE, enumIndexOf } from "./param_meta.mjs";
 import { formatParamValue } from "../param_format.mjs";
-import { asciiFold, fitText, shortenLabel, line } from "./render_page.mjs";
+import { asciiFold, fitText, shortenLabel, line, circle } from "./render_page.mjs";
 import { drawVizGroup } from "./viz_draw.mjs";
 import { enumSquareLines } from "./font5x3.mjs";
 import { fontPrint as tzPrint, fontWidth as tzWidth, HEIGHT as TZ_H } from "./font_tamzen6x12.mjs";
 import { fontWidth4x5, fontPrint4x5, FONT4_HEIGHT, FONT4_MEASURE } from "./font4x5.mjs";
+import { fontWidth5x3, fontPrint5x3 } from "./font5x3.mjs";
 
 /**
  * Text is set in caps with labels abbreviated to a mnemonic. The HEADER and the
@@ -599,10 +600,193 @@ function fitLine(text, maxWidth) {
     return fontWidth4x5(t) > maxWidth ? "" : t;
 }
 
-/* What a trigger's square says when the module has not chosen its own wording.
- * Two characters, so it can never truncate in the 3-per-line square, and a verb
- * rather than a state — the cell label below already names the action. */
-const TRIGGER_MARK = "GO";
+/*
+ * A TRIGGER is a BANG, not a square.
+ *
+ * Reusing the enum square said "this is an enum", which is the one thing a
+ * momentary action is not — reported from the device as "this shouldn't be a
+ * square. It's different."
+ *
+ * A circle because that is what a momentary action looks like in music
+ * software: Max and Pd both draw a bang as a circle, so the shape already
+ * means "click me and something happens" to the people using this. It is also
+ * unambiguous against everything else on the grid — the dial is a circle WITH
+ * a pointer and a gap, the enum is a rectangle, the fader is a column.
+ *
+ * FILLED while firing, and that matters more than it looks: a trigger has no
+ * state, so nothing else on the screen changes when you click it. Without the
+ * flash there is no confirmation that anything happened at all.
+ */
+/*
+ * A TRIGGER is a PUSH BUTTON, not a square and not a value.
+ *
+ * Reusing the enum square said "this is an enum", which is the one thing a
+ * momentary action is not. Drawn as a cap ellipse with two straight sides down
+ * to a base arc -- a physical button in perspective -- because it is then
+ * unmistakable against everything else on the grid: the dial is an arc with a
+ * pointer, the enum a rectangle, the fader a column.
+ *
+ * The cap TRAVELS when it fires. That is the whole reason to prefer it to a
+ * flash: a trigger has no value, so nothing else on screen changes when you
+ * click it, and a button that visibly moves is a stronger confirmation than a
+ * widget that merely inverts.
+ *
+ * Sized to the cell rather than to taste: BTN_RX 7 makes it 15 wide inside a
+ * KW of 17, and cap + depth + base is 12 rows inside a BOX_H of 15, which
+ * leaves room for the 2px travel without touching the label below.
+ */
+/*
+ * Sized by the row budget, not by taste. The widget band is BOX_H = 15 rows
+ * and everything must stay inside it (see the note above drawKnobWidget):
+ *
+ *     1  air
+ *    13  the button: BTN_RY (cap top half) + BTN_DEPTH + BTN_RY (base arc)
+ *     1  air                              ... + 1, because a span from a to b
+ *    ---                                      is b - a + 1 rows, not b - a
+ *    15
+ *
+ * That +1 is not pedantry: it is the bug this shape shipped with first. The
+ * button overflowed one row into the label beneath it, and clipped() cannot
+ * catch that because the pixels are still on the screen.
+ *
+ * There is no CLK cue on the widget. It was tried, cost 7 of these 15 rows,
+ * and squeezed the cap to a 15x5 lozenge -- and the footer already says CLK
+ * FIRE the moment the knob is held, which is the same promise in a place that
+ * costs nothing.
+ */
+const BTN_RX = 7;
+const BTN_RY = 3;
+const BTN_DEPTH = 6;
+const BTN_TRAVEL = 2;
+
+/*
+ * Timing, and why the two halves come apart.
+ *
+ * A real button pops back long before the flash of the thing it did has
+ * faded, so the cap returns at BTN_PRESS_MS while the burst keeps expanding
+ * to BTN_FLASH_MS. Held together they read as one state change; apart they
+ * read as an event with a consequence.
+ *
+ * The burst geometry is the startup animation's impact lines
+ * (src/modules/tools/splash-test/ui.js): IMPACT_GAP 2 and a very SHORT line.
+ * Unlike the splash, which holds three static lines for 20 ticks, these
+ * EXPAND -- the gap grows as the burst travels outward and the stubs go with
+ * it, which is what makes it read as radiating rather than as a decoration
+ * switched on.
+ */
+const BTN_PRESS_MS = 120;
+const BTN_FLASH_MS = 300;
+const BTN_RAYS = 8;
+const BTN_RAY_GAP = 2;
+const BTN_RAY_LEN = 2;
+const BTN_RAY_TRAVEL = 4;   /* how far the burst moves out over its life */
+
+/*
+ * A clean 1px ellipse outline.
+ *
+ * Thresholding on distance (|hypot(dx/rx, dy/ry) - 1| <= k) is the obvious
+ * way and it looks JAGGED at this size: the tolerance band is wider where the
+ * curve runs shallow, so the outline goes two and three pixels thick along the
+ * top and bottom and thin at the sides. Walking each column for its exact y
+ * and each row for its exact x, and taking the union, gives an even, connected
+ * hairline instead.
+ */
+function ellipseOutline(ctx, cx, cy, rx, ry, color, bottomOnly) {
+    const put = (x, y) => {
+        if (bottomOnly && y < cy) return;
+        ctx.fillRect(x, y, 1, 1, color);
+    };
+    for (let dx = -rx; dx <= rx; dx++) {
+        const dy = Math.round(ry * Math.sqrt(Math.max(0, 1 - (dx / rx) ** 2)));
+        put(cx + dx, cy + dy);
+        put(cx + dx, cy - dy);
+    }
+    for (let dy = -ry; dy <= ry; dy++) {
+        const dx = Math.round(rx * Math.sqrt(Math.max(0, 1 - (dy / ry) ** 2)));
+        put(cx + dx, cy + dy);
+        put(cx - dx, cy + dy);
+    }
+}
+
+function ellipseFill(ctx, cx, cy, rx, ry, color) {
+    for (let dy = -ry; dy <= ry; dy++) {
+        const w = Math.round(rx * Math.sqrt(Math.max(0, 1 - (dy / ry) ** 2)));
+        if (w > 0) ctx.fillRect(cx - w, cy + dy, w * 2 + 1, 1, color);
+    }
+}
+
+/* Impact stubs, following the cap's ellipse so they sit an even gap off the
+ * rim rather than bunching at the flat top and bottom. */
+function buttonRays(ctx, cx, cy, progress) {
+    const out = BTN_RAY_GAP + Math.round(progress * BTN_RAY_TRAVEL);
+    for (let i = 0; i < BTN_RAYS; i++) {
+        const a = (Math.PI * 2 * i) / BTN_RAYS;
+        const ux = Math.cos(a), uy = Math.sin(a);
+        const x0 = cx + ux * (BTN_RX + out);
+        const y0 = cy + uy * (BTN_RY + out);
+        const x1 = cx + ux * (BTN_RX + out + BTN_RAY_LEN);
+        const y1 = cy + uy * (BTN_RY + out + BTN_RAY_LEN);
+        line(ctx, Math.round(x0), Math.round(y0), Math.round(x1), Math.round(y1), 1);
+    }
+}
+
+/*
+ * Three states:
+ *   idle      raised outline
+ *   selected  cap filled with CLK knocked out -- the affordance has to be ON
+ *             the control, not only in the footer, because a button has no
+ *             value to read and nothing else says it is pressable
+ *   fired     cap pressed down BTN_TRAVEL, sides shortened, stubs radiating
+ */
+function drawButton(ctx, cx, rowY, phase) {
+    const pressed = phase.pressed;
+    const travel = pressed ? BTN_TRAVEL : 0;
+    /* One row of air top and bottom; see the budget above. */
+    const capY = rowY + 1 + BTN_RY + travel;
+    const baseY = capY + BTN_DEPTH - travel;
+
+    ellipseOutline(ctx, cx, baseY, BTN_RX, BTN_RY, 1, true);   /* base arc */
+    line(ctx, cx - BTN_RX, capY, cx - BTN_RX, baseY, 1);        /* sides */
+    line(ctx, cx + BTN_RX, capY, cx + BTN_RX, baseY, 1);
+
+    /* Highlighted and pressed both FILL the cap -- the filled disk is the
+     * highlight. The outline goes on top of the fill, not instead of it:
+     * filling alone left the rim a pixel short at the shallow top and bottom,
+     * so the disk looked like it was missing a line. */
+    if (phase.filled) ellipseFill(ctx, cx, capY, BTN_RX, BTN_RY, 1);
+    ellipseOutline(ctx, cx, capY, BTN_RX, BTN_RY, 1, false);
+
+    /* One burst per press still in flight, so a fast double-tap throws two
+     * expanding rings rather than cancelling the first. */
+    for (const b of phase.bursts) buttonRays(ctx, cx, capY, b);
+}
+
+/*
+ * Idle / highlighted / pressed, resolved from the press timestamps alone.
+ *
+ * A press does NOT clear the bursts already travelling. Overwriting a single
+ * timestamp made a rapid second press swallow the first ring and restart from
+ * the centre, which reads as an animation glitch rather than as two events.
+ * Keeping every press still inside BTN_FLASH_MS lets them overlap, and the
+ * cap is pressed if ANY of them is recent.
+ *
+ * Accepts a bare number as well as a list: a caller that has only ever stamped
+ * one time still works.
+ */
+function buttonPhase(fired, now, held) {
+    const stamps = Array.isArray(fired) ? fired : (fired > 0 ? [fired] : []);
+    const bursts = [];
+    let pressed = false;
+    if (typeof now === "number") {
+        for (const t of stamps) {
+            const age = now - t;
+            if (age < 0 || age >= BTN_FLASH_MS) continue;
+            bursts.push(age / BTN_FLASH_MS);
+            if (age < BTN_PRESS_MS) pressed = true;
+        }
+    }
+    return { pressed, filled: held || bursts.length > 0, bursts };
+}
 
 function drawEnumSquare(ctx, kx, ky, text) {
     const w = ENUM_W, h = BOX_H;
@@ -701,7 +885,7 @@ function drawDivableMark(ctx, g, col, rowY) {
     drawBrackets(ctx, cellLeft(g, col) + 1, rowY, g.cellW - 2, BOX_H);
 }
 
-function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, cellText) {
+function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, cellText, btnPhase) {
     const kx = cellLeft(g, col) + Math.floor((g.cellW - KW) / 2), ky = rowY;
     /* Anything that cannot show two values at once shows the live one, so it
      * animates under modulation instead of freezing on the base. */
@@ -726,11 +910,15 @@ function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, cellText)
      * hook for "what this widget should say in three characters".
      */
     if (meta.writeOnly) {
-        const shortActs = Array.isArray(meta.short_options) ? meta.short_options : null;
-        const label = (shortActs && shortActs[1] !== undefined)
-            ? String(shortActs[1])
-            : TRIGGER_MARK;
-        drawEnumSquare(ctx, cellLeft(g, col) + Math.floor((g.cellW - ENUM_W) / 2), ky, label);
+        /* The cell's own label underneath names the action ("Clear", "Rnd
+         * Preset"), so the bang carries no text — which also sidesteps the
+         * module's idle spelling entirely. euclidrum's is an em-dash the 5x7
+         * atlas cannot draw, and drawing it was the original blank square. */
+        /* Clock injected, never read here: this renderer is pure with respect
+         * to the device, which is what lets the harness draw what the device
+         * draws. `now` absent simply means "never lit". */
+        drawButton(ctx, cellLeft(g, col) + Math.floor(g.cellW / 2), ky,
+                   btnPhase || { pressed: false, filled: false, burst: -1 });
         return;
     }
     if (meta.kind === KIND_ENUM) {
@@ -934,10 +1122,15 @@ export function drawKnobRow(ctx, o, row, rowY, lblY, geom) {
              * driving; `values` stays the base the user dialled in. */
             /* Knob: base + dot. Enum/opaque: the live value, no baseline —
              * drawKnobWidget picks per kind. */
+            /* Trigger flash: injected, never clocked here — this renderer is
+             * pure with respect to the device, which is what lets the harness
+             * draw what the device draws. Absent means "never lit". */
+            const firedAt = (o.triggerFiredAt && o.triggerFiredAt[key]) || 0;
+            const btnPhase = buttonPhase(firedAt, o.nowMs, isTouched);
             drawKnobWidget(ctx, g, col, rowY, meta, raw,
                            modValues ? modValues[key] : undefined,
                            liveValues ? liveValues[key] : undefined,
-                           cellText);
+                           cellText, btnPhase);
         }
 
         /* Budget in CHARACTERS, not pixels: Elektron's labels are 3-4 glyphs

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -599,6 +599,11 @@ function fitLine(text, maxWidth) {
     return fontWidth4x5(t) > maxWidth ? "" : t;
 }
 
+/* What a trigger's square says when the module has not chosen its own wording.
+ * Two characters, so it can never truncate in the 3-per-line square, and a verb
+ * rather than a state — the cell label below already names the action. */
+const TRIGGER_MARK = "GO";
+
 function drawEnumSquare(ctx, kx, ky, text) {
     const w = ENUM_W, h = BOX_H;
     ctx.fillRect(kx, ky, w, 1, 1);
@@ -702,6 +707,32 @@ function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, cellText)
      * animates under modulation instead of freezing on the base. */
     const shown = (liveRaw === null || liveRaw === undefined) ? raw : liveRaw;
     if (meta.kind === KIND_OPAQUE) { drawOpaqueBox(ctx, kx, ky, shown, cellText); return; }
+    /*
+     * A TRIGGER is a button, so the cell shows the ACTION, not the value.
+     *
+     * Drawing its "current option" is meaningless — the module reports a
+     * constant idle spelling, and for euclidrum that constant is an em-dash,
+     * which the 5x7 atlas cannot draw at all. The result was a blank square:
+     * a control that looked broken while working perfectly.
+     *
+     * So the square shows an ACTION mark and the cell's own label underneath
+     * says which action it is — "Clear", "Rnd Preset", "Recover Loop".
+     *
+     * Deliberately NOT options[1]. That is the value that FIRES it, not a verb,
+     * and the fleet proves it is not reliably readable: euclidrum's is "Rnd!"
+     * (fine) but magneto's is "Cleared" and "Saved" — past participles that
+     * read as STATUS under a label that already says "Clear". A module that
+     * wants its own wording can supply short_options[1], which is the existing
+     * hook for "what this widget should say in three characters".
+     */
+    if (meta.writeOnly) {
+        const shortActs = Array.isArray(meta.short_options) ? meta.short_options : null;
+        const label = (shortActs && shortActs[1] !== undefined)
+            ? String(shortActs[1])
+            : TRIGGER_MARK;
+        drawEnumSquare(ctx, cellLeft(g, col) + Math.floor((g.cellW - ENUM_W) / 2), ky, label);
+        return;
+    }
     if (meta.kind === KIND_ENUM) {
         /* A plugin may report an enum as its option NAME rather than as an
          * index (see learnEnumWireFormat) — resolve either to the index, or

--- a/tests/host/test_param_access.sh
+++ b/tests/host/test_param_access.sh
@@ -197,3 +197,34 @@ Promise.all([
   console.log("PASS: access read/write/readwrite");
 });
 '
+
+# ---- the footer names the GESTURE, not the consequence ----------------------
+#
+# The hint vocabulary is a canon (JOG SEL / CLK OPEN / BACK EXIT) and the canon
+# names what to DO. A trigger is drawn as a push button, so it asks to be
+# PUSHed. It said FIRE first, which names the consequence instead -- a second
+# thing to learn about a control the picture already explains.
+#
+# footerHints() is module-private and reads a module-level controller, so this
+# is asserted at the source, the same way the other footer rules in this file
+# are. The value is pinned, not merely the absence of MENU: "not MENU" would
+# pass for any word at all, including the one being replaced.
+pp="src/shadow/shadow_ui_param_pages.mjs"
+wo=$(awk '/if \(meta && meta.writeOnly\)/,/^        }/' "$pp")
+if [ -z "$wo" ]; then
+  echo "FAIL: could not find the held-trigger footer branch in $pp" >&2
+  exit 1
+fi
+if ! grep -q 'click: "PUSH"' <<<"$wo"; then
+  echo "FAIL: a held trigger does not advertise CLK PUSH." >&2
+  echo "      The widget is a push button; the hint must name that gesture." >&2
+  echo "$wo" >&2
+  exit 1
+fi
+# The neighbouring vocabulary must not have moved with it.
+dv=$(awk '/if \(meta && meta.divable\)/,/^        }/' "$pp")
+if ! grep -q 'click: "OPEN"' <<<"$dv"; then
+  echo "FAIL: a held divable no longer advertises CLK OPEN" >&2
+  exit 1
+fi
+echo "  ok  a held trigger advertises CLK PUSH, divable still CLK OPEN"

--- a/tests/host/test_param_access.sh
+++ b/tests/host/test_param_access.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# `access` — which direction a parameter actually means something in.
+#
+#   "readwrite"  (default) an ordinary control
+#   "read"       a READOUT: the value means something, writing means nothing
+#   "write"      a TRIGGER: writing does something, the value means nothing
+#
+# Two ends of one axis, and both were unexpressible before 1.0.
+#
+# The read end is a design gap we walked into: keydetect's `detected_key` is 25
+# key names with no set_param branch at all, deliberately, and documented as
+# such back when an enum could only be nudged one detent. Enums became divable
+# in 1.0, so the picker opened on it and silently discarded the choice.
+#
+# The write end is the dangerous one. euclidrum's `rnd_preset` declares
+# ["—","Rnd!"] and fires on anything that is not the em-dash — so an INDEX
+# write of "0", which MEANS the em-dash, "do nothing", randomises all eight
+# lanes and destroys the kit. A trigger must be fired through the module's own
+# enum wire, never as a bare number.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_pages/param_meta.mjs"),
+  import("./src/shared/param_pages/page_controller.mjs"),
+]).then(([M, C]) => {
+  const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+  /* ---- the axis itself --------------------------------------------- */
+  const ix = M.buildMetaIndex({ chainParams: [
+    { key: "cutoff",       type: "float", min: 0, max: 1 },
+    { key: "mode",         type: "enum",  options: ["LP", "HP"] },
+    { key: "detected_key", type: "enum",  options: ["C", "C#", "D"], access: "read" },
+    { key: "rnd_preset",   type: "enum",  options: ["—", "Rnd!"], access: "write" },
+  ]});
+  const meta = (k) => ix.getOrGuess(k);
+
+  /* An ordinary enum is unaffected — the default must stay readwrite. */
+  if (!M.isTurnable(meta("mode"))) fail("a plain enum stopped being turnable");
+  if (!meta("mode").divable)       fail("a plain enum stopped being divable");
+  if (M.isReadOnly(meta("mode")) || M.isTrigger(meta("mode")))
+    fail("a param with no access declared is not readwrite by default");
+  if (!M.isTurnable(meta("cutoff"))) fail("a plain float stopped being turnable");
+
+  /* A readout: nothing to set, nothing to open. */
+  if (M.isTurnable(meta("detected_key"))) fail("a read-only param is still turnable");
+  if (meta("detected_key").divable)       fail("a read-only param still opens a picker");
+  if (!M.isReadOnly(meta("detected_key"))) fail("isReadOnly did not recognise access:read");
+
+  /* A trigger: fired, not scrubbed, not opened. */
+  if (M.isTurnable(meta("rnd_preset")))
+    fail("a trigger is still turnable — turning it walks THROUGH the fire value");
+  if (meta("rnd_preset").divable) fail("a trigger still opens a picker");
+  if (!M.isTrigger(meta("rnd_preset"))) fail("isTrigger did not recognise access:write");
+
+  /* ---- clicking a trigger FIRES it, through the module wire ---- */
+  const writes = [];
+  const HIER = JSON.stringify({ modes: null, levels: { root: { label: "S",
+      knobs: ["rnd_preset", "detected_key"],
+      params: [{ key: "rnd_preset" }, { key: "detected_key" }] } } });
+  const CP = JSON.stringify([
+    { key: "rnd_preset",   name: "Randomise", type: "enum", options: ["—", "Rnd!"], access: "write" },
+    { key: "detected_key", name: "Key",       type: "enum", options: ["C", "C#"],        access: "read"  },
+  ]);
+  const ctl = C.createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return HIER;
+      if (b === "chain_params") return CP;
+      if (b === "rnd_preset") return "—";      /* a trigger reports its idle spelling */
+      if (b === "detected_key") return "C#";
+      return "0";
+    },
+    setParam: (k, v) => writes.push([k, v]),
+    announce: () => {},
+  });
+  ctl.load({ slot: 0, component: "synth" });
+  for (let i = 0; i < 6; i++) ctl.tick();
+
+  const slotOf = (key) => (ctl.page.keys || []).indexOf(key);
+  const trigSlot = slotOf("rnd_preset");
+  const roSlot   = slotOf("detected_key");
+  if (trigSlot < 0 || roSlot < 0) fail("fixture did not put both params on the grid");
+
+  /* Clicking the trigger must WRITE, and must not hand back an open intent. */
+  writes.length = 0;
+  const intent = ctl.onClick(trigSlot);
+  if (intent) fail("clicking a trigger returned an open intent instead of firing");
+  if (writes.length !== 1) fail("clicking a trigger wrote " + writes.length + " times, expected 1");
+  /* THE bug: the module fires on anything that is not the em-dash, so a bare
+   * "0" would mean "do nothing" and a bare "1" is not its spelling either.
+   * The module reports names, so the wire must be the NAME of option 1. */
+  if (writes[0][1] !== "Rnd!")
+    fail("a trigger fired with " + JSON.stringify(writes[0][1]) + ", expected \"Rnd!\" — " +
+         "a bare index is exactly what destroys euclidrum kits");
+
+  /* Turning a trigger must do nothing at all. */
+  writes.length = 0;
+  ctl.onKnobTurn(trigSlot, 1, 5000);
+  if (writes.length) fail("turning a trigger wrote " + JSON.stringify(writes));
+
+  /* A readout: click opens nothing, turn writes nothing. */
+  writes.length = 0;
+  if (ctl.onClick(roSlot)) fail("clicking a readout returned an intent");
+  ctl.onKnobTurn(roSlot, 1, 6000);
+  if (writes.length) fail("a readout was written to: " + JSON.stringify(writes));
+
+  console.log("  ok  default is readwrite; plain enums and floats unaffected");
+  console.log("  ok  readout: not turnable, not divable, never written");
+  console.log("  ok  trigger: fires once on click, through the module wire (\"Rnd!\"), not turnable");
+  console.log("PASS: access read/write/readwrite");
+});
+'

--- a/tests/host/test_param_access.sh
+++ b/tests/host/test_param_access.sh
@@ -154,6 +154,68 @@ Promise.all([
            " for the unrenderable idle value — it is still blank");
   }
 
+  /* ---- the animation must be WIRED, not merely implemented -----------
+   *
+   * This is the bug it shipped with, reported from the device as "i dont see
+   * the animation". The renderer is pure and reads its clock and its fire
+   * times off the options object, and the production draw call in
+   * page_controller passed NEITHER -- so every button drew its idle phase
+   * forever. The renderer tests above did not catch it because they hand
+   * renderPageMovy both values directly, proving the renderer and never the
+   * wiring.
+   *
+   * So this drives controller.render(), the real path.
+   *
+   * Its own controller with an INJECTED clock, for two reasons: the shared
+   * one above has already fired this trigger, so it is mid-animation and both
+   * snapshots would match (the first version of this test failed exactly
+   * there), and settling on the wall clock would mean really sleeping. */
+  {
+    const fbmod = await import("./tools/param-pages/harness.mjs");
+    const RPM = await import("./src/shared/param_pages/render_page_movy.mjs");
+    let clock = 100000;
+    const anim = C.createController({
+      getParam: (k) => {
+        const b = String(k).replace(/^[^:]+:/, "");
+        if (b === "ui_hierarchy") return HIER;
+        if (b === "chain_params") return CP;
+        if (b === "rnd_preset") return "\u2014";
+        return "0";
+      },
+      setParam: () => {}, announce: () => {}, now: () => clock,
+    });
+    anim.load({ slot: 0, component: "synth" });
+    for (let i = 0; i < 6; i++) anim.tick();
+    /* The button only exists in the movy layout; the default is the dial grid,
+     * where there would be no button and so no difference to detect. */
+    anim.setLayout(RPM.LAYOUT_MOVY);
+    const slot = (anim.page.keys || []).indexOf("rnd_preset");
+    if (slot < 0) fail("the animation fixture did not put the trigger on the grid");
+
+    /* A SIGNATURE of the buffer, not a pixel COUNT: the button travels, so a
+     * count can be identical while the image is completely different. */
+    const sig = () => {
+      const fb = fbmod.createFramebuffer();
+      anim.render(fbmod.drawContext(fb), { title: "T" });
+      const px = fb.pixels || fb.px;
+      let h = 0;
+      for (let i = 0; i < 128 * 64; i++) if (px[i]) h = (h * 31 + i) | 0;
+      return h;
+    };
+
+    const idle = sig();
+    anim.onClick(slot);
+    const pressed = sig();
+    if (pressed === idle)
+      fail("the button drew identically before and after a click -- the press " +
+           "animation is not reaching the renderer through controller.render()");
+
+    /* ...and it must come back down on its own, or it is a latch, not a press. */
+    clock += 5000;
+    if (sig() !== idle)
+      fail("the button never returned to idle -- a press that stays down is a switch");
+  }
+
   /* ---- the button must stay INSIDE its row band ---------------------
    *
    * This is the bug it shipped with: a span from a to b is b - a + 1 rows,
@@ -191,6 +253,7 @@ Promise.all([
 
   console.log("  ok  trigger draws a button, never the unrenderable idle value");
   console.log("  ok  the button stays inside its 15-row band");
+  console.log("  ok  the press animation reaches the screen through controller.render()");
   console.log("  ok  default is readwrite; plain enums and floats unaffected");
   console.log("  ok  readout: not turnable, not divable, never written");
   console.log("  ok  trigger: fires once on click, through the module wire (\"Rnd!\"), not turnable");

--- a/tests/host/test_param_access.sh
+++ b/tests/host/test_param_access.sh
@@ -31,7 +31,7 @@ node -e '
 Promise.all([
   import("./src/shared/param_pages/param_meta.mjs"),
   import("./src/shared/param_pages/page_controller.mjs"),
-]).then(([M, C]) => {
+]).then(async ([M, C]) => {
   const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
 
   /* ---- the axis itself --------------------------------------------- */
@@ -113,6 +113,48 @@ Promise.all([
   ctl.onKnobTurn(roSlot, 1, 6000);
   if (writes.length) fail("a readout was written to: " + JSON.stringify(writes));
 
+  /* ---- a trigger must LOOK like a button ----------------------------
+   *
+   * It works and looks broken otherwise: the module reports a constant idle
+   * spelling, and euclidrum reports an em-dash the 5x7 atlas cannot draw at
+   * all, so the cell rendered as a BLANK square with no footer hint. Reported
+   * from the device as "works, but we need some other way to do it than a
+   * blank square and no footer".
+   *
+   * The square is drawn with a bitmap font through fillRect, not ctx.print, so
+   * "blank" is a pixel question and is asserted as one: render the same cell
+   * as a trigger and as a plain enum showing that same unrenderable value, and
+   * the trigger must put glyph pixels inside the box where the plain enum puts
+   * none. */
+  {
+    const R = await import("./src/shared/param_pages/render_page_movy.mjs");
+    const render = (access) => {
+      let pixels = 0;
+      const ctx = {
+        /* Count only small rects: the box frame is 1px lines the full width,
+         * glyphs are little blocks. Both are fillRect, so size discriminates. */
+        fillRect: (x, y, w, h) => { if (w <= 4 && h <= 6) pixels += w * h; },
+        print: () => {}, textWidth: (t) => String(t).length * 4,
+      };
+      const decl = { key: "rnd_preset", name: "Rnd Preset", type: "enum",
+                     options: ["\u2014", "Rnd!"] };
+      if (access) decl.access = access;
+      const ix2 = M.buildMetaIndex({ chainParams: [decl] });
+      R.renderPageMovy(ctx, {
+        page: { kind: "knobs", name: "P", keys: ["rnd_preset"], level: "root" },
+        metaIndex: ix2, values: { rnd_preset: "\u2014" },
+        pageIndex: 0, pageCount: 1, header: "T",
+      });
+      return pixels;
+    };
+    const plain = render(null);        /* today: an em-dash the font cannot draw */
+    const trigger = render("write");   /* the action mark */
+    if (trigger <= plain)
+      fail("a trigger cell drew " + trigger + " glyph pixels vs " + plain +
+           " for the unrenderable idle value — it is still blank");
+  }
+
+  console.log("  ok  trigger cell draws an action mark, never the idle value");
   console.log("  ok  default is readwrite; plain enums and floats unaffected");
   console.log("  ok  readout: not turnable, not divable, never written");
   console.log("  ok  trigger: fires once on click, through the module wire (\"Rnd!\"), not turnable");

--- a/tests/host/test_param_access.sh
+++ b/tests/host/test_param_access.sh
@@ -154,7 +154,43 @@ Promise.all([
            " for the unrenderable idle value — it is still blank");
   }
 
-  console.log("  ok  trigger cell draws an action mark, never the idle value");
+  /* ---- the button must stay INSIDE its row band ---------------------
+   *
+   * This is the bug it shipped with: a span from a to b is b - a + 1 rows,
+   * so a button budgeted at 2*RY + DEPTH was one row taller than that and
+   * overflowed into the label beneath it. The harness clipped() counter
+   * cannot catch it, because those pixels are still on the screen.
+   *
+   * Rendered with a BLANK label, so any ink at or below the label row is the
+   * widget overflowing and nothing else. */
+  {
+    const R = await import("./src/shared/param_pages/render_page_movy.mjs");
+    const fbmod = await import("./tools/param-pages/harness.mjs");
+    const probe = (access) => {
+      const fb = fbmod.createFramebuffer();
+      const ix3 = M.buildMetaIndex({ chainParams: [
+        { key: "t", name: " ", type: "enum", options: ["a", "b"],
+          ...(access ? { access } : {}) } ] });
+      R.renderPageMovy(fbmod.drawContext(fb), {
+        page: { kind: "knobs", name: "P", keys: ["t"], level: "root" },
+        metaIndex: ix3, values: { t: "a" }, pageIndex: 0, pageCount: 1, header: " ",
+        triggerFiredAt: { t: 1 }, nowMs: 40,      /* pressed: the tallest state */
+      });
+      const px = fb.pixels || fb.px;
+      let lowest = -1;
+      for (let y = 0; y < 64; y++) for (let x = 0; x < 128; x++)
+        if (px[y * 128 + x]) { lowest = Math.max(lowest, y); }
+      return lowest;
+    };
+    const band_end = R.ROW0_Y + 15 - 1;          /* BOX_H */
+    const lowest = probe("write");
+    if (lowest > band_end)
+      fail("the trigger widget drew down to row " + lowest + ", past the band end at " +
+           band_end + " — it is overflowing into the label");
+  }
+
+  console.log("  ok  trigger draws a button, never the unrenderable idle value");
+  console.log("  ok  the button stays inside its 15-row band");
   console.log("  ok  default is readwrite; plain enums and floats unaffected");
   console.log("  ok  readout: not turnable, not divable, never written");
   console.log("  ok  trigger: fires once on click, through the module wire (\"Rnd!\"), not turnable");


### PR DESCRIPTION
Adds an `access` axis to `chain_params`, so a module can say which *direction* a parameter means something in.

```
"readwrite"  (default) an ordinary control
"read"       a READOUT: the value means something, writing means nothing
"write"      a TRIGGER: writing does something, the value means nothing
```

Both ends were unexpressible before 1.0, and both are live bugs.

**The read end** is a gap we walked into. keydetect's `detected_key` is 25 key names with no `set_param` branch at all — deliberately, and documented as such back when an enum could only be nudged one detent. Enums became divable in 1.0, so the picker now opens on it and silently discards the choice.

**The write end is the dangerous one.** euclidrum's `rnd_preset` declares `["—","Rnd!"]` and fires on anything that is not the em-dash — so an *index* write of `"0"`, which means the em-dash, i.e. "do nothing", randomises all eight lanes and destroys the kit. A trigger must be fired through the module's own enum wire, never as a bare number.

## The widget

A trigger renders as a push button rather than a value box — it has no value worth showing, and euclidrum's idle spelling is an em-dash the 5x7 atlas cannot draw at all, so the cell was literally blank. Pressing it animates: the disk travels, rays fire, overlapping presses restart the animation.

The footer says `CLK PUSH`. It said `FIRE` first; the hint vocabulary is a canon and the canon names the *gesture* (`JOG SEL`, `CLK OPEN`), not the consequence.

## Compatibility

Verified in both directions against the v0.12.1 C and JS parsers: an older host ignores an unknown `access` key, and a newer host defaults absent `access` to `readwrite`. Declaring it does not break older hosts.

## Tests

`tests/host/test_param_access.sh` — the axis itself, that a click fires **once** and through the module's wire (`"Rnd!"`, not `"1"`), that turning a trigger writes nothing, that a readout is never written, that the button draws glyph pixels where a plain enum draws none, that it stays inside its 15-row band, and that the footer says PUSH while a divable still says OPEN.

Three module-side PRs follow separately (keydetect, euclidrum, magneto).