### PR TITLE
shadow: the knob grid is the default param view

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2126,11 +2126,23 @@ const MASTER_FX_SETTINGS_ITEMS_BASE = [
     { key: "delete", label: "[Delete]", type: "action" }
 ];
 
-/* Param View (preview): 0 = the hierarchy list editor, 1 = the knob grid.
- * Defaults to the list — the grid ships as an opt-in preview before becoming
- * the default in a later release. Read through a global so the view module can
- * ask without importing shadow_ui.js. See shadow_ui_param_pages.mjs. */
-let paramViewGlobal = 0;
+/* Param View: 0 = the hierarchy list editor, 1 = the knob grid.
+ *
+ * The grid is now the default. It shipped as an opt-in preview because it
+ * could not draw everything the list could, and that gap is what kept it
+ * opt-in rather than any doubt about the layout: mode selectors, child levels
+ * and enum lists all had to land first, and the fleet contract fixture had to
+ * be recaptured (76 modules -> 95) before "the grid covers the fleet" was a
+ * measurement rather than a hope.
+ *
+ * The list is not deprecated. It stays reachable from Global Settings, and it
+ * remains the better view for a module whose contract the grid cannot serve
+ * well -- 11 modules publish no ui_hierarchy at all, and a knob grid over a
+ * flat paginated param list is worse than a list of them.
+ *
+ * Read through a global so the view module can ask without importing
+ * shadow_ui.js. See shadow_ui_param_pages.mjs. */
+let paramViewGlobal = 1;
 const PARAM_VIEW_CONFIG_PATH = "/data/UserData/schwung/param_view.json";
 globalThis.param_view_get_mode = function() { return paramViewGlobal; };
 

--- a/tests/host/test_param_pages_wiring.sh
+++ b/tests/host/test_param_pages_wiring.sh
@@ -71,7 +71,15 @@ want(/view === VIEWS\.PARAM_PAGES && paramPagesActive\(\)[\s\S]{0,200}handlePara
 
 /* ---- the setting is real, defaults to the list, and persists ---------- */
 want(/key: "param_view"[\s\S]{0,120}options: \["List", "Knobs"\]/, "the Param View setting is not in the menu");
-want(/let paramViewGlobal = 0;/, "Param View must default to 0 (the list) — this ships as an opt-in preview");
+/* The DEFAULT itself, and the migration around it, now live in
+ * test_param_view_default.sh -- it flipped to the knob grid once the grid could
+ * draw everything the list could (mode selectors, child levels, enum pickers,
+ * and a fleet fixture recaptured at 95 modules to prove the coverage).
+ *
+ * Kept here as a wiring check only: the setting must still be a real, readable
+ * global. Pinning the VALUE in two places is how a deliberate change turns into
+ * a CI failure in a file nobody was looking at. */
+want(/let paramViewGlobal = [01];/, "the Param View global is gone — the view module reads it through param_view_get_mode");
 want(/globalThis\.param_view_get_mode/, "the view module reads the setting through a global that is not defined");
 want(/function saveParamViewConfig/, "the setting does not persist");
 want(/loadParamViewConfig\(\);/, "the setting is never loaded at init");
@@ -187,7 +195,7 @@ want(/function slotChainComponents\(slotIndex\) \{\s*\n\s*return chainEditorComp
 want(/\{[^}]*chainComponents[^}]*\}\s*\n?\s*from [^\n]*chain_model\.mjs/,
      "shadow_ui.js does not import chainComponents from the chain model");
 
-console.log("PASS: shadow wiring — parses, view dispatched/ticked/fed, setting defaults to List, " +
+console.log("PASS: shadow wiring — parses, view dispatched/ticked/fed, setting is wired, " +
             "hand-off cannot loop, screen reader keeps the list, device keys use the prefix, " +
             "LFO targets resolve to names");
 '

--- a/tests/host/test_param_view_default.sh
+++ b/tests/host/test_param_view_default.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Param View defaults to the KNOB GRID (1), not the hierarchy list (0).
+#
+# The grid shipped opt-in because it could not draw everything the list could.
+# That gap is closed -- mode selectors, child levels and enum pickers all
+# landed, and the fleet contract fixture was recaptured (76 modules -> 95) so
+# that "the grid covers the fleet" is a measurement rather than a hope.
+#
+# The half that is easy to break silently is the MIGRATION. param_view.json is
+# written only when the user toggles the setting, so:
+#
+#   * a device that never touched it has NO file and must pick up the new
+#     default -- if the setting were saved on every boot instead, every
+#     existing install would be pinned to the old default forever and the flip
+#     would appear to do nothing;
+#   * a device where the user explicitly chose List has a file saying 0, and
+#     that choice must still win.
+#
+# Both halves are asserted here because both are one line away from wrong, and
+# neither is visible on a developer device that has already toggled the setting
+# at some point.
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+file="src/shadow/shadow_ui.js"
+
+# ---- the default itself -----------------------------------------------------
+decl=$(command grep '^let paramViewGlobal = ' "$file" || true)
+[ -n "$decl" ] || fail "could not find the paramViewGlobal declaration in $file"
+if [ "$decl" != "let paramViewGlobal = 1;" ]; then
+  fail "Param View no longer defaults to the knob grid: $decl
+      0 is the hierarchy list, which is the pre-recapture opt-in default."
+fi
+echo "  ok  Param View defaults to the knob grid (1)"
+
+# ---- the config is written on TOGGLE, never unconditionally ------------------
+#
+# Asserted as a count rather than by inspecting the call site: one call means
+# the toggle. A second call anywhere -- init, a load path, an autosave -- is how
+# every existing install would get pinned to whatever it booted with.
+calls=$(command grep -c 'saveParamViewConfig();' "$file" || true)
+if [ "$calls" != "1" ]; then
+  fail "saveParamViewConfig() is called $calls times, expected exactly 1 (the
+      toggle). Writing the file anywhere else pins every existing device to the
+      value it happened to boot with, and the default can never change again."
+fi
+echo "  ok  the config is written only by the toggle, so an untouched device follows the default"
+
+# ---- an explicit choice still wins ------------------------------------------
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+const grab = (name) => {
+  const re = new RegExp("^function " + name + "[(][^]*?^}", "m");
+  const m = src.match(re);
+  if (!m) fail("could not lift " + name + "() out of shadow_ui.js");
+  return m[0];
+};
+
+/* Lift the loader and drive it with a fake file. shadow_ui.js imports by
+ * absolute on-device paths and cannot be loaded off the Move. */
+const run = (fileContents) => {
+  let paramViewGlobal = 1;               /* the new default */
+  const host_read_file = () => fileContents;
+  const PARAM_VIEW_CONFIG_PATH = "/param_view.json";
+  const fn = new Function("host_read_file", "PARAM_VIEW_CONFIG_PATH", "startValue",
+    "let paramViewGlobal = startValue;\n" +
+    grab("loadParamViewConfig") +
+    "\nloadParamViewConfig();\nreturn paramViewGlobal;");
+  return fn(host_read_file, PARAM_VIEW_CONFIG_PATH, paramViewGlobal);
+};
+
+/* No file: a device that never touched the setting follows the default. */
+if (run(null) !== 1)
+  fail("a device with no param_view.json did not follow the new default");
+if (run("") !== 1)
+  fail("an empty param_view.json did not follow the new default");
+
+/* An explicit List choice survives the flip -- this is somebody who tried the
+ * grid and went back, and the release must not silently overrule them. */
+if (run(JSON.stringify({ param_view: 0 })) !== 0)
+  fail("an explicitly saved List choice was overruled by the new default");
+
+/* An explicit Knobs choice is a no-op, and unparseable JSON must not throw. */
+if (run(JSON.stringify({ param_view: 1 })) !== 1)
+  fail("an explicitly saved Knobs choice did not survive");
+if (run("{not json") !== 1)
+  fail("a corrupt config threw or changed the value instead of being ignored");
+
+console.log("  ok  no file follows the default; an explicit List choice still wins");
+console.log("PASS: Param View defaults to the knob grid without overruling anybody");
+'


### PR DESCRIPTION
The knob grid shipped as an opt-in preview because it **could not draw everything the list could** — not because of any doubt about the layout. That gap is now closed:

- mode selectors (#258)
- child levels
- enum pickers
- and the fleet contract fixture recaptured 76 → 95 modules (#260), so *"the grid covers the fleet"* is a measurement rather than a hope

**The list is not deprecated.** It stays under Global Settings → Display → Param View, and it remains the better view for the 11 modules that publish no `ui_hierarchy` at all — a knob grid over a flat paginated param list is worse than a list of one.

## The migration is the part that breaks silently

Both halves are pinned by `tests/host/test_param_view_default.sh`, because **neither is visible on a developer device** — one that has toggled the setting at some point always has a config file, so it never exercises either path:

- `param_view.json` is written **only** by the toggle. A device that never touched the setting has no file and picks up the new default. Were the value saved on any other path — init, a load, an autosave — every existing install would be pinned to whatever it booted with, and the default could never change again. Asserted as a call **count**, because a second call site *is* the whole failure.
- A device where the user explicitly chose *List* has a file saying `0`, and that still wins. Somebody who tried the grid and went back must not be silently overruled by a release.

Both mutation-checked: flipping the default back fails it, and adding a second `saveParamViewConfig()` call fails it.

Manual entry added in `schwung-catalog-site` (that repo, separate commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kqae7GKuzfSXCbNTDzpg56