### PR TITLE
catalog: fold Tape Echo 2 into tapedelay, drop the separate entry

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -148,14 +148,14 @@
     },
     {
       "id": "tapedelay",
-      "name": "TapeDelay",
-      "description": "Tape delay with flutter and tone shaping",
-      "author": "Charles Vestal",
+      "name": "Tape Echo 2",
+      "description": "Component-modeled vintage three-head tape echo with spring reverb: 12 head/reverb modes, in-loop tape saturation, wow & flutter, tape age, and tempo sync with the reference machine's leading-head note tables.",
+      "author": "Tape Echo 2 by Dusk Audio (GPL-3.0) · port: athousanddetails, charlesvestal",
       "component_type": "audio_fx",
       "github_repo": "charlesvestal/schwung-space-delay",
       "default_branch": "main",
       "asset_name": "tapedelay-module.tar.gz",
-      "min_host_version": "0.3.0"
+      "min_host_version": "0.7.13"
     },
     {
       "id": "junologue-chorus",
@@ -1278,17 +1278,6 @@
       "asset_name": "chord-finder-module.tar.gz",
       "min_host_version": "0.11.6",
       "requires": "Ableton Move 1.8 or newer; Move/USB-C audition requires matching Move track MIDI routing"
-    },
-    {
-      "id": "tape-echo2",
-      "name": "Tape Echo 2",
-      "description": "Component-modeled vintage three-head tape echo with spring reverb: 12 head/reverb modes, in-loop tape saturation, wow & flutter, tape age, and tempo sync with the reference machine's leading-head note tables.",
-      "author": "Tape Echo 2 by Dusk Audio (GPL-3.0) \u00b7 port: athousanddetails",
-      "component_type": "audio_fx",
-      "github_repo": "athousanddetails/schwung-tape-echo2",
-      "default_branch": "main",
-      "asset_name": "tape-echo2-module.tar.gz",
-      "min_host_version": "0.7.13"
     },
     {
       "id": "capicola",


### PR DESCRIPTION
The catalog carried two tape delays where the second is the first one done properly: `tapedelay` was a circular buffer with a one-pole tone control, `tape-echo2` is a component model of a three-head machine with a spring tank. Keeping both asks every user to work that out from two descriptions.

So `tapedelay` now ships the Tape Echo 2 engine, with **athousanddetails** — who ported it from Dusk Audio's GPL-3.0 core — credited alongside, and with their permission. The standalone entry goes.

## This is an upgrade, not a second install

The store extracts a tarball's own top-level directory into `modules/audio_fx/`, so keeping the id is what makes `tapedelay/` overwrite `tapedelay/`. Nothing needs converting either: the engine sniffs an incoming state blob and maps an old TapeDelay one (time → the playback head that can reach it, feedback → intensity, tone → treble, plus division/mix/stereo_width), and still answers to the old parameter names one at a time. Neither path keys on the module id, so existing patches and slot autosaves carry over untouched.

`min_host_version` follows the engine to 0.7.13.

Anyone who installed `tape-echo2` while it was listed keeps it on disk — it just stops being offered, and the module they get from `tapedelay` is the same DSP.

## Upstream is already published

Depends on charlesvestal/schwung-space-delay#2, which is merged and released:

- https://github.com/charlesvestal/schwung-space-delay/releases/tag/v1.3.3
- `release.json` on main serves v1.3.3 → `tapedelay-module.tar.gz`
- Downloaded and checked: the asset packs `tapedelay/tapedelay.so` (ELF aarch64) with `module.json` id `tapedelay`, name `Tape Echo 2`, version 1.3.3

Nothing else in the repo referenced `tape-echo2`, and the catalog site needs no change — its `tapedelay` entries are auto-generated download counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtmMXS3SjqZivqrht7Vgy3