### PR TITLE
remote UI: size a custom UI iframe to its content, not to 60vh

### DIFF
--- a/schwung-manager/static/remote-ui.css
+++ b/schwung-manager/static/remote-ui.css
@@ -617,6 +617,10 @@
     display: block;
     width: 100%;
     min-height: 400px;
+    /* Starting guess only. The embedded page reports its real height via
+     * postMessage (schwung-remote-api.js) and this is overwritten inline —
+     * a panel taller than 60vh used to be cropped with no way to scroll to
+     * the rest of it, because the iframe body does not scroll the parent. */
     height: 60vh;
     border: none;
     background: var(--bg);

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -2171,6 +2171,17 @@
         if (!msg || !msg.type) return;
 
         switch (msg.type) {
+            case "height":
+                // The panel measured itself, so stop guessing at 60vh. Clamped
+                // both ways: a module that mis-measures should look wrong, not
+                // produce a 40000px frame or collapse to a sliver.
+                var hf = customUIFrames[srcComp];
+                var h = Number(msg.height);
+                if (hf && hf.iframe && isFinite(h) && h > 0) {
+                    hf.iframe.style.height =
+                        Math.min(Math.max(Math.round(h), 200), 4000) + "px";
+                }
+                break;
             case "getParam":
                 handleIframeGetParam(msg, srcComp);
                 break;

--- a/schwung-manager/static/schwung-remote-api.js
+++ b/schwung-manager/static/schwung-remote-api.js
@@ -64,6 +64,34 @@
             });
         }
 
+        // Tell the parent how tall this page actually is, so the iframe can be
+        // sized to its content instead of to a guess. Every embedded module
+        // gets this without opting in — the alternative is each module posting
+        // its own height, which means the ones that never do stay cropped.
+        //
+        // documentElement.scrollHeight, not body's: the body may be shorter
+        // than a floated/absolutely-positioned child, and cropping is exactly
+        // what we are fixing. Rounded up, because a fractional height the
+        // parent floors reintroduces a 1px scrollbar, which changes the width,
+        // which can change the height — a loop that never settles.
+        var lastHeight = 0;
+        function reportHeight() {
+            var h = Math.ceil(document.documentElement.scrollHeight);
+            if (!h || Math.abs(h - lastHeight) < 2) return;
+            lastHeight = h;
+            window.parent.postMessage({ type: "height", height: h }, "*");
+        }
+        if (typeof ResizeObserver === "function") {
+            new ResizeObserver(reportHeight).observe(document.documentElement);
+        } else {
+            window.addEventListener("resize", reportHeight);
+        }
+        window.addEventListener("load", reportHeight);
+        /* Fonts and late layout land after load; a few cheap re-checks cost
+         * nothing and save a permanently short frame. */
+        setTimeout(reportHeight, 100);
+        setTimeout(reportHeight, 600);
+
         window.schwungRemote = {
             /** Chain component this page drives ("synth", "fx1", …). */
             component: component,


### PR DESCRIPTION
Follow-on to #253. With FX panels finally reachable, the next thing you hit is that they are the wrong height.

`.custom-ui-iframe` is `height: 60vh` and there is **no resize protocol anywhere in the manager** — no `scrollHeight` read, no `postMessage` height handler. Every module's custom UI has always been squeezed into 60% of the viewport whatever its natural height, and the overflow is unreachable: an iframe body scrolls itself, not the parent, so there is nothing to scroll to the rest of it with.

`schwung-remote-api.js` now reports `documentElement.scrollHeight` on load and on every `ResizeObserver` tick; `remote-ui.js` sets the iframe height from it.

Notes on the choices:

- **In the shim, not per module.** Every embedded panel gets it without opting in. An opt-in version leaves every existing module exactly as cropped as it is today.
- **`documentElement`, not `body`** — a body shorter than a floated or absolutely positioned child is the case that gets cropped.
- **Rounded up**, because a fractional height the parent floors brings back a 1px scrollbar, which changes the width, which can change the height.
- **Clamped 200–4000px** in the parent, so a module that mis-measures looks wrong rather than producing a 40000px frame.
- `60vh` stays as the pre-measurement guess and `min-height: 400px` still holds, so nothing regresses if a panel never reports.

Found while validating Tape Echo 2's panel on hardware, which was cropped both ways — the horizontal half was the module's own CSS and is fixed in its repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UnGSyzZkzLo6WELtWzfrer