### PR TITLE
catalog: add 4K EQ

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1311,6 +1311,17 @@
       "default_branch": "main",
       "asset_name": "capicola-module.tar.gz",
       "min_host_version": "0.3.0"
+    },
+    {
+      "id": "4k-eq",
+      "name": "4K EQ",
+      "description": "British console EQ for the master bus: four calibrated bands, stepped high- and low-pass filters, and the Brown and Black circuit revisions with their own control laws and band interactions. About 6.6% of one core at the 2x default.",
+      "author": "4K EQ 2 by Dusk Audio (GPL-3.0) \u00b7 port: athousanddetails",
+      "component_type": "audio_fx",
+      "github_repo": "athousanddetails/schwung-4keq",
+      "default_branch": "main",
+      "asset_name": "4k-eq-module.tar.gz",
+      "min_host_version": "0.12.1"
     }
   ]
 }


### PR DESCRIPTION
Adds **4K EQ** to `module-catalog.json` — a British console EQ for the master bus.

Four calibrated bands (LF / LMF / HMF / HF), stepped high- and low-pass filters whose dials carry their own OUT position, and the Brown and Black circuit revisions with their own control laws and band interactions. One page per band on the device, plus a preset browser for the fourteen factory programs.

**DSP:** [4K EQ 2](https://github.com/dusk-audio/dusk-audio-plugins) by Dusk Audio (GPL-3.0), vendored unmodified. The module is the Move shell around it; the build byte-compares every vendored file against upstream, and the parameter surface is 1:1 with the plugin’s own table.

**Repo:** https://github.com/athousanddetails/schwung-4keq · release [v1.0.0](https://github.com/athousanddetails/schwung-4keq/releases/tag/v1.0.0)

**Validated on hardware from the release tarball**, not a local build — installed the Actions-built artifact on a Move, rebooted, and confirmed the running build fingerprint matches the released one. 110 on-device checks pass, including that every control changes the audio, bypass is byte-identical to input, state round-trips, and all fifteen programs recall.

**CPU** (Move, 44.1 kHz, 128-frame blocks, stereo, % of one core):

| | flat | all bands + filters |
|---|---|---|
| 1x | 2.0% | 3.0% |
| **2x (default)** | 4.7% | **6.6%** |
| 4x | 7.6% | 11.0% |

The console nonlinearity is always on and is included in every figure. `min_host_version` is 0.12.1 — the module uses the stock 0.12 knob pages, declared `viz` graphics and a preset-browser level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)