### PR TITLE
Catalog: add Capicola

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1289,6 +1289,17 @@
       "default_branch": "main",
       "asset_name": "tape-echo2-module.tar.gz",
       "min_host_version": "0.7.13"
+    },
+    {
+      "id": "capicola",
+      "name": "Capicola",
+      "description": "Live keyframe time stretcher with transient re-anchoring, by Heavylight Industries",
+      "author": "Heavylight Industries (port: charlesvestal)",
+      "component_type": "audio_fx",
+      "github_repo": "charlesvestal/schwung-capicola",
+      "default_branch": "main",
+      "asset_name": "capicola-module.tar.gz",
+      "min_host_version": "0.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Capicola** to the module catalog so it can be installed from Schwung Manager.

A live time-stretch / pitch-shift audio FX. Incoming stereo is reduced to bandlimited local extrema ("keyframes") and replayed by a lagging read head under independent time and pitch control; a transient detector snaps that head back to the present on every kept hit, so stretched tails ring out underneath while the output stays locked to the input's rhythm.

### Provenance

A port of [heavylight-industries/capicola](https://github.com/heavylight-industries/capicola) — the hardware embodiment of their independently authored, peer-reviewed DAFx26 paper *Keyframe Time Stretching via Extrema Sampling*. The DSP core is vendored unmodified. **Ported with the author's permission.** AGPL-3.0, matching upstream (precedent: surge, obxd, wavewarp are GPL-3.0).

### Verified before opening

- `module-catalog.json` still parses; 116 modules
- diff is purely additive — 11 insertions, 0 deletions, no other entries touched
- `release.json` on the module's `main` reports `0.1.1` with a matching `download_url`
- the release asset returns HTTP 200 (29,608 bytes)
- module builds ARM64 and exports `move_audio_fx_init_v2` + `move_audio_fx_on_midi`
- loads and runs on hardware; `slice_count` increments on a MIDI note-on

### Notes

`min_host_version` is `0.3.0`, matching the other audio FX — it uses only `audio_fx_api_v2` and standard `ui_hierarchy`/`chain_params`, nothing newer.

Known issue, documented in the module's README: ~11 ms allocation on load, audible as a click. Steady-state render is ~44 µs against a ~900 µs budget.