### PR TITLE
catalog: add Tablor (2-osc wavetable synth, athousanddetails/schwung-tablor)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1257,6 +1257,17 @@
       "min_host_version": "0.11.6"
     },
     {
+      "id": "tablor",
+      "name": "Tablor",
+      "description": "2-osc wavetable synth. Position morphing, bend, formant shift and 4-voice unison; sub and noise; multimode filter with its own ADSR; 2 envelopes, 2 LFOs, 4-slot mod matrix and 8 assignable macros. 8 voices poly or mono with glide. Unlimited shareable .tblr presets, 115 seeded wavetables, and Serum/Vital/Ableton tables via Move Manager. Web panel with a live display of the loaded wavetable.",
+      "author": "athousanddetails; after Wavetable by Roland Rabien (FigBug)",
+      "component_type": "sound_generator",
+      "github_repo": "athousanddetails/schwung-tablor",
+      "default_branch": "main",
+      "asset_name": "tablor-module.tar.gz",
+      "min_host_version": "0.12.0"
+    },
+    {
       "id": "chord-finder",
       "name": "Chord Finder",
       "description": "Scale-aware chord progression finder with 16 ranked chord choices, root-driven revoicing, a piano-note display, and eight-slot MIDI loop capture.",


### PR DESCRIPTION
Adds **Tablor**, a 2-oscillator wavetable synth, to the module catalog.

- **Repo:** https://github.com/athousanddetails/schwung-tablor
- **Release:** [v1.0.0](https://github.com/athousanddetails/schwung-tablor/releases/tag/v1.0.0) (`tablor-module.tar.gz`, 20.3 MB — most of it the seeded wavetable library)
- **Min host:** 0.12.0 (it uses the 0.12 hierarchy and declared `viz` graphics)
- **Licence:** BSD-3-Clause. A from-scratch port of [Wavetable](https://github.com/FigBug/Wavetable) / [gin](https://github.com/FigBug/Gin) by Roland Rabien, JUCE removed, DSP re-implemented against the plugin API and checked against the original with numeric golden tests. Seeded wavetables are public domain (Adventure Kid) and free-to-use (Neu KatalYst).

![Main page](https://raw.githubusercontent.com/athousanddetails/schwung-tablor/main/docs/img/move-main.png)

Both wavetables are knobs 1–2 on the main page: turn to step through the library, hold+click for the scrolling picker. 13 pages, 95 controls, no custom editor code — the pages are the stock 0.12 hierarchy with 19 declared `viz` graphics, validated against `validate_contract`.

Sub and noise, multimode filter with its own ADSR, two envelopes, two LFOs, a 4-slot mod matrix, 8 assignable macros, 8 voices poly or mono with glide. Presets are plain `.tblr` files in the user library, so they can be copied and shared.

The web panel draws the wavetable that is actually loaded, and follows the pot on the device:

![Web panel](https://raw.githubusercontent.com/athousanddetails/schwung-tablor/main/docs/img/web-panel.png)

**Realtime hygiene:** the one worker thread it spawns is created `SCHED_OTHER` with explicit scheduling attributes and named `tablor-wtload`, after your audit flagged that a thread born from an entry point inherits FIFO 90 and the audio thread's name. Its loadtest asserts that against `/proc`, creating the instance from a `SCHED_FIFO 90` thread so the check would actually fail if inheritance came back.

Diff is the catalog entry only — 11 added lines, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
