### PR TITLE
catalog: rename SFZ Player entry to Multisampler

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -35,7 +35,7 @@
     },
     {
       "id": "sfz",
-      "name": "SFZ Player",
+      "name": "Multisampler",
       "description": "SFZ and DecentSampler (.dspreset) sample player using sfizz engine",
       "author": "sfizz by sfztools (port: charlesvestal)",
       "component_type": "sound_generator",


### PR DESCRIPTION
## Summary
- Renames the `sfz` module's catalog `name` from "SFZ Player" to "Multisampler", matching the on-device name already declared in schwung-sfz's `module.json`.

## Test plan
- [x] Diff reviewed — single-field rename, no other changes