### PR TITLE
docs: draft 1.0 release notes

### DIFF
--- a/docs/releases/1.0.md
+++ b/docs/releases/1.0.md
@@ -1,0 +1,171 @@
+# Schwung 1.0
+
+**DRAFT — not released.** `src/host/version.txt` and `module-catalog.json` are
+still on 0.12.1 and stay there until this is tested on hardware and tagged. See
+"Before tagging" at the bottom.
+
+209 commits and 11 merged pull requests since v0.12.1, including the first
+contribution from outside the project.
+
+---
+
+## The headline
+
+**Chains became variable length, and Master FX became a real chain.**
+
+A slot now takes up to **8 MIDI FX and 8 audio FX** either side of the synth,
+with `+` boxes, Shift+Jog reorder and Move Left/Right in the picker. Master FX
+went from a fixed 4-slot array with no reorder at all to **8 slots on the same
+editor** — one diagram, one picker, one set of verbs.
+
+The part that matters musically: **a shape edit is a permutation, not a
+reload.** Adding, removing or moving a module does not disturb the ones already
+running, so an arp keeps its phase and a reverb keeps its tail. Inserting at the
+head used to rebuild everything behind it.
+
+**Every enum now opens a list.** Hold its knob and click to get a scrolling
+picker — the other half of a control that could only ever be nudged one detent
+at a time. It earns its keep on a Recv Ch with 17 options, a Braids model list
+with 47, or an airwindows bank with 519. The knob still steps it; the list is
+the alternative, not the replacement.
+
+**The chain editor answers a knob with a card** — the touched knob and its three
+neighbours with their real widgets, drawn by the knob grid's own renderer,
+instead of a bare `Value: 0.62`.
+
+---
+
+## Fixes you will feel
+
+**Enum knobs that silently did nothing now work.** The grid held every enum as a
+number and always wrote an index, but several modules' `set_param` is a `strcmp`
+over the option *names* with no trailing `else` — so every write was discarded
+while the display showed the value moving and snapping back. "Always reverts to
+major" was never a revert; it never moved at all. The grid now **learns the
+convention from what the module reports**, per key, adding no IPC of its own.
+
+**Choosing something takes you where you meant to go.** Picking a category or a
+bank lands you on that level's **preset browser** rather than its knob grid when
+it has both (obxd's `banks → root` was the reported case), and a page you were
+*sent* to **arrives already open** — you chose your way there, so you should not
+have to click in as well. Paging onto a browser with the jog still leaves it
+shut, which is what stops browsing from auditioning every preset it passes.
+
+**A knob scrolls the option list it just opened.** You reach the picker by
+holding a knob, so the hand is already there. It scrolls at knob speed — about
+six detents per entry — and only accelerates on a genuine flick, scaled to how
+long the list actually is: a 6-option enum never accelerates, a 519-entry list
+can move 8 at a time. Releasing and re-gripping no longer throws the parameter
+overlay over the list.
+
+**A two-state switch actually switches** (contributed by
+[@athousanddetails](https://github.com/athousanddetails), #228). It read its
+state with `Number(raw)`, which is `NaN` for the `Off`/`On` spelling, so the
+knob stayed pinned to the OFF seat whatever the module said. It also took four
+detents to move and up to seven to come back; a switch has two states and no
+travel, so it now flips on one. Reversing direction no longer spends the banked
+partial turn cancelling itself, which affected every enum.
+
+**A blank chain recovers on its own.** If a module blocks its parameter channel
+long enough (one does a 20 MB file copy while loading), the contract read fails
+and the grid correctly refuses to invent a page set from it — but it then stayed
+blank until you navigated away and back. Giving up the *screen* and giving up
+the *component* are now separate; a slow probe keeps looking and the page returns
+by itself.
+
+**A module with no saved state no longer takes its whole slot down with it.**
+Two modules implement no `state` key. The host could not tell "declares none"
+from "the read did not complete", assumed the worse one, and skipped the
+autosave for the **entire slot** — including the other components in it,
+silently, because the thing that fires is the guard designed to protect a good
+file.
+
+Also fixed on the way through: slot FX 5–8 and MIDI FX 2–8 never had bypass
+restored at boot; a rejected knob-mapping row bled its fields into the next one;
+an unmatched `fx5:` key routed into **slot 0** with a garbage key, silently
+corrupting a different running module; MIDI capture was hard-wired to Master FX
+position 0; and Master FX filled unmapped knobs by index, which on `smack` put
+trigger enums like "Capture Now" on knobs 5–8.
+
+---
+
+## For module authors
+
+**`plugin_api_v1.h` now states which thread your code runs on.** It never did,
+and that turned out to be the single most expensive omission in the project.
+
+An audit of **all 113 catalogued modules** found ~150 confirmed realtime
+violations — and several modules *document the opposite of the truth* in their
+own comments: *"control-thread only (blocking dir + file I/O)"*, *"run on the
+control thread, NEVER from process_block — so this malloc is realtime-safe"*.
+Authors inferred a plausible architecture and nothing we shipped contradicted
+them.
+
+There is no control thread. `create_instance`, `destroy_instance`, `set_param`,
+`get_param`, `on_midi` and `render_block` are all the SPI audio callback, at
+SCHED_FIFO 90, with ~900 µs of budget. Two consequences are called out
+explicitly because they bite hardest:
+
+- **`pthread_create` from those entry points inherits FIFO 90.** At least 14
+  modules do this. Move's own `Link Main` publisher runs at FIFO 35, so an
+  inherited-priority worker starves Move's audio — the very dropouts going
+  off-thread was meant to avoid. The demote-and-pin snippet is inline, with
+  `keydetect` and `clap` named as the references that get it right.
+- **A `get_param` that rescans a directory is served once per *repaint*,** not
+  once per click, which makes it worse than the equivalent `set_param`. Seven
+  modules have exactly that.
+
+Same contract in `docs/MODULES.md` and as rule 4 of `docs/REALTIME_SAFETY.md`.
+
+**Other declarations that now behave, or are honestly documented as not:**
+
+- **Selector keys are dropped from `knobs[]`.** `list_param`/`items_param` and
+  friends already get their own page; two modules listed one as a knob as well,
+  in both cases because `knobs[]` was a copy of `params[]`.
+- **`max_param` is not implemented, and no longer corrupts what it decorates.**
+  Eight modules declare it and nothing has ever read it — but it planted an
+  internal marker that shipped as `{"min":0,"max":-1}`. Publish a real `max`;
+  you know the count when you build the string.
+- **`navigate_to` is documented at all**, for the first time, along with what a
+  level that plans both a browser and a grid resolves to.
+- **A degenerate `"[]"` for `chain_params`** is treated as "no answer", not as
+  "declares nothing". Return `-1`.
+- **A pattern for a knob whose options depend on another selection** — folder,
+  then wavetable — with the reason `type: "filepath"` cannot do it, and the
+  limits (`MAX_ENUM_OPTIONS` 128, 64 KB contract) to design against.
+
+**A parameter read has three answers, not two.** JSON means served; `""` means
+served-but-nothing; `null` means the read did not complete. Collapsing the last
+two caused three separate bugs in one day, and a fourth a layer up in autosave.
+Never let a failed read produce a plan, a default or a cached verdict.
+
+---
+
+## Known issues
+
+- **Module loading blocks the SPI callback — measured at 673 ms**, roughly 232
+  dropped frames, device-wide rather than per-slot. The design to fix it is
+  written up and its blocking question has been answered (no plugin calls the
+  dangerous host callbacks during `create_instance`), but the work is not done.
+  See `docs/REALTIME_SAFETY.md` and the 2026-08-21 spike.
+- **`impressive-chords` leaks a note** alongside the chord. The chain host is
+  exonerated — every route from a pad to the synth was traced and its
+  `process_midi` never emits the input note. Diagnosis and the experiment that
+  settles it are in `docs/plans/2026-08-21-impressive-chords-dry-note.md`.
+- **`granny` and several others do blocking file I/O on the audio thread.** The
+  host survives it; the stall is real and lives in those repos. Full per-module
+  findings are in the fleet audit.
+- The broader `tests/{shadow,store,build}` suites are not run by CI and carry
+  ~20 stale failures pinning since-moved code. `tests/host` is the gate.
+
+---
+
+## Before tagging
+
+1. Hardware test — nothing here is release-verified.
+2. Bump `src/host/version.txt` and `module-catalog.json` (`latest_version` +
+   download URL).
+3. `min_host_version` for any module depending on this work.
+4. `../schwung-catalog-site/manual.html` — three commits are already written and
+   deliberately unpushed, describing features that were unreleased at the time.
+5. Tag, then `gh release edit` with notes derived from this file.


### PR DESCRIPTION
Draft release notes for 1.0 at `docs/releases/1.0.md`.

Docs only — no code. Not a release: the tag and the catalog bump are deliberately out of scope until hardware testing is done.

Covers the enum picker and wire-format learning, the contract tri-state (`null` is a failed read, not "declares none"), chain shape permutation, the movy knob grid and knob card, list-knob acceleration, the door rule, and the fleet audit's threading contract.

Known issues are listed honestly, including the ones that need module-side fixes rather than host fixes.