### PR TITLE
midi: keep a dedup entry alive while its event is still in MIDI_IN

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1267,6 +1267,17 @@
       "asset_name": "chord-finder-module.tar.gz",
       "min_host_version": "0.11.6",
       "requires": "Ableton Move 1.8 or newer; Move/USB-C audition requires matching Move track MIDI routing"
+    },
+    {
+      "id": "tape-echo2",
+      "name": "Tape Echo 2",
+      "description": "Component-modeled vintage three-head tape echo with spring reverb: 12 head/reverb modes, in-loop tape saturation, wow & flutter, tape age, and tempo sync with the reference machine's leading-head note tables.",
+      "author": "Tape Echo 2 by Dusk Audio (GPL-3.0) \u00b7 port: athousanddetails",
+      "component_type": "audio_fx",
+      "github_repo": "athousanddetails/schwung-tape-echo2",
+      "default_branch": "main",
+      "asset_name": "tape-echo2-module.tar.gz",
+      "min_host_version": "0.7.13"
     }
   ]
 }

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -126,7 +126,24 @@ static int event_dedup_check_and_record(event_dedup_entry_t *ring, int *head,
     for (int i = 0; i < EVENT_DEDUP_RING_SIZE; i++) {
         if (!ring[i].valid) continue;
         if ((g_dispatched_ext_tick - ring[i].tick) > EVENT_DEDUP_MAX_AGE_TICKS) continue;
-        if (memcmp(ring[i].key, key, 8) == 0) return 1;
+        if (memcmp(ring[i].key, key, 8) == 0) {
+            /* Still in MIDI_IN, so keep the entry alive. The age window has to
+             * outlive the EVENT, and an event's lifetime in MIDI_IN is set by
+             * Move's firmware, not by us -- measured at 621 ms on hardware
+             * against a 16-tick (~46 ms) window. Without this refresh the
+             * entry expired while its event was still sitting in the buffer,
+             * and the next scan dispatched that event a second time: a
+             * re-dispatched note-ON became a voice no note-off would ever
+             * reach, and the pad LED it lit never cleared.
+             *
+             * Refreshing cannot suppress a DIFFERENT event: the key carries
+             * the XMOS per-event timestamp, so a retrigger of the same pitch
+             * has a different key and still dispatches. The age window only
+             * reclaims ring slots, and now it starts when the event actually
+             * leaves MIDI_IN. */
+            ring[i].tick = g_dispatched_ext_tick;
+            return 1;
+        }
     }
     event_dedup_entry_t *e = &ring[*head];
     memcpy(e->key, key, 8);


### PR DESCRIPTION
## The bug

A pad note sometimes keeps sounding after the pad is released, and only stops when another note steals its voice. The pad's LED stays lit too. It's rare, and it takes playing pads while turning an encoder to provoke — which is what makes it look like a synth-module bug rather than a host one.

It isn't. The host dispatches the same physical note-on twice.

## Evidence

Traced at two layers on hardware, using `chain_midi_trace_on` plus a raw-MIDI log at the synth module's own `on_midi` boundary.

For the stuck pitch, both layers agree:

```
chain IN  note-ON  91 29:  14      -> synth ON:  14
chain IN  note-OFF 81 29:  13      -> synth OFF: 13
```

The chain host forwarded exactly what it received, so nothing below it lost the event. Every other pitch in the session balanced perfectly — one unpaired note-on in ~330 note events.

And the unpaired note-on is a **duplicate**, not a real press:

```
214378.54  midi_in  81 26 00    note-off for 38
214378.59  midi_in  91 26 7f    note-on  for 38   <- 50 microseconds later
213757.25  midi_in  91 26 7f    ...the original press, 621 ms earlier
```

Two events 50 µs apart are one scan of MIDI_IN, not two fingers.

## Root cause

`shadow_dispatch_direct_external_midi()` walks MIDI_IN every frame and leans on the 8-byte dedup key so an event still sitting in the buffer isn't dispatched twice — as the comment above `EVENT_DEDUP_RING_SIZE` describes.

That entry expires after `EVENT_DEDUP_MAX_AGE_TICKS` (16), and the tick advances once per SPI frame (`schwung_shim.c:5401`), so the window is **~46 ms**. But how long an event stays in MIDI_IN is Move's firmware's business, not ours — measured at **621 ms** here. Once the entry expires, the still-present event is dispatched a second time.

A re-dispatched note-**on** is a voice that no note-off will ever reach. Same for the LED that lights with it.

Turning an encoder makes the frame late (`param_giveup: error=16` shows up in the seconds before each occurrence), which is why load provokes it.

## The fix

Refresh the entry's tick whenever it matches, so the age window starts when the event **leaves** MIDI_IN rather than when it was first seen.

This can't suppress a different event: the key carries the XMOS per-event timestamp, so a genuine retrigger of the same pitch has a different key and still dispatches. Ageing here only reclaims ring slots — it was never load-bearing for correctness, which is what makes the one-line change safe.

## Testing

- `scripts/hooks` pre-commit (host unit + contract tests, `schwung-manager` go vet/build/test) passes
- aarch64 cross-build passes
- Verified on hardware: [see the follow-up comment]

Found while debugging a stuck note in [Tablor](https://github.com/athousanddetails/schwung-tablor); the write-up lives in that repo's `docs/UPSTREAM-NOTES.md` §4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
