### PR TITLE
catalog: 9W9 min_host_version 0.11.6 -> 0.12.1

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1254,7 +1254,7 @@
       "github_repo": "athousanddetails/schwung-9W9",
       "default_branch": "main",
       "asset_name": "9w9-module.tar.gz",
-      "min_host_version": "0.11.6"
+      "min_host_version": "0.12.1"
     },
     {
       "id": "tablor",


### PR DESCRIPTION
9W9 1.0.0 ([athousanddetails/schwung-9W9](https://github.com/athousanddetails/schwung-9W9)) now draws its on-device editor with the shared `param_pages` library that shipped in 0.12.1 (Movy knob grid, viz, section picker). On a host older than that the editor cannot load, so the catalog entry's `min_host_version` needs to follow. One-line change to the existing entry from #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)