### PR TITLE
rt-audit: find the threads that inherit the audio thread's priority, and measure what they burn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,16 @@ half an event, and never stabilised for reasons it recorded as unknown.
 
 ## Realtime Safety
 
-SPI callback runs SCHED_FIFO 90 on core 3. Budget ~900µs/frame after the ~2ms transfer.
+SPI callback runs on core 3. Budget ~900µs/frame after the ~2ms transfer.
+
+**Priority: FIFO 70, not 90.** Measured 2026-08-22 with the RT-thread audit —
+nothing anywhere in the MoveOriginal process is above 70. This file said 90
+here and "the shim runs in MoveOriginal's FIFO 70 threads" two lines down; the
+second one is right. What the hardware runs, with no module loaded, is 23
+threads of which 11 are realtime: `MoveOriginal` at 10, **`Link Main` at 35**,
+three `Audio Worker` at 70, and six threads named `Audio Main/SPI` at 70 (one
+at 45). Arm it and look before reasoning about priorities:
+`touch /data/UserData/schwung/rt_thread_audit_on`.
 
 **Never in the SPI callback path:** `unified_log()`, `fprintf()`, `fopen()`, any file I/O; allocation; locks held by non-RT threads.
 
@@ -240,8 +249,12 @@ lives at the top of `src/host/plugin_api_v1.h`, in `docs/MODULES.md`, and as
 rule 4 of `docs/REALTIME_SAFETY.md` — **keep all three in sync.**
 
 Two consequences worth remembering: `pthread_create` from those entry points
-inherits **FIFO 90** (at least 14 modules do this; Move's own `Link Main` is
-FIFO 35, so it starves), and a **`get_param` that scans a directory is served
+inherits the callback's priority — **FIFO 70** (Move's own `Link Main` is FIFO
+35, so it starves). A source audit put this at seven modules; measuring it
+found five, and not the same five — see
+`docs/plans/2026-08-22-rt-thread-audit-findings.md`. **Existence is not the
+harm**: a worker that parks on a condvar starves nobody, so the number that
+matters is CPU burned at realtime priority, which is what the audit reports, and a **`get_param` that scans a directory is served
 once per repaint**, which makes it worse than the equivalent `set_param`.
 
 ## Deployment Layout

--- a/docs/plans/2026-08-22-rt-thread-audit-findings.md
+++ b/docs/plans/2026-08-22-rt-thread-audit-findings.md
@@ -1,0 +1,172 @@
+# RT-thread audit — what the fleet actually does, and what is still owed
+
+Measured on hardware 2026-08-22. **Parked mid-investigation**; the instrument
+is merged, the conclusion is not reached.
+
+## Why this exists
+
+The end goal is the **Link Audio dropouts** (open since 2026-08-19). The
+3-point bisect there: stock Move = 0 stalls, Schwung with empty slots = 0
+stalls, Schwung with modules loaded = a stall every 4–40 s. Move's `Link Main`
+runs at **SCHED_FIFO 35**; Schwung's DSP runs at **70**. So a module worker
+born at 70 that runs long is the mechanism that fits.
+
+Module entry points ARE the SPI callback, and POSIX `PTHREAD_INHERIT_SCHED` is
+the default, so a `pthread_create` from `create_instance` / `set_param` yields
+a worker at the callback's priority. A 2026-08 source audit put this at seven
+modules.
+
+**That estimate did not survive measurement.** tablor was its headline case,
+and by the time anyone looked, tablor had moved the call into
+`create_instance`, was shedding priority on the worker's first line, and the
+thing actually wrong with it — the thread was never *named*, so it wore the
+parent's `comm` and hid from the very audit that found it — was not in the
+estimate at all.
+
+## The instrument
+
+`src/host/rt_thread_audit.{c,h}`, reported from the shim worker. Off unless
+armed:
+
+```
+touch /data/UserData/schwung/rt_thread_audit_on
+touch /data/UserData/schwung/debug_log_on
+```
+
+**It cannot be a name check, and that is the whole design.** A child inherits
+the parent's `comm`, so an inherited worker reports as `Audio Main/SPI` —
+indistinguishable from the real SPI thread in `top`, in a thread list, or to
+its own author. That invisibility is why these exist. The detector diffs the
+SET of realtime threads by **tid**; `tests/host/test_rt_thread_audit.c` fails
+if anyone reduces it to a name comparison.
+
+Two reports:
+
+- **arrival** — a realtime thread that was not there before, attributed to the
+  module whose `<prefix>:module` write was most recent.
+- **burn** — CPU consumed at realtime priority since the last sample, worst
+  first, excluding everything present before the first module loaded.
+
+## Hardware baseline (no modules loaded)
+
+23 threads, **11 realtime**:
+
+| tid | policy | comm |
+|---|---|---|
+| 939 | FIFO 10 | `MoveOriginal` |
+| 967 | **FIFO 35** | **`Link Main`** |
+| 977–979 | FIFO 70 | `Audio Worker` ×3 |
+| 981–1005 | FIFO 70 (one at 45) | `Audio Main/SPI` ×6 |
+
+**Nothing is at FIFO 90.** CLAUDE.md claimed both 90 and 70 in two places
+three lines apart; 70 is what the hardware runs. Fixed in the same commit.
+
+`Link Main` at 35 sharing a core with an `Audio Worker` at 70 is the
+starvation relationship, visible.
+
+## Fleet sweep — 96 modules
+
+Ten realtime threads across six modules. Every one cross-checked against
+source, because the audit is a **lead list, not a verdict**:
+
+| Module | Threads | Source |
+|---|---|---|
+| **sfz** | 5 × FIFO 70 | sfizz's global `FilePool` `ThreadPool` (`FilePool.cpp:53`) ✅ |
+| **osirus** | 1 × FIFO 70 | `pthread_create(&inst->boot_thread, nullptr, …)` (`virus_plugin.cpp:1886`) + 3 `restart_thread_func` sites ✅ |
+| **minijv** | 1 × **FIFO 45** | `emu_thread`, `load_thread`, `NULL` attrs (`jv880_plugin.cpp:1465`, `:1591`) ✅ |
+| **po32-drum** | 1 × FIFO 70 | `pthread_create(&m->render_thread, NULL, …)` in `create_instance` ✅ |
+| **fork** | 1 × FIFO 70 | `pthread_create(&inst->io_thread, NULL, …)` in `create_instance` ✅ |
+| **breakbeat** | 1 × FIFO 70 | **none — zero threading primitives in the repo** ❌ |
+
+Against the estimate: **five confirmed, and not the same five.** sfz's five
+threads were never counted; the module everyone was talking about is not in the
+list.
+
+### breakbeat is the audit being wrong, and why
+
+The sweep ran 96 modules in ~90 s — about one per second — against a 1 Hz
+audit sample. Attribution is "most recently loaded module", so at that rate it
+is close to a coin flip. Anything this tool names must be confirmed in source
+before it is acted on. A targeted slow re-run is the fix; the general fix is
+sampling synchronously around the load rather than at 1 Hz.
+
+### Existence is not the harm
+
+`Link Main` gets only the CPU a FIFO 70 thread leaves it, so what starves it is
+a thread that **runs**, not one that exists. po32-drum's render worker and
+fork's I/O thread park on a condvar immediately — they cost nothing, and on a
+headcount they would have sat near the top of a suspect list forever.
+
+The three that plausibly matter are **sfz** (loading samples), **minijv**
+(reading ROM) and **osirus** (booting a DSP56300) — all of which do sustained
+work. **This is a hypothesis, not a result.**
+
+### A thread outlived its module
+
+Baseline was 11 realtime before the sweep and **12 after**. Something spawned
+during the sweep survived its module's unload. If that generalises, realtime
+threads accumulate across a session, which is its own contribution.
+Unexplained.
+
+## What is still owed
+
+1. **The burn number on hardware.** The measurement is written, unit-tested and
+   mutation-checked; it has never produced a device figure. Three attempts
+   failed for reasons unrelated to the code — see the gotchas below.
+2. **Correlation with the dropouts.** Burn figures next to
+   `link_audio_avail_log_on` stalls is what turns a suspect list into cause and
+   effect.
+3. **The leaked thread.**
+4. **breakbeat**, resolved by a slow targeted run.
+
+## Sizing the real fix (residual option 3)
+
+Moving module loading off the SPI thread so `create_instance` / `set_param` no
+longer run at realtime:
+
+- **Fixes** sfz and osirus — pure inheritance, so a normal-priority loader
+  makes the inherited priority harmless.
+- **Does not fix** minijv, which is at FIFO **45**, i.e. it sets its own
+  priority rather than only inheriting.
+- **Does not touch** the ~143 non-thread violations (malloc, `fopen`, locks in
+  `render_block`) — though it does make `fopen` in `set_param` legal, which
+  retires a large part of the documentation problem.
+- **Real cost is not the moving.** Thread-safety is currently *free* because
+  everything is on one thread — `chain_reorder.c`'s permutation and the
+  `dlopen`/`create_instance` path both rely on it. Taking loading off that
+  thread means a loader and `render_block` touching one instance concurrently,
+  needing real synchronisation on a realtime deadline, for 113 modules whose
+  internal state assumes single-threaded access.
+
+## The documentation problem this exposed
+
+The RT contract lives at the top of `src/host/plugin_api_v1.h`. **Every module
+vendors its own frozen copy of that header**, and the contract is present in
+**4 of 44**. Module repos' own `CLAUDE.md`: **1 of 35** (80 repos, 35 have
+one). Most of these modules are LLM-authored, so the model's context is the
+vendored copy — which never told it.
+
+So "the contract deserves louder placement" understates it: the contract is
+*absent* from the file authors actually read. Making the canonical header
+louder reaches none of the 40, and a helper added there would sit in a file
+they do not have.
+
+## Gotchas that cost time here
+
+- **Arm order matters.** `unified_log` only starts writing once it notices
+  `debug_log_on`, rechecked every 100 calls. Arming both flags together latched
+  the baseline into a log still dropping writes, and the audit then ran twelve
+  minutes reporting nothing — indistinguishable from a clean result. Fixed: it
+  waits for the log before latching. Sequence that works is **reboot → arm →
+  wait for a `rt-audit: armed` line with a FRESH timestamp → trigger**.
+- **One trigger per boot.** `contractDumpDone` in `shadow_ui.js` latches for the
+  life of the process; re-touching the trigger without a restart is a no-op.
+- **`debugLog` is not in scope** in a script evaluated through that trigger
+  (`new Function("os","std",src)`) — same trap the tool's own comments record
+  for `os`. It throws into the trigger's `catch` and the run silently does
+  nothing.
+- **Never truncate `debug.log` while the shim holds it open.** It stops writing.
+  And a truncated log leaves NUL padding, after which `grep` treats the file as
+  binary and prints nothing — use `grep -a`.
+- **Do not trust `set_state/` mtimes** to tell you which set is live. The
+  newest-mtime directory was hours stale while the device was in use.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -243,6 +243,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_xmos_audio.c src/host/shadow_xmos_audio.h \
     src/host/shadow_midi.c src/host/shadow_midi_filter.c src/host/shadow_midi_filter.h \
     src/host/unified_log.c src/host/shim_worker.c \
+    src/host/rt_thread_audit.c src/host/rt_thread_audit.h \
     src/host/shadow_shm_util.c src/host/schwung_trace.c src/host/shadow_test_stream.c src/host/shadow_test_stream.h \
     $SHIM_TTS_SRC \
     src/host/shadow_constants.h src/host/shadow_midi_inject_writer.h src/host/shadow_midi.h src/host/shadow_sampler.h \
@@ -277,6 +278,7 @@ if needs_rebuild build/schwung-shim.so \
         src/host/shadow_midi_filter.c \
         src/host/unified_log.c \
         src/host/shim_worker.c \
+        src/host/rt_thread_audit.c \
         src/host/shadow_shm_util.c \
         src/host/schwung_trace.c \
         src/host/shadow_test_stream.c \

--- a/src/host/rt_thread_audit.c
+++ b/src/host/rt_thread_audit.c
@@ -1,0 +1,160 @@
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rt_thread_audit.h"
+
+/* Field numbers in proc(5), 1-based, counting the bracketed comm as field 2. */
+#define FIELD_PROCESSOR 39
+#define FIELD_RT_PRIO   40
+#define FIELD_POLICY    41
+
+int rt_thread_parse_stat(const char *line, rt_thread_info_t *out)
+{
+    if (!line || !out) return 0;
+
+    memset(out, 0, sizeof(*out));
+
+    out->tid = atoi(line);
+    if (out->tid <= 0) return 0;
+
+    /* comm is bracketed and may contain spaces AND parentheses — "Audio
+     * Main/SPI" has the first, a name like "worker (2)" has both. Delimit on
+     * the LAST ')', never on whitespace. */
+    const char *open = strchr(line, '(');
+    const char *close = open ? strrchr(open, ')') : NULL;
+    if (!open || !close || close < open) return 0;
+
+    int comm_len = (int)(close - open - 1);
+    if (comm_len < 0) return 0;
+    if (comm_len > RT_AUDIT_COMM_LEN - 1) comm_len = RT_AUDIT_COMM_LEN - 1;
+    memcpy(out->comm, open + 1, (size_t)comm_len);
+    out->comm[comm_len] = '\0';
+
+    /* Everything after the ')' is field 3 onward, all whitespace-separated. */
+    const char *p = close + 1;
+    int field = 2;                 /* we have just consumed comm */
+    int got_cpu = 0, got_prio = 0, got_policy = 0;
+
+    while (*p) {
+        while (*p == ' ' || *p == '\t') p++;
+        if (!*p || *p == '\n') break;
+
+        field++;
+        const char *tok = p;
+        while (*p && *p != ' ' && *p != '\t' && *p != '\n') p++;
+
+        if (field == FIELD_PROCESSOR) { out->cpu = atoi(tok);    got_cpu = 1; }
+        else if (field == FIELD_RT_PRIO) { out->rtprio = atoi(tok); got_prio = 1; }
+        else if (field == FIELD_POLICY)  { out->policy = atoi(tok); got_policy = 1; break; }
+    }
+
+    /* A line that stops before field 41 tells us nothing about scheduling, and
+     * reporting it as SCHED_OTHER 0 would be a false all-clear. */
+    if (!got_cpu || !got_prio || !got_policy) return 0;
+
+    return 1;
+}
+
+int rt_thread_is_realtime(const rt_thread_info_t *t)
+{
+    if (!t) return 0;
+    if (t->policy != RT_AUDIT_SCHED_FIFO && t->policy != RT_AUDIT_SCHED_RR)
+        return 0;
+    return t->rtprio > 0;
+}
+
+int rt_thread_count_realtime(const rt_thread_info_t *t, int n)
+{
+    if (!t || n <= 0) return 0;
+    int c = 0;
+    for (int i = 0; i < n; i++)
+        if (rt_thread_is_realtime(&t[i])) c++;
+    return c;
+}
+
+int rt_thread_new_realtime(const rt_thread_info_t *prev, int prev_n,
+                           const rt_thread_info_t *cur, int cur_n,
+                           rt_thread_info_t *out, int out_max)
+{
+    if (!cur || cur_n <= 0 || !out || out_max <= 0) return 0;
+    if (prev_n < 0) prev_n = 0;
+
+    int written = 0;
+    for (int i = 0; i < cur_n && written < out_max; i++) {
+        if (!rt_thread_is_realtime(&cur[i])) continue;
+
+        int seen = 0;
+        for (int j = 0; j < prev_n; j++) {
+            if (prev && prev[j].tid == cur[i].tid) { seen = 1; break; }
+        }
+        if (seen) continue;
+
+        out[written++] = cur[i];
+    }
+    return written;
+}
+
+int rt_thread_format(const rt_thread_info_t *t, const char *module,
+                     char *buf, int buf_len)
+{
+    if (!buf || buf_len <= 0) return 0;
+    buf[0] = '\0';
+    if (!t) return 0;
+
+    const char *pol = (t->policy == RT_AUDIT_SCHED_FIFO) ? "FIFO"
+                    : (t->policy == RT_AUDIT_SCHED_RR)   ? "RR"
+                    : "OTHER";
+
+    /* Describe the thread; the CALLER says whether it is a baseline entry or a
+     * new arrival, because only the caller knows.
+     *
+     * The name is reported and never interpreted. An earlier version appended
+     * "name inherited — NOT the SPI thread" whenever comm was "Audio Main/SPI",
+     * which was a conclusion drawn from a name match — the exact reasoning this
+     * tool exists to avoid — and measurement showed it was wrong: Move runs SIX
+     * threads under that name as its own, none of them inherited from us. All
+     * the name can honestly carry is that it does not identify anything. */
+    int shared_name = (strcmp(t->comm, "Audio Main/SPI") == 0);
+
+    int n = snprintf(buf, (size_t)buf_len,
+                     "tid=%d %s:%d cpu=%d comm=\"%s\"%s%s%s",
+                     t->tid, pol, t->rtprio, t->cpu, t->comm,
+                     module ? " after loading " : "",
+                     module ? module : "",
+                     shared_name ? " (shared name — Move uses it too; identify by tid)" : "");
+
+    if (n < 0) { buf[0] = '\0'; return 0; }
+    if (n >= buf_len) n = buf_len - 1;
+    return n;
+}
+
+int rt_thread_audit_scan(rt_thread_info_t *out, int out_max)
+{
+    if (!out || out_max <= 0) return -1;
+
+    DIR *d = opendir("/proc/self/task");
+    if (!d) return -1;
+
+    int n = 0;
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL && n < out_max) {
+        if (e->d_name[0] < '0' || e->d_name[0] > '9') continue;
+
+        char path[128];
+        snprintf(path, sizeof(path), "/proc/self/task/%s/stat", e->d_name);
+
+        FILE *f = fopen(path, "r");
+        if (!f) continue;   /* thread exited between readdir and open */
+
+        char line[1024];
+        if (fgets(line, sizeof(line), f) && rt_thread_parse_stat(line, &out[n]))
+            n++;
+
+        fclose(f);
+    }
+    closedir(d);
+
+    return n;
+}

--- a/src/host/rt_thread_audit.c
+++ b/src/host/rt_thread_audit.c
@@ -6,6 +6,8 @@
 #include "rt_thread_audit.h"
 
 /* Field numbers in proc(5), 1-based, counting the bracketed comm as field 2. */
+#define FIELD_UTIME     14
+#define FIELD_STIME     15
 #define FIELD_PROCESSOR 39
 #define FIELD_RT_PRIO   40
 #define FIELD_POLICY    41
@@ -45,7 +47,9 @@ int rt_thread_parse_stat(const char *line, rt_thread_info_t *out)
         const char *tok = p;
         while (*p && *p != ' ' && *p != '\t' && *p != '\n') p++;
 
-        if (field == FIELD_PROCESSOR) { out->cpu = atoi(tok);    got_cpu = 1; }
+        if (field == FIELD_UTIME)      out->utime = strtoul(tok, NULL, 10);
+        else if (field == FIELD_STIME) out->stime = strtoul(tok, NULL, 10);
+        else if (field == FIELD_PROCESSOR) { out->cpu = atoi(tok);    got_cpu = 1; }
         else if (field == FIELD_RT_PRIO) { out->rtprio = atoi(tok); got_prio = 1; }
         else if (field == FIELD_POLICY)  { out->policy = atoi(tok); got_policy = 1; break; }
     }
@@ -125,6 +129,80 @@ int rt_thread_format(const rt_thread_info_t *t, const char *module,
                      module ? module : "",
                      shared_name ? " (shared name — Move uses it too; identify by tid)" : "");
 
+    if (n < 0) { buf[0] = '\0'; return 0; }
+    if (n >= buf_len) n = buf_len - 1;
+    return n;
+}
+
+static int burn_find(const rt_thread_info_t *a, int n, int tid)
+{
+    for (int i = 0; i < n; i++)
+        if (a[i].tid == tid) return i;
+    return -1;
+}
+
+int rt_thread_burners(const rt_thread_info_t *base, int base_n,
+                      const rt_thread_info_t *prev, int prev_n,
+                      const rt_thread_info_t *cur, int cur_n,
+                      int hz, int min_ms,
+                      rt_thread_burn_t *out, int out_max)
+{
+    if (!cur || cur_n <= 0 || !out || out_max <= 0) return 0;
+    if (hz <= 0) return 0;
+    if (base_n < 0) base_n = 0;
+    if (prev_n < 0) prev_n = 0;
+
+    int written = 0;
+    for (int i = 0; i < cur_n; i++) {
+        if (!rt_thread_is_realtime(&cur[i])) continue;
+
+        /* Move's own audio threads are permanently busy at FIFO 70; they are
+         * the environment, not the finding. */
+        if (base && burn_find(base, base_n, cur[i].tid) >= 0) continue;
+
+        int pi = prev ? burn_find(prev, prev_n, cur[i].tid) : -1;
+        unsigned long before = (pi >= 0) ? (prev[pi].utime + prev[pi].stime) : 0;
+        unsigned long now = cur[i].utime + cur[i].stime;
+
+        /* A tid absent from prev is brand new; count its whole lifetime so a
+         * thread that does all its damage in its first second is not missed. */
+        if (now < before) continue;                 /* tid reuse — do not guess */
+        unsigned long ticks = now - before;
+
+        int ms = (int)((ticks * 1000UL) / (unsigned long)hz);
+        if (ms < min_ms) continue;
+
+        /* Insertion sort, worst first: the list is at most a handful and the
+         * top entry is the one anybody reads. */
+        int at = written;
+        while (at > 0 && out[at - 1].cpu_ms < ms) at--;
+        if (written < out_max) written++;
+        for (int k = (written < out_max ? written : out_max) - 1; k > at; k--)
+            out[k] = out[k - 1];
+        if (at < out_max) {
+            out[at].thread = cur[i];
+            out[at].cpu_ms = ms;
+        }
+    }
+    return written;
+}
+
+int rt_thread_format_burn(const rt_thread_burn_t *b, const char *module,
+                          int window_ms, char *buf, int buf_len)
+{
+    if (!buf || buf_len <= 0) return 0;
+    buf[0] = '\0';
+    if (!b) return 0;
+
+    char who[192];
+    rt_thread_format(&b->thread, module, who, sizeof(who));
+
+    /* Percent of the window is the number that maps onto the harm: `Link Main`
+     * runs at FIFO 35 and only gets the CPU this thread does not take. */
+    int pct = (window_ms > 0) ? (int)((b->cpu_ms * 100) / window_ms) : 0;
+
+    int n = snprintf(buf, (size_t)buf_len, "%s BURNED %d ms (%d%% of %d ms)",
+                     who, b->cpu_ms, pct, window_ms);
     if (n < 0) { buf[0] = '\0'; return 0; }
     if (n >= buf_len) n = buf_len - 1;
     return n;

--- a/src/host/rt_thread_audit.h
+++ b/src/host/rt_thread_audit.h
@@ -1,0 +1,87 @@
+/* rt_thread_audit.h — find threads that inherited the SPI callback's priority.
+ *
+ * Module entry points ARE the SPI callback (SCHED_FIFO 90, core 3). POSIX
+ * `PTHREAD_INHERIT_SCHED` is the default, so a `pthread_create` from
+ * `create_instance` / `set_param` / `render_block` produces a worker born at
+ * FIFO 90 — which starves Move's own `Link Main` (FIFO 35) for as long as it
+ * runs. A 2026-08 source audit put this at seven plugins.
+ *
+ * **You cannot identify such a thread by name.** A child inherits the parent's
+ * `comm`, so an inherited worker reports as "Audio Main/SPI" — indistinguishable
+ * from the real SPI thread in `top`, in a thread list, or to its own author.
+ * That invisibility is the whole reason the seven exist. tablor's worker ran
+ * unnamed for months and only surfaced because someone went looking at the
+ * per-thread `stat` files under /proc directly.
+ *
+ * So this does not match names. It watches the SET of realtime threads and
+ * reports what is NEW since the last look, alongside the module most recently
+ * loaded. An inherited thread cannot hide from that, whatever it calls itself.
+ *
+ * Everything here except `rt_thread_audit_scan` is pure — no I/O, no
+ * allocation, no locks — and is unit-tested on the dev host (see
+ * tests/host/test_rt_thread_audit.c). `rt_thread_audit_scan` reads /proc and
+ * is therefore WORKER-ONLY: never call it from an SPI callback.
+ */
+
+#ifndef RT_THREAD_AUDIT_H
+#define RT_THREAD_AUDIT_H
+
+/* Move runs a handful of threads and a loaded fleet adds more; 64 is well
+ * clear of both and bounds every loop here. A scan that fills the array
+ * reports it rather than silently truncating. */
+#define RT_AUDIT_MAX_THREADS 64
+
+/* /proc caps `comm` at 15 chars + NUL. */
+#define RT_AUDIT_COMM_LEN 16
+
+/* Linux scheduling policies, spelled out so the parser needs no headers and
+ * the tests need no Linux. */
+#define RT_AUDIT_SCHED_OTHER 0
+#define RT_AUDIT_SCHED_FIFO  1
+#define RT_AUDIT_SCHED_RR    2
+
+typedef struct {
+    int  tid;
+    int  policy;   /* RT_AUDIT_SCHED_* */
+    int  rtprio;   /* 0 for SCHED_OTHER; 1-99 for FIFO/RR */
+    int  cpu;      /* last CPU it ran on — core 3 is meant to be SPI's alone */
+    char comm[RT_AUDIT_COMM_LEN];
+} rt_thread_info_t;
+
+/* Parse one line of /proc/<pid>/task/<tid>/stat. Returns 1 on success, 0 if
+ * the line is malformed or truncated.
+ *
+ * The comm field is bracketed and may itself contain spaces and parentheses
+ * ("Audio Main/SPI" has a space; a name like "worker (2)" has both), so it is
+ * delimited by the LAST ')' rather than tokenised. Field numbers after it are
+ * 1-based as in proc(5): 39 processor, 40 rt_priority, 41 policy. */
+int rt_thread_parse_stat(const char *line, rt_thread_info_t *out);
+
+/* Is this thread realtime-scheduled (FIFO or RR at a nonzero priority)? */
+int rt_thread_is_realtime(const rt_thread_info_t *t);
+
+/* Threads present in `cur` but not in `prev` (matched by tid) AND realtime.
+ * Returns how many were written to `out`, capped at `out_max`.
+ *
+ * Deliberately NOT a name comparison — see the header comment. A tid is only
+ * reused after wraparound, which is far longer than the interval between two
+ * scans, so tid identity is sound here. */
+int rt_thread_new_realtime(const rt_thread_info_t *prev, int prev_n,
+                           const rt_thread_info_t *cur, int cur_n,
+                           rt_thread_info_t *out, int out_max);
+
+/* How many of these threads are realtime. */
+int rt_thread_count_realtime(const rt_thread_info_t *t, int n);
+
+/* Format one finding as a single log line. Writes at most `buf_len` bytes
+ * including the NUL and always terminates. `module` may be NULL. */
+int rt_thread_format(const rt_thread_info_t *t, const char *module,
+                     char *buf, int buf_len);
+
+/* Read /proc/self/task into `out`. Returns the number of threads written, or
+ * -1 if /proc could not be read. Fills at most `out_max`.
+ *
+ * FILE I/O — worker thread only, NEVER the SPI callback. */
+int rt_thread_audit_scan(rt_thread_info_t *out, int out_max);
+
+#endif /* RT_THREAD_AUDIT_H */

--- a/src/host/rt_thread_audit.h
+++ b/src/host/rt_thread_audit.h
@@ -46,7 +46,18 @@ typedef struct {
     int  rtprio;   /* 0 for SCHED_OTHER; 1-99 for FIFO/RR */
     int  cpu;      /* last CPU it ran on — core 3 is meant to be SPI's alone */
     char comm[RT_AUDIT_COMM_LEN];
+    /* CPU consumed, in kernel clock ticks (proc(5) fields 14 and 15). Raw
+     * ticks rather than ms so the parser stays pure — USER_HZ comes from
+     * sysconf at the call site. */
+    unsigned long utime;
+    unsigned long stime;
 } rt_thread_info_t;
+
+/* A thread and how much CPU it burned between two snapshots. */
+typedef struct {
+    rt_thread_info_t thread;
+    int cpu_ms;
+} rt_thread_burn_t;
 
 /* Parse one line of /proc/<pid>/task/<tid>/stat. Returns 1 on success, 0 if
  * the line is malformed or truncated.
@@ -72,6 +83,34 @@ int rt_thread_new_realtime(const rt_thread_info_t *prev, int prev_n,
 
 /* How many of these threads are realtime. */
 int rt_thread_count_realtime(const rt_thread_info_t *t, int n);
+
+/* Realtime threads that BURNED CPU between two snapshots, excluding anything
+ * present in `base`. Returns how many were written to `out`, most CPU first.
+ *
+ * This, not the headcount, is the number that matters. A thread merely
+ * EXISTING at FIFO 70 starves nobody — po32-drum's render worker and fork's
+ * I/O thread are parked on a condvar and cost nothing. The Link Audio dropouts
+ * need a thread that RUNS at 70 while Move's `Link Main` waits at 35, which is
+ * what a sample loader or a ROM boot does. Counting threads answers the wrong
+ * question; this answers the right one.
+ *
+ * `base` is the snapshot taken before any module was loaded, so Move's own
+ * permanently-busy audio threads are excluded and what remains is
+ * module-spawned. `hz` is sysconf(_SC_CLK_TCK). `min_ms` drops the noise
+ * floor — CPU time is accounted in whole clock ticks (10 ms at the usual
+ * USER_HZ 100), so a burst shorter than one tick is invisible here however
+ * badly timed it was.
+ *
+ * Pure: no I/O, no allocation, no locks. */
+int rt_thread_burners(const rt_thread_info_t *base, int base_n,
+                      const rt_thread_info_t *prev, int prev_n,
+                      const rt_thread_info_t *cur, int cur_n,
+                      int hz, int min_ms,
+                      rt_thread_burn_t *out, int out_max);
+
+/* Format one burn finding. Same contract as rt_thread_format. */
+int rt_thread_format_burn(const rt_thread_burn_t *b, const char *module,
+                          int window_ms, char *buf, int buf_len);
 
 /* Format one finding as a single log line. Writes at most `buf_len` bytes
  * including the NUL and always terminates. `module` may be NULL. */

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -14,6 +14,7 @@
 
 #include "shadow_chain_mgmt.h"
 #include "shadow_fx_key.h"    /* shadow_key_is_fx_module — header-only so tests/host can run it */
+#include "shim_worker.h"   /* SHIM_FLAG_RT_AUDIT, shim_rt_audit_note_module */
 #include "master_fx_key.h"    /* master_fx_route_* — header-only so tests/host can run it */
 #include "fx_midi_filter.h"   /* fx_midi_channel_accepts — header-only so tests/host can run it */
 #include "chain_permute.h"    /* insert/remove/move as an array permutation; shared with the chain DSP */
@@ -3352,10 +3353,30 @@ void shadow_inprocess_handle_param_request(void) {
             strncpy(value_copy, shadow_param->value, sizeof(value_copy) - 1);
             value_copy[sizeof(value_copy) - 1] = '\0';
 
+            /* A `<prefix>:module` write is where the chain host dlopens the
+             * sub-plugin and calls its create_instance — synchronously, right
+             * here, on the SPI callback. So it is also the only moment at
+             * which a thread the module spawns can be attributed to it by
+             * name. Name it for the RT-thread audit across the call and clear
+             * it after; costs a bounded strcmp per param write when the audit
+             * is disarmed, which is every normal session. */
+            int noted_module = (shim_debug_flags & SHIM_FLAG_RT_AUDIT) &&
+                               (strcmp(key_copy, "synth:module") == 0 ||
+                                shadow_key_is_fx_module(key_copy));
+            if (noted_module)
+                shim_rt_audit_note_module(value_copy[0] ? value_copy : "(unload)");
+
             shadow_plugin_v2->set_param(shadow_chain_slots[slot].instance,
                                         key_copy, value_copy);
             shadow_param->error = 0;
             shadow_param->result_len = 0;
+
+            /* Deliberately NOT cleared here. The audit runs on the worker at
+             * ~1 Hz, so a thread created during this call is seen up to a
+             * second later — clearing now would strip the attribution off
+             * every finding it is meant to carry. The next module load
+             * overwrites it, which is the correct lifetime. */
+            (void)noted_module;
 
             if (strcmp(key_copy, "synth:module") == 0) {
                 if (value_copy[0] != '\0') {

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -14,7 +14,7 @@
 
 #include "shadow_chain_mgmt.h"
 #include "shadow_fx_key.h"    /* shadow_key_is_fx_module — header-only so tests/host can run it */
-#include "shim_worker.h"   /* SHIM_FLAG_RT_AUDIT, shim_rt_audit_note_module */
+#include "shim_worker.h"   /* shim_rt_audit_note_module */
 #include "master_fx_key.h"    /* master_fx_route_* — header-only so tests/host can run it */
 #include "fx_midi_filter.h"   /* fx_midi_channel_accepts — header-only so tests/host can run it */
 #include "chain_permute.h"    /* insert/remove/move as an array permutation; shared with the chain DSP */
@@ -25,6 +25,21 @@
 #include "shadow_midi.h"
 #include "unified_log.h"
 #include "schwung_trace.h"   /* Phase 2b: emit param.serve as a child of the JS param.get span */
+
+
+/* Weak no-op for the RT-thread audit's module attribution.
+ *
+ * The shim worker owns the real one; its strong definition overrides this
+ * whenever it is in the link. This exists because the host tests compile
+ * shadow_chain_mgmt.c on its own, and a hard reference to a worker symbol made
+ * test_master_fx_cache_ownership fail to link — a diagnostic must not force
+ * every consumer of the chain manager to drag in the worker and its deps.
+ *
+ * A weak DECLARATION is the more obvious shape and is ELF-only: Darwin does
+ * not resolve an undefined weak symbol to null, so that version linked in CI
+ * and failed on the dev machine. A weak definition works on both.
+ */
+__attribute__((weak)) void shim_rt_audit_note_module(const char *id) { (void)id; }
 
 /* ============================================================================
  * Globals
@@ -3360,23 +3375,21 @@ void shadow_inprocess_handle_param_request(void) {
              * name. Name it for the RT-thread audit across the call and clear
              * it after; costs a bounded strcmp per param write when the audit
              * is disarmed, which is every normal session. */
-            int noted_module = (shim_debug_flags & SHIM_FLAG_RT_AUDIT) &&
-                               (strcmp(key_copy, "synth:module") == 0 ||
-                                shadow_key_is_fx_module(key_copy));
-            if (noted_module)
+            if (strcmp(key_copy, "synth:module") == 0 ||
+                shadow_key_is_fx_module(key_copy)) {
                 shim_rt_audit_note_module(value_copy[0] ? value_copy : "(unload)");
+            }
 
             shadow_plugin_v2->set_param(shadow_chain_slots[slot].instance,
                                         key_copy, value_copy);
             shadow_param->error = 0;
             shadow_param->result_len = 0;
 
-            /* Deliberately NOT cleared here. The audit runs on the worker at
-             * ~1 Hz, so a thread created during this call is seen up to a
-             * second later — clearing now would strip the attribution off
+            /* Deliberately NOT cleared after the write. The audit runs on the
+             * worker at ~1 Hz, so a thread created during this call is seen up
+             * to a second later — clearing now would strip the attribution off
              * every finding it is meant to carry. The next module load
              * overwrites it, which is the correct lifetime. */
-            (void)noted_module;
 
             if (strcmp(key_copy, "synth:module") == 0) {
                 if (value_copy[0] != '\0') {

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -135,6 +135,19 @@ static void rt_audit_tick(void)
     static rt_thread_info_t prev[RT_AUDIT_MAX_THREADS];
     static int prev_n = 0;
     static int have_baseline = 0;
+    /* The pre-module snapshot, kept separately from `prev`: Move's own audio
+     * threads are permanently busy at FIFO 70 and would otherwise be reported
+     * as burners on every single tick, burying the finding. */
+    static rt_thread_info_t base[RT_AUDIT_MAX_THREADS];
+    static int base_n = 0;
+    static long clk_hz = 0;
+
+    /* CPU accounting is in whole clock ticks (10 ms at the usual USER_HZ 100),
+     * so the floor cannot usefully go below one tick. 20 ms in a ~1 s window is
+     * 2% of a core — well under what starves `Link Main`, and high enough that
+     * an idle thread never trips it. */
+    const int RT_BURN_FLOOR_MS = 20;
+    const int RT_BURN_WINDOW_MS = 1000;   /* nominal; the tick is ~1 Hz */
 
     if (!(shim_debug_flags & SHIM_FLAG_RT_AUDIT)) {
         /* Disarmed: drop the baseline so re-arming starts clean rather than
@@ -201,6 +214,10 @@ static void rt_audit_tick(void)
 
         memcpy(prev, cur, sizeof(rt_thread_info_t) * (size_t)cur_n);
         prev_n = cur_n;
+        memcpy(base, cur, sizeof(rt_thread_info_t) * (size_t)cur_n);
+        base_n = cur_n;
+        clk_hz = sysconf(_SC_CLK_TCK);
+        if (clk_hz <= 0) clk_hz = 100;
         have_baseline = 1;
         return;
     }
@@ -214,6 +231,23 @@ static void rt_audit_tick(void)
                          rt_audit_module[0] ? rt_audit_module : NULL,
                          desc, sizeof(desc));
         snprintf(line, sizeof(line), "rt-audit: NEW realtime thread %s", desc);
+        unified_log("shim", LOG_LEVEL_WARN, line);
+    }
+
+    /* WHICH threads exist is the suspect list; how much CPU they BURN at
+     * realtime priority is the harm. `Link Main` runs at FIFO 35 and only gets
+     * what a FIFO 70 thread leaves it, so a parked worker costs nothing and a
+     * sample loader costs everything. Report the second. */
+    rt_thread_burn_t burn[RT_AUDIT_MAX_THREADS];
+    int bn = rt_thread_burners(base, base_n, prev, prev_n, cur, cur_n,
+                               (int)clk_hz, RT_BURN_FLOOR_MS,
+                               burn, RT_AUDIT_MAX_THREADS);
+    for (int i = 0; i < bn; i++) {
+        char desc[224];
+        rt_thread_format_burn(&burn[i],
+                              rt_audit_module[0] ? rt_audit_module : NULL,
+                              RT_BURN_WINDOW_MS, desc, sizeof(desc));
+        snprintf(line, sizeof(line), "rt-audit: %s", desc);
         unified_log("shim", LOG_LEVEL_WARN, line);
     }
 

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -10,8 +10,10 @@
 #include <pthread.h>
 #include <sched.h>
 #include <fcntl.h>
+#include <errno.h>
 
 #include "shim_worker.h"
+#include "rt_thread_audit.h"
 #include "shadow_set_pages.h"
 #include "unified_log.h"
 
@@ -95,7 +97,129 @@ static const flag_spec_t FLAGS[] = {
     { "/data/UserData/schwung/slot_fx_dump_trigger", SHIM_FLAG_SLOT_FX_DUMP, 1 },
     { "/data/UserData/schwung/align_dump_trigger",   SHIM_FLAG_ALIGN_DUMP,   1 },
     { "/data/UserData/schwung/main_fx_dump_trigger", SHIM_FLAG_MAIN_FX_DUMP, 1 },
+    { "/data/UserData/schwung/rt_thread_audit_on",   SHIM_FLAG_RT_AUDIT,     0 },
 };
+
+/* ---- realtime-thread audit ------------------------------------------- */
+
+/* Module entry points run on the SPI callback at SCHED_FIFO 90, and POSIX
+ * inherits scheduling by default — so a pthread_create from create_instance or
+ * set_param yields a worker born at FIFO 90 that starves Move's Link Main
+ * (FIFO 35). It also inherits the parent's `comm`, so it reports as
+ * "Audio Main/SPI" and is invisible in top or any thread list. See
+ * rt_thread_audit.h; the detector is a set diff over tids for that reason.
+ *
+ * Reading /proc is file I/O, which is why this lives on the worker and not in
+ * the callback. Off unless armed:
+ *     touch /data/UserData/schwung/rt_thread_audit_on
+ */
+
+static char rt_audit_module[64];
+static volatile int rt_audit_module_seq;
+
+void shim_rt_audit_note_module(const char *id)
+{
+    /* RT-safe: bounded copy, no allocation, no lock. */
+    if (!id || !id[0]) {
+        rt_audit_module[0] = '\0';
+    } else {
+        size_t n = strnlen(id, sizeof(rt_audit_module) - 1);
+        memcpy(rt_audit_module, id, n);
+        rt_audit_module[n] = '\0';
+    }
+    __sync_fetch_and_add(&rt_audit_module_seq, 1);
+}
+
+static void rt_audit_tick(void)
+{
+    static rt_thread_info_t prev[RT_AUDIT_MAX_THREADS];
+    static int prev_n = 0;
+    static int have_baseline = 0;
+
+    if (!(shim_debug_flags & SHIM_FLAG_RT_AUDIT)) {
+        /* Disarmed: drop the baseline so re-arming starts clean rather than
+         * diffing against a snapshot from minutes ago. */
+        have_baseline = 0;
+        prev_n = 0;
+        return;
+    }
+
+    /* Do not latch a baseline the log will not accept.
+     *
+     * The baseline is emitted ONCE and is the whole report for anything
+     * already loaded, so losing it loses the finding. unified_log only starts
+     * accepting after it notices debug_log_on, which it rechecks every 100
+     * calls — so arming both flags together, or leaving rt_thread_audit_on in
+     * place across a reboot, latched the baseline into a log that was still
+     * dropping writes. The audit then ran for twelve minutes reporting
+     * nothing, which is indistinguishable from a clean result. Wait for the
+     * log instead; the audit is a diagnostic and has nothing to do until
+     * someone can read it. */
+    if (!unified_log_enabled()) return;
+
+    rt_thread_info_t cur[RT_AUDIT_MAX_THREADS];
+    int cur_n = rt_thread_audit_scan(cur, RT_AUDIT_MAX_THREADS);
+
+    char line[256];
+
+    /* A scan that cannot read /proc must SAY so. Returning quietly here reads
+     * downstream as "armed, nothing realtime found" — a false all-clear, which
+     * is the one answer this tool must never give. */
+    if (cur_n < 0) {
+        static int moaned = 0;
+        if (!moaned) {
+            moaned = 1;
+            snprintf(line, sizeof(line),
+                     "rt-audit: armed but /proc/self/task is unreadable (errno=%d) — NO audit is running",
+                     errno);
+            unified_log("shim", LOG_LEVEL_ERROR, line);
+        }
+        return;
+    }
+
+    if (!have_baseline) {
+        /* Report the whole realtime set once. Arming mid-session cannot
+         * retroactively see a thread inherited at boot, so the baseline IS the
+         * finding for anything already loaded — printing only the diff would
+         * silently exonerate every module in the current set. */
+        snprintf(line, sizeof(line),
+                 "rt-audit: armed — %d thread(s), %d realtime (baseline)",
+                 cur_n, rt_thread_count_realtime(cur, cur_n));
+        unified_log("shim", LOG_LEVEL_INFO, line);
+
+        for (int i = 0; i < cur_n; i++) {
+            if (!rt_thread_is_realtime(&cur[i])) continue;
+            char desc[224];
+            rt_thread_format(&cur[i], NULL, desc, sizeof(desc));
+            snprintf(line, sizeof(line), "rt-audit: baseline %s", desc);
+            unified_log("shim", LOG_LEVEL_INFO, line);
+        }
+
+        if (cur_n >= RT_AUDIT_MAX_THREADS)
+            unified_log("shim", LOG_LEVEL_WARN,
+                        "rt-audit: thread table full — some threads not scanned");
+
+        memcpy(prev, cur, sizeof(rt_thread_info_t) * (size_t)cur_n);
+        prev_n = cur_n;
+        have_baseline = 1;
+        return;
+    }
+
+    rt_thread_info_t found[RT_AUDIT_MAX_THREADS];
+    int n = rt_thread_new_realtime(prev, prev_n, cur, cur_n,
+                                   found, RT_AUDIT_MAX_THREADS);
+    for (int i = 0; i < n; i++) {
+        char desc[224];
+        rt_thread_format(&found[i],
+                         rt_audit_module[0] ? rt_audit_module : NULL,
+                         desc, sizeof(desc));
+        snprintf(line, sizeof(line), "rt-audit: NEW realtime thread %s", desc);
+        unified_log("shim", LOG_LEVEL_WARN, line);
+    }
+
+    memcpy(prev, cur, sizeof(rt_thread_info_t) * (size_t)cur_n);
+    prev_n = cur_n;
+}
 
 /* Knob-touch ground truth — see the touch trace block in schwung_shim.c.
  * A plain int rather than a shim_debug_flags bit because the SPI callback
@@ -317,6 +441,7 @@ static void *worker_main(void *arg) {
         }
 
         if (tick % 5 == 0) poll_flags();          /* ~1 Hz */
+        if (tick % 5 == 0) rt_audit_tick();       /* ~1 Hz, no-op unless armed */
         if (tick % 7 == 0) shadow_poll_current_set(); /* ~1.4 s FS scan */
         tick++;
     }

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -23,6 +23,7 @@
 #define SHIM_FLAG_SPI_SNAP       (1u << 0)  /* spi_snap_trigger */
 #define SHIM_FLAG_XMOS_LOG       (1u << 1)  /* log_xmos_sysex_on */
 #define SHIM_FLAG_SPI_MIDI_LOG   (1u << 2)  /* spi_midi_log_on */
+#define SHIM_FLAG_RT_AUDIT       (1u << 3)  /* rt_thread_audit_on */
 
 /* One-shot flags: worker unlinks the trigger file and sets the bit; the
  * RT consumer clears it with shim_debug_flag_consume(). */
@@ -75,6 +76,15 @@ extern volatile int shim_usbc_out_replay;
 #define SHIM_EVT_OVERTAKE_DSP_FREE  10 /* destroy_instance + dlclose a retired overtake module */
 
 void shim_worker_post(uint8_t evt);
+
+/* Name the module currently being loaded, so the RT-thread audit can say WHICH
+ * module a newly-realtime thread appeared behind.
+ *
+ * Called from the SPI callback (module loading runs there), so it must stay
+ * RT-safe: a bounded copy into a static buffer, no allocation, no lock. A torn
+ * read at worst mislabels one log line, which is why the audit reports the
+ * name as context rather than as proof. Pass NULL when the load finishes. */
+void shim_rt_audit_note_module(const char *id);
 
 /* Hook table for events whose implementations live in schwung_shim.c /
  * shadow_sampler.c (worker can't see their statics). Registered once at

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -80,6 +80,15 @@ void shim_worker_post(uint8_t evt);
 /* Name the module currently being loaded, so the RT-thread audit can say WHICH
  * module a newly-realtime thread appeared behind.
  *
+ * shadow_chain_mgmt.c calls this, and the host tests compile that file on its
+ * own without the shim worker — a hard reference made
+ * test_master_fx_cache_ownership fail to link. It carries a WEAK no-op
+ * definition next to that call site, which this strong one overrides whenever
+ * the worker is in the link. A weak *declaration* would have been the obvious
+ * fix and only works on ELF: Darwin does not resolve an undefined weak symbol
+ * to null, so the local suite failed to link where CI passed. A weak
+ * definition works on both.
+ *
  * Called from the SPI callback (module loading runs there), so it must stay
  * RT-safe: a bounded copy into a static buffer, no allocation, no lock. A torn
  * read at worst mislabels one log line, which is why the audit reports the

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -18,6 +18,7 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_overtake_native_led_repaint \
 	$(BUILD_DIR)/test_shadow_midi_filter \
 	$(BUILD_DIR)/test_midi_in_compact \
+	$(BUILD_DIR)/test_rt_thread_audit \
 	$(BUILD_DIR)/test_master_fx_slot_routing
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
@@ -46,6 +47,9 @@ $(BUILD_DIR)/test_shadow_midi_filter: test_shadow_midi_filter.c ../../src/host/s
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_midi_in_compact: test_midi_in_compact.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/test_rt_thread_audit: test_rt_thread_audit.c ../../src/host/rt_thread_audit.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_master_fx_slot_routing: test_master_fx_slot_routing.c ../../src/host/master_fx_key.h ../../src/host/shadow_chain_mgmt.h | $(BUILD_DIR)

--- a/tests/host/test_rt_thread_audit.c
+++ b/tests/host/test_rt_thread_audit.c
@@ -1,0 +1,201 @@
+/* Unit test: detect threads that inherited the SPI callback's priority.
+ *
+ * The failure being detected is invisible by construction. A thread created
+ * from a module entry point inherits SCHED_FIFO 90 AND the parent's `comm`, so
+ * it reports as "Audio Main/SPI" and looks exactly like the real SPI thread in
+ * `top` or any thread listing. A name-based check would therefore pass while
+ * the bug is present, which is worse than no check at all.
+ *
+ * So the detector is a SET DIFF over tids, and these tests are written to fail
+ * if anyone ever reduces it to a name comparison.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "rt_thread_audit.h"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } \
+} while (0)
+
+/* Build a /proc stat line: fields 1-2 then filler up to 38, then
+ * processor / rt_priority / policy at 39 / 40 / 41. */
+static void make_stat(char *buf, int len, int tid, const char *comm,
+                      int cpu, int rtprio, int policy)
+{
+    int n = snprintf(buf, (size_t)len, "%d (%s) S 1 1 1 0 -1 4194560", tid, comm);
+    /* fields so far: 1 pid, 2 comm, 3 state, 4-9 = six more. Next is 10. */
+    for (int f = 10; f <= 38; f++)
+        n += snprintf(buf + n, (size_t)(len - n), " %d", f);
+    snprintf(buf + n, (size_t)(len - n), " %d %d %d 0 0 0", cpu, rtprio, policy);
+}
+
+static void test_parses_the_scheduling_fields(void)
+{
+    char line[1024];
+    rt_thread_info_t t;
+
+    make_stat(line, sizeof(line), 22339, "Audio Main/SPI", 3, 90, RT_AUDIT_SCHED_FIFO);
+    CHECK(rt_thread_parse_stat(line, &t), "a well-formed stat line parses");
+    CHECK(t.tid == 22339, "tid");
+    CHECK(t.policy == RT_AUDIT_SCHED_FIFO, "policy is field 41");
+    CHECK(t.rtprio == 90, "rt_priority is field 40");
+    CHECK(t.cpu == 3, "processor is field 39");
+    CHECK(strcmp(t.comm, "Audio Main/SPI") == 0, "comm survives its embedded space");
+    CHECK(rt_thread_is_realtime(&t), "FIFO 90 is realtime");
+}
+
+/* comm is bracketed and unescaped, so a name with a ')' in it will split a
+ * naive tokeniser and shift every field after it — silently reporting
+ * SCHED_OTHER for a thread that is actually FIFO. */
+static void test_comm_with_parens_does_not_shift_the_fields(void)
+{
+    char line[1024];
+    rt_thread_info_t t;
+
+    make_stat(line, sizeof(line), 41, "worker (2)", 1, 70, RT_AUDIT_SCHED_FIFO);
+    CHECK(rt_thread_parse_stat(line, &t), "a comm containing parens still parses");
+    CHECK(strcmp(t.comm, "worker (2)") == 0, "comm delimited by the LAST ')'");
+    CHECK(t.rtprio == 70 && t.policy == RT_AUDIT_SCHED_FIFO,
+          "fields after a parenthesised comm are not shifted");
+}
+
+/* A truncated line must not read as a clean SCHED_OTHER — a false all-clear is
+ * the one wrong answer here. */
+static void test_truncated_line_is_rejected(void)
+{
+    rt_thread_info_t t;
+    CHECK(!rt_thread_parse_stat("1234 (short) S 1 1 1", &t),
+          "a line that stops before field 41 must be REJECTED, not read as OTHER");
+    CHECK(!rt_thread_parse_stat("", &t), "an empty line is rejected");
+    CHECK(!rt_thread_parse_stat("nonsense", &t), "a line with no brackets is rejected");
+}
+
+static void test_only_nonzero_fifo_rr_counts_as_realtime(void)
+{
+    rt_thread_info_t t = { 0 };
+    t.policy = RT_AUDIT_SCHED_OTHER; t.rtprio = 0;
+    CHECK(!rt_thread_is_realtime(&t), "SCHED_OTHER is not realtime");
+    t.policy = RT_AUDIT_SCHED_FIFO; t.rtprio = 0;
+    CHECK(!rt_thread_is_realtime(&t), "FIFO at priority 0 is not realtime");
+    t.policy = RT_AUDIT_SCHED_RR; t.rtprio = 35;
+    CHECK(rt_thread_is_realtime(&t), "RR 35 is realtime");
+    t.policy = RT_AUDIT_SCHED_FIFO; t.rtprio = 90;
+    CHECK(rt_thread_is_realtime(&t), "FIFO 90 is realtime");
+}
+
+/* THE CASE. A module spawns a worker from create_instance; it is born FIFO 90
+ * and wearing its parent's name. Two threads now claim to be "Audio Main/SPI"
+ * and nothing about either one distinguishes it. Only the diff sees it. */
+static void test_an_inherited_thread_wearing_the_spi_name_is_caught(void)
+{
+    rt_thread_info_t before[2], after[3], found[8];
+
+    before[0] = (rt_thread_info_t){ .tid = 900, .policy = RT_AUDIT_SCHED_FIFO,
+                                    .rtprio = 90, .cpu = 3, .comm = "Audio Main/SPI" };
+    before[1] = (rt_thread_info_t){ .tid = 901, .policy = RT_AUDIT_SCHED_OTHER,
+                                    .rtprio = 0, .cpu = 0, .comm = "shim-worker" };
+
+    after[0] = before[0];
+    after[1] = before[1];
+    after[2] = (rt_thread_info_t){ .tid = 22339, .policy = RT_AUDIT_SCHED_FIFO,
+                                   .rtprio = 90, .cpu = 3, .comm = "Audio Main/SPI" };
+
+    int n = rt_thread_new_realtime(before, 2, after, 3, found, 8);
+    CHECK(n == 1, "exactly one new realtime thread");
+    CHECK(found[0].tid == 22339, "and it is the inherited one, found by tid not name");
+    CHECK(strcmp(found[0].comm, "Audio Main/SPI") == 0,
+          "which is indistinguishable from the SPI thread by name — the point of the diff");
+
+    /* The message has to say so, or the next reader dismisses it. */
+    char buf[256];
+    rt_thread_format(&found[0], "tablor", buf, sizeof(buf));
+    CHECK(strstr(buf, "tablor") != NULL, "the finding names the module that was loading");
+    CHECK(strstr(buf, "shared name") != NULL,
+          "and flags the name as shared rather than concluding anything from it");
+    CHECK(strstr(buf, "NOT the SPI thread") == NULL,
+          "it must NOT conclude a thread is inherited from its name — measurement "
+          "showed Move runs six of its own threads under exactly this name");
+}
+
+static void test_a_properly_spawned_worker_is_not_reported(void)
+{
+    rt_thread_info_t before[1], after[2], found[8];
+
+    before[0] = (rt_thread_info_t){ .tid = 900, .policy = RT_AUDIT_SCHED_FIFO,
+                                    .rtprio = 90, .cpu = 3, .comm = "Audio Main/SPI" };
+    after[0] = before[0];
+    /* What tablor now does: SCHED_OTHER on the attributes, and named. */
+    after[1] = (rt_thread_info_t){ .tid = 22400, .policy = RT_AUDIT_SCHED_OTHER,
+                                   .rtprio = 0, .cpu = 1, .comm = "tablor-wtload" };
+
+    CHECK(rt_thread_new_realtime(before, 1, after, 2, found, 8) == 0,
+          "a worker spawned SCHED_OTHER is not a finding");
+}
+
+/* A thread that exits and one that starts must not cancel out. */
+static void test_churn_does_not_mask_a_new_rt_thread(void)
+{
+    rt_thread_info_t before[2], after[2], found[8];
+
+    before[0] = (rt_thread_info_t){ .tid = 900, .policy = RT_AUDIT_SCHED_FIFO,
+                                    .rtprio = 90, .cpu = 3, .comm = "Audio Main/SPI" };
+    before[1] = (rt_thread_info_t){ .tid = 905, .policy = RT_AUDIT_SCHED_FIFO,
+                                    .rtprio = 70, .cpu = 2, .comm = "old-worker" };
+    after[0] = before[0];
+    after[1] = (rt_thread_info_t){ .tid = 906, .policy = RT_AUDIT_SCHED_FIFO,
+                                   .rtprio = 70, .cpu = 2, .comm = "old-worker" };
+
+    int n = rt_thread_new_realtime(before, 2, after, 2, found, 8);
+    CHECK(n == 1 && found[0].tid == 906,
+          "same count and same name, different tid — still a finding");
+}
+
+static void test_counting_and_bounds(void)
+{
+    rt_thread_info_t t[3] = {
+        { .tid = 1, .policy = RT_AUDIT_SCHED_FIFO,  .rtprio = 90 },
+        { .tid = 2, .policy = RT_AUDIT_SCHED_OTHER, .rtprio = 0  },
+        { .tid = 3, .policy = RT_AUDIT_SCHED_RR,    .rtprio = 35 },
+    };
+    CHECK(rt_thread_count_realtime(t, 3) == 2, "two of three are realtime");
+
+    rt_thread_info_t one[1];
+    rt_thread_info_t empty[1] = {{ .tid = 0 }};
+    CHECK(rt_thread_new_realtime(empty, 0, t, 3, one, 1) == 1,
+          "out_max is honoured rather than overrun");
+    CHECK(rt_thread_new_realtime(NULL, 0, t, 3, one, 1) == 1,
+          "a NULL previous snapshot means everything realtime is new");
+}
+
+static void test_format_never_overruns(void)
+{
+    rt_thread_info_t t = { .tid = 22339, .policy = RT_AUDIT_SCHED_FIFO,
+                           .rtprio = 90, .cpu = 3, .comm = "Audio Main/SPI" };
+    char tiny[8];
+    memset(tiny, 'X', sizeof(tiny));
+    int n = rt_thread_format(&t, "some-very-long-module-id", tiny, sizeof(tiny));
+    CHECK(n < (int)sizeof(tiny), "returns a length inside the buffer");
+    CHECK(tiny[sizeof(tiny) - 1] == '\0', "always NUL-terminates");
+}
+
+int main(void)
+{
+    test_parses_the_scheduling_fields();
+    test_comm_with_parens_does_not_shift_the_fields();
+    test_truncated_line_is_rejected();
+    test_only_nonzero_fifo_rr_counts_as_realtime();
+    test_an_inherited_thread_wearing_the_spi_name_is_caught();
+    test_a_properly_spawned_worker_is_not_reported();
+    test_churn_does_not_mask_a_new_rt_thread();
+    test_counting_and_bounds();
+    test_format_never_overruns();
+
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    printf("PASS: rt thread audit — an inherited FIFO thread is caught by tid, not by name\n");
+    return 0;
+}

--- a/tests/host/test_rt_thread_audit.c
+++ b/tests/host/test_rt_thread_audit.c
@@ -21,12 +21,27 @@ static int fails = 0;
 
 /* Build a /proc stat line: fields 1-2 then filler up to 38, then
  * processor / rt_priority / policy at 39 / 40 / 41. */
+static void make_stat_cpu(char *buf, int len, int tid, const char *comm,
+                          int cpu, int rtprio, int policy,
+                          unsigned long utime, unsigned long stime);
+
 static void make_stat(char *buf, int len, int tid, const char *comm,
                       int cpu, int rtprio, int policy)
 {
+    make_stat_cpu(buf, len, tid, comm, cpu, rtprio, policy, 0, 0);
+}
+
+/* Same, with utime/stime (proc(5) fields 14 and 15) placed exactly. */
+static void make_stat_cpu(char *buf, int len, int tid, const char *comm,
+                          int cpu, int rtprio, int policy,
+                          unsigned long utime, unsigned long stime)
+{
     int n = snprintf(buf, (size_t)len, "%d (%s) S 1 1 1 0 -1 4194560", tid, comm);
     /* fields so far: 1 pid, 2 comm, 3 state, 4-9 = six more. Next is 10. */
-    for (int f = 10; f <= 38; f++)
+    for (int f = 10; f <= 13; f++)
+        n += snprintf(buf + n, (size_t)(len - n), " %d", f);
+    n += snprintf(buf + n, (size_t)(len - n), " %lu %lu", utime, stime);
+    for (int f = 16; f <= 38; f++)
         n += snprintf(buf + n, (size_t)(len - n), " %d", f);
     snprintf(buf + n, (size_t)(len - n), " %d %d %d 0 0 0", cpu, rtprio, policy);
 }
@@ -180,6 +195,123 @@ static void test_format_never_overruns(void)
     CHECK(tiny[sizeof(tiny) - 1] == '\0', "always NUL-terminates");
 }
 
+
+/* ---- CPU burn: the number that actually maps onto the dropouts ---------- */
+
+static rt_thread_info_t mk(int tid, int prio, unsigned long ut, unsigned long st)
+{
+    rt_thread_info_t t = { 0 };
+    t.tid = tid; t.policy = RT_AUDIT_SCHED_FIFO; t.rtprio = prio;
+    t.utime = ut; t.stime = st;
+    snprintf(t.comm, sizeof(t.comm), "Audio Main/SPI");
+    return t;
+}
+
+static void test_utime_stime_are_parsed_from_fields_14_15(void)
+{
+    char line[1024];
+    rt_thread_info_t t;
+    make_stat_cpu(line, sizeof(line), 22339, "Audio Main/SPI", 3, 70,
+                  RT_AUDIT_SCHED_FIFO, 1234, 56);
+    CHECK(rt_thread_parse_stat(line, &t), "a line with CPU fields parses");
+    CHECK(t.utime == 1234, "utime is field 14");
+    CHECK(t.stime == 56, "stime is field 15");
+    CHECK(t.rtprio == 70 && t.cpu == 3,
+          "adding the CPU fields did not shift the scheduling fields");
+}
+
+/* A parked thread is NOT the finding. This is the whole point of measuring
+ * burn instead of counting threads: po32-drum's render worker and fork's I/O
+ * thread sit on a condvar at FIFO 70 and starve nobody. */
+static void test_a_parked_realtime_thread_is_not_a_burner(void)
+{
+    rt_thread_info_t base[1] = { mk(900, 90, 0, 0) };
+    rt_thread_info_t prev[2] = { mk(900, 90, 100, 0), mk(1000, 70, 5, 0) };
+    rt_thread_info_t cur[2]  = { mk(900, 90, 200, 0), mk(1000, 70, 5, 0) };
+    rt_thread_burn_t out[8];
+
+    CHECK(rt_thread_burners(base, 1, prev, 2, cur, 2, 100, 20, out, 8) == 0,
+          "a module thread that consumed no CPU is not reported");
+}
+
+static void test_a_busy_module_thread_is_reported_with_its_ms(void)
+{
+    rt_thread_info_t base[1] = { mk(900, 90, 0, 0) };
+    rt_thread_info_t prev[2] = { mk(900, 90, 100, 0), mk(1000, 70, 0, 0) };
+    /* 18 ticks user + 4 system at 100 Hz = 220 ms. */
+    rt_thread_info_t cur[2]  = { mk(900, 90, 200, 0), mk(1000, 70, 18, 4) };
+    rt_thread_burn_t out[8];
+
+    int n = rt_thread_burners(base, 1, prev, 2, cur, 2, 100, 20, out, 8);
+    CHECK(n == 1, "the busy module thread is reported");
+    CHECK(out[0].thread.tid == 1000, "and it is the right one");
+    CHECK(out[0].cpu_ms == 220, "220 ms from 22 ticks at 100 Hz");
+
+    char buf[256];
+    rt_thread_format_burn(&out[0], "sfz", 1000, buf, sizeof(buf));
+    CHECK(strstr(buf, "BURNED 220 ms") != NULL, "the message states the cost");
+    CHECK(strstr(buf, "22%") != NULL, "and it as a share of the window");
+    CHECK(strstr(buf, "sfz") != NULL, "and names the module");
+}
+
+/* Move's own audio threads are permanently busy at FIFO 70. If they were not
+ * excluded they would drown every real finding on every tick. */
+static void test_moves_own_threads_are_excluded_by_the_baseline(void)
+{
+    rt_thread_info_t base[2] = { mk(900, 90, 0, 0), mk(976, 70, 0, 0) };
+    rt_thread_info_t prev[2] = { mk(900, 90, 100, 0), mk(976, 70, 500, 0) };
+    rt_thread_info_t cur[2]  = { mk(900, 90, 300, 0), mk(976, 70, 900, 0) };
+    rt_thread_burn_t out[8];
+
+    CHECK(rt_thread_burners(base, 2, prev, 2, cur, 2, 100, 20, out, 8) == 0,
+          "threads present before any module loaded are the environment");
+}
+
+/* A thread that appears AND does its damage inside one sample window must not
+ * be missed for having no previous reading. */
+static void test_a_brand_new_thread_counts_its_whole_lifetime(void)
+{
+    rt_thread_info_t base[1] = { mk(900, 90, 0, 0) };
+    rt_thread_info_t prev[1] = { mk(900, 90, 100, 0) };
+    rt_thread_info_t cur[2]  = { mk(900, 90, 200, 0), mk(1100, 70, 21, 0) };
+    rt_thread_burn_t out[8];
+
+    int n = rt_thread_burners(base, 1, prev, 1, cur, 2, 100, 20, out, 8);
+    CHECK(n == 1 && out[0].cpu_ms == 210,
+          "a thread absent from prev is measured from zero, not skipped");
+}
+
+static void test_burners_are_ordered_worst_first_and_bounded(void)
+{
+    rt_thread_info_t base[1] = { mk(900, 90, 0, 0) };
+    rt_thread_info_t prev[4] = { mk(900,90,0,0), mk(1,70,0,0), mk(2,70,0,0), mk(3,70,0,0) };
+    rt_thread_info_t cur[4]  = { mk(900,90,0,0), mk(1,70,5,0), mk(2,70,50,0), mk(3,70,20,0) };
+    rt_thread_burn_t out[8];
+
+    int n = rt_thread_burners(base, 1, prev, 4, cur, 4, 100, 20, out, 8);
+    CHECK(n == 3, "three burners over the floor");
+    CHECK(out[0].thread.tid == 2 && out[1].thread.tid == 3 && out[2].thread.tid == 1,
+          "ordered worst first");
+
+    rt_thread_burn_t one[1];
+    CHECK(rt_thread_burners(base, 1, prev, 4, cur, 4, 100, 20, one, 1) >= 1,
+          "out_max is honoured");
+    CHECK(one[0].thread.tid == 2, "and the ONE kept is the worst, not the first seen");
+}
+
+/* Counters only go up. A tid reused by a new thread reads as a huge negative
+ * delta; guessing at it would invent a finding. */
+static void test_tid_reuse_is_not_guessed_at(void)
+{
+    rt_thread_info_t base[1] = { mk(900, 90, 0, 0) };
+    rt_thread_info_t prev[2] = { mk(900,90,0,0), mk(1000, 70, 5000, 0) };
+    rt_thread_info_t cur[2]  = { mk(900,90,0,0), mk(1000, 70, 3, 0) };
+    rt_thread_burn_t out[8];
+
+    CHECK(rt_thread_burners(base, 1, prev, 2, cur, 2, 100, 20, out, 8) == 0,
+          "a counter that went backwards is dropped, not reported");
+}
+
 int main(void)
 {
     test_parses_the_scheduling_fields();
@@ -191,6 +323,13 @@ int main(void)
     test_churn_does_not_mask_a_new_rt_thread();
     test_counting_and_bounds();
     test_format_never_overruns();
+    test_utime_stime_are_parsed_from_fields_14_15();
+    test_a_parked_realtime_thread_is_not_a_burner();
+    test_a_busy_module_thread_is_reported_with_its_ms();
+    test_moves_own_threads_are_excluded_by_the_baseline();
+    test_a_brand_new_thread_counts_its_whole_lifetime();
+    test_burners_are_ordered_worst_first_and_bounded();
+    test_tid_reuse_is_not_guessed_at();
 
     if (fails) {
         fprintf(stderr, "%d check(s) failed\n", fails);


### PR DESCRIPTION
Diagnostic only, **off unless armed**. Groundwork for the Link Audio dropouts.

## Why

`Link Main` runs at SCHED_FIFO **35**; Schwung's DSP runs at **70**. The
2026-08-19 bisect: stock = 0 stalls, Schwung + empty slots = 0 stalls, Schwung
+ modules = a stall every 4–40 s. Module entry points ARE the SPI callback and
POSIX inherits scheduling by default, so a `pthread_create` from
`create_instance` yields a worker at the callback's priority.

A source audit put that at seven modules. **The estimate did not survive
measurement** — tablor was its headline case and had already moved the call,
already shed the priority, and its actual defect (an unnamed thread wearing the
parent's `comm`) was not in the estimate at all.

## The detector cannot be a name check

A child inherits the parent's `comm`, so an inherited worker reports as
`Audio Main/SPI` — indistinguishable from the real SPI thread in `top`, in a
thread list, or to its own author. That invisibility is *why* these exist. So
it diffs the SET of realtime threads by **tid**. The test fails if anyone
reduces it to a name comparison; verified by mutating it to one.

Reading `/proc` is file I/O, so it runs on the shim worker, never the callback.

## Existence is not the harm

`Link Main` gets only the CPU a FIFO 70 thread leaves it, so what starves it is
a thread that **runs**. po32-drum's render worker and fork's I/O thread park on
a condvar — they cost nothing, and on a headcount they'd sit near the top of a
suspect list forever. So the second commit reports **CPU burned at realtime
priority**, worst first, excluding everything present before the first module
loaded (Move's own audio threads are permanently busy at 70 and would bury
every real finding).

## Measured

Baseline, no modules: 23 threads, 11 realtime. `Link Main` at 35 sharing a core
with an `Audio Worker` at 70 — the starvation relationship, visible.

Fleet sweep, 96 modules: 10 realtime threads across 6 modules, **each
cross-checked against source**:

| Module | Threads | Source |
|---|---|---|
| **sfz** | 5 × FIFO 70 | sfizz's global `FilePool` `ThreadPool` ✅ |
| **osirus** | 1 × FIFO 70 | `pthread_create(&inst->boot_thread, nullptr, …)` ✅ |
| **minijv** | 1 × FIFO 45 | `emu_thread` / `load_thread`, `NULL` attrs ✅ |
| **po32-drum** | 1 × FIFO 70 | `render_thread`, `NULL` attrs, in `create_instance` ✅ |
| **fork** | 1 × FIFO 70 | `io_thread`, `NULL` attrs, in `create_instance` ✅ |
| **breakbeat** | 1 × FIFO 70 | **none — zero threading primitives in the repo** ❌ |

Five confirmed, and not the same five as the estimate. **breakbeat is the audit
being wrong**: the sweep ran 96 modules in 90 s against a 1 Hz sample, so
attribution is a lead, never a verdict.

## Three things measurement corrected, which is the point of running it

- **The tool must not conclude anything from a name.** v1 appended
  "name inherited — NOT the SPI thread" on a name match. Move runs SIX threads
  under that name as its own. That was the exact reasoning the tool exists to
  avoid, and it was wrong.
- **A baseline the log will not accept is a silent false all-clear.**
  `unified_log` starts writing only once it notices `debug_log_on`, rechecked
  every 100 calls; arming both flags together latched the baseline into a log
  still dropping writes, and the audit ran twelve minutes reporting nothing.
  It now waits for the log before latching.
- **A `/proc` read failure says so** rather than returning quietly.

## Also

**CLAUDE.md said the SPI callback runs at FIFO 90**, three lines above saying
the shim runs in MoveOriginal's FIFO 70 threads. Nothing in the process is
above 70. Corrected, with the measured thread table.

## Not done, and stated in the commits

**No hardware burn number.** The measurement is unit-tested and
mutation-checked but has never produced a device figure — three attempts
failed on harness issues (`debugLog` out of scope under the trigger's
`new Function` eval; `contractDumpDone` latching per process). Written up with
the rest in `docs/plans/2026-08-22-rt-thread-audit-findings.md`, along with the
sizing for moving loading off the SPI thread: it fixes sfz and osirus, not
minijv (FIFO 45 is set, not inherited), and its real cost is that thread-safety
is currently free because everything is single-threaded.

## Tests

`tests/host/test_rt_thread_audit.c` — field parsing against a real device stat
line, a comm containing parens not shifting the fields, a truncated line
rejected rather than read as SCHED_OTHER, the inherited-name case, parked
threads not reported, Move's own threads excluded, a brand-new thread measured
from zero, worst-first ordering under a bound, and tid reuse dropped rather
than guessed at. Two mutations verified to fail it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DTqGxpq8bxa8JR7UXTAjjG