### PR TITLE
chain editor: no `+` on a full section, and a slot opens on its synth

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -472,11 +472,34 @@ const CHAIN_CAP = { midiFx: MAX_MIDI_FX, fx: MAX_FX };
 function chainEditorComponents(cfg, caps) {
     const hasSynth = !caps || caps.hasSynth !== false;
     const hasMidiFx = !caps || caps.hasMidiFx !== false;
+    /*
+     * A FULL section has no `+`.
+     *
+     * chainComponents emits both boxes unconditionally -- it models the chain,
+     * not the caps -- so Master FX kept offering "New effect" with all 8 slots
+     * taken, and clicking it either did nothing or silently landed on a
+     * position that could not exist. Reported from the device.
+     *
+     * The limit comes from the target's own cap(), which both chains already
+     * publish (CHAIN_CAP for a slot, MASTER_FX_SLOTS for the master bus), so
+     * this reads the number rather than keeping a third copy of it -- the
+     * thing that has gone wrong every previous time a chain cap moved.
+     */
+    const full = (section) => {
+        if (!caps || typeof caps.cap !== "function") return false;
+        const limit = caps.cap(section);
+        if (!(limit > 0)) return false;
+        const held = section === "midiFx" ? (cfg.midiFx || []).length
+                                          : (cfg.fx || []).length;
+        return held >= limit;
+    };
+
     const out = [];
     for (const pos of chainComponents(cfg)) {
         if (pos.kind === "patch") continue;
         if (!hasSynth && pos.kind === "synth") continue;
         if (!hasMidiFx && pos.section === "midiFx") continue;
+        if (pos.kind === "add" && full(pos.section)) continue;
         const key = pos.kind === "synth" ? "synth"
             : pos.kind === "add" ? pos.id
             : pos.kind === "settings" ? "settings"
@@ -2691,7 +2714,20 @@ let chainConfigs = [];         // In-memory chain configs per slot
 // -1 = chain/patch; 0..n = an index into slotChainComponents(), whose length
 // follows the chain rather than being fixed at five.
 let selectedChainComponent = 0;
-let lastChainComponent = [0, 0, 0, 0]; // Remember last selected component per slot
+/*
+ * Remember the last selected component per slot -- or null for "never chosen".
+ *
+ * NULL, not 0. Index 0 of a slot chain is the MIDI FX `+` box (the editor list
+ * is add_midi, [midi fx...], synth, [fx...], add_fx, settings), so seeding
+ * these with 0 meant every slot opened on "add a MIDI effect" in a fresh
+ * session -- reported from the device as slots defaulting to MIDI FX. And 0 is
+ * a VALID index, so restoreChainComponent accepted it and defaultChainComponent
+ * (which returns the synth) never ran.
+ *
+ * null makes "no memory" unrepresentable as a position, which is what lets the
+ * default apply.
+ */
+let lastChainComponent = [null, null, null, null];
 let selectingModule = false;   // True when in module selection for a component
 let availableModules = [];     // Modules available for selected component type
 let selectedModuleIndex = 0;   // Index in availableModules
@@ -18160,6 +18196,12 @@ globalThis.tick = function() {
              * behalf. */
             invalidateAutosaveWriteCache();
             debugLog("SET_CHANGED: " + oldDir + " -> " + newDir);
+            /* A remembered position belongs to the set it was chosen in. Carried
+             * across, it points at whatever occupies that index in the NEW
+             * chain -- usually the MIDI FX `+`, since a fresh set is empty and
+             * that is index 0. Forgetting lets defaultChainComponent put the
+             * selection on the synth, which is what a slot is about. */
+            for (let i = 0; i < lastChainComponent.length; i++) lastChainComponent[i] = null;
             loadChainConfigFromDir(newDir);
 
             /* 6. Two-pass reload: clear ALL old slots first (freeing memory),

--- a/tests/host/test_add_box_hidden_when_full.sh
+++ b/tests/host/test_add_box_hidden_when_full.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A FULL chain section must not offer a `+`.
+#
+# Reported from the device: "On master fx, when you have reached 8 FX, we still
+# show the 'new effect' cell."
+#
+# chainComponents emits both `+` boxes unconditionally -- it models the chain,
+# not the caps -- so the box stayed at the cap and clicking it either did
+# nothing or aimed at a position that cannot exist.
+#
+# The limit is read from the TARGET's own cap(), which both chains already
+# publish (CHAIN_CAP for a slot, MASTER_FX_SLOTS for the master bus). A third
+# copy of the number is precisely what has gone wrong every previous time a
+# chain cap moved, so this pins that it is read and not re-declared.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+file="src/shadow/shadow_ui.js"
+
+blk=$(awk '/A FULL section has no `\+`/,/^    const out = \[\];/' "$file")
+[ -n "$blk" ] || fail "the full-section guard is gone from chainEditorComponents"
+command grep -q "caps.cap(section)" <<<"$blk" || \
+  fail "the guard does not read the target's own cap() -- a second copy of the limit"
+command grep -q 'pos.kind === "add" && full(pos.section)' "$file" || \
+  fail "the `+` is no longer filtered when its section is full"
+
+# It must be the TARGET's cap, not a literal: a hardcoded 8 would pass the
+# greps above and break the slot chain the moment either cap moves.
+command grep -qE 'const limit = caps\.cap\(section\)' <<<"$blk" || \
+  fail "the limit is not taken from cap(section)"
+grep -qE '>= *8|=== *8' <<<"$blk" && fail "the guard contains a hardcoded cap"
+
+echo "  ok  the guard reads the target's cap() rather than re-declaring a limit"
+
+node -e '
+import("./src/shared/chain_model.mjs").then((M) => {
+  const say = (m) => { console.log("FAIL: " + m); process.exit(1); };
+  /* chainComponents itself stays cap-blind ON PURPOSE -- it models the chain.
+     If that ever changes, the filter above becomes a double-negative. */
+  const cfg = (n) => ({ synth: "", midiFx: [], fx: Array.from({ length: n }, (_, i) => "fx" + i) });
+  const has = (n) => M.chainComponents(cfg(n)).some((c) => c.id === "add_fx");
+  if (!has(0) || !has(99))
+    say("chainComponents has grown its own cap — the filter in chainEditorComponents " +
+        "would then be applied twice, and the model is the wrong place for it");
+  console.log("  ok  chainComponents stays cap-blind; the editor does the filtering");
+});
+'
+echo "PASS: a full section offers no + box"

--- a/tests/host/test_master_fx_slots_js.sh
+++ b/tests/host/test_master_fx_slots_js.sh
@@ -115,16 +115,22 @@ check(decls.MASTER_FX_SLOTS === cap, "evaluated MASTER_FX_SLOTS !== parsed cap")
     check(comps[1] && comps[1].key === "settings", "the second box is not Settings");
 }
 
-/* And a FULL one is cap modules, then the `+`, then Settings — the same shape
- * the slot chain's audio-FX section has at its own cap. */
+/* And a FULL one is cap modules then Settings, with NO `+`.
+ *
+ * This used to assert the `+` was still there, on the grounds that the slot
+ * chain drew one at its cap too. The invariant worth keeping is that the two
+ * chains AGREE -- and they still do; both hide it now. Offering "New effect"
+ * with every slot taken was reported from the device, and clicking it either
+ * did nothing or aimed at a position that cannot exist. */
 decls.setConfig((() => {
     const c = decls.makeEmptyMasterFxConfig();
     for (let i = 1; i <= cap; i++) c["fx" + i] = { module: "freeverb" };
     return c;
 })());
 const comps = decls.masterFxChainComponents();
-check(comps.length === cap + 2,
-    "a full Master FX has " + comps.length + " boxes, expected cap+2 = " + (cap + 2));
+check(comps.length === cap + 1,
+    "a full Master FX has " + comps.length + " boxes, expected cap+1 = " + (cap + 1) +
+    " (the modules and Settings, with no `+`)");
 
 for (let i = 0; i < cap; i++) {
     const c = comps[i] || {};
@@ -141,9 +147,19 @@ for (let i = 0; i < cap; i++) {
 
 const last = comps[comps.length - 1] || {};
 check(last.key === "settings", "last component key is " + JSON.stringify(last.key) + ", expected settings");
-check(last.position === cap + 1, "settings component position is " + last.position);
-check(comps[cap] && comps[cap].kind === "add",
-    "a full Master FX does not draw its `+` — the slot chain draws one at its cap too");
+check(last.position === cap, "settings component position is " + last.position);
+check(!comps.some((c) => c && c.kind === "add"),
+    "a full Master FX still draws a `+` — there is nowhere for it to add to");
+
+/* One BELOW the cap it must come back, or the guard has turned into "never". */
+decls.setConfig((() => {
+    const c = decls.makeEmptyMasterFxConfig();
+    for (let i = 1; i <= cap - 1; i++) c["fx" + i] = { module: "freeverb" };
+    return c;
+})());
+const nearly = decls.masterFxChainComponents();
+check(nearly.some((c) => c && c.kind === "add"),
+    "one below the cap there is no `+` — the guard is hiding it always");
 
 check(!comps.some(c => c.key === "fx" + (cap + 1)),
     "a component is keyed fx" + (cap + 1) + " — one past the cap");

--- a/tests/host/test_slot_defaults_to_synth.sh
+++ b/tests/host/test_slot_defaults_to_synth.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A slot opens on its SYNTH, not on "add a MIDI effect".
+#
+# Reported from the device: "Slots should default to the synth slot when
+# they're on a new set / new session. Right now I think we default to midi fx?"
+#
+# They did. The editor list for a slot is
+#
+#     add_midi | [midi fx...] | synth | [fx...] | add_fx | settings
+#
+# so INDEX 0 IS THE MIDI FX `+`. lastChainComponent was seeded [0,0,0,0], and 0
+# is a perfectly valid index, so restoreChainComponent accepted the remembered
+# value and defaultChainComponent -- which returns the synth -- never ran.
+#
+# Two halves, and only fixing one leaves the bug: a fresh session (the seed)
+# and a set switch (a position remembered in a different set, pointing at
+# whatever now occupies that index).
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+file="src/shadow/shadow_ui.js"
+
+command grep -q "let lastChainComponent = \[null, null, null, null\]" "$file" || \
+  fail "lastChainComponent is seeded with positions again -- index 0 is the MIDI FX +, so a fresh session opens there"
+
+sw=$(awk '/SET_CHANGED: " \+ oldDir/,/loadChainConfigFromDir\(newDir\)/' "$file")
+[ -n "$sw" ] || fail "could not find the set-switch block"
+command grep -q "lastChainComponent\[i\] = null" <<<"$sw" || \
+  fail "a set switch keeps the remembered position, which points into the OLD set's chain"
+
+# The default must still be the synth, and must be derived rather than a literal.
+d=$(awk '/^function defaultChainComponent\(/,/^}/' "$file")
+command grep -q 'slotChainComponentIndex(slotIndex, "synth")' <<<"$d" || \
+  fail "defaultChainComponent no longer resolves the synth by name"
+
+echo "  ok  no remembered position on a fresh session or across a set switch"
+echo "  ok  the default is the synth, resolved by name"
+
+# And the ORDER that makes index 0 dangerous is itself pinned: if the model
+# ever puts the synth first, this whole class of bug changes shape and the
+# comments above go stale.
+node -e '
+import("./src/shared/chain_model.mjs").then((M) => {
+  const say = (m) => { console.log("FAIL: " + m); process.exit(1); };
+  const c = M.chainComponents({ synth: "", midiFx: [], fx: [] })
+             .filter((x) => x.kind !== "patch");
+  if (!c.length) say("chainComponents returned nothing");
+  if (c[0].id !== "add_midi")
+    say("the first editor position is now " + JSON.stringify(c[0].id) +
+        ", not the MIDI FX + -- the reasoning recorded in this test is stale");
+  const synthAt = c.findIndex((x) => x.kind === "synth");
+  if (synthAt <= 0) say("the synth is at index " + synthAt + "; it is meant to sit after the MIDI section");
+  console.log("  ok  index 0 is still the MIDI FX + (synth at " + synthAt + ")");
+});
+'
+echo "PASS: a slot opens on its synth"


### PR DESCRIPTION
Two device reports that share a cause: the editor's position list is built from the chain model, which knows nothing about caps or about which position *means* anything.

## 1. Master FX still shows "New effect" at 8 FX

`chainComponents` emits both `+` boxes unconditionally. That's right for a model of the chain — the filtering belongs one layer up. The limit is read from the **target's own `cap()`** (`CHAIN_CAP` for a slot, `MASTER_FX_SLOTS` for the master bus) rather than kept as a third copy of the number, which is what has gone wrong every previous time a chain cap moved.

`test_master_fx_slots_js.sh` asserted the **old** behaviour, on the grounds that *"the slot chain draws one at its cap too"*. The invariant worth keeping there is that the two chains **agree** — and they still do, both hide it now. Updated rather than deleted, plus a new check one *below* the cap so the guard can't degrade into "never".

## 2. Slots default to MIDI FX instead of the synth

Index 0 is why. The editor list runs:

```
add_midi | [midi fx...] | synth | [fx...] | add_fx | settings
```

**Index 0 is the MIDI FX `+`.** `lastChainComponent` was seeded `[0,0,0,0]`, and `0` is a perfectly valid index — so `restoreChainComponent` accepted it and `defaultChainComponent`, which resolves the synth by name, never ran.

Seeded `null` now, so "never chosen" is unrepresentable as a position. **And cleared on a set switch**: a remembered position belongs to the set it was chosen in; carried across it points at whatever occupies that index in the new chain — usually the MIDI `+` again, since a fresh set is empty. Fixing only one half leaves the other.

The test also pins the *order* that makes index 0 dangerous, so if the model ever puts the synth first, the reasoning recorded here fails loudly instead of going stale.

Six mutations kill the two tests. Not deployed — held per request.