### PR TITLE
fix(shadow): the keyboard outranks the knob grid it is drawn over

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -19733,7 +19733,15 @@ globalThis.onMidiMessageInternal = function(data) {
      * records: it is what keeps a fourth modal-raising setting from being
      * silently unanswerable. Left the overlay up with the grid eating every
      * button and there is no press that can clear it. */
-    if (view === VIEWS.PARAM_PAGES && paramPagesActive()) {
+    /* The KEYBOARD outranks the page for the same reason, and the early-out is
+     * what makes it need saying: the text-entry handler is ~100 lines below,
+     * so the grid would otherwise be offered the event first. That was safe
+     * only while no keyboard could be raised over PARAM_PAGES. User Presets is
+     * now a trailing page INSIDE the grid and enterPresetSaveAs opens the
+     * keyboard without calling setView, so `view` is still PARAM_PAGES — the
+     * jog paged the grid drawn UNDERNEATH the keyboard while pad typing kept
+     * working, because decodeInput claims CC 14 but returns null for pads. */
+    if (view === VIEWS.PARAM_PAGES && paramPagesActive() && !isTextEntryActive()) {
         if (maybeDismissWarningFromInput(status, d1, d2)) { needsRedraw = true; return; }
         if (handleParamPagesMidi(data)) { needsRedraw = true; return; }
     }

--- a/tests/host/test_text_entry_outranks_grid.sh
+++ b/tests/host/test_text_entry_outranks_grid.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# The keyboard is drawn ON TOP of the knob grid, so it must be FED first.
+#
+# `onMidiMessageInternal` gives the knob grid an early-out before any of the
+# per-view switches, and the text-entry handler sits ~100 lines below it. That
+# ordering was safe only for as long as no keyboard could be raised while
+# PARAM_PAGES was the live view. User Presets became a trailing page INSIDE the
+# grid, and `enterPresetSaveAs` opens the keyboard without calling setView --
+# so `view` stays PARAM_PAGES and the grid ate the jog while the keyboard was
+# on screen: pad typing worked, the jog paged the menu underneath.
+#
+# The asymmetry is the whole tell, and it is why this looked like a keyboard
+# bug rather than a dispatch-order bug: `decodeInput` returns null for pad
+# notes (they fall through to text entry) but decodes CC 14 as navigation (it
+# does not). Both halves are pinned below -- a future decodeInput that starts
+# claiming pads would break pad typing the same way, silently.
+
+if ! command -v node >/dev/null 2>&1; then echo "FAIL: node required" >&2; exit 1; fi
+
+node -e '
+const fs = require("fs");
+let failures = 0;
+const fail = (m) => { console.error("FAIL: " + m); failures++; };
+const ok = (m) => { console.error("ok: " + m); };
+
+/* ---- 1. dispatch order: nothing routes to the grid while typing --------- */
+
+const ui = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+const start = ui.indexOf("globalThis.onMidiMessageInternal = function(data)");
+if (start < 0) {
+  fail("could not find onMidiMessageInternal in shadow_ui.js");
+} else {
+  /* Bound the search at the next top-level globalThis assignment so a match
+     from a later handler cannot stand in for one in this one. */
+  let end = ui.indexOf("\nglobalThis.", start + 1);
+  if (end < 0) end = ui.length;
+  const body = ui.slice(start, end);
+
+  const gridCall = body.indexOf("handleParamPagesMidi(");
+  if (gridCall < 0) {
+    fail("onMidiMessageInternal no longer routes to handleParamPagesMidi");
+  } else {
+    /* The guard must be reachable BEFORE the grid gets the event. Either
+       spelling counts: a condition on the grid block itself, or a text-entry
+       early-out hoisted above it. */
+    const guard = body.slice(0, gridCall).indexOf("isTextEntryActive()");
+    if (guard >= 0) {
+      ok("text entry is consulted before the knob grid is offered the event");
+    } else {
+      fail("the knob grid gets MIDI before isTextEntryActive() is checked -- " +
+           "the jog will page the grid underneath an open keyboard");
+    }
+  }
+}
+
+/* ---- 2. the asymmetry that made this look like a keyboard bug ----------- */
+
+const { pathToFileURL } = require("url");
+const url = pathToFileURL(process.cwd() + "/src/shared/param_pages/page_input.mjs");
+
+import(url).then(({ decodeInput }) => {
+  const mods = { shift: false, mute: false };
+
+  const jog = decodeInput([0xb0, 14, 1], mods);
+  if (jog) ok("the grid DOES claim jog turns (CC 14) -- so it must be gated");
+  else fail("decodeInput no longer claims CC 14; this test pins the wrong key");
+
+  for (const note of [68, 84, 99]) {
+    const pad = decodeInput([0x90, note, 100], mods);
+    if (pad === null) ok("the grid does not claim pad note " + note);
+    else fail("decodeInput now claims pad note " + note + " (" + JSON.stringify(pad) +
+              ") -- pad typing over the grid would break the same way the jog did");
+  }
+}).then(() => process.exit(failures ? 1 : 0),
+        (e) => { fail("could not load page_input.mjs: " + e); process.exit(1); });
+'


### PR DESCRIPTION
The jog stopped working during pad typing and scrolled a menu underneath the keyboard instead.

## Root cause

`onMidiMessageInternal` gives the knob grid an early-out ahead of every per-view switch (`shadow_ui.js:19736`), and the text-entry handler sits ~100 lines below it (`:19836`). That ordering was safe only while no keyboard could be raised over `PARAM_PAGES`.

#283 made User Presets a trailing page **inside** the grid, and `enterPresetSaveAs` opens the keyboard **without calling `setView`** — unlike its sibling `enterPresetDeleteConfirm`, which does. So `view` is still `PARAM_PAGES`, the grid claims the jog first, and the keyboard drawn on top never sees it. The "menu underneath" is literally the grid: `drawTextEntry()` paints over it at `:19682`, so both are on screen and only one is being driven.

Pad typing kept working, which is what made this read as a keyboard bug rather than a dispatch-order one: `decodeInput` (`page_input.mjs:79`) returns `null` for notes 68–99 so pads fall through to text entry, but it decodes CC 14 as navigation and consumes it.

## Fix

One condition:

```js
if (view === VIEWS.PARAM_PAGES && paramPagesActive() && !isTextEntryActive()) {
```

Gated on the block rather than by hoisting the text-entry check to the top of the handler: the feedback-gate and canvas-steal blocks already sit between the two, and moving the keyboard above a safety modal is a precedence change this bug does not ask for.

Side benefit — knob CCs 71–78 no longer edit params behind an open keyboard.

## Test

`tests/host/test_text_entry_outranks_grid.sh` pins both halves:

- the **order invariant** — text entry must be consulted before the grid is offered the event. Red before the fix, green after.
- the **`decodeInput` asymmetry** — CC 14 is claimed, pad notes 68/84/99 are not. Asserted separately so a future change that starts claiming pad notes breaks pad typing loudly instead of silently.

## Verification

- `make -C tests/host test` — all green
- 122/154 `tests/host/*.sh` pass; the 32 failures are the known local `rg`-is-a-shell-function artifact (`rg: command not found`), none in shadow-UI or param-pages
- Deployed to hardware and confirmed by @charlesvestal: the jog drives the keyboard, pad typing unaffected

## Note

`enterPresetSaveAs` is still the only modal entry point that does not move `view`. Left alone — the dispatch guard is the correct fix and covers any future keyboard raised over the grid — but making the two preset entry points symmetrical would be a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JPxyotCW9K1MtfLgbB4Fv