### PR TITLE
catalog: give tapedelay back its engine, re-list Tape Echo 2

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -148,13 +148,24 @@
     },
     {
       "id": "tapedelay",
-      "name": "Tape Echo 2",
-      "description": "Component-modeled vintage three-head tape echo with spring reverb: 12 head/reverb modes, in-loop tape saturation, wow & flutter, tape age, and tempo sync with the reference machine's leading-head note tables.",
-      "author": "Tape Echo 2 by Dusk Audio (GPL-3.0) · port: athousanddetails, charlesvestal",
+      "name": "TapeDelay",
+      "description": "Tape delay with flutter and tone shaping. Light on CPU — fits on every slot.",
+      "author": "cyrusasfa (port: charlesvestal)",
       "component_type": "audio_fx",
       "github_repo": "charlesvestal/schwung-space-delay",
       "default_branch": "main",
       "asset_name": "tapedelay-module.tar.gz",
+      "min_host_version": "0.3.0"
+    },
+    {
+      "id": "tape-echo2",
+      "name": "Tape Echo 2",
+      "description": "Component-modeled vintage three-head tape echo with spring reverb: 12 head/reverb modes, in-loop tape saturation, wow & flutter, tape age, and tempo sync with the reference machine's leading-head note tables. CPU-heavy: about two instances fit.",
+      "author": "Tape Echo 2 by Dusk Audio (GPL-3.0) · port: athousanddetails",
+      "component_type": "audio_fx",
+      "github_repo": "athousanddetails/schwung-tape-echo2",
+      "default_branch": "main",
+      "asset_name": "tape-echo2-module.tar.gz",
       "min_host_version": "0.7.13"
     },
     {


### PR DESCRIPTION
Reverses yesterday's fold. `tapedelay` goes back to the light engine; Tape Echo 2 returns as its own entry.

## Why — measured on the device

| | spacecho | Tape Echo 2 |
|---|---|---|
| per block | 0.013 ms | 0.37 ms |
| % of the ~900 µs DSP budget | 1.4% | **41%** |
| instances that fit | dozens | **2** |

`tapedelay` is a utility delay — people put it on several slots and expect it to disappear into the background. An id that quietly became **28× heavier** is a promise broken, whatever the sound is worth. It's worth a lot, which is why Tape Echo 2 returns as its own entry rather than going away.

The CPU cost is now stated in Tape Echo 2's description, so nobody discovers it the way we did.

**Note the budget.** A loadtest naturally prints against the 2.902 ms block period, which is three times too generous — the SPI callback has ~900 µs left after the transfer, covering all four slots, master FX and mixing. That's how a 41% module read as 14% for a day.

## Migration

- v1.3.3–v1.3.5 have **22 downloads** between them, several of them mine. v0.4.3 has **1995**.
- The old engine **ignores** a Tape Echo 2 state blob (verified against both binaries), so an upgraded slot comes back at defaults rather than corrupted. Those users lose their TE2 settings and nothing else.
- schwung-space-delay published **v2.0.0**, not 0.4.4: the store compares versions, so anything lower would never reach the people who took the update.

`min_host_version` for `tapedelay` returns to 0.3.0 — the light engine needs nothing recent.

Upstream: https://github.com/charlesvestal/schwung-space-delay/releases/tag/v2.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtmMXS3SjqZivqrht7Vgy3