### PR TITLE
slots: never cache a failed read, and clear a slot's LFOs with it

### DIFF
--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -857,6 +857,24 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
         v2_unload_all_midi_fx(inst);
         v2_unload_all_audio_fx(inst);
         v2_unload_synth(inst);
+        /*
+         * The LFOs go too. They are per-SLOT state, not per-module, so
+         * unloading everything they could point at used to leave them running
+         * and aimed at a component that no longer exists.
+         *
+         * Reported from the device: "when i created a new set, the LFO was
+         * still active and targeting the now empty synth slot." A set switch
+         * clears every slot through here, so the routing outlived the set that
+         * defined it.
+         *
+         * Safe to zero rather than preserve: loading a patch assigns the whole
+         * array from the patch (chain_patch.c, `inst->lfos[i] = patch->lfos[i]`),
+         * so nothing a patch defines can be lost by clearing first. Zero is
+         * inert -- no target, no depth.
+         */
+        memset(inst->lfos, 0, sizeof(inst->lfos));
+        memset(inst->lfo_base_values, 0, sizeof(inst->lfo_base_values));
+        memset(inst->lfo_base_valid, 0, sizeof(inst->lfo_base_valid));
         inst->current_patch = -1;
         inst->dirty = 0;
         malloc_trim(0);

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -836,6 +836,34 @@ function getSlotParamCached(slot, key, moduleId) {
         return hit.value;
     }
     const value = getSlotParam(slot, key);
+
+    /*
+     * A FAILED read is never cached.
+     *
+     * null from getSlotParam is the third answer: the read did not complete --
+     * the claim was refused, or the response timed out, or it belonged to
+     * somebody else. It is not news about the module, and storing it turns a
+     * momentary channel stall into a 500ms lie about the chain.
+     *
+     * That is what a blank slot after loading granny is: granny reads its WAV
+     * synchronously inside set_param, on the SPI thread that also serves param
+     * requests, so every read during the load fails. Cached, the slot rendered
+     * empty and STAYED empty for the TTL -- and because the cache is keyed by
+     * slot, coming back to it hit the same poisoned entry, which is why it
+     * took switching slots a few times to clear.
+     *
+     * "" is a different thing and IS cached: the channel served us and the key
+     * produced nothing.
+     *
+     * On failure the last known-good value for the same module is preferred
+     * over propagating the failure. It is stale by at most the stall, and it
+     * is a value the module really did report -- where null makes the caller
+     * draw a blank it will only redraw on the next frame anyway.
+     */
+    if (value === null || value === undefined) {
+        return (hit && hit.module === moduleId) ? hit.value : value;
+    }
+
     slotParamCache[ck] = { module: moduleId, value, ts: now };
     return value;
 }

--- a/tests/host/test_clear_resets_lfos.sh
+++ b/tests/host/test_clear_resets_lfos.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A slot `clear` must reset that slot's LFOs.
+#
+# The LFOs are per-SLOT state, not per-module, so unloading the synth and every
+# FX used to leave them running and aimed at a component that no longer exists.
+# A set switch clears every slot through this path, so the routing outlived the
+# set that defined it.
+#
+# Reported from the device: "when i created a new set, the LFO was still active
+# and targeting the now empty synth slot."
+#
+# Zeroing is safe rather than lossy: loading a patch assigns the whole array
+# from the patch, so nothing a patch defines can be lost by clearing first.
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+f="src/modules/chain/dsp/chain_host.c"
+
+blk=$(awk '/strcmp\(key, "clear"\) == 0/,/malloc_trim\(0\)/' "$f")
+[ -n "$blk" ] || fail "the clear handler is gone from $f"
+
+command grep -q "memset(inst->lfos, 0, sizeof(inst->lfos))" <<<"$blk" || \
+  fail "clear does not reset inst->lfos — a new set keeps the old set's LFO routing"
+command grep -q "memset(inst->lfo_base_valid" <<<"$blk" || \
+  fail "clear does not reset lfo_base_valid — a stale base would be re-applied to whatever loads next"
+
+# It must clear AFTER the unloads, not before: the targets are only meaningless
+# once the modules are gone, and ordering it first would be a silent no-op the
+# moment an unload path grows an LFO write of its own.
+u=$(command grep -n "v2_unload_synth(inst)" <<<"$blk" | head -n 1 | cut -d: -f1)
+l=$(command grep -n "memset(inst->lfos" <<<"$blk" | head -n 1 | cut -d: -f1)
+[ -n "$u" ] && [ -n "$l" ] && [ "$u" -lt "$l" ] || \
+  fail "the LFO reset runs before the modules are unloaded"
+
+# And a patch load must still assign the whole array, which is what makes
+# zeroing safe. If that ever becomes a merge, clearing first LOSES settings.
+command grep -q "inst->lfos\[i\] = patch->lfos\[i\]" src/modules/chain/dsp/chain_patch.c || \
+  fail "a patch load no longer assigns the LFO array wholesale — clearing first is then lossy"
+
+echo "  ok  clear resets the LFOs, after the unloads"
+echo "  ok  a patch load still assigns the array wholesale, so clearing first loses nothing"
+echo "PASS: a cleared slot carries no LFO routing into the next set"

--- a/tests/host/test_slot_cache_never_stores_failures.sh
+++ b/tests/host/test_slot_cache_never_stores_failures.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The slot param cache must never store a FAILED read.
+#
+# null from getSlotParam is the third answer -- the read did not complete --
+# and it is not news about the module. Cached, it turns a momentary channel
+# stall into a 500ms lie about the chain.
+#
+# Reported from the device: "i just had a blank slot after loading granny. had
+# to switch slots a few times to get it to come back." granny reads its WAV
+# synchronously inside set_param, on the SPI thread that also serves param
+# requests, so every read during the load fails; the blank was then held by the
+# cache, keyed by slot, so returning to the slot hit the same poisoned entry.
+#
+# "" is a different answer and IS cached: the channel served us, the key
+# produced nothing.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+const src = require("fs").readFileSync("src/shadow/shadow_ui.js", "utf8");
+const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+const at = src.indexOf("function getSlotParamCached(");
+if (at < 0) fail("getSlotParamCached is gone");
+const body = src.slice(at, src.indexOf("\n}\n", at) + 2);
+
+/* Lifted with its two dependencies so the real logic runs. */
+let store = {};
+let answer = null;
+/* TTL 0 so every call actually READS. With the real 500ms the entry written by
+ * the good read is still warm, the stall call returns from cache without ever
+ * calling getSlotParam, and the failure path is never exercised -- which let a
+ * "cache failures again" mutation survive the first version of this test. */
+const make = (ttl) => new Function(
+  "slotParamCache", "SLOT_PARAM_CACHE_TTL_MS", "getSlotParam",
+  body + "\nreturn getSlotParamCached;"
+)(store, ttl === undefined ? 0 : ttl, () => answer);
+
+/* A good read is cached. */
+store = {}; answer = "granny";
+let f = make();
+if (f(0, "synth_module", "granny") !== "granny") fail("a good read was not returned");
+if (!store["0:synth_module"]) fail("a good read was not cached");
+
+/* A FAILED read must not overwrite it, and must not be stored. */
+answer = null;
+const during = f(0, "synth_module", "granny");
+if (store["0:synth_module"].value === null)
+  fail("a failed read was written into the cache -- the slot now reads blank for the whole TTL");
+if (during === null)
+  fail("a failed read returned null even though a known-good value for the same module was cached");
+if (during !== "granny")
+  fail("expected the last known-good value during a stall, got " + JSON.stringify(during));
+
+/* "" is served-but-empty and IS a value. */
+store = {}; answer = "";
+f = make();
+if (f(1, "fx1_module", "x") !== "") fail("an empty answer was not returned");
+if (!store["1:fx1_module"]) fail("an empty answer was not cached — it is a real answer");
+
+/* With nothing cached, a failure is reported as a failure rather than
+   invented as empty. */
+store = {}; answer = null;
+f = make();
+const cold = f(2, "synth_module", "granny");
+if (cold === "") fail("a failed read with a cold cache was turned into \"\" — that is the " +
+                      "collapse of null and empty the tri-state rule exists to stop");
+
+console.log("  ok  a failed read is neither cached nor allowed to overwrite a good one");
+console.log("  ok  during a stall the last known-good value for the same module is used");
+console.log("  ok  \"\" is still treated as a real answer and cached");
+console.log("PASS: the slot cache never stores a read that did not complete");
+'


### PR DESCRIPTION
Two device reports, both state outliving the thing it described.

## 1. Blank slot after loading granny

> *"i just had a blank slot after loading granny. had to switch slots a few times to get it to come back."*

`getSlotParamCached` stored whatever `getSlotParam` returned — **including `null`**, which is the third answer: *the read did not complete*. It isn't news about the module, and caching it turns a momentary channel stall into a 500 ms lie about the chain.

granny reads its WAV **synchronously inside `set_param`**, on the SPI thread that also serves param requests, so every read during the load fails. Cached, the slot drew empty and stayed empty — and because the cache is keyed by slot, coming back to it hit the same poisoned entry. That's precisely why it took switching slots a few times.

A failed read is now neither stored nor allowed to overwrite a good one, and during a stall the last known-good value for the same module is returned instead. `""` is untouched — the channel served us and the key produced nothing, which is a real answer.

This is the tri-state rule applied to a cache that predates it.

## 2. LFO survives into a new set

> *"when i created a new set, the LFO was still active and targeting the now empty synth slot."*

The chain's `clear` unloaded the synth, the audio FX and the MIDI FX, and left `inst->lfos` untouched. LFOs are **per-slot** state, so they kept running and kept pointing at components that no longer existed. A set switch clears every slot through this path, so the routing outlived the set that defined it.

Zeroing is safe rather than lossy, and the test pins **why**: loading a patch assigns the whole array (`inst->lfos[i] = patch->lfos[i]`), so nothing a patch defines can be lost by clearing first. If that ever becomes a merge, the test fails.

## A test that couldn't fail

The cache test needed fixing before it was worth anything: with the real 500 ms TTL, the entry written by the good read is still warm, so the stall call returned from cache **without ever attempting a read** — and a "cache failures again" mutation walked straight through. It now runs with TTL 0 so the read actually happens.