### PR TITLE
grid: modulation stays visible at the base, and the page you left survives

### DIFF
--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -208,15 +208,22 @@ export function enterParamPages(slot, component, prefix, restorePageName, io, ch
      * earlier dial/bar grid — see render_page_movy.mjs. The setting stays a
      * plain List/Knobs toggle; this is what "Knobs" draws. */
     controller.setLayout(LAYOUT_MOVY);
-    if (restorePageName) {
-        const pages = controller.pages || [];
-        for (let i = 0; i < pages.length; i++) {
-            if (pages[i] && pages[i].name === restorePageName) {
-                controller.goToPage(i);
-                break;
-            }
-        }
-    }
+    /*
+     * Hand the NAME to the controller rather than resolving it here.
+     *
+     * This used to look through controller.pages once and give up if the page
+     * was not there. Coming back from granny's file browser it is not: granny
+     * loads the WAV synchronously inside set_param, on the SPI thread that
+     * also serves param reads, so the contract read straight after a sample
+     * selection times out and the planner correctly refuses to invent pages
+     * from a failed read. The list was empty, the loop found nothing, and you
+     * landed on page 1 -- reported from the device.
+     *
+     * controller.restorePage() re-applies the request each time the pages are
+     * planned, and drops it once the contract settles without producing that
+     * page.
+     */
+    if (restorePageName) controller.restorePage(restorePageName);
     ctx.setView(ctx.VIEWS.PARAM_PAGES);
 }
 

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -311,6 +311,8 @@ export function createController(io = {}) {
         /* key -> last-read modulation flag, refreshed on the read cursor
          * rather than per cell per draw. See tick(). */
         modCache: Object.create(null),
+        /* A page name to land on once the pages exist; see restorePage(). */
+        restoreName: null,
         /* key -> live modulated ("effective") value, for the dot on the arc.
          * Only modulated keys are in here, and they get their own fast lane in
          * tick() because they are the only values that move on their own. */
@@ -555,8 +557,49 @@ export function createController(io = {}) {
         /* A rebuild after a module finishes loading shifts every index, so land
          * by name rather than by position; a first load lands on a grid. */
         s.pageIndex = oldPages.length ? reanchor(oldPages, oldIndex, s.pages) : firstGrid(s.pages);
+        /* A restore that could not be honoured yet gets its chance here.
+         * See restorePage(): the pages may not have existed when the caller
+         * asked. */
+        applyPendingRestore();
         announcePageChange();
         return true;
+    }
+
+    /**
+     * Land on the page with this NAME, now or as soon as it exists.
+     *
+     * The caller (returnToParamPagesFromEditor) knows which page you left; it
+     * cannot know whether the pages are back yet. Coming out of granny's file
+     * browser they are NOT: granny loads the WAV synchronously inside
+     * set_param, on the SPI thread that also serves param reads, so the
+     * contract read right after a sample selection times out and planPages
+     * refuses to invent pages from a failed read. The old restore looked once,
+     * found an empty list, and silently gave up -- which is why choosing a
+     * sample dropped you on page 1 instead of the page you were on.
+     *
+     * So the request is REMEMBERED and re-applied whenever the page set is
+     * (re)planned. It is one-shot: once honoured, or once the user has moved
+     * somewhere themselves, it is dropped rather than fighting them.
+     */
+    function restorePage(name) {
+        s.restoreName = (typeof name === "string" && name) ? name : null;
+        applyPendingRestore();
+    }
+
+    function applyPendingRestore() {
+        if (!s.restoreName) return;
+        const pages = s.pages || [];
+        for (let i = 0; i < pages.length; i++) {
+            if (pages[i] && pages[i].name === s.restoreName) {
+                s.pageIndex = i;
+                s.restoreName = null;
+                return;
+            }
+        }
+        /* Not there yet. Left armed for the next plan -- unless the contract
+         * has settled, in which case the page genuinely does not exist and
+         * waiting forever would hijack a later navigation. */
+        if (s.metaSettled) s.restoreName = null;
     }
 
     /** Poll for a contract that changed underneath us (async ROM/sample loads). */
@@ -2085,7 +2128,7 @@ export function createController(io = {}) {
          * the same modules through its own preset browser and has the same
          * race. Books the settle; costs nothing until it comes due. */
         selectionChanged: armContractSettle,
-        onJog, goToPage, onKnobTurn, onKnobTouch, onClick, takePending, commitEnum,
+        onJog, goToPage, restorePage, onKnobTurn, onKnobTouch, onClick, takePending, commitEnum,
         openPicker, closePicker, pickerSelect, showHint, dismissHint,
         menuEntry, menuIndex: () => menuIndex(page()),
         menuEntered, enterMenu, exitMenu, clearTouch,

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -1217,14 +1217,26 @@ function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, cellText,
     const num = Number(raw);
     const normVal = (max > min && isFinite(num)) ? Math.max(0, Math.min(1, (num - min) / (max - min))) : 0;
     drawArcKnob(ctx, kx, ky, normVal);
-    /* Only when modulation is actually driving this param somewhere OTHER
-     * than the base — a dot sitting under the pointer says nothing and just
-     * thickens it. */
+    /*
+     * The dot is drawn whenever a source is driving this parameter, INCLUDING
+     * when the live value has landed exactly on the base.
+     *
+     * It used to be suppressed within 0.02 of the base, on the reasoning that
+     * "a dot sitting under the pointer says nothing and just thickens it".
+     * That is true about the pixels and wrong about the meaning: absent, the
+     * knob is pixel-identical to an unmodulated one, so the reading is not
+     * "the LFO is at its base" but "there is no LFO". Reported from the
+     * device -- a bipolar LFO on a knob at 0 spends half its cycle clamped
+     * there, and the indicator vanished for that half.
+     *
+     * The label keeps its own tilde either way, but that is four pixels on
+     * the row beneath; the dot is the mark you actually read on the knob.
+     */
     if (modRaw !== null && modRaw !== undefined) {
         const mnum = Number(modRaw);
         if (isFinite(mnum) && max > min) {
             const modNorm = Math.max(0, Math.min(1, (mnum - min) / (max - min)));
-            if (Math.abs(modNorm - normVal) > 0.02) drawModDot(ctx, kx, ky, modNorm);
+            drawModDot(ctx, kx, ky, modNorm);
         }
     }
 }

--- a/tests/host/test_mod_dot_at_base.sh
+++ b/tests/host/test_mod_dot_at_base.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A modulated knob must never render identically to an unmodulated one.
+#
+# The modulation dot used to be suppressed when the live value was within 0.02
+# of the base, on the reasoning that a dot under the pointer only thickens it.
+# True about the pixels, wrong about the meaning: with the dot gone the knob is
+# pixel-identical to a parameter nothing is driving, so it does not read as
+# "the LFO is at its base", it reads as "there is no LFO".
+#
+# Reported from the device: a BIPOLAR LFO on a knob at 0 is clamped at 0 for
+# half its cycle, so the indicator vanished for half of every cycle.
+#
+# Asserted on the KNOB region only. The label keeps a tilde either way, and
+# including it would let this pass on four pixels a row below the thing being
+# looked at.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./tools/param-pages/harness.mjs"),
+  import("./src/shared/param_pages/render_page_movy.mjs"),
+  import("./src/shared/param_pages/param_meta.mjs"),
+]).then(([H, R, M]) => {
+  const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+  const cp = [{ key: "k", name: "Depth", type: "float", min: 0, max: 1, step: 0.01 }];
+  const ix = M.buildMetaIndex({ chainParams: cp });
+  const page = { kind: "knobs", name: "P", level: "root", keys: ["k"] };
+
+  /* Signature of the WIDGET band only -- ROW0_Y..ROW0_Y+BOX_H -- so the
+   * label tilde a row below cannot carry this assertion. */
+  const knobSig = (value, modValue, isMod) => {
+    const fb = H.createFramebuffer();
+    R.renderPageMovy(H.drawContext(fb), {
+      page, metaIndex: ix, values: { k: value },
+      modValues: modValue === null ? null : { k: modValue },
+      modulated: () => isMod, pageIndex: 0, pageCount: 1, header: "L",
+    });
+    const px = fb.pixels || fb.px;
+    let h = 0;
+    for (let y = R.ROW0_Y; y < R.ROW0_Y + R.BOX_H; y++)
+      for (let x = 0; x < R.W; x++) if (px[y * R.W + x]) h = (h * 31 + (y * R.W + x)) | 0;
+    return h;
+  };
+
+  const unmodulated = knobSig("0", null, false);
+
+  /* Pinned exactly at the base -- the reported case. */
+  if (knobSig("0", "0", true) === unmodulated)
+    fail("a modulated knob pinned at its base renders EXACTLY like an unmodulated " +
+         "one -- there is no way to tell the LFO exists");
+
+  /* And across the range, including the top, where a bipolar source clamps
+   * just as it does at the bottom. */
+  for (const at of ["0", "0.5", "1"]) {
+    const un = knobSig(at, null, false);
+    if (knobSig(at, at, true) === un)
+      fail("at " + at + ", a modulated knob sitting on its base is indistinguishable " +
+           "from an unmodulated one");
+  }
+
+  /* The dot must still MOVE when the source moves -- suppressing the old
+   * threshold must not have flattened it to a decoration. */
+  if (knobSig("0.5", "0.5", true) === knobSig("0.5", "0.9", true))
+    fail("the dot does not move with the modulated value");
+
+  console.log("  ok  a modulated knob is distinguishable at base, mid and top");
+  console.log("  ok  the dot still tracks the live value");
+  console.log("PASS: modulation stays visible when the source lands on the base");
+});
+'

--- a/tests/host/test_page_restore_survives_late_pages.sh
+++ b/tests/host/test_page_restore_survives_late_pages.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Coming back from an editor must land on the page you left, even when the
+# pages are not back yet.
+#
+# Reported from the device: choosing a sample in granny returned you to page 1
+# instead of the page the sample knob was on.
+#
+# The restore looked through controller.pages ONCE, at the moment of re-entry,
+# and gave up if the page was not there. Coming out of granny it is not:
+# granny loads the WAV synchronously inside set_param, on the SPI thread that
+# also serves param requests, so the contract read straight after a selection
+# times out -- and planPages correctly refuses to invent pages from a failed
+# read. Empty list, nothing matched, page 1.
+#
+# So the request is REMEMBERED and re-applied when the pages arrive.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+import("./src/shared/param_pages/page_controller.mjs").then((C) => {
+  const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+  /* Two levels, so there is more than one page to be wrong about. */
+  const HIER = JSON.stringify({ modes: null, levels: {
+    root:  { label: "Main",   knobs: ["a"], params: [{ key: "a" }, { level: "more", label: "More" }] },
+    more:  { label: "More",   knobs: ["b"], params: [{ key: "b" }] },
+  }});
+  const CP = JSON.stringify([
+    { key: "a", name: "A", type: "float", min: 0, max: 1, step: 0.01 },
+    { key: "b", name: "B", type: "float", min: 0, max: 1, step: 0.01 },
+  ]);
+
+  /* answering=false models the module blocking the param channel while it
+     loads a sample -- the read does not complete, which is NOT the same as
+     the module declaring nothing. */
+  let answering = false;
+  const ctl = C.createController({
+    getParam: (k) => {
+      if (!answering) return null;
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return HIER;
+      if (b === "chain_params") return CP;
+      return "0.5";
+    },
+    setParam: () => {}, announce: () => {},
+  });
+
+  /* Enter while the module is busy: no pages exist yet. */
+  ctl.load({ slot: 0, component: "synth" });
+  for (let i = 0; i < 4; i++) ctl.tick();
+  if (ctl.pages.length) fail("fixture: pages planned from a failed read");
+
+  ctl.restorePage("More");
+
+  /* The module finishes; the pages arrive. */
+  answering = true;
+  for (let i = 0; i < 40; i++) ctl.tick();
+  if (!ctl.pages.length) fail("fixture: pages never arrived");
+
+  const landed = ctl.page && ctl.page.name;
+  if (landed !== "More")
+    fail("landed on " + JSON.stringify(landed) + " -- the restore was dropped when " +
+         "the pages were not ready, which is the granny bug");
+
+  /*
+   * NOT asserted here: that the request is one-shot, and that a request for a
+   * page which never appears is abandoned once the contract settles. Both are
+   * implemented (applyPendingRestore clears s.restoreName on success, and on
+   * metaSettled when it cannot be satisfied) and BOTH ARE UNOBSERVABLE through
+   * the public API: they only differ on a SECOND replan, and the controller
+   * performs at most one re-resolution -- maybeResettle is gated by
+   * triedReresolve, so no amount of ticking produces another.
+   *
+   * Mutating either clause therefore survives this test. That is stated rather
+   * than papered over with assertions that cannot fail: two such checks were
+   * written first, passed against the mutations, and were deleted.
+   */
+
+  console.log("  ok  a restore asked for before the pages exist is honoured when they arrive");
+  console.log("PASS: the page you left survives a module that was still loading");
+});
+'
+
+# The call site must actually ASK. The controller can be perfect and the
+# feature still absent — this is a unit test of the controller, so the wiring
+# is pinned at the source.
+pp="src/shadow/shadow_ui_param_pages.mjs"
+if ! command grep -q "controller.restorePage(restorePageName)" "$pp"; then
+  echo "FAIL: enterParamPages no longer asks the controller to restore the page" >&2
+  exit 1
+fi
+echo "  ok  enterParamPages hands the page name to the controller"

--- a/tests/host/test_param_pages_movy.sh
+++ b/tests/host/test_param_pages_movy.sh
@@ -627,9 +627,22 @@ Promise.all([
     if (added <= 0) fail("the modulation dot drew nothing");
     if (added > 8) fail("the modulation dot drew " + added + " pixels — it should be a 2x2 mark, not a blob");
 
-    /* Coincident with the pointer it says nothing and just thickens it. */
-    if (draw({ modValues: { cutoff: "0.5" } }).countLit() !== plain.countLit()) {
-      fail("a modulation dot equal to the base value must be suppressed");
+    /* Coincident with the pointer, the dot is drawn ANYWAY.
+     *
+     * This used to assert the opposite -- suppressed within 0.02 of the base,
+     * because a dot under the pointer only thickens it. True about the pixels
+     * and wrong about the meaning: with it gone the knob is pixel-identical to
+     * one nothing is driving, so it reads as "there is no LFO" rather than
+     * "the LFO is at its base". Reported from the device, where a bipolar LFO
+     * on a knob at 0 clamps there for half of every cycle and the indicator
+     * blinked out for that half.
+     *
+     * Pinned as a DIFFERENCE from the unmodulated render rather than as an
+     * exact pixel count, which is what test_mod_dot_at_base.sh measures per
+     * position. */
+    if (draw({ modValues: { cutoff: "0.5" } }).countLit() === plain.countLit()) {
+      fail("a modulation dot coincident with the base was suppressed — the knob " +
+           "is then indistinguishable from an unmodulated one");
     }
 
     /* Both rails, every knob — the arc is what it rides, so an off-by-one in
@@ -638,7 +651,7 @@ Promise.all([
       const fb = draw({ modValues: Object.fromEntries(KEYS.map((k) => [k, v])) });
       if (fb.clipped() > 0) fail("modulation dots drew outside the display at value " + v);
     }
-    console.log("PASS: Movy modulation dot — rides the arc, suppressed at base, never clipped");
+    console.log("PASS: Movy modulation dot — rides the arc, visible even AT the base, never clipped");
   }
 
   /* ---- displayFor: a value the HOST resolves, per surface ---------------


### PR DESCRIPTION
Two device reports.

## 1. LFO indicator disappears when the knob is at 0 and the LFO pins to 0

The modulation dot was suppressed within 0.02 of the base, on the reasoning that *"a dot sitting under the pointer says nothing and just thickens it"*. True about the pixels, wrong about the meaning: with the dot gone the knob is **pixel-identical** to a parameter nothing is driving — so it reads as "there is no LFO", not "the LFO is at its base". A bipolar LFO on a knob at 0 is clamped there for half of every cycle, so the indicator blinked out half the time.

The label keeps its tilde either way, but that's four pixels a row below; the dot is the mark you read on the knob.

`test_param_pages_movy.sh` asserted the **old** behaviour explicitly, so this overturns a deliberate decision — the assertion is inverted with the reasoning attached rather than quietly deleted.

## 2. Granny returns to page 1 after a sample selection

The restore looked through `controller.pages` **once**, at re-entry, and gave up if the page wasn't there. Coming out of granny it isn't: granny loads the WAV **synchronously inside `set_param`**, on the SPI thread that also serves param requests, so the contract read straight after a selection times out — and `planPages` correctly refuses to invent pages from a failed read. Empty list, nothing matched, page 1.

The name now goes to the controller, which re-applies it whenever the pages are planned and drops it once the contract settles without producing that page.

## A limit I'm stating rather than hiding

The test **cannot** assert that the request is one-shot, or that a never-appearing page is abandoned. Both are implemented, and both are unobservable through the public API: they differ only on a *second* replan, and `maybeResettle` is gated by `triedReresolve` so there is never another one — 600 ticks produce nothing.

Two assertions covering them were written first, **passed against their own mutations**, and were deleted rather than left looking like coverage.