### PR TITLE
catalog: add 6W6 (TR-606 style drum machine, athousanddetails/schwung-6W6)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1268,6 +1268,17 @@
       "min_host_version": "0.12.1"
     },
     {
+      "id": "6w6",
+      "name": "6W6",
+      "description": "TR-606 style drum machine. Every voice synthesized, no samples: kick, snare, low and hi tom, closed and open hat, cymbal, plus a clap. Fitted against recordings of a hardware 606 \u2014 the cymbal and the hi-hat metal bank are measured partial tables, and the default pot positions are the machine. Switchable hat choke (off / closed cuts open / mutual), per-voice and master drive/distortion, pad editor, remote web panel that follows the pad you hit, Movy template.",
+      "author": "athousanddetails; voices after 606-Inspired-Synth-Drums (Matthew Fecher / AudioKit Pro)",
+      "component_type": "sound_generator",
+      "github_repo": "athousanddetails/schwung-6W6",
+      "default_branch": "main",
+      "asset_name": "6w6-module.tar.gz",
+      "min_host_version": "0.12.1"
+    },
+    {
       "id": "tablor",
       "name": "Tablor",
       "description": "2-osc wavetable synth. Position morphing, bend, formant shift and 4-voice unison; sub and noise; multimode filter with its own ADSR; 2 envelopes, 2 LFOs, 4-slot mod matrix and 8 assignable macros. 8 voices poly or mono with glide. Unlimited shareable .tblr presets, 115 seeded wavetables, and Serum/Vital/Ableton tables via Move Manager. Web panel with a live display of the loaded wavetable.",


### PR DESCRIPTION
Adds [6W6](https://github.com/athousanddetails/schwung-6W6), a TR-606 style drum machine, as a `sound_generator`. Placed next to 9W9; the entry is additive, 11 lines, nothing else in the file changes.

Every voice is synthesized — no samples. Kick, snare, low and hi tom, closed and open hat, cymbal, and a clap. The 606 roster is all there, including the cymbal, which the upstream DSP the voices come from does not ship: it is a third `HiHatSpec` on the same metal source, which is how the hardware does it too.

The voices are fitted rather than tuned by ear. Partial tables for the cymbal and the hi-hat metal bank were measured from recordings of a hardware 606 (FFTs through the decay, keeping the lines that survive it), and the default pot positions come from a grid search of each voice against its matching hardware hit. Scored against seven hardware recordings on 1/3-octave spectrum, decay envelope and within-band crest, the kit averages 9.36 where the same measurement of an already-shipping, accepted fit scores 10.85.

Features: switchable hat choke (off / closed cuts open / mutual — the 606 hardwires the middle one), drive and a distortion type on every voice and on the master, accent on velocity, per-lane mutes, a pad editor over the stock `param_pages` grid, a remote web panel that follows the pad you hit, and a Movy template.

**CPU:** 24–25% of the block budget with the whole kit retriggering at maximum density; a normal pattern is well under that. The metal voices and the clap were profiled and optimised on the device — the hat/cymbal oscillator bank and the clap colour bank both got rewritten against measurements, the clap bit-identically.

**Verified:** the release artifact itself — not a local build — was downloaded from the public release, installed on a Move, and passed a 61-check on-device test that dlopens `dsp.so` exactly as the chain host does (every pad sounds on both note maps, pots change the audio, the choke, mutes, state round-trip, the sequencer). Requires host 0.12.1.

**Licence:** GPL-3.0. The voices are [606-Inspired-Synth-Drums](https://github.com/analogcode/606-Inspired-Synth-Drums) by Matthew Fecher / AudioKit Pro (MIT), vendored unmodified; provenance is spelled out in the repo's `THIRD_PARTY.md`.