### PR TITLE
param pages: a string cell's keyboard returns to the grid it was opened from

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2218,8 +2218,26 @@ function openHierarchyParamEditor(selectedKey, meta, forceOpen) {
                 refreshHierarchyVisibility();
                 announceParameter(meta.name || selectedKey, String(nextText || ""));
                 needsRedraw = true;
+                /*
+                 * Come back to the KNOB PAGE if that is where the click came
+                 * from -- the same promise the enum picker keeps with
+                 * returnToGrid, and the same one Back already keeps from here.
+                 *
+                 * A string cell has no editor of its own, so opening one exits
+                 * the grid into the list editor and edits the row there. That
+                 * is an implementation detail the user never asked for: naming
+                 * a preset from a Save cell left them sitting in a list of
+                 * rows, on a page they did not navigate to, with the grid they
+                 * were working on gone.
+                 */
+                if (paramEditorOpenedFromGrid) returnToParamPagesFromEditor();
             },
-            onCancel: () => { needsRedraw = true; }
+            onCancel: () => {
+                needsRedraw = true;
+                /* Cancel returns the same way: backing out of the keyboard
+                 * should undo the hand-off, not complete it. */
+                if (paramEditorOpenedFromGrid) returnToParamPagesFromEditor();
+            }
         });
         return;
     }


### PR DESCRIPTION
## What

Committing (or cancelling) the on-screen keyboard for a `string` param opened from a knob page now returns to that knob page.

## Why

A string param has no editor of its own, so `openParamEditorFromGrid` exits the grid, enters the hierarchy editor and opens the row there. That's an implementation detail, and every other divable thing already hides it:

- the enum picker passes `returnToGrid: true`
- the LFO target picker sets `lfoTargetFromGrid` and `returnToSlotGridFromLfoTarget()`
- **Back** from the editor already calls `returnToParamPagesFromEditor()`

The keyboard's `onConfirm` / `onCancel` were the two paths that didn't. So the user typed a name, confirmed, and landed in a list of rows on a level they never navigated to, with the page they were working on gone.

Found on a module whose preset page has a **Save** cell: naming a preset dropped the user off the page that has the Save cell on it.

## How

Both callbacks call the existing `returnToParamPagesFromEditor()` when `paramEditorOpenedFromGrid` is set — no new machinery. Cancel returns too, since backing out of the keyboard should undo the hand-off rather than complete it.

`closeTextEntry()` only clears its own state and never touches views, so switching view from inside the callback is safe.

## Testing

- `tests/host/test_param_access.sh` passes
- Full pre-commit suite (host unit + contract, go) passes
- Installed on a Move and exercised via a module with a `string` cell on a knob page: confirm and cancel both land back on the page, with the cell still there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
