### PR TITLE
modes: the last page kind the grid could not draw

### DIFF
--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -1073,15 +1073,15 @@ export function createController(io = {}) {
          * The level declares how many children and what to call them, so this
          * is arithmetic, not I/O.
          */
-        if (pg.childCount !== undefined) {
-            const n = Math.max(0, pg.childCount | 0);
+        if (Array.isArray(pg.derivedLabels)) {
+            const n = pg.derivedLabels.length;
             if (st.list.length !== n) {
-                st.list = [];
-                for (let i = 0; i < n; i++)
-                    st.list.push({ index: i, label: `${pg.childLabel || "Item"} ${i + 1}` });
+                st.list = pg.derivedLabels.map((label, i) => ({ index: i, label }));
                 if (st.cursor >= n) st.cursor = Math.max(0, n - 1);
             }
-            st.current = childIndexFor(pg.childOf);
+            /* A child selector knows its own answer; a mode selector is told
+             * by the module, so its `current` comes from the tick read. */
+            if (pg.childOf) st.current = childIndexFor(pg.childOf);
         }
         return st;
     }
@@ -1102,8 +1102,28 @@ export function createController(io = {}) {
          * can go stale -- and `current` comes from local state rather than
          * from a module param.
          */
-        /* itemsState has already built it, and there is nothing to read. */
-        if (p.childCount !== undefined) return;
+        /*
+         * The LIST is already built and cannot go stale. A child selector has
+         * nothing else to ask for either -- the selection is ours. A MODE is
+         * the module's state, so its current value is still read, on the same
+         * one-per-tick budget.
+         */
+        if (Array.isArray(p.derivedLabels)) {
+            if (!p.selectParam || p.childOf) return;
+            const raw = getParam(fullKey(p.selectParam));
+            if (raw === null || raw === undefined) return;   /* failed read: not news */
+            const at = p.derivedLabels.findIndex(
+                (l) => String(l).toLowerCase() === String(raw).trim().toLowerCase());
+            /* The module answers "Performance" where the hierarchy says
+             * "performance", so the match is case-insensitive. A numeric
+             * answer is an index. */
+            if (at >= 0) st.current = at;
+            else {
+                const n = parseInt(raw, 10);
+                if (isFinite(n) && n >= 0 && n < st.list.length) st.current = n;
+            }
+            return;
+        }
         const at = st.read % 2;
         st.read++;
         if (at === 0) {
@@ -1146,6 +1166,24 @@ export function createController(io = {}) {
         const st = itemsState(p);
         if (!st || !st.list.length) return false;
         const it = st.list[st.cursor];
+        if (p.modeSelect) {
+            /*
+             * A mode RE-ROOTS the hierarchy: the level named by the mode
+             * becomes the walk root, so every page after this one is a
+             * different page. The param write below tells the module; this
+             * tells the planner, and re-plans from the cached contract so the
+             * new pages are there before the next frame.
+             *
+             * armContractSettle further down books a re-read as well, because
+             * the module may republish once it has switched -- minijv resets
+             * its emulator to change mode, which is not instant.
+             */
+            const chosen = (p.derivedLabels || [])[it.index];
+            if (chosen !== undefined) {
+                if (s.lastLoadOpts) s.lastLoadOpts.mode = chosen;
+                else s.lastLoadOpts = { mode: chosen };
+            }
+        }
         if (p.childOf) {
             /*
              * A child is chosen LOCALLY -- there is no param to write. It
@@ -1179,6 +1217,7 @@ export function createController(io = {}) {
          * read.
          */
         armContractSettle();
+        if (p.modeSelect) replanForMode();
         s.menuEntered = null;
         let target = -1;
         if (p.navigateTo) {
@@ -1737,6 +1776,31 @@ export function createController(io = {}) {
      * fired. Switching an LFO to Sync left the Hz cell on screen — the value had
      * moved and the page had not.
      */
+    /*
+     * Re-plan from the cached contract with the current mode.
+     *
+     * Same operation replanIfCondition performs for a visibility change -- the
+     * hierarchy and chain_params are already in hand, so this costs no device
+     * reads -- but unconditional, because a mode changes the walk ROOT and
+     * therefore every page, not just which of them are visible.
+     */
+    function replanForMode() {
+        if (!s.hierarchy) return;
+        const planned = planPages({
+            hierarchy: s.hierarchy, chainParams: s.chainParams,
+            mode: s.lastLoadOpts && s.lastLoadOpts.mode,
+            visible: s.lastLoadOpts && s.lastLoadOpts.visible,
+        });
+        if (!planned.pages.length) return;   /* never plan from nothing */
+        s.pages = planned.pages;
+        s.fingerprint = planned.fingerprint;
+        s.conditionKeys = planned.conditionKeys || new Set();
+        s.values = Object.create(null);
+        s.knobStates = Object.create(null);
+        s.cursor = 0;
+        s.pageIndex = firstGrid(s.pages);
+    }
+
     function replanIfCondition(key) {
         if (!s.conditionKeys.has(key)) return;
         const oldPages = s.pages, oldIndex = s.pageIndex;

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -28,7 +28,6 @@ export const KNOBS_PER_PAGE = 8;
 export const PAGE_KNOBS  = "knobs";   /* grid of up to 8 turnable params */
 export const PAGE_PRESET = "preset";  /* list_param/count_param/name_param browser */
 export const PAGE_ITEMS  = "items";   /* items_param/select_param runtime list */
-export const PAGE_MODES  = "modes";   /* hierarchy-level mode select (minijv) */
 /*
  * A list of entries that are NOT parameters — an action with a name and a
  * consequence and nothing to show, or a plain jump to another level.
@@ -284,9 +283,23 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved } 
     let rootKey = "root";
     const modes = Array.isArray(hierarchy.modes) ? hierarchy.modes : null;
     if (modes && modes.length > 0) {
+        /*
+         * The mode selector IS an items page too -- a list, a cursor, a
+         * current marker, click to choose -- so it reuses that machinery
+         * instead of being a kind nothing draws. PAGE_MODES was planned and
+         * rendered by NOBODY, so minijv's Mode page ejected to the list
+         * editor, which is also why its performance mode was unreachable from
+         * the grid (and therefore why editing parts appeared to do nothing).
+         *
+         * Unlike a child selector this one DOES write a param: the module
+         * takes the mode name. Unlike an ordinary items page the choice
+         * re-roots the whole hierarchy, so it also forces a re-plan.
+         */
         pages.push({
-            kind: PAGE_MODES, name: claimName("Mode"), level: null,
-            modes: modes.slice(), modeParam: hierarchy.mode_param || "mode",
+            kind: PAGE_ITEMS, name: claimName("Mode"), level: null,
+            derivedLabels: modes.slice(),
+            selectParam: hierarchy.mode_param || "mode",
+            modeSelect: true,
         });
         const active = (mode && modes.includes(mode)) ? mode : modes[0];
         rootKey = levels[active] ? active : "root";
@@ -386,6 +399,12 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved } 
                 kind: PAGE_ITEMS, name: claimName(base), level: levelKey,
                 childCount: childCount(lvl),
                 childLabel: lvl.child_label || "Item",
+                /* The SAME derived-list field the mode selector uses. One
+                 * mechanism: the planner decides what the labels say, and
+                 * itemsState never learns there are two kinds of source. */
+                derivedLabels: Array.from(
+                    { length: childCount(lvl) },
+                    (_, i) => `${lvl.child_label || "Item"} ${i + 1}`),
                 childOf: levelKey,
                 childLevel: lvl,
             });

--- a/tests/host/test_mode_select.sh
+++ b/tests/host/test_mode_select.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A hierarchy `modes` selector, on the grid.
+#
+# PAGE_MODES was planned by the planner and rendered by NOBODY, so minijv's
+# Mode page ejected to the list editor. The consequence went further than one
+# screen: performance mode was unreachable from the grid, and parts only exist
+# in performance mode -- so "edit parts does nothing" was partly this.
+#
+# It is an items page now: a list, a cursor, a current marker, click to choose.
+# The same machinery the child selector uses, and for the same reason -- a
+# second page kind means a second jog handler and a second renderer, and the
+# two module pickers drifted apart exactly that way once already.
+#
+# Two things make a mode different from an ordinary items page, and both are
+# pinned below: it writes a real param, and choosing RE-ROOTS the hierarchy so
+# every page after it is a different page.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_pages/page_plan.mjs"),
+  import("./src/shared/param_pages/page_controller.mjs"),
+]).then(([P, C]) => {
+  const say = (m) => { console.log("FAIL: " + m); process.exit(1); };
+  const j = JSON.parse(require("fs").readFileSync("tests/fixtures/module-contracts.json", "utf8"));
+  const m = j.modules.find((x) => x.id === "minijv");
+  let h = m.ui_hierarchy, cp = m.chain_params;
+  if (typeof h === "string") h = JSON.parse(h);
+  if (typeof cp === "string") cp = JSON.parse(cp);
+
+  /* ---- there is no page kind the grid cannot draw --------------------- */
+  const owned = new Set(["knobs", "menu", "preset", "items"]);
+  const planned = P.planPages({ hierarchy: h, chainParams: cp }).pages;
+  for (const p of planned)
+    if (!owned.has(p.kind))
+      say("minijv still plans a " + p.kind + " page, which nothing draws — it will eject");
+
+  const sel = planned.find((p) => p.modeSelect);
+  if (!sel) say("no mode selector page");
+  if (sel.kind !== P.PAGE_ITEMS) say("the mode selector is a " + sel.kind + ", not an items page");
+  if (!sel.selectParam) say("the mode selector writes no param");
+
+  /* ---- choosing a mode writes it AND re-roots the hierarchy ----------- */
+  let modeVal = "Patch";
+  const writes = [];
+  const ctl = C.createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return JSON.stringify(h);
+      if (b === "chain_params") return JSON.stringify(cp);
+      if (b === "mode") return modeVal;
+      return "10";
+    },
+    setParam: (k, v) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      writes.push(b + "=" + v);
+      if (b === "mode") modeVal = v;
+    },
+    announce: () => {},
+  });
+  ctl.load({ slot: 0, component: "synth" });
+  for (let i = 0; i < 10; i++) ctl.tick();
+
+  /*
+   * The ROOT is the first page that has a level -- the mode page itself has
+   * none. Testing "does the level list CONTAIN performance" is not enough:
+   * the patch-rooted walk reaches that level too, so the containment holds
+   * with or without a re-plan and two mutations survived on it.
+   */
+  const rootOf = (pages) => (pages.filter((p) => p.level)[0] || {}).level;
+  const before = rootOf(ctl.pages);
+  if (before !== "patch") say("did not start rooted at the first mode, got " + before);
+
+  const at = ctl.pages.findIndex((p) => p.modeSelect);
+  ctl.goToPage(at);
+  ctl.onClick(0);                 /* enter */
+  ctl.onJog(1);                   /* highlight performance */
+  writes.length = 0;
+  ctl.onClick(0);                 /* choose */
+
+  if (!writes.some((w) => w.startsWith("mode=")))
+    say("choosing a mode wrote " + JSON.stringify(writes) + " — the module is never told");
+
+  const after = rootOf(ctl.pages);
+  if (after !== "performance")
+    say("after choosing performance the pages are still rooted at " + JSON.stringify(after) +
+        " — the hierarchy was not re-planned");
+  /* The parts level is what performance mode unlocks, and it must be reachable
+     EARLY: rooted at performance it is one of the first levels, where rooted at
+     patch it is buried. */
+  const partsAt = ctl.pages.findIndex((p) => p.childOf);
+  if (partsAt < 0) say("performance mode does not reach the part selector");
+  const patchPlan = P.planPages({ hierarchy: h, chainParams: cp, mode: "patch" }).pages;
+  const partsAtPatch = patchPlan.findIndex((p) => p.childOf);
+  if (!(partsAt < partsAtPatch))
+    say("the part selector is at page " + partsAt + " in performance and " + partsAtPatch +
+        " in patch — the root did not actually move");
+
+  /*
+   * NOT asserted: that the current-mode marker follows the module rather than
+   * what we asked for. tickItems reads it back and matches case-insensitively
+   * ("Performance" against "performance"), but `current` is not reachable
+   * through the public API, so a test for it would only be able to assert
+   * itself. Said here rather than written as a check that cannot fail.
+   */
+
+  console.log("  ok  every page minijv plans is one the grid draws");
+  console.log("  ok  the mode selector is an items page and writes its param");
+  console.log("  ok  choosing a mode re-roots the hierarchy and reaches the parts level");
+  console.log("PASS: modes are selectable on the grid");
+});
+'

--- a/tests/host/test_param_pages_nav.sh
+++ b/tests/host/test_param_pages_nav.sh
@@ -129,7 +129,10 @@ Promise.all([
   /* ---- 8. the landing page skips a leading preset/mode screen ----------- */
   {
     const jv = plan("minijv");
-    if (jv[0].kind !== "modes") fail("minijv should open with a mode page");
+    /* "items" with modeSelect: the mode picker reuses the items page rather
+       than being a kind nothing draws. */
+    if (!(jv[0].kind === "items" && jv[0].modeSelect))
+      fail("minijv should open with a mode page, got " + jv[0].kind);
     if (jv[N.firstGrid(jv)].kind !== "knobs") fail("firstGrid should find a grid page");
     const only = [{ kind: "preset", name: "Presets", level: "root" }];
     if (N.firstGrid(only) !== 0) fail("with no grid page, firstGrid should be 0");

--- a/tests/host/test_param_pages_plan.sh
+++ b/tests/host/test_param_pages_plan.sh
@@ -24,7 +24,7 @@ fi
 node -e '
 import("./src/shared/param_pages/page_plan.mjs").then(async (m) => {
   const fs = await import("node:fs");
-  const { planPages, pageSlotKeys, PAGE_KNOBS, PAGE_PRESET, PAGE_MODES, PAGE_ITEMS } = m;
+  const { planPages, pageSlotKeys, PAGE_KNOBS, PAGE_PRESET, PAGE_ITEMS } = m;
   const fx = JSON.parse(fs.readFileSync("tests/fixtures/module-contracts.json", "utf8"));
   const fail = (msg) => { console.log("FAIL: " + msg); process.exit(1); };
   const plan = (id) => {
@@ -157,7 +157,10 @@ import("./src/shared/param_pages/page_plan.mjs").then(async (m) => {
   /* ---- 4. minijv: the fleet in one module ------------------------------- */
   {
     const { pages } = plan("minijv");
-    if (pages[0].kind !== PAGE_MODES) fail("minijv must open on the mode select, got " + pages[0].kind);
+    /* The mode selector is an ITEMS page now -- same gesture, same machinery.
+       PAGE_ITEMS was a kind nothing ever drew. */
+    if (!(pages[0].kind === PAGE_ITEMS && pages[0].modeSelect))
+      fail("minijv must open on the mode select, got " + pages[0].kind);
     if (!pages.some((p) => p.kind === PAGE_PRESET)) fail("minijv has no preset page");
     if (!pages.some((p) => p.kind === PAGE_ITEMS && p.childOf))
       fail("minijv lost its child_prefix part selector");

--- a/tests/host/test_param_pages_view.sh
+++ b/tests/host/test_param_pages_view.sh
@@ -240,26 +240,29 @@ Promise.all([
     C.ctx.getSlotParam = (slot, key) => dev3.getParam(key);
     C.ctx.setSlotParam = (slot, key, value) => dev3.setParam(key, value);
     V.enterParamPages(0, "synth", "synth");
-    /* Entering lands on the first GRID page, so minijv mode-select and child
-     * pages sit behind it — jogging back reaches them, and those belong to the
-     * list editor rather than to the grid.
+    /*
+     * The grid now owns EVERY page minijv plans, so jogging never ejects.
      *
-     * PRESET, MENU and ITEMS are NOT in that set: the grid draws all three, in
-     * its own chrome, as doors you click into. A preset page especially had to
-     * stop handing off — the list editor it landed in wires the jog to the
-     * preset browser, so jogging past one loaded every preset it crossed. */
+     * This used to assert the opposite: that jogging back reached a kind the
+     * grid did not own (the mode select), and that drawParamPages refused it.
+     * That was true while PAGE_MODES was planned and rendered by nobody --
+     * which is exactly what made the performance mode of minijv unreachable from
+     * the grid. The mode selector is an items page now, and the child selector
+     * with it, so there is nothing left to hand off.
+     *
+     * minijv is the module that had all three unowned features, so if any kind
+     * can still escape the grid it will escape here.
+     */
     if (V.currentParamPage().kind !== "knobs") fail("entering should land on a grid page");
-    let sawNonGrid = false;
-    for (let i = 0; i < 8; i++) {
+    const ownKinds = ["knobs", "menu", "preset", "items"];
+    for (let i = 0; i < 12; i++) {
       V.handleParamPagesMidi([0xb0, 14, 127]);   /* jog anticlockwise */
       const page = V.currentParamPage();
-      const ownKinds = ["knobs", "menu", "preset", "items"];
-      if (page && ownKinds.indexOf(page.kind) < 0) {
-        sawNonGrid = true;
-        if (V.drawParamPages()) fail("the grid drew a " + page.kind + " page it does not own");
-      }
+      if (page && ownKinds.indexOf(page.kind) < 0)
+        fail("jogging reached a " + page.kind + " page the grid does not own — it will eject to the list");
+      if (page && !V.drawParamPages())
+        fail("the grid refused to draw its own " + page.kind + " page");
     }
-    if (!sawNonGrid) fail("jogging back should reach minijv non-grid pages");
     V.exitParamPages();
   }
 


### PR DESCRIPTION
`PAGE_MODES` was planned by the planner and rendered by **nobody**, so mini-JV's Mode page ejected to the list editor. The consequence went past one screen: **performance mode was unreachable from the grid**, and parts only exist in performance mode — so *"edit parts doesn't do anything"* was partly this.

## Reuse, again

It's an **items page** now. Same gesture — a list, a cursor, a current marker, click to choose — so it reuses that machinery rather than being a kind with its own jog handler and its own renderer. Same reasoning as the child selector, and the same reason: two module pickers drifted apart exactly that way once already.

**One** derived-list mechanism serves both. `derivedLabels` is filled by the *planner* — generated names for a child level, the declared mode names for a mode — so `itemsState` never learns there are two kinds of source.

## What makes a mode different

- **It writes a real param.** The generic items path already does that, and an *index* is what the module wants (jv880 accepts `patch`/`Patch`/`performance`/`Performance` or `atoi`), so no special case.
- **Choosing re-roots the hierarchy.** The level named by the mode becomes the walk root, so every page after it is a different page. `replanForMode` re-plans from the cached contract — no device reads — and `armContractSettle` still books a re-read, because minijv **resets its emulator** to switch and isn't instant about it.

The current-mode marker is read back and matched case-insensitively: the module answers `"Performance"` where the hierarchy declares `"performance"`.

## The grid now draws every page kind the planner emits

`test_param_pages_view.sh` used to assert the **opposite** — that jogging mini-JV reached a kind the grid refused to draw. It now asserts nothing escapes. mini-JV is the module that had all three unowned features, so if a kind can still escape, it escapes there.

## Tests

Three mutations kill the new test. **Two survived the first version:** asserting the level list *contains* `"performance"` holds with or without a re-plan, because the patch-rooted walk reaches that level too. It now pins the **root** — the first page carrying a level — and where the part selector lands in each mode. A third "mutation" changed nothing at all: falsifying an `if` whose `else` branch does the same assignment.

This unblocks knobs-as-default from the grid-coverage side.