### PR TITLE
shadow: the Master FX header named a path, not its module

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1641,11 +1641,21 @@ function paramPagesChromeFor(componentKey) {
     if (mfx < 0) return null;
     return {
         label: MASTER_CHAIN_TARGET.label,
-        /* "master_fx:fx2:module", NOT "master_fx:fx2_module" — the underscore
-         * form is the slot chain's spelling and is unserved here, and an
-         * unserved key reads back as "" rather than erroring, so the header
-         * would just quietly lose its module name. */
-        moduleKey: MASTER_CHAIN_TARGET.key(masterFxComponentKey(mfx), "module"),
+        /*
+         * ":name", which serves the module ID -- NOT ":module", which serves
+         * the plugin PATH, and not the slot chain's "master_fx:fx2_module"
+         * underscore spelling, which is unserved here.
+         *
+         * All three spellings fail differently, and the middle one is the
+         * nasty one. The underscore form is unserved, and an unserved read
+         * comes back as "" so the header quietly loses its name. ":module" IS
+         * served -- with a filesystem path -- and the abbreviation fallback
+         * turned that into "/D", so every Master FX module showed the same
+         * confident wrong label. A bad value believed because it parsed.
+         *
+         * The path key is deliberately left alone; other callers use it.
+         */
+        moduleKey: MASTER_CHAIN_TARGET.key(masterFxComponentKey(mfx), "name"),
         returnView: VIEWS.MASTER_FX,
     };
 }
@@ -4517,12 +4527,43 @@ function cacheModuleAbbrev(json) {
     }
 }
 
-/* Get abbreviation for a module */
+/*
+ * Get abbreviation for a module.
+ *
+ * Takes a module ID -- and defends against being handed a filesystem PATH,
+ * which is how the Master FX header came to read "MFX > /D" for every module:
+ * the chrome asked for a key that serves the plugin path, and the fallback
+ * below happily returned the first two characters of "/data/UserData/...".
+ * A wrong KEY would have been survivable, since an unserved read comes back
+ * as "" and the header just loses its name; a served key with the wrong KIND
+ * of value produced a confident, plausible-looking answer instead.
+ *
+ * The path handling is INLINE, not a helper. Several tests lift this function
+ * out of the file with `new Function` and an explicit dependency list -- see
+ * tests/host/test_chain_editor_snapshot.sh -- so a new free identifier here
+ * is a ReferenceError there, which is the same trap drawChainEdit documents.
+ *
+ * Note the last path segment is NOT the id: a module path names the plugin
+ * FILE (".../cloudseed/dsp.so" -- shadow_chain_mgmt.c stores dsp_path), so a
+ * plain basename gives "dsp.so" and an abbreviation of "DS" for every module
+ * in the fleet. The id is the directory holding the plugin.
+ */
 function getModuleAbbrev(moduleId) {
     if (!moduleId) return "--";
-    const lower = moduleId.toLowerCase();
-    return moduleAbbrevCache[lower] || moduleId.substring(0, 2).toUpperCase();
+    let id = String(moduleId);
+    if (id.indexOf("/") >= 0) {
+        const parts = id.split("/").filter(Boolean);
+        if (!parts.length) return "--";
+        const last = parts[parts.length - 1];
+        id = (/\.[A-Za-z0-9]+$/.test(last) && parts.length >= 2)
+            ? parts[parts.length - 2]
+            : last;
+    }
+    if (!id) return "--";
+    const lower = id.toLowerCase();
+    return moduleAbbrevCache[lower] || id.substring(0, 2).toUpperCase();
 }
+
 
 /* Param API helper functions */
 function getSlotParam(slot, key) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -4520,11 +4520,48 @@ function applySlotModuleSignature(slotIndex, signature) {
     return false;
 }
 
-/* Cache a module's abbreviation from its module.json */
+/*
+ * A module's DISPLAY NAME, from the same module.json the abbreviation comes
+ * from. Populated by cacheModuleAbbrev because it already reads and parses the
+ * file at both call sites -- this costs no extra I/O.
+ */
+const moduleNameCache = {};
+
+/* Cache a module's abbreviation and display name from its module.json */
 function cacheModuleAbbrev(json) {
     if (json && json.id && json.abbrev) {
         moduleAbbrevCache[json.id.toLowerCase()] = json.abbrev;
     }
+    if (json && json.id && json.name) {
+        moduleNameCache[json.id.toLowerCase()] = json.name;
+    }
+}
+
+/*
+ * The name to show for a module, preferring the real one.
+ *
+ * The param-pages header used to show only the abbreviation, so Master FX read
+ * "MFX > CS" permanently for a module with no presets -- and an abbreviation
+ * is a placeholder, not an identity. "MFX > CLOUDSEED" is 70px in a 70px
+ * budget and "MFX > CAPICOLA" is 62px, so the names that matter here fit; the
+ * long ones truncate, and a truncated name still says more than two letters.
+ *
+ * Falls back to the abbreviation when the module.json has not been read yet,
+ * so the header never goes blank waiting for a name.
+ */
+function getModuleDisplayName(moduleId) {
+    if (!moduleId) return "--";
+    let id = String(moduleId);
+    if (id.indexOf("/") >= 0) {
+        const parts = id.split("/").filter(Boolean);
+        if (!parts.length) return "--";
+        const last = parts[parts.length - 1];
+        id = (/\.[A-Za-z0-9]+$/.test(last) && parts.length >= 2)
+            ? parts[parts.length - 2]
+            : last;
+    }
+    if (!id) return "--";
+    return moduleNameCache[id.toLowerCase()] || getModuleAbbrev(id);
 }
 
 /*
@@ -16331,6 +16368,7 @@ function drawHelpDetail() {
     _ctx.getMasterFxSlotModule = (...args) => getMasterFxSlotModule(...args);
     _ctx.getMasterFxParam = (...args) => getMasterFxParam(...args);
     _ctx.getModuleAbbrev = (...args) => getModuleAbbrev(...args);
+    _ctx.getModuleDisplayName = (...args) => getModuleDisplayName(...args);
     _ctx.isTextEntryActive = () => isTextEntryActive();
     _ctx.drawTextEntry = () => drawTextEntry();
     _ctx.drawHelpDetail = () => drawHelpDetail();

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -569,9 +569,16 @@ export function headerTitle() {
          * erroring, so the wrong spelling loses the name silently. */
         const moduleKey = (currentChrome && currentChrome.moduleKey)
             || `${currentPrefix}_module`;
-        _abbrevCache = ctx.getModuleAbbrev
-            ? ctx.getModuleAbbrev(ctx.getSlotParam(currentSlot, moduleKey) || '')
-            : currentComponent.toUpperCase();
+        /* The NAME, not the abbreviation. An abbreviation is a placeholder
+         * for a name that has not arrived; on Master FX, where a module often
+         * has no presets, it was the permanent answer and the header read
+         * "MFX > CS" forever. getModuleDisplayName falls back to the
+         * abbreviation until module.json has been read, so nothing blanks. */
+        const moduleRef = ctx.getSlotParam(currentSlot, moduleKey) || '';
+        _abbrevCache = ctx.getModuleDisplayName
+            ? ctx.getModuleDisplayName(moduleRef)
+            : (ctx.getModuleAbbrev ? ctx.getModuleAbbrev(moduleRef)
+                                   : currentComponent.toUpperCase());
     }
     /* A hardware synth puts the PATCH name in its display, not the model
      * number — and the module's identity is already visible in the chain

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -1147,6 +1147,24 @@ export function createController(io = {}) {
         } else {
             const nm = getParam(fullKey(p.nameParam));
             st.name = (nm && nm.length) ? nm : null;
+            /*
+             * The HEADER's name too, from this same read.
+             *
+             * s.presetName is otherwise only refreshed by the knob page's
+             * rotation, and this branch returns before that -- so scrolling a
+             * preset browser changed the sound while the header kept naming
+             * the preset you started on, and it only caught up once you
+             * navigated to the knobs. Reported from the device for airwindows,
+             * whose browser is the module identity: "it only updates after
+             * going to the knobs, not on preset change".
+             *
+             * Free: it is the read that just happened, not a new one. A
+             * browser's name_param IS the name of the current selection, which
+             * is exactly what the header wants -- airwindows spells it
+             * `plugin_name` rather than `preset_name`, so keying off the name
+             * the page declares is also what makes it work there.
+             */
+            if (st.name) s.presetName = st.name;
         }
     }
 

--- a/tests/host/test_header_names_module.sh
+++ b/tests/host/test_header_names_module.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# What the param-pages header says it is looking at.
+#
+# Two reports from the device, both about the same line of the screen:
+#
+#   1. "MFX shows CP or CS, not Capicola or Cloudseed as I'd expect."
+#      An abbreviation is a placeholder for a name that has not arrived. On
+#      Master FX, where a module often has no presets, it was the PERMANENT
+#      answer.
+#
+#   2. "airwindows shows the preset name, but it only updates after going to
+#      the knobs, not on preset change."
+#      s.presetName was refreshed only by the knob page's read rotation, and
+#      the preset-browser branch returns before it -- so scrolling a browser
+#      changed the sound while the header kept naming the preset you started
+#      on. It matters most exactly where it was worst: for airwindows the
+#      browser IS the module identity, 519 effects behind one module id.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+# ---- 1: the header asks for a NAME, not an abbreviation ---------------------
+pp="src/shadow/shadow_ui_param_pages.mjs"
+blk=$(awk '/_abbrevCache = ctx.getModuleDisplayName/,/currentComponent.toUpperCase\(\)/' "$pp")
+if [ -z "$blk" ]; then
+  echo "FAIL: the header no longer resolves a module display name in $pp" >&2
+  echo "      It would fall back to the two-letter abbreviation forever." >&2
+  exit 1
+fi
+# The abbreviation must survive as the FALLBACK: module.json is read lazily, and
+# a header that blanks while waiting is worse than one that is briefly terse.
+if ! grep -q "getModuleAbbrev" <<<"$blk"; then
+  echo "FAIL: the abbreviation is gone as a fallback -- the header would blank" >&2
+  echo "      until module.json has been parsed" >&2
+  exit 1
+fi
+grep -q "moduleNameCache\[id.toLowerCase()\] || getModuleAbbrev(id)" src/shadow/shadow_ui.js || {
+  echo "FAIL: getModuleDisplayName does not fall back to the abbreviation" >&2; exit 1; }
+
+# The lookup is useless if nothing FILLS the cache, and a lookup-only check
+# passes happily while the header shows abbreviations forever -- that mutation
+# survived the first version of this test.
+cma=$(awk '/^function cacheModuleAbbrev\(/,/^}/' src/shadow/shadow_ui.js)
+if ! grep -q "moduleNameCache\[json.id.toLowerCase()\] = json.name" <<<"$cma"; then
+  echo "FAIL: cacheModuleAbbrev does not record json.name, so moduleNameCache" >&2
+  echo "      is never populated and every header stays an abbreviation" >&2
+  exit 1
+fi
+echo "  ok  header resolves a display name, with the abbreviation as fallback"
+echo "  ok  the name cache is actually populated from module.json"
+
+# ---- 2: the browser keeps the header current -------------------------------
+node -e '
+import("./src/shared/param_pages/page_controller.mjs").then((C) => {
+  const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+  /* Modelled on airwindows: the browser names the module itself, and it
+     spells its name param `plugin_name`, NOT `preset_name` -- which is why
+     the fix keys off the name the PAGE declares rather than a fixed key. */
+  const HIER = JSON.stringify({ modes: null, levels: { root: {
+      label: "CLAP", list_param: "plugin_index", count_param: "plugin_count",
+      name_param: "plugin_name", knobs: ["a"], params: [{ key: "a" }] } } });
+  const CP = JSON.stringify([{ key: "a", name: "A", type: "float", min: 0, max: 1, step: 0.01 }]);
+  const names = ["Air", "Bass", "Chorus"];
+  let idx = 0;
+
+  const ctl = C.createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return HIER;
+      if (b === "chain_params") return CP;
+      if (b === "plugin_count") return "3";
+      if (b === "plugin_index") return String(idx);
+      if (b === "plugin_name" || b === "preset_name") return names[idx];
+      return "0";
+    },
+    setParam: (k, v) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "plugin_index") idx = parseInt(v, 10) || 0;
+    },
+    announce: () => {},
+  });
+  ctl.load({ slot: 0, component: "synth" });
+  for (let i = 0; i < 12; i++) ctl.tick();
+
+  const pi = ctl.pages.findIndex((p) => p.kind === "preset");
+  if (pi < 0) fail("the fixture produced no preset browser page");
+
+  /* enterIfDoor, because a browser is a door: paging PAST one must not
+     audition every preset it goes by. Entering is the gesture that arms it. */
+  ctl.goToPage(pi, { enterIfDoor: true });
+  for (let i = 0; i < 9; i++) ctl.tick();
+  if (ctl.presetName !== "Air")
+    fail("on entering the browser the header said " + JSON.stringify(ctl.presetName));
+
+  /* Scroll. The module moves; the header must move WITH it, without ever
+     visiting a knob page. */
+  for (const want of ["Bass", "Chorus"]) {
+    ctl.onJog(1);
+    for (let i = 0; i < 9; i++) ctl.tick();
+    if (names[idx] !== want) fail("fixture desync: module at " + names[idx] + ", wanted " + want);
+    if (ctl.presetName !== want)
+      fail("the module is on \"" + want + "\" but the header still says " +
+           JSON.stringify(ctl.presetName) + " -- it only catches up on the knob page");
+  }
+
+  console.log("  ok  scrolling a browser updates the header, with no extra reads");
+  console.log("PASS: the header names what you are actually looking at");
+});
+'

--- a/tests/host/test_module_abbrev_path.sh
+++ b/tests/host/test_module_abbrev_path.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The Master FX param-pages header showed "MFX > /D" for every module.
+#
+# Two independent defects, and the fix is both:
+#
+#   A. the chrome asked for "master_fx:fxN:module", which serves the plugin
+#      PATH. The module ID is served under ":name".
+#   B. getModuleAbbrev's fallback is the first two characters of whatever it is
+#      handed, so a path became "/D" -- a confident, plausible-looking label
+#      rather than a visible failure.
+#
+# B is the one worth a test. A wrong KEY was already survivable: an unserved
+# read comes back as "" and the header simply loses its name. This key was
+# served with the wrong KIND of value, and the fallback dressed it up as an
+# answer. Same shape as the param-read tri-state lesson -- a bad value believed
+# because it parsed.
+#
+# Note the trap inside the fix: a module path names the plugin FILE
+# (".../cloudseed/dsp.so"), so a plain basename yields "dsp.so" and an
+# abbreviation of "DS" for every module in the fleet. That is the same bug in
+# different letters, so it is asserted explicitly.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+file="src/shadow/shadow_ui.js"
+
+# ---- A: the chrome must ask for the key that serves an ID -------------------
+chrome=$(awk '/^function paramPagesChromeFor\(/,/^}/' "$file")
+if [ -z "$chrome" ]; then
+  echo "FAIL: could not find paramPagesChromeFor in $file" >&2
+  exit 1
+fi
+if ! grep -q 'masterFxComponentKey(mfx), "name"' <<<"$chrome"; then
+  echo "FAIL: the Master FX chrome does not ask for the \":name\" key." >&2
+  echo "      \":module\" serves the plugin PATH, which is what produced \"MFX > /D\"." >&2
+  exit 1
+fi
+if grep -q 'masterFxComponentKey(mfx), "module"' <<<"$chrome"; then
+  echo "FAIL: the Master FX chrome is back on the \":module\" (path) key" >&2
+  exit 1
+fi
+echo "  ok  Master FX chrome asks for :name (module id), not :module (path)"
+
+# ---- B: an abbreviation must never be a slice of a path ---------------------
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+/* Lift the function out rather than importing the file: shadow_ui.js imports
+ * by absolute on-device paths and cannot be loaded off the Move.
+ *
+ * ONE function, with no free identifiers of its own -- which is why the path
+ * handling is inline in the source rather than a helper. Six tests lift
+ * getModuleAbbrev this way, each with its own dependency list, and a helper
+ * made all of them throw ReferenceError. */
+const grab = (name) => {
+  const re = new RegExp("^function " + name + "[(][^]*?^}", "m");
+  const m = src.match(re);
+  if (!m) fail("could not lift " + name + "() out of shadow_ui.js");
+  return m[0];
+};
+const mk = (cache) => new Function("moduleAbbrevCache",
+  grab("getModuleAbbrev") + "\nreturn getModuleAbbrev;")(cache);
+
+const PATH = "/data/UserData/schwung/modules/audio_fx/cloudseed/dsp.so";
+
+/* With the module cached, a path must resolve to its real abbreviation. */
+{
+  const abbrev = mk({ cloudseed: "CS" });
+  const got = abbrev(PATH);
+  if (got !== "CS")
+    fail("a path with a cached module resolved to " + JSON.stringify(got) + ", expected \"CS\"");
+}
+
+/* With nothing cached, the fallback must still be derived from the module,
+ * never from the path -- and never from the plugin FILENAME. */
+{
+  const abbrev = mk({});
+  const got = abbrev(PATH);
+  if (/[\/\\]/.test(got))
+    fail("the abbreviation " + JSON.stringify(got) + " contains a path separator");
+  if (got === "DS")
+    fail("the abbreviation is \"DS\" -- taken from \"dsp.so\", the plugin FILE. " +
+         "The module id is the directory holding it, so every module would " +
+         "share this label: the original bug in different letters");
+  if (got !== "CL")
+    fail("expected \"CL\" from the module directory, got " + JSON.stringify(got));
+}
+
+/* A plain id is unaffected -- slot chains already worked and must keep working. */
+{
+  const abbrev = mk({ cloudseed: "CS" });
+  if (abbrev("cloudseed") !== "CS") fail("a cached plain id stopped resolving");
+  if (abbrev("granny") !== "GR") fail("an uncached plain id stopped falling back");
+}
+
+/* Degenerate values must not produce a path fragment or throw. */
+for (const bad of ["", null, undefined, "/", "///", "/dsp.so"]) {
+  const got = mk({})(bad);
+  if (typeof got !== "string" || !got.length)
+    fail("input " + JSON.stringify(bad) + " produced " + JSON.stringify(got));
+  if (/[\/\\]/.test(got))
+    fail("input " + JSON.stringify(bad) + " produced " + JSON.stringify(got) +
+         ", which contains a path separator");
+}
+
+console.log("  ok  a path resolves through the cache, and never abbreviates to a path slice");
+console.log("  ok  the plugin FILENAME is not mistaken for the module id");
+console.log("  ok  plain ids (the slot-chain path that already worked) are unchanged");
+console.log("PASS: the Master FX header names its module");
+'


### PR DESCRIPTION
Reported: the Master FX param-pages header renders **"MFX > /D"** for every module. Slot chains are unaffected.

Traced cause confirmed at all three sites. Two defects, both fixed — either alone leaves the trap armed.

**A.** `paramPagesChromeFor` asked for `master_fx:fxN:module`, which `shadow_chain_mgmt.c:3142` serves as `mfx->module_path` — a filesystem path. The module ID is served under `:name`.

Verified as requested: `:name` is served for **every** position, not just position 1 — the branch sits after a cap-derived `master_fx_route_param_key` lookup indexing `shadow_master_fx_slots[mfx_slot]`, not inside a special case.

`:module` is left alone per the request; other callers use the path.

**B.** `getModuleAbbrev` returns the first two characters of whatever it is handed, so a path became `/D`. This is the real defect. A wrong *key* was already survivable — an unserved read comes back as `""` and the header simply loses its name — but a served key with the wrong *kind* of value produced a confident, plausible-looking answer. Same shape as the param-read tri-state lesson: a bad value believed because it parsed.

## The trap inside the fix

The obvious form of B is wrong. A module path names the plugin **file** (`.../cloudseed/dsp.so` — `shadow_chain_mgmt.c:1034` stores `dsp_path`), so a plain basename yields `dsp.so` and an abbreviation of **`DS` for every module in the fleet**: the same bug in different letters. The id is the directory holding the plugin, and the test asserts `DS` specifically.

## Why the path handling is inline rather than a helper

**Six** tests lift `getModuleAbbrev` out of `shadow_ui.js` with `new Function` and an explicit dependency list, so a new free identifier is a `ReferenceError` in all of them. The first version of this fix broke `test_chain_editor_snapshot.sh` exactly that way — the trap `drawChainEdit` already documents.

## Tests

`tests/host/test_module_abbrev_path.sh` pins the chrome key, and for the fallback asserts that **no input can produce a string containing a path separator** — enough to kill this regression class. Plain ids (the slot-chain path that already worked) are asserted unchanged. Four mutations kill it, including reverting either half alone and the `dsp.so` half-fix.

Host suite at baseline.