### PR TITLE
midi: a filtered MIDI_IN slot is a terminator, and it was eating note-offs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,43 @@ TX (offset 0):                       RX (offset 2048):
 
 Cable numbers: 0 = internal hw, 2 = external USB, 14 = system, 15 = SPI protocol. See `docs/SPI_PROTOCOL.md`.
 
+### A zeroed MIDI_IN slot is a TERMINATOR, not a hole
+
+MIDI_IN is **31 × 8 = 248 bytes** — not `MIDI_BUFFER_SIZE` (256), which runs one
+slot into the RX display-status word at +248. Bound every 8-stride walk with
+`SHADOW_MIDI_IN_BYTES`.
+
+Move's firmware reads MIDI_IN **until the first empty slot** (cable, CIN and all
+three payload bytes zero — `schwung_usb_midi_msg_is_empty`; `schwung_jack_bridge.c`
+breaks on it too). So suppressing an event by zeroing its slot in place does not
+punch a hole, it plants an end-of-list marker and **everything behind it is
+invisible to Move for that frame**.
+
+That is a real stuck-note bug, not a theoretical one. Knob CCs 71-78, knob-touch
+notes 0-9, jog, Back and Menu are filtered on every event while the shadow UI is
+up; spin a knob with pads held and the pad note-off lands behind a terminator.
+Move keeps the pad lit and its instrument sounding — **and so does the slot
+synth, because chain slots are fed from Move's MIDI_OUT echo, not from MIDI_IN.**
+One drop, two stuck consumers, with the note-off sitting present and correctly
+ordered in the raw hardware mailbox the whole time. That last part is what makes
+this look like it must be somewhere else; it isn't.
+
+`shadow_midi_in_compact()` (`src/host/shadow_midi_filter.c`) closes the gaps and
+runs **last** in `shim_post_transfer` — the blocking sites above it pair `sh[j]`
+with `hw[j]` by index, so nothing may move while they run. Zero a slot after it
+and the bug is back; `tests/host/test_midi_in_compact_call_site.sh` fails on
+exactly that.
+
+Compaction is safe because events already shift between slots across frames —
+which is why the dedup rings key on content + timestamp rather than position.
+The old "never compact MIDI_IN (SIGABRT)" note came from the RTP-MIDI WIP
+(`271bcd0b`), which walked MIDI_IN at a **4-byte stride**, i.e. shifted events by
+half an event, and never stabilised for reasons it recorded as unknown.
+
+**Nothing may walk MIDI_IN at a 4-byte stride.** Two places still do
+(`shadow_forward_external_cc_to_out` and `shadow_forward_midi`, both in
+`shadow_midi.c`); they read timestamps as packets and are unfixed.
+
 ## Realtime Safety
 
 SPI callback runs SCHED_FIFO 90 on core 3. Budget ~900µs/frame after the ~2ms transfer.

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -5,6 +5,7 @@
 #include <string.h>
 #include <unistd.h>
 #include "shadow_midi.h"
+#include "shadow_midi_filter.h"   /* SHADOW_MIDI_IN_* geometry */
 #include "shadow_midi_inject_writer.h"
 #include "shadow_chain_mgmt.h"
 #include "shadow_led_queue.h"
@@ -837,7 +838,7 @@ void shadow_dispatch_direct_external_midi(void)
      * partially consumes MIDI_IN and events at higher offsets may shift
      * down or persist across frames; we rely on the timestamp-keyed dedup
      * to skip duplicates regardless of where the event lives. */
-    for (int i = 0; i + 8 <= MIDI_BUFFER_SIZE; i += 8) {
+    for (int i = 0; i + 8 <= SHADOW_MIDI_IN_BYTES; i += 8) {
         uint8_t cin = in_src[i] & 0x0F;
         uint8_t cable = (in_src[i] >> 4) & 0x0F;
 
@@ -945,7 +946,7 @@ void shadow_dispatch_cable2_channeled_slots(void)
     uint8_t *in_src = *host_global_mmap_addr + MIDI_IN_OFFSET;
 
     /* 8-byte stride (USB-MIDI + timestamp); don't break on zero. */
-    for (int i = 0; i + 8 <= MIDI_BUFFER_SIZE; i += 8) {
+    for (int i = 0; i + 8 <= SHADOW_MIDI_IN_BYTES; i += 8) {
         uint8_t header = in_src[i];
         if (header == 0) continue;
 

--- a/src/host/shadow_midi_filter.c
+++ b/src/host/shadow_midi_filter.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "shadow_midi_filter.h"
 
 int shadow_midi_forwardable(uint8_t head, uint8_t status, uint8_t d1, uint8_t d2)
@@ -17,4 +19,26 @@ int shadow_midi_forwardable(uint8_t head, uint8_t status, uint8_t d1, uint8_t d2
      * least one nonzero byte (F0, F7, or data), so an all-zero payload is a
      * stale slot rather than a message. */
     return (status || d1 || d2) ? 1 : 0;
+}
+
+int shadow_midi_in_slot_empty(const uint8_t *slot)
+{
+    if (!slot) return 1;
+    return (slot[0] == 0 && slot[1] == 0 && slot[2] == 0 && slot[3] == 0) ? 1 : 0;
+}
+
+int shadow_midi_in_compact(uint8_t *midi_in)
+{
+    if (!midi_in) return 0;
+
+    int w = 0;
+    for (int r = 0; r < SHADOW_MIDI_IN_BYTES; r += SHADOW_MIDI_IN_STRIDE) {
+        if (shadow_midi_in_slot_empty(&midi_in[r])) continue;
+        if (w != r) memcpy(&midi_in[w], &midi_in[r], SHADOW_MIDI_IN_STRIDE);
+        w += SHADOW_MIDI_IN_STRIDE;
+    }
+    if (w < SHADOW_MIDI_IN_BYTES)
+        memset(&midi_in[w], 0, (size_t)(SHADOW_MIDI_IN_BYTES - w));
+
+    return w / SHADOW_MIDI_IN_STRIDE;
 }

--- a/src/host/shadow_midi_filter.h
+++ b/src/host/shadow_midi_filter.h
@@ -28,4 +28,33 @@
  */
 int shadow_midi_forwardable(uint8_t head, uint8_t status, uint8_t d1, uint8_t d2);
 
+/* MIDI_IN geometry.  31 events of 8 bytes (4-byte USB-MIDI + 4-byte XMOS
+ * timestamp) = 248 bytes, and then the display-status word at +248.  NOT
+ * MIDI_BUFFER_SIZE, which is 256 and runs one slot into that word. */
+#define SHADOW_MIDI_IN_STRIDE 8
+#define SHADOW_MIDI_IN_SLOTS  31
+#define SHADOW_MIDI_IN_BYTES  (SHADOW_MIDI_IN_STRIDE * SHADOW_MIDI_IN_SLOTS)
+
+/* Is this slot the terminator?  The Ableton SPI convention (see
+ * schwung_usb_midi_msg_is_empty) is cable, CIN and all three payload bytes
+ * zero — the timestamp is not part of the test. */
+int shadow_midi_in_slot_empty(const uint8_t *slot);
+
+/* Close every gap in MIDI_IN: shift surviving events down, order preserved,
+ * and zero the tail.  Returns the number of survivors.
+ *
+ * Move's firmware MIDI_IN reader STOPS at the first empty slot, so a gap
+ * hides every event behind it.  The shim suppresses an event by zeroing its
+ * slot in place, which manufactures exactly that gap — see the call site in
+ * schwung_shim.c for how it loses pad note-offs.  Run this after every
+ * MIDI_IN mutation to restore the dense-prefix/zero-tail shape the hardware
+ * itself delivers and Move's reader assumes.
+ *
+ * Moving an event between slots is invisible to the other readers: the
+ * dedup rings key on content plus timestamp, and the timestamp travels with
+ * its event here.
+ *
+ * SPI-callback safe: bounded loop, no allocation, I/O or locks. */
+int shadow_midi_in_compact(uint8_t *midi_in);
+
 #endif /* SHADOW_MIDI_FILTER_H */

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1305,7 +1305,7 @@ static void shadow_inprocess_process_midi(void) {
              * frame and the echo frame.  The ring closes that race. */
             int is_external_echo = 0;
             const uint8_t *in_buf = global_mmap_addr + MIDI_IN_OFFSET;
-            for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+            for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
                 if ((in_buf[j] >> 4) == 2 &&          /* cable 2 */
                     in_buf[j + 1] == p1 &&             /* same status+channel */
                     in_buf[j + 2] == p2 &&             /* same data1 */
@@ -4771,7 +4771,7 @@ void midi_monitor()
         return;
     }
 
-    for (int i = 0; i < MIDI_BUFFER_SIZE; i += 8)
+    for (int i = 0; i < SHADOW_MIDI_IN_BYTES; i += 8)
     {
         if (memcmp(&src[i], &hotkey_prev[i], 4) == 0) {
             continue;
@@ -5415,7 +5415,7 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
         extern int midi_indicator_active_notes;
         extern int midi_indicator_out_active_notes;
         const uint8_t *mi = global_mmap_addr + MIDI_IN_OFFSET;
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             if (((mi[j] >> 4) & 0x0F) != 2) continue;  /* cable 2 only */
             uint8_t st = mi[j + 1], ty = st & 0xF0, d1b = mi[j + 2], d2b = mi[j + 3];
             if (ty == 0x90 && d2b > 0) {
@@ -6326,7 +6326,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
      */
     if (shim_touch_trace_on && hw) {
         const uint8_t *tsrc = (const uint8_t *)hw + MIDI_IN_OFFSET;
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t thead = tsrc[j];
             if (thead == 0) continue;
             uint8_t tstatus = tsrc[j + 1];
@@ -6567,8 +6567,14 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
             (corun_target(shadow_control) == CORUN_TARGET_MOVE_NATIVE) &&
             !(corun_keep_mask_eff(shadow_control) & CORUN_GRP_KNOBS);
 
-        /* Filter MIDI_IN: zero out jog/back/knobs */
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        /* Filter MIDI_IN: zero out jog/back/knobs.
+         *
+         * Bound is SHADOW_MIDI_IN_BYTES (248 = 31 × 8), NOT MIDI_BUFFER_SIZE
+         * (256). MIDI_IN holds 31 events and the RX display-status word sits
+         * immediately behind it at +248; at the 256 bound the last iteration
+         * read that word as a 32nd event and, whenever it looked like a
+         * filtered control, ZEROED it. */
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin = hw_midi[j] & 0x0F;
             uint8_t cable = (hw_midi[j] >> 4) & 0x0F;
             uint8_t status = hw_midi[j + 1];
@@ -6732,7 +6738,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                 else if (delta < -63) delta = -63;
                 s_corun_knob_accum[k] -= delta;   /* carry remainder to next emit */
                 uint8_t d2 = (delta >= 0) ? (uint8_t)delta : (uint8_t)(delta + 128);
-                for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+                for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
                     if (sh_midi[j] == 0 && sh_midi[j + 1] == 0 &&
                         sh_midi[j + 2] == 0 && sh_midi[j + 3] == 0) {
                         sh_midi[j]     = 0x0B;     /* cable 0, CIN 0x0B = CC */
@@ -6764,7 +6770,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
      * This works regardless of shadow_display_mode.
      * Skip entirely in overtake mode - overtake module owns all input. */
     if (overtake_mode) goto skip_shift_menu;
-    for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+    for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
         uint8_t cin = hw_midi[j] & 0x0F;
         uint8_t cable = (hw_midi[j] >> 4) & 0x0F;
         if (cable != 0x00) continue;  /* Only internal cable */
@@ -6847,7 +6853,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
      * Always block Shift+Record so the first press doesn't leak through.
      * Block jog while sampler is armed or recording. */
     {
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin = sh_midi[j] & 0x0F;
             uint8_t cable = (sh_midi[j] >> 4) & 0x0F;
             if (cable != 0x00) continue;
@@ -6944,7 +6950,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
      * MIDI_IN events are 8 bytes (4 USB-MIDI + 4 timestamp). */
     if (hardware_mmap_addr) {
         const uint8_t *src_early = hardware_mmap_addr + MIDI_IN_OFFSET;
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin   = src_early[j] & 0x0F;
             uint8_t cable = (src_early[j] >> 4) & 0x0F;
             if (cable != 0x00) continue;
@@ -6992,7 +6998,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
     if (hardware_mmap_addr && shadow_inprocess_ready) {
         uint8_t *src = hardware_mmap_addr + MIDI_IN_OFFSET;
         int overtake_active = shadow_control ? shadow_control->overtake_mode : 0;
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin = src[j] & 0x0F;
             uint8_t cable = (src[j] >> 4) & 0x0F;
             if (cable != 0x00) continue;  /* Only internal cable */
@@ -7453,7 +7459,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
 
         /* External MIDI trigger (cable 2): any note-on triggers recording when armed */
         if (sampler_state == SAMPLER_ARMED) {
-            for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+            for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
                 uint8_t cable = (src[j] >> 4) & 0x0F;
                 uint8_t cin = src[j] & 0x0F;
                 if (cable != 0x02) continue;
@@ -7488,7 +7494,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
     if (!shadow_display_mode && overlay_active && shadow_ui_enabled &&
         shadow_inprocess_ready && global_mmap_addr) {
         uint8_t *src = global_mmap_addr + MIDI_IN_OFFSET;
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin = src[j] & 0x0F;
             uint8_t cable = (src[j] >> 4) & 0x0F;
             if (cable != 0x00) continue;  /* Only internal cable */
@@ -7578,7 +7584,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
     if (!shadow_display_mode && overlay_knobs_mode == OVERLAY_KNOBS_NATIVE &&
         shadow_ui_enabled && shadow_inprocess_ready && global_mmap_addr) {
         uint8_t *src = global_mmap_addr + MIDI_IN_OFFSET;
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin = src[j] & 0x0F;
             uint8_t cable = (src[j] >> 4) & 0x0F;
             if (cable != 0x00) continue;  /* Only internal cable */
@@ -7665,7 +7671,7 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
         uint8_t *src = hardware_mmap_addr + MIDI_IN_OFFSET;  /* Scan unfiltered hardware buffer */
         int overtake_mode = shadow_control->overtake_mode;
 
-        for (int j = 0; j < MIDI_BUFFER_SIZE; j += 8) {
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin = src[j] & 0x0F;
             uint8_t cable = (src[j] >> 4) & 0x0F;
             /* In overtake mode, allow sysex (CIN 0x04-0x07) and normal messages (0x08-0x0E) */
@@ -7933,23 +7939,58 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
         shadow_flush_pending_input_leds();
     }
 
+    /* === POST-IOCTL: CLOSE THE GAPS THE FILTERING LEFT ===
+     * Every place above that suppresses an event does it by zeroing that slot
+     * in place. Move's firmware MIDI_IN reader STOPS at the first empty slot
+     * (the Ableton SPI convention — schwung_usb_midi_msg_is_empty), so a
+     * zeroed slot is not a hole, it is a TERMINATOR: everything behind it is
+     * invisible to Move for that frame.
+     *
+     * That is how a held pad gets stuck. With the shadow UI up, knob CCs
+     * (71-78) and knob-touch notes (0-9) are filtered on every detent; spin a
+     * knob while pads are held and a pad note-off landing in a later slot of
+     * the same frame never reaches Move. Move keeps the pad lit and its own
+     * instrument sounding — and chain slots are fed from Move's MIDI_OUT
+     * echo, so the slot synth never sees the note-off either. One drop, two
+     * stuck consumers, which is exactly what was measured on hardware while
+     * the note-off sat correct and in order in the raw mailbox.
+     *
+     * Compact LAST: the blocking sites above pair `sh[j]` with `hw[j]` by
+     * index, so nothing may move while they run.
+     *
+     * Not compacting was recorded as a rule ("never compact MIDI_IN",
+     * SIGABRT) from the RTP-MIDI WIP — but that branch walked MIDI_IN at a
+     * 4-byte stride, i.e. it was shifting events by half an event, and it
+     * never stabilised for unrelated reasons. Dense-prefix-then-zero is the
+     * shape the hardware delivers, and events already shift between slots
+     * across frames, which is why the dedup rings key on content plus
+     * timestamp rather than position. */
+    if (global_mmap_addr)
+        shadow_midi_in_compact(global_mmap_addr + MIDI_IN_OFFSET);
+
     /* === POST-IOCTL: INJECT KNOB RELEASE EVENTS ===
      * When toggling shadow mode, inject note-off events for knob touches
      * so Move doesn't think knobs are still being held.
-     * This MUST happen AFTER filtering to avoid being zeroed out. */
+     * This MUST happen AFTER filtering to avoid being zeroed out — and after
+     * the compaction above, so the free slots are a contiguous tail. */
     if (shadow_inject_knob_release && global_mmap_addr) {
         shadow_inject_knob_release = 0;
         uint8_t *src = global_mmap_addr + MIDI_IN_OFFSET;
         /* Find empty slots and inject note-offs for knobs 0, 7, 8 (Knob1, Knob8, Volume) */
         const uint8_t knob_notes[] = { 0, 7, 8 };  /* Knob 1, Knob 8, Volume */
         int injected = 0;
-        for (int j = 0; j < MIDI_BUFFER_SIZE && injected < 3; j += 4) {
-            if (src[j] == 0 && src[j+1] == 0 && src[j+2] == 0 && src[j+3] == 0) {
+        /* 8-byte stride: MIDI_IN events are 4 USB-MIDI + 4 timestamp bytes.
+         * At the old 4-byte stride the second and third note-offs were written
+         * into the *timestamp* halves of the events before them — malformed,
+         * and it also left the injected packets' own timestamps un-zeroed. */
+        for (int j = 0; j < SHADOW_MIDI_IN_BYTES && injected < 3; j += SHADOW_MIDI_IN_STRIDE) {
+            if (shadow_midi_in_slot_empty(&src[j])) {
                 /* Empty slot - inject note-off */
                 src[j] = 0x08;  /* CIN = Note Off, Cable 0 */
                 src[j + 1] = 0x80;  /* Note Off, channel 0 */
                 src[j + 2] = knob_notes[injected];  /* Note number */
                 src[j + 3] = 0x00;  /* Velocity 0 */
+                memset(&src[j + 4], 0, 4);  /* synthetic event: zero timestamp */
                 injected++;
             }
         }

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -17,6 +17,7 @@ BUILD_DIR = ../../build/tests/host
 TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_overtake_native_led_repaint \
 	$(BUILD_DIR)/test_shadow_midi_filter \
+	$(BUILD_DIR)/test_midi_in_compact \
 	$(BUILD_DIR)/test_master_fx_slot_routing
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
@@ -42,6 +43,9 @@ $(BUILD_DIR)/test_overtake_native_led_repaint: test_overtake_native_led_repaint.
 	$(CC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_shadow_midi_filter: test_shadow_midi_filter.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/test_midi_in_compact: test_midi_in_compact.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_master_fx_slot_routing: test_master_fx_slot_routing.c ../../src/host/master_fx_key.h ../../src/host/shadow_chain_mgmt.h | $(BUILD_DIR)

--- a/tests/host/test_midi_in_compact.c
+++ b/tests/host/test_midi_in_compact.c
@@ -1,0 +1,167 @@
+/* Regression test: a filtered MIDI_IN slot must not hide the events behind it.
+ *
+ * Move's firmware reads MIDI_IN until the first EMPTY slot (the Ableton SPI
+ * convention — schwung_usb_midi_msg_is_empty: cable, CIN and all three payload
+ * bytes zero).  The shim suppresses an event by zeroing its slot in place, so
+ * a suppressed event is not a hole, it is a TERMINATOR.
+ *
+ * The bug that produced this test: with the shadow UI up, knob CCs (71-78) and
+ * knob-touch notes (0-9) are filtered on every detent.  Spin a knob while pads
+ * are held and a pad note-off landing in a later slot of the same frame never
+ * reaches Move — Move keeps the pad lit and its own instrument sounding, and
+ * because chain slots are fed from Move's MIDI_OUT echo, the slot synth never
+ * sees the note-off either.  One drop, two stuck consumers, with the note-off
+ * present and correctly ordered in the raw hardware mailbox the whole time.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "shadow_midi_filter.h"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } \
+} while (0)
+
+/* Model Move's reader: walk from slot 0 and stop dead at the first empty
+ * slot.  Returns how many events it got to see. */
+static int move_sees(const uint8_t *midi_in)
+{
+    int n = 0;
+    for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += SHADOW_MIDI_IN_STRIDE) {
+        if (shadow_midi_in_slot_empty(&midi_in[j])) break;
+        n++;
+    }
+    return n;
+}
+
+static void put(uint8_t *buf, int slot, uint8_t head, uint8_t status,
+                uint8_t d1, uint8_t d2, uint8_t stamp)
+{
+    uint8_t *p = &buf[slot * SHADOW_MIDI_IN_STRIDE];
+    p[0] = head; p[1] = status; p[2] = d1; p[3] = d2;
+    p[4] = stamp; p[5] = 0; p[6] = 0; p[7] = 0;
+}
+
+static void clear_slot(uint8_t *buf, int slot)
+{
+    memset(&buf[slot * SHADOW_MIDI_IN_STRIDE], 0, 4);
+}
+
+/* THE BUG, and the fix. */
+static void test_note_off_behind_a_filtered_knob(void)
+{
+    uint8_t buf[SHADOW_MIDI_IN_BYTES];
+    memset(buf, 0, sizeof(buf));
+
+    put(buf, 0, 0x0B, 0xB0, 71, 0x01, 0x11);   /* knob 1 detent  — filtered */
+    put(buf, 1, 0x08, 0x80, 85, 0x40, 0x22);   /* pad 85 note-off — must survive */
+    put(buf, 2, 0x0B, 0xB0, 72, 0x01, 0x33);   /* knob 2 detent  — filtered */
+    put(buf, 3, 0x08, 0x80, 86, 0x40, 0x44);   /* pad 86 note-off — must survive */
+
+    clear_slot(buf, 0);   /* what the shim's filter does */
+    clear_slot(buf, 2);
+
+    CHECK(move_sees(buf) == 0,
+          "precondition: a zeroed slot 0 hides EVERY event behind it");
+
+    CHECK(shadow_midi_in_compact(buf) == 2, "two events survive the filter");
+    CHECK(move_sees(buf) == 2, "Move must see both surviving note-offs");
+
+    CHECK(buf[0] == 0x08 && buf[2] == 85, "note-off 85 moved down to slot 0");
+    CHECK(buf[4] == 0x22, "its timestamp travelled with it");
+    CHECK(buf[8] == 0x08 && buf[10] == 86, "note-off 86 kept its order, slot 1");
+    CHECK(buf[12] == 0x44, "and its timestamp too");
+}
+
+static void test_order_is_preserved_across_many_gaps(void)
+{
+    uint8_t buf[SHADOW_MIDI_IN_BYTES];
+    memset(buf, 0, sizeof(buf));
+
+    /* 10 events, every other one filtered out. */
+    for (int i = 0; i < 10; i++)
+        put(buf, i, 0x09, 0x90, (uint8_t)(60 + i), 100, (uint8_t)(i + 1));
+    for (int i = 0; i < 10; i += 2)
+        clear_slot(buf, i);
+
+    CHECK(shadow_midi_in_compact(buf) == 5, "five survivors");
+    CHECK(move_sees(buf) == 5, "Move sees all five");
+    for (int i = 0; i < 5; i++) {
+        const uint8_t *p = &buf[i * SHADOW_MIDI_IN_STRIDE];
+        CHECK(p[2] == (uint8_t)(61 + 2 * i), "survivors kept their arrival order");
+        CHECK(p[4] == (uint8_t)(2 + 2 * i), "each carried its own timestamp");
+    }
+}
+
+/* A frame with nothing filtered must come out byte-identical — compaction runs
+ * unconditionally on every SPI frame, so a no-op has to really be a no-op. */
+static void test_dense_frame_is_untouched(void)
+{
+    uint8_t buf[SHADOW_MIDI_IN_BYTES], before[SHADOW_MIDI_IN_BYTES];
+    memset(buf, 0, sizeof(buf));
+    put(buf, 0, 0x09, 0x90, 68, 100, 0x01);
+    put(buf, 1, 0x09, 0x90, 69, 100, 0x02);
+    put(buf, 2, 0x08, 0x80, 68, 0x40, 0x03);
+    memcpy(before, buf, sizeof(buf));
+
+    CHECK(shadow_midi_in_compact(buf) == 3, "three events, no gaps");
+    CHECK(memcmp(buf, before, sizeof(buf)) == 0,
+          "a gapless frame must come out byte-identical");
+}
+
+static void test_empty_and_full_frames(void)
+{
+    uint8_t buf[SHADOW_MIDI_IN_BYTES];
+
+    memset(buf, 0, sizeof(buf));
+    CHECK(shadow_midi_in_compact(buf) == 0, "an empty frame compacts to zero events");
+    CHECK(move_sees(buf) == 0, "and stays empty");
+
+    /* All 31 slots occupied: the compaction must not run off the end into the
+     * display-status word that sits immediately behind MIDI_IN. */
+    for (int i = 0; i < SHADOW_MIDI_IN_SLOTS; i++)
+        put(buf, i, 0x09, 0x90, (uint8_t)(40 + i), 100, (uint8_t)i);
+    clear_slot(buf, 0);
+    CHECK(shadow_midi_in_compact(buf) == SHADOW_MIDI_IN_SLOTS - 1,
+          "30 survivors out of a full frame");
+    CHECK(move_sees(buf) == SHADOW_MIDI_IN_SLOTS - 1, "Move sees all 30");
+    CHECK(shadow_midi_in_slot_empty(&buf[(SHADOW_MIDI_IN_SLOTS - 1) *
+                                         SHADOW_MIDI_IN_STRIDE]),
+          "the vacated last slot is zeroed, not left as a duplicate");
+}
+
+/* The timestamp is not part of the emptiness test — a slot carrying only a
+ * stale timestamp is still a terminator, exactly as the SPI library reads it. */
+static void test_empty_ignores_the_timestamp(void)
+{
+    uint8_t slot[SHADOW_MIDI_IN_STRIDE] = { 0, 0, 0, 0, 0xDE, 0xAD, 0xBE, 0xEF };
+    CHECK(shadow_midi_in_slot_empty(slot),
+          "a zero USB-MIDI payload is empty however stale the timestamp is");
+    slot[0] = 0x09;
+    CHECK(!shadow_midi_in_slot_empty(slot), "a nonzero header is an event");
+}
+
+static void test_geometry(void)
+{
+    CHECK(SHADOW_MIDI_IN_BYTES == 248,
+          "MIDI_IN is 31 x 8 = 248 bytes, not MIDI_BUFFER_SIZE (256)");
+}
+
+int main(void)
+{
+    test_geometry();
+    test_note_off_behind_a_filtered_knob();
+    test_order_is_preserved_across_many_gaps();
+    test_dense_frame_is_untouched();
+    test_empty_and_full_frames();
+    test_empty_ignores_the_timestamp();
+
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    printf("PASS: MIDI_IN compaction — a filtered slot no longer hides the events behind it\n");
+    return 0;
+}

--- a/tests/host/test_midi_in_compact_call_site.sh
+++ b/tests/host/test_midi_in_compact_call_site.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Source pin: the shim must close MIDI_IN gaps, and must do it LAST.
+#
+# shadow_midi_in_compact() is what stops a filtered (zeroed) slot from acting
+# as a terminator that hides every event behind it from Move's firmware — the
+# stuck-pad bug. The unit test (test_midi_in_compact.c) proves the function is
+# correct; only this pin proves the shim still calls it, and in the one place
+# where it is safe to.
+#
+# "Last" is load-bearing: the blocking sites in shim_post_transfer pair the
+# shadow slot `sh[j]` with the hardware slot `hw[j]` by index. Moving the
+# compaction above any of them would let indices shift under a live pairing,
+# so a block would zero the wrong event.
+set -u
+
+SHIM="$(dirname "$0")/../../src/schwung_shim.c"
+fails=0
+fail() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
+
+[ -f "$SHIM" ] || { echo "FAIL: cannot find $SHIM" >&2; exit 1; }
+
+calls=$(grep -c 'shadow_midi_in_compact(' "$SHIM")
+[ "$calls" -eq 1 ] || fail "expected exactly 1 call to shadow_midi_in_compact, found $calls"
+
+compact_line=$(grep -n 'shadow_midi_in_compact(' "$SHIM" | head -1 | cut -d: -f1)
+[ -n "$compact_line" ] || fail "shim never calls shadow_midi_in_compact — a filtered slot again hides the events behind it"
+
+# Every write that zeroes a shadow MIDI_IN slot must happen BEFORE the
+# compaction, or its gap survives into Move's reader.
+if [ -n "${compact_line:-}" ]; then
+    last_zero=$(grep -n -E '^\s*(sh|sh_midi|src)\[j\] = 0;' "$SHIM" | tail -1 | cut -d: -f1)
+    [ -n "$last_zero" ] || fail "no slot-zeroing sites found — has the filter moved?"
+    if [ -n "$last_zero" ] && [ "$last_zero" -gt "$compact_line" ]; then
+        fail "a MIDI_IN slot is zeroed at line $last_zero, AFTER the compaction at $compact_line — that gap reaches Move"
+    fi
+fi
+
+# The 8-byte-stride MIDI_IN walks must stop at 248, not at MIDI_BUFFER_SIZE
+# (256) — the extra iteration reads, and in the filter loop WROTE, the RX
+# display-status word that sits immediately behind MIDI_IN.
+overrun=$(grep -c -E 'for \(int [ij] = 0; [ij] (\+ 8 )?<=? MIDI_BUFFER_SIZE; [ij] \+= 8\)' "$SHIM")
+[ "$overrun" -eq 0 ] || fail "$overrun MIDI_IN loop(s) still bounded by MIDI_BUFFER_SIZE at an 8-byte stride"
+
+if [ "$fails" -ne 0 ]; then
+    echo "$fails check(s) failed" >&2
+    exit 1
+fi
+echo "PASS: the shim compacts MIDI_IN, once, after every slot-zeroing site"


### PR DESCRIPTION
Reported as a stuck-note bug in tablor. It is neither tablor's nor any module's.

## The bug

Move's firmware reads MIDI_IN **until the first empty slot** — the Ableton SPI
convention, and our own `schwung_usb_midi_msg_is_empty` / `schwung_jack_bridge.c`
break on it the same way. `shadow_drain_midi_inject` already stated it outright:
*"Move terminates the scan at the first zero slot, so any gap loses all following
real events."*

Every place the shim suppresses an event zeroes that slot **in place**. That does
not punch a hole, it plants an end-of-list marker — everything behind it is
invisible to Move for that frame. The filter loop's comment claimed the opposite
(*"later slots stay valid — readers skip, not break"*), which is true of
Schwung's readers and false of the one that matters.

One knob detent is enough. Knob CCs 71-78, knob-touch notes 0-9, jog, Back and
Menu are filtered on every event while the shadow UI is up; spin a knob with pads
held and a pad note-off landing in a later slot of the same frame is dropped.

```
slot:      0            1              2            3
frame:  [knob CC 71] [note-off 85] [knob CC 72] [note-off 86]
filter: [   ZEROED  ] [note-off 85] [   ZEROED  ] [note-off 86]
Move:    ^ stops here — sees nothing at all this frame
```

## Why two unrelated consumers hang

The handoff reasoned that tablor and Move's Drift share no code, so the loss had
to be at a point common to both — after the mailbox, before the split into chain
dispatch and forward-to-Move.

**There is no split.** Chain slots are fed from Move's **MIDI_OUT echo**
(`shadow_inprocess_process_midi`, cable 2), not from MIDI_IN. tablor sits
*downstream* of Move's firmware. One drop, two stuck consumers.

That also reconciles the measurement that made this look impossible: the
note-off is present and correctly ordered in the raw hardware mailbox, because
the loss is in the hardware→shadow copy, which the hardware buffer never sees.

Predicted twice and never acted on — `docs/plans/2026-06-11-codebase-cleanup-review.md`
"Field note 3 (2026-06-12)" names this exact scenario and parks it.

## The fix

`shadow_midi_in_compact()` — survivors shift down, order preserved, timestamps
carried, tail zeroed. Dense-prefix-then-zero is the shape the hardware itself
delivers and the shape the reader assumes.

It runs **last** in `shim_post_transfer`: the blocking sites above it pair
`sh[j]` with `hw[j]` by index, so nothing may move while they run.

### On "never compact MIDI_IN"

That rule came from the RTP-MIDI WIP (`271bcd0b`), which walked MIDI_IN at a
**4-byte stride** — shifting events by half an event — and whose own commit
message records "Move freezes after RTP MIDI injection (cause unknown)". Not
evidence against 8-byte compaction. Events already shift between slots across
frames, which is exactly why the dedup rings key on content + timestamp rather
than position.

## Two bugs fixed on the way

Both prerequisites, not passengers:

- Every 8-stride MIDI_IN walk was bounded by `MIDI_BUFFER_SIZE` (256) when
  MIDI_IN is 31 × 8 = **248**. The extra iteration read the RX display-status
  word as a 32nd event — and the filter loop **wrote** there, zeroing it whenever
  it looked like a filtered control.
- The knob-release injector walked at a **4-byte stride**, so its 2nd and 3rd
  note-offs landed inside the timestamps of the events in front of them, and its
  own timestamps were never zeroed.

## Tests

- `tests/host/test_midi_in_compact.c` models Move's break-on-empty reader and
  pins the repro shape directly: a knob detent in slot 0 hides both pad note-offs
  behind it, and must not after compaction. Also covers order, timestamp
  carriage, a gapless frame being byte-identical, and a full 31-slot frame not
  running into the display-status word.
- `tests/host/test_midi_in_compact_call_site.sh` fails if the shim stops
  compacting, compacts twice, zeroes a slot **after** the compaction, or
  reintroduces a 256-bounded MIDI_IN walk. Mutation-checked.
- Full `tests/host` suite: no new failures.

## Hardware verification (2026-08-22)

- Repro **confirmed with no module loaded at all** — shadow UI up, pads held, jog
  wheel turned. That alone exonerates tablor.
- After deploy: no longer reproduces, with tablor loaded or without.
- `MoveOriginal` ran 37+ minutes across the test session with no restart — a
  SIGABRT was the one plausible failure mode this change carried.
- Shortcuts (Shift+Menu, Shift+Vol+Track, Mute+Track) and note triggering
  checked clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTqGxpq8bxa8JR7UXTAjjG