### PR TITLE
remote UI: allow a custom web_ui.html on any chain component, not just the synth

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -267,15 +267,38 @@ repos typically mirror that pattern.
 A module that wants a fully custom browser-based UI ships a
 `web_ui.html` next to its `module.json`. schwung-manager
 auto-discovers it and loads it in a sandboxed iframe on the Remote
-UI page (`http://move.local:7700/remote-ui`) whenever the module
-is loaded as the synth component of a shadow slot. The iframe
-replaces the auto-generated knob/slider UI for that component;
-the slot's FX and MIDI FX sections still render below it.
+UI page (`http://move.local:7700/remote-ui`) whenever that module
+is loaded in a shadow slot. The iframe replaces the auto-generated
+knob/slider UI for that component.
 
-**Synth slot only.** The iframe path is detected on the `synth`
-component of a shadow slot (`remote_ui.go` only checks there).
-Audio FX, MIDI FX, and master FX modules cannot supply a custom
-web UI — they always use the auto-generated controls.
+**Any chain component can supply one** — the synth, an audio FX
+(`fx1`/`fx2`), or a MIDI FX (`midi_fx1`). Where it appears differs:
+
+- A **synth** panel takes over the slot view, with the other
+  components' sections rendered below it.
+- An **audio/MIDI FX** panel renders inside that component's own
+  collapsible section, with its own pop-out button, so a slot can
+  show a custom synth panel and a custom FX panel at once.
+
+The slot's **Interface: Default** toggle still shows the
+auto-generated controls for every component, so a module's own
+parameters stay reachable whatever its panel does.
+
+Master FX slots have no custom-UI path yet.
+
+**Know which component you are driving.** The manager appends
+`?component=<comp>` to the iframe URL and exposes it as
+`schwungRemote.component`. Use it to build your parameter keys —
+an FX panel must write `fx1:mix`, not `synth:mix`:
+
+```js
+var comp = schwungRemote.component || "synth";   // "synth", "fx1", …
+schwungRemote.setParam(comp + ":mix", "0.5");
+```
+
+`getHierarchy()` and `getChainParams()` already return the metadata
+for *your* component, so they need no prefix. A page that ignores
+the flag defaults to `synth` and behaves exactly as before.
 
 ### File layout
 
@@ -329,11 +352,14 @@ Include the bundled helper to get a Promise-based wrapper:
 | `onParamChange(cb)` | device → iframe | Subscribes the iframe to all `param_update` messages for the active slot. Includes hardware knob changes and updates from other browser clients. |
 | `getParam(key)` | local cache | Returns the **last value the iframe has seen** for `key`, not a fresh device read. If you need a value before any update has arrived, call `onParamChange` first and seed from the initial burst. |
 | `setParam(key, value)` | iframe → device | Goes through the WebSocket `set_param` path. Value is coerced to a string. |
-| `getHierarchy()` | local cache | Returns the parsed `ui_hierarchy` object for the synth component (or `null` if the module didn't expose one). |
-| `getChainParams()` | local cache | Returns the parsed `chain_params` array (or `null`). |
+| `getHierarchy()` | local cache | Returns the parsed `ui_hierarchy` object for **your** component (or `null` if the module didn't expose one). |
+| `getChainParams()` | local cache | Returns the parsed `chain_params` array for **your** component (or `null`). |
+| `component` | property | The chain component this page drives — `"synth"`, `"fx1"`, `"fx2"`, `"midi_fx1"`. Use it to build parameter keys. |
 
 **Param keys are component-prefixed.** Use `"synth:cutoff"`, not
-`"cutoff"`. Slot-level keys like `slot:volume` and `knob_1_value`
+`"cutoff"` — and build the prefix from `schwungRemote.component`
+rather than hardcoding `synth`, or your page will only work in a
+synth slot. Slot-level keys like `slot:volume` and `knob_1_value`
 also flow through `onParamChange` if you want to mirror the
 slot/knob state.
 
@@ -361,13 +387,17 @@ That means:
 
   <script src="/static/schwung-remote-api.js"></script>
   <script>
+    // Works in a synth slot or an FX slot: the host says which.
+    const comp = schwungRemote.component || "synth";
+    const key = comp + ":cutoff";
+
     const cutoff = document.getElementById("cutoff");
     cutoff.addEventListener("input", () => {
-      schwungRemote.setParam("synth:cutoff", cutoff.value);
+      schwungRemote.setParam(key, cutoff.value);
     });
     schwungRemote.onParamChange((params) => {
-      if (params["synth:cutoff"] !== undefined) {
-        cutoff.value = params["synth:cutoff"];
+      if (params[key] !== undefined) {
+        cutoff.value = params[key];
       }
     });
   </script>

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -502,6 +502,11 @@ func (ru *RemoteUI) handleSubscribe(ctx context.Context, c *ruClient, msg wsMess
 			continue
 		}
 		if comp != "synth" {
+			// An audio/MIDI FX may ship its own web_ui.html too; the client
+			// renders it inside that component's section.
+			if url := ru.findModuleWebUI(modID); url != "" {
+				ru.sendCustomUI(ctx, c, slot, comp, url)
+			}
 			ru.sendHierarchy(ctx, c, slot, comp)
 			ru.sendChainParams(ctx, c, slot, comp)
 		}
@@ -819,10 +824,12 @@ func (ru *RemoteUI) handleGetHierarchy(ctx context.Context, c *ruClient, msg wsM
 		if err != nil || modID == "" {
 			continue
 		}
-		if comp == "synth" {
-			if url := ru.findModuleWebUI(modID); url != "" {
-				ru.sendCustomUI(ctx, c, slot, comp, url)
-			}
+		// Any component may ship a web_ui.html, not just the synth: an audio
+		// FX gets its panel rendered inside its own section (the client keys
+		// custom UIs by component). findModuleWebUI already searches audio_fx
+		// and midi_fx.
+		if url := ru.findModuleWebUI(modID); url != "" {
+			ru.sendCustomUI(ctx, c, slot, comp, url)
 		}
 		ru.sendHierarchy(ctx, c, slot, comp)
 		ru.sendChainParams(ctx, c, slot, comp)
@@ -1811,10 +1818,8 @@ func (ru *RemoteUI) pollSlot(ctx context.Context, slot uint8, cache *slotCache) 
 			cache.modules[comp] = modID
 			ru.broadcastSlotInfo(ctx, slot)
 			if modID != "" {
-				if comp == "synth" {
-					if url := ru.findModuleWebUI(modID); url != "" {
-						ru.broadcastCustomUI(ctx, slot, comp, url)
-					}
+				if url := ru.findModuleWebUI(modID); url != "" {
+					ru.broadcastCustomUI(ctx, slot, comp, url)
 				}
 				ru.broadcastHierarchy(ctx, slot, comp)
 				ru.broadcastChainParams(ctx, slot, comp)

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -35,8 +35,9 @@
             },
             // Track which component sections are collapsed (true = collapsed).
             collapsed: { synth: false, fx1: true, fx2: true, midi_fx1: true },
-            // Custom web UI URL for synth component (null = use auto-generated UI).
-            customUI: null,
+            // Custom web UI URLs, keyed by component ("synth", "fx1", …).
+            // A component absent from this map uses the auto-generated UI.
+            customUI: {},
             // When true, ignore customUI and show the auto-generated parameter
             // UI even though a module web_ui.html is available. Session-only.
             useDefaultUI: false
@@ -82,11 +83,11 @@
     var isConnected = false;
     var waitingForData = false; // True after subscribe, before first data arrives
 
-    // Custom module web UI state.
-    var customUIIframe = null; // Reference to active custom UI iframe element
-    var customUISubscribed = false; // Whether the iframe has subscribed to param updates
-    var customUILoadingEl = null; // Loading overlay shown until the module UI is ready
-    var customUILoadingTimer = null; // Fallback timer to clear the overlay
+    // Custom module web UI state. A slot can show more than one at once (a
+    // synth panel plus a panel for each audio FX), so frames are tracked per
+    // component rather than as a single active iframe.
+    //   customUIFrames[component] = { iframe, subscribed, overlay, timer }
+    var customUIFrames = {};
 
     // Knob drag state.
     var dragging = null; // { component, key, startY, startValue, min, max, step, type, slot }
@@ -278,14 +279,20 @@
 
     function handleSlotInfo(slot, msg) {
         var s = slots[slot];
-        // Clear custom UI if synth module changed.
-        var prevSynth = s.components.synth.module;
-        s.components.synth.module = msg.synth || "";
-        s.components.fx1.module = msg.fx1 || "";
-        s.components.fx2.module = msg.fx2 || "";
-        s.components.midi_fx1.module = msg.midi_fx1 || "";
-        if (prevSynth !== s.components.synth.module) {
-            s.customUI = null;
+        // A component's custom UI belongs to the module that supplied it, so
+        // drop it when that particular component's module changes.
+        var incoming = {
+            synth: msg.synth || "",
+            fx1: msg.fx1 || "",
+            fx2: msg.fx2 || "",
+            midi_fx1: msg.midi_fx1 || ""
+        };
+        for (var ci = 0; ci < COMPONENT_KEYS.length; ci++) {
+            var ck = COMPONENT_KEYS[ci];
+            if (s.components[ck].module !== incoming[ck]) {
+                s.components[ck].module = incoming[ck];
+                delete s.customUI[ck];
+            }
         }
         if (slot === activeSlot) renderSlot();
     }
@@ -293,7 +300,10 @@
     function handleCustomUI(slot, msg) {
         if (slot < 0 || slot > 3) return;
         var s = slots[slot];
-        s.customUI = { component: msg.component || "synth", url: msg.url || "" };
+        var comp = msg.component || "synth";
+        var url = msg.url || "";
+        if (s.customUI[comp] === url) return;   // avoid reloading a live iframe
+        s.customUI[comp] = url;
         if (slot === activeSlot) renderSlot();
     }
 
@@ -324,7 +334,7 @@
             }
         }
         // Forward live updates to the tool iframe if it's the active view.
-        if (activeSlot === "tool" && customUISubscribed && customUIIframe) {
+        if (activeSlot === "tool") {
             postToIframe({ type: "paramUpdate", params: msg.params });
         }
     }
@@ -435,7 +445,7 @@
             updateParamValues(slot, msg.params);
         }
         // Forward to custom UI iframe if subscribed.
-        if (customUISubscribed && customUIIframe && slot === activeSlot) {
+        if (slot === activeSlot) {
             postToIframe({ type: "paramUpdate", params: msg.params });
         }
     }
@@ -1407,6 +1417,25 @@
 
         if (isCollapsed) return section;
 
+        // A component that ships its own web_ui.html draws it here instead of
+        // the generated rows. Honour the slot's Default override so the
+        // generated controls stay reachable.
+        var slotState = slots[activeSlot];
+        var compCustomUrl = (typeof activeSlot === "number" && slotState)
+            ? (slotState.customUI[compKey] || "") : "";
+        if (compCustomUrl && compKey !== "synth" && !slotState.useDefaultUI) {
+            var popOut = makePopOutButton(customUIUrlFor(compCustomUrl, compKey), activeSlot);
+            popOut.classList.add("component-popout");
+            popOut.onclick = (function (orig) {
+                return function (ev) { ev.stopPropagation(); return orig.apply(this, arguments); };
+            })(popOut.onclick);
+            header.appendChild(popOut);
+            section.appendChild(
+                buildCustomUIFrame(compKey, compCustomUrl,
+                                   (COMPONENT_LABELS[compKey] || compKey) + " UI"));
+            return section;
+        }
+
         // Body
         var body = document.createElement("div");
         body.className = "component-body";
@@ -1501,10 +1530,11 @@
         if (slotHeaderControlsEl) slotHeaderControlsEl.innerHTML = "";
 
         // Clear custom UI iframe state on re-render.
-        customUIIframe = null;
-        customUISubscribed = false;
-        customUILoadingEl = null;
-        if (customUILoadingTimer) { clearTimeout(customUILoadingTimer); customUILoadingTimer = null; }
+        // The DOM is about to be rebuilt, so every registered frame is stale.
+        for (var fk in customUIFrames) {
+            if (customUIFrames[fk] && customUIFrames[fk].timer) clearTimeout(customUIFrames[fk].timer);
+        }
+        customUIFrames = {};
 
         if (activeSlot === "master") {
             renderMasterFx();
@@ -1536,12 +1566,15 @@
             return;
         }
 
-        // When the synth ships a custom web UI, put the Interface toggle and
-        // the pop-out button inline next to the slot label (compact, both modes).
-        var hasCustomUI = !!(s.customUI && s.customUI.url && hasAnyModule);
+        // The slot-level Interface toggle and pop-out follow the SYNTH panel,
+        // which is the one that takes over the whole slot view. A custom FX
+        // panel lives inside its own section and carries its own pop-out.
+        var synthCustomUrl = s.customUI.synth || "";
+        var hasCustomUI = !!(synthCustomUrl && hasAnyModule);
         if (hasCustomUI && slotHeaderControlsEl) {
             slotHeaderControlsEl.appendChild(renderUiModeToggle(s));
-            slotHeaderControlsEl.appendChild(makePopOutButton(s.customUI.url, activeSlot));
+            slotHeaderControlsEl.appendChild(
+                makePopOutButton(customUIUrlFor(synthCustomUrl, "synth"), activeSlot));
         }
 
         // Render the custom web UI unless the user opted out for this slot.
@@ -2051,64 +2084,66 @@
             slotHeaderControlsEl.appendChild(makePopOutButton(tool.customUI.url, "tool"));
         }
 
+        slotContentEl.appendChild(buildCustomUIFrame("tool", tool.customUI.url, "Tool UI"));
+    }
+
+    /** Tag a module UI URL with the component it is driving, so the page can
+     *  address the right parameter prefix ("fx1:mix" rather than "synth:mix")
+     *  and a popped-out window can ask for the right metadata. */
+    function customUIUrlFor(url, comp) {
+        if (!url) return url;
+        return url + (url.indexOf("?") >= 0 ? "&" : "?") + "component=" + encodeURIComponent(comp);
+    }
+
+    /** Build the iframe + loading overlay for one component's custom UI and
+     *  register it so messages can be routed back to the right component. */
+    function buildCustomUIFrame(comp, url, title) {
         var container = document.createElement("div");
         container.className = "custom-ui-container";
 
         var iframe = document.createElement("iframe");
         iframe.className = "custom-ui-iframe";
-        iframe.src = tool.customUI.url;
+        iframe.src = customUIUrlFor(url, comp);
         iframe.sandbox = "allow-scripts allow-same-origin";
-        iframe.setAttribute("title", "Tool UI");
+        iframe.setAttribute("title", title || "Custom Module UI");
         container.appendChild(iframe);
 
+        // Cleared when the iframe subscribes (module JS ran), on load, or after
+        // a timeout — whichever comes first.
         var overlay = document.createElement("div");
         overlay.className = "custom-ui-loading";
         overlay.innerHTML = '<span class="loading-spinner"></span> Loading module…';
         container.appendChild(overlay);
-        customUILoadingEl = overlay;
-        iframe.addEventListener("load", hideCustomUILoading);
-        customUILoadingTimer = setTimeout(hideCustomUILoading, 10000);
 
-        slotContentEl.appendChild(container);
-        customUIIframe = iframe;
-        customUISubscribed = false;
+        var entry = { iframe: iframe, subscribed: false, overlay: overlay, timer: null };
+        customUIFrames[comp] = entry;
+        iframe.addEventListener("load", function () { hideCustomUILoading(comp); });
+        entry.timer = setTimeout(function () { hideCustomUILoading(comp); }, 10000);
+        return container;
+    }
+
+    /** Which component owns the iframe a postMessage came from. */
+    function componentForSource(source) {
+        for (var comp in customUIFrames) {
+            var e = customUIFrames[comp];
+            if (e && e.iframe && e.iframe.contentWindow === source) return comp;
+        }
+        return null;
     }
 
     function renderCustomUI(s) {
-        var url = s.customUI.url;
+        slotContentEl.appendChild(
+            buildCustomUIFrame("synth", s.customUI.synth, "Custom Module UI"));
 
-        // Create iframe container.
-        var container = document.createElement("div");
-        container.className = "custom-ui-container";
-
-        var iframe = document.createElement("iframe");
-        iframe.className = "custom-ui-iframe";
-        iframe.src = url;
-        iframe.sandbox = "allow-scripts allow-same-origin";
-        iframe.setAttribute("title", "Custom Module UI");
-        container.appendChild(iframe);
-
-        // Loading overlay shown over the iframe until the module UI is ready.
-        // Cleared when the iframe subscribes (module JS ran), or on iframe
-        // onload, or after a timeout — whichever comes first.
-        var overlay = document.createElement("div");
-        overlay.className = "custom-ui-loading";
-        overlay.innerHTML = '<span class="loading-spinner"></span> Loading module…';
-        container.appendChild(overlay);
-        customUILoadingEl = overlay;
-        iframe.addEventListener("load", hideCustomUILoading);
-        customUILoadingTimer = setTimeout(hideCustomUILoading, 10000);
-
-        slotContentEl.appendChild(container);
-
-        // Also render FX sections below the iframe if any are loaded.
+        // The other components still render below the synth panel. Each one
+        // draws its own custom UI inside its section if it ships one.
         for (var k = 0; k < COMPONENT_KEYS.length; k++) {
             var compKey = COMPONENT_KEYS[k];
             if (compKey === "synth") continue; // synth is replaced by iframe
             var compState = s.components[compKey];
             if (!compState.module) continue;
-            var section = renderComponentSection(compKey, compState, s.collapsed[compKey]);
-            slotContentEl.appendChild(section);
+            slotContentEl.appendChild(
+                renderComponentSection(compKey, compState, s.collapsed[compKey]));
         }
 
         // Slot settings (volume, sends, channels, LFO, …) are module-independent
@@ -2116,43 +2151,41 @@
         // appends them at the bottom, so do the same here.
         var settingsSection = renderSlotSettings(s);
         if (settingsSection) slotContentEl.appendChild(settingsSection);
-
-        customUIIframe = iframe;
-        customUISubscribed = false;
     }
 
     // Listen for postMessage from custom UI iframes.
     window.addEventListener("message", function (e) {
-        if (!customUIIframe) return;
-        // Only accept messages from our iframe.
-        if (e.source !== customUIIframe.contentWindow) return;
+        // Only accept messages from a registered module iframe, and remember
+        // which component it speaks for.
+        var srcComp = componentForSource(e.source);
+        if (!srcComp) return;
 
         var msg = e.data;
         if (!msg || !msg.type) return;
 
         switch (msg.type) {
             case "getParam":
-                handleIframeGetParam(msg);
+                handleIframeGetParam(msg, srcComp);
                 break;
             case "setParam":
-                handleIframeSetParam(msg);
+                handleIframeSetParam(msg, srcComp);
                 break;
             case "subscribe":
-                customUISubscribed = true;
+                customUIFrames[srcComp].subscribed = true;
                 // Module JS has run — clear the loading overlay.
-                hideCustomUILoading();
+                hideCustomUILoading(srcComp);
                 // Bulk-seed: push every param value the parent has already
                 // cached (from the host's initial fetch) in one message, so the
                 // iframe paints real values immediately instead of pulling them
                 // back one-by-one via getParam. Late-arriving values still flow
                 // through the normal param_update path below.
-                seedCustomUI();
+                seedCustomUI(srcComp);
                 break;
             case "getHierarchy":
-                handleIframeGetHierarchy(msg);
+                handleIframeGetHierarchy(msg, srcComp);
                 break;
             case "getChainParams":
-                handleIframeGetChainParams(msg);
+                handleIframeGetChainParams(msg, srcComp);
                 break;
             case "resubscribe":
                 // Iframe asked for a fresh device read (e.g. tool polling for the
@@ -2208,53 +2241,64 @@
         });
     }
 
-    function handleIframeGetHierarchy(msg) {
+    function handleIframeGetHierarchy(msg, comp) {
         var slot = activeSlot;
         if (typeof slot !== "number") return;
-        var compState = slots[slot].components.synth;
+        var compState = slots[slot].components[comp || "synth"];
         postToIframe({
             type: "hierarchy",
             id: msg.id || null,
+            component: comp || "synth",
             data: compState ? compState.hierarchy : null
-        });
+        }, comp);
     }
 
-    function handleIframeGetChainParams(msg) {
+    function handleIframeGetChainParams(msg, comp) {
         var slot = activeSlot;
         if (typeof slot !== "number") return;
-        var compState = slots[slot].components.synth;
+        var compState = slots[slot].components[comp || "synth"];
         postToIframe({
             type: "chainParams",
             id: msg.id || null,
+            component: comp || "synth",
             data: compState ? compState.chainParams : null
-        });
+        }, comp);
     }
 
-    function postToIframe(msg) {
-        if (customUIIframe && customUIIframe.contentWindow) {
-            customUIIframe.contentWindow.postMessage(msg, "*");
+    /** Post to one component's iframe, or to every live one when comp is omitted. */
+    function postToIframe(msg, comp) {
+        if (comp) {
+            var one = customUIFrames[comp];
+            if (one && one.iframe && one.iframe.contentWindow)
+                one.iframe.contentWindow.postMessage(msg, "*");
+            return;
+        }
+        for (var k in customUIFrames) {
+            var e = customUIFrames[k];
+            if (e && e.subscribed && e.iframe && e.iframe.contentWindow)
+                e.iframe.contentWindow.postMessage(msg, "*");
         }
     }
 
-    // Remove the custom-UI loading overlay (idempotent).
-    function hideCustomUILoading() {
-        if (customUILoadingTimer) { clearTimeout(customUILoadingTimer); customUILoadingTimer = null; }
-        if (customUILoadingEl && customUILoadingEl.parentNode) {
-            customUILoadingEl.parentNode.removeChild(customUILoadingEl);
-        }
-        customUILoadingEl = null;
+    // Remove one component's loading overlay (idempotent).
+    function hideCustomUILoading(comp) {
+        var e = customUIFrames[comp];
+        if (!e) return;
+        if (e.timer) { clearTimeout(e.timer); e.timer = null; }
+        if (e.overlay && e.overlay.parentNode) e.overlay.parentNode.removeChild(e.overlay);
+        e.overlay = null;
     }
 
     // Push all params the parent has already cached for the active slot to the
     // custom UI iframe in a single paramUpdate. Called when the iframe first
     // subscribes so it can seed its controls without a round-trip per param.
-    function seedCustomUI() {
-        if (!customUIIframe) return;
+    function seedCustomUI(comp) {
+        if (!customUIFrames[comp]) return;
 
         // Tool view: seed from the overtake tool's cached params.
         if (activeSlot === "tool") {
             var keys = Object.keys(tool.params);
-            if (keys.length > 0) postToIframe({ type: "paramUpdate", params: tool.params });
+            if (keys.length > 0) postToIframe({ type: "paramUpdate", params: tool.params }, comp);
             return;
         }
 
@@ -2272,7 +2316,7 @@
                 }
             }
         }
-        if (any) postToIframe({ type: "paramUpdate", params: params });
+        if (any) postToIframe({ type: "paramUpdate", params: params }, comp);
     }
 
     function renderMasterFx() {

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -1566,19 +1566,26 @@
             return;
         }
 
-        // The slot-level Interface toggle and pop-out follow the SYNTH panel,
-        // which is the one that takes over the whole slot view. A custom FX
-        // panel lives inside its own section and carries its own pop-out.
+        // Two separate questions. The Interface toggle is slot-wide — it flips
+        // every panel in the slot, which is what renderComponentSection already
+        // assumes by reading useDefaultUI — so it has to appear whenever ANY
+        // component has a panel. Gating it on the synth left an FX-only slot
+        // with no way back to the generated controls.
         var synthCustomUrl = s.customUI.synth || "";
-        var hasCustomUI = !!(synthCustomUrl && hasAnyModule);
-        if (hasCustomUI && slotHeaderControlsEl) {
+        var hasAnyCustomUI = hasAnyModule && COMPONENT_KEYS.some(function (k) {
+            return s.customUI[k];
+        });
+        if (hasAnyCustomUI && slotHeaderControlsEl) {
             slotHeaderControlsEl.appendChild(renderUiModeToggle(s));
-            slotHeaderControlsEl.appendChild(
-                makePopOutButton(customUIUrlFor(synthCustomUrl, "synth"), activeSlot));
+            // Pop-out stays synth-only; an FX section carries its own.
+            if (synthCustomUrl) {
+                slotHeaderControlsEl.appendChild(
+                    makePopOutButton(customUIUrlFor(synthCustomUrl, "synth"), activeSlot));
+            }
         }
 
-        // Render the custom web UI unless the user opted out for this slot.
-        if (hasCustomUI && !s.useDefaultUI) {
+        // Only a synth panel takes over the slot view.
+        if (synthCustomUrl && !s.useDefaultUI) {
             renderCustomUI(s);
             return;
         }
@@ -2200,13 +2207,13 @@
         }
     });
 
-    function handleIframeGetParam(msg) {
+    function handleIframeGetParam(msg, comp) {
         if (!msg.key || !msg.id) return;
         var slot = activeSlot;
 
         // Tool view: params come from the overtake tool's cache (overtake_dsp:*).
         if (slot === "tool") {
-            postToIframe({ type: "paramResult", id: msg.id, value: tool.params[msg.key] || "" });
+            postToIframe({ type: "paramResult", id: msg.id, value: tool.params[msg.key] || "" }, comp);
             return;
         }
         if (typeof slot !== "number") return;
@@ -2217,10 +2224,14 @@
         var compState = slots[slot].components[parts.comp];
         var value = compState ? (compState.params[msg.key] || "") : "";
 
-        postToIframe({ type: "paramResult", id: msg.id, value: value });
+        // Targeted: request ids come from a per-page counter in
+        // schwung-remote-api.js ("req_<n>_<ms>"), so two panels can mint the
+        // same id in the same millisecond and a broadcast reply would resolve
+        // in the wrong one with another component's value.
+        postToIframe({ type: "paramResult", id: msg.id, value: value }, comp);
     }
 
-    function handleIframeSetParam(msg) {
+    function handleIframeSetParam(msg, comp) {   // comp unused: no reply is sent
         if (!msg.key) return;
         var slot = activeSlot;
 

--- a/schwung-manager/static/schwung-remote-api.js
+++ b/schwung-manager/static/schwung-remote-api.js
@@ -32,6 +32,10 @@
     // (and carries the slot); window.top === window.self is the fallback.
     var query = new URLSearchParams(window.location.search);
     var standalone = query.get("schwungStandalone") === "1" || window.top === window.self;
+    // Which chain component this page drives. The manager appends it to the
+    // iframe URL, so an audio FX panel asks for fx1/fx2 metadata rather than
+    // the synth's. Defaults to synth for pages predating the flag.
+    var component = query.get("component") || "synth";
 
     if (!standalone) {
         // ----------------------------------------------------------------
@@ -61,6 +65,8 @@
         }
 
         window.schwungRemote = {
+            /** Chain component this page drives ("synth", "fx1", …). */
+            component: component,
             /**
              * Get the current value of a parameter.
              * @param {string} key - Parameter key, e.g. "synth:cutoff"
@@ -180,14 +186,14 @@
                 }
                 break;
             case "hierarchy":
-                // Only the synth component drives the custom UI.
-                if (msg.component === "synth") {
+                // Take the metadata for the component this page drives.
+                if (msg.component === component) {
                     hierarchyData = msg.data;
                     resolveWaiters(hierarchyWaiters, hierarchyData);
                 }
                 break;
             case "chain_params":
-                if (msg.component === "synth") {
+                if (msg.component === component) {
                     chainParamsData = msg.data;
                     resolveWaiters(chainParamsWaiters, chainParamsData);
                 }
@@ -228,6 +234,8 @@
     connect();
 
     window.schwungRemote = {
+        /** Chain component this page drives ("synth", "fx1", …). */
+        component: component,
         getParam: function (key) {
             // Resolve from the local cache. Values stream in via param_update
             // shortly after subscribe, so early reads may be undefined — the


### PR DESCRIPTION
Any chain component can now ship a `web_ui.html`, not just the synth. This is a platform capability rather than a change for one module: every audio FX and MIDI FX in the catalog can have a designed panel from here on, the same way synths already can.

`findModuleWebUI()` already searched `modules/audio_fx` and `modules/midi_fx`, but every call site was gated on the synth and the client modelled **one** custom UI per slot — so an FX could ship a panel and it would silently never be offered. `docs/MODULES.md` documented that as a hard limitation.

### Server

`custom_ui` is sent for any component that has one:

- the **subscribe** path, which handled only the synth before falling through to a loop that sent hierarchy/chain_params for the rest
- `handleGetHierarchy`

`sendCustomUI` / `broadcastCustomUI` already carried the component, so this part is small.

### Client

- `s.customUI` becomes a map keyed by component, and a panel is dropped when *that* component's module changes (it previously cleared on any synth change).
- A **synth** panel still takes over the slot view exactly as before. An **FX** panel renders inside that component's own collapsible section, with its own pop-out — so a slot can show a custom synth panel and a custom FX panel at once.
- The slot's **Interface: Default** toggle still shows the generated controls for every component, so a module's parameters stay reachable whatever its panel does.
- The single `customUIIframe` becomes a registry, since a slot can now show several panels. `postMessage` is routed back by matching the sender, so `getParam` / `setParam` / `getHierarchy` / `getChainParams` answer for the component that asked instead of always the synth. Loading overlays and the subscribe-time seed are per frame.

### The bridge — the part module authors need

The iframe URL carries `?component=`, exposed as `schwungRemote.component`, and `hierarchy` / `chain_params` are filtered on it. Without this a popped-out FX panel asks for synth metadata and renders empty. A page that ignores the flag defaults to `synth`, so every existing module UI is unaffected.

`docs/MODULES.md` is updated accordingly — it previously said "Synth slot only … Audio FX, MIDI FX, and master FX modules cannot supply a custom web UI", which is the one place an author would look before building one. It now documents where each panel appears, that Default still exposes the generated controls, that master FX remains unsupported, and that a page should build its keys from `schwungRemote.component` rather than hardcoding `synth:`. The worked example does that too, so anyone copying it gets a panel that works in either kind of slot.

### Verified on hardware

Move with `tablor` on synth and an audio FX on `fx1`:

- both panels render together — synth on top, FX panel inside its own section
- the FX panel reports its component, addresses `fx1:` keys, and shows live values
- a synth-only slot (9W9) is unchanged
- collapse/expand and the per-section pop-out work
- `tests/host`: **120/120**, `go vet` clean

Open question for you: an FX panel currently follows the slot's Custom/Default switch. A per-component switch might be nicer once several modules ship panels — happy to add it if you'd prefer that shape.
