### PR TITLE
overtake: add shadow_set_overtake_suppress_master_volume(flag)

### DIFF
--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -52,7 +52,7 @@
  * MIDI_OUT must be bounded by this to avoid corrupting the display. */
 #define HW_MIDI_OUT_SIZE    80
 #define DISPLAY_BUFFER_SIZE 1024  /* 128x64 @ 1bpp = 1024 bytes */
-#define CONTROL_BUFFER_SIZE 84  /* corun masks widened to uint32 + flags byte (cede-default model); static-asserted below */
+#define CONTROL_BUFFER_SIZE 84  /* overtake_suppress_master_volume added into existing trailing pad byte; static-asserted below */
 #define SHADOW_UI_BUFFER_SIZE     512
 #define SHADOW_PARAM_BUFFER_SIZE  65664  /* Large buffer for complex ui_hierarchy */
 #define SHADOW_MIDI_OUT_BUFFER_SIZE 512  /* MIDI out buffer from shadow UI (128 packets) */
@@ -209,6 +209,17 @@ typedef struct shadow_control_t {
      * Set by JS on leaving the grid; the shim consumes it and clears it, so it
      * is an edge and not a state. */
     volatile uint8_t restore_knob_leds;
+    /* 1 = suppress CC 79 (master volume) and the master-touch note (8) from
+     * their hardcoded overtake passthrough to Move firmware, and from the
+     * plain-volume-touch OLED handoff in shadow_swap_display(). Both of
+     * those exemptions exist unconditionally today so Move can show its
+     * native volume overlay; a tool with its own per-track volume gesture
+     * (movy: hold a track button + turn master volume) sets this for the
+     * duration of that gesture so Move is excluded entirely instead of
+     * quietly tracking the turn on its own copy of the value. Opt-in per
+     * tool (shadow_set_overtake_suppress_master_volume); default 0 leaves
+     * the existing passthrough unchanged. */
+    volatile uint8_t overtake_suppress_master_volume;
 } shadow_control_t;
 
 /* Co-run control-surface groups. A co-running overtake tool declares which

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -3264,6 +3264,7 @@ static void init_shadow_shm(void)
         shadow_control->selected_slot    = 0;
         shadow_control->skip_led_clear   = 0;
         shadow_control->overtake_suppress_sysex = 0;
+        shadow_control->overtake_suppress_master_volume = 0;
         shadow_control->overtake_fx_end_of_chain = 0;
         shadow_control->corun.target = CORUN_TARGET_NONE;  /* co-run inactive at boot */
         shadow_control->corun.id = -1;
@@ -3629,7 +3630,8 @@ static void shadow_swap_display(void)
     if (!shadow_volume_knob_touched) {
         shadow_block_plain_volume_hide_until_release = 0;
     }
-    if (shadow_volume_knob_touched && !shadow_shift_held) {
+    if (shadow_volume_knob_touched && !shadow_shift_held &&
+        !shadow_control->overtake_suppress_master_volume) {
         if (shadow_block_plain_volume_hide_until_release) {
             /* Keep shadow UI visible until shortcut's volume touch is fully released. */
             if (display_hidden_for_volume) {
@@ -6542,6 +6544,12 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
         /* Run overtake exit hook if it exists (modules install their own cleanup).
          * Skip if suspend_overtake is set — JACK keeps running. */
         if (prev_overtake_mode != 0 && overtake_mode == 0) {
+            /* Belt-and-braces: a stuck suppression permanently breaks the
+             * master volume knob for every module loaded after this one
+             * (unlike overtake_suppress_sysex's equivalent stuck state,
+             * which only affects LEDs). Clear it unconditionally on exit
+             * rather than relying solely on the tool's own endDivert(). */
+            if (shadow_control) shadow_control->overtake_suppress_master_volume = 0;
             if (shadow_control && shadow_control->suspend_overtake) {
                 shadow_control->suspend_overtake = 0;  /* consumed */
                 /* Freeze sysex cache so RNBO's init batch on resume
@@ -6623,13 +6631,19 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                  * - mode 1 (menu): allow only volume touch/turn passthrough */
                 if (overtake_mode == 2) {
                     if (status >= 0x80) filter = 1;
-                    /* Let volume knob CC and touch through so Move shows volume overlay */
-                    if (cin == 0x0B && type == 0xB0 && d1 == CC_MASTER_KNOB) {
+                    /* Let volume knob CC and touch through so Move shows volume overlay
+                     * — unless a tool has claimed the gesture for itself (movy:
+                     * hold a track button + turn master volume) and asked to
+                     * suppress it via overtake_suppress_master_volume, in which
+                     * case this behaves like any other cable-0 event. */
+                    if (cin == 0x0B && type == 0xB0 && d1 == CC_MASTER_KNOB &&
+                        !shadow_control->overtake_suppress_master_volume) {
                         filter = 0;
                     }
                     if ((cin == 0x09 || cin == 0x08) &&
                         (type == 0x90 || type == 0x80) &&
-                        d1 == 8) {
+                        d1 == 8 &&
+                        !shadow_control->overtake_suppress_master_volume) {
                         filter = 0;
                     }
                     /* Per-CC passthrough list (from the module's
@@ -6663,12 +6677,14 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                     }
                 } else if (overtake_mode == 1) {
                     filter = 1;
-                    if (cin == 0x0B && type == 0xB0 && d1 == CC_MASTER_KNOB) {
+                    if (cin == 0x0B && type == 0xB0 && d1 == CC_MASTER_KNOB &&
+                        !shadow_control->overtake_suppress_master_volume) {
                         filter = 0;
                     }
                     if ((cin == 0x09 || cin == 0x08) &&
                         (type == 0x90 || type == 0x80) &&
-                        d1 == 8) {
+                        d1 == 8 &&
+                        !shadow_control->overtake_suppress_master_volume) {
                         filter = 0;
                     }
                     /* Same per-CC passthrough list applies at mode 1 (tool

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -618,6 +618,20 @@ static JSValue js_shadow_set_overtake_suppress_sysex(JSContext *ctx, JSValueCons
     return JS_UNDEFINED;
 }
 
+/* shadow_set_overtake_suppress_master_volume(flag) -> void
+ * Opt a full-overtake tool into suppressing CC 79 / master-touch note 8's
+ * hardcoded passthrough to Move firmware (and the matching OLED handoff in
+ * shadow_swap_display()) for the duration the tool sets. Set/cleared around
+ * the tool's own volume gesture; cleared automatically on shim init. */
+static JSValue js_shadow_set_overtake_suppress_master_volume(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (!shadow_control || argc < 1) return JS_UNDEFINED;
+    int32_t flag = 0;
+    JS_ToInt32(ctx, &flag, argv[0]);
+    shadow_control->overtake_suppress_master_volume = flag ? 1 : 0;
+    return JS_UNDEFINED;
+}
+
 /* host_mute_move_audio(flag) -> void
  * Mute/unmute Move's audio output. Used for silent clip switching. */
 static JSValue js_host_mute_move_audio(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
@@ -2818,6 +2832,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_skip_led_clear", JS_NewCFunction(ctx, js_shadow_set_skip_led_clear, "shadow_set_skip_led_clear", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_restore_knob_leds", JS_NewCFunction(ctx, js_shadow_restore_knob_leds, "shadow_restore_knob_leds", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_overtake_suppress_sysex", JS_NewCFunction(ctx, js_shadow_set_overtake_suppress_sysex, "shadow_set_overtake_suppress_sysex", 1));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_set_overtake_suppress_master_volume", JS_NewCFunction(ctx, js_shadow_set_overtake_suppress_master_volume, "shadow_set_overtake_suppress_master_volume", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_overtake_fx_end_of_chain", JS_NewCFunction(ctx, js_shadow_set_overtake_fx_end_of_chain, "shadow_set_overtake_fx_end_of_chain", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_set_suspend_overtake", JS_NewCFunction(ctx, js_shadow_set_suspend_overtake, "shadow_set_suspend_overtake", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_suspend_overtake", JS_NewCFunction(ctx, js_shadow_get_suspend_overtake, "shadow_get_suspend_overtake", 0));


### PR DESCRIPTION
## What

Adds `shadow_set_overtake_suppress_master_volume(flag)`, a new dynamic control-surface flag mirroring the existing `overtake_suppress_sysex`. When set, it excludes Move firmware entirely from CC 79 (master volume) and the master-touch note (8) for as long as the flag is on, instead of the two exemptions in the overtake input filter that today *always* let those two through (so Move can show its native volume overlay). It also gates the matching plain-volume-touch OLED handoff in `shadow_swap_display()` — both guards are needed together; either alone doesn't reproduce the intended effect (see the field's doc comment in `shadow_constants.h`).

Default off, so every other tool (davebox, etc.) is unaffected. Reset on shim init, and — belt-and-braces, unlike `overtake_suppress_sysex`'s equivalent — also on overtake exit, since a stuck flag here permanently breaks the master volume knob for every module loaded afterward rather than just an LED cache.

## Why

Built for [movy](https://github.com/DimaDake/schwung-movy)'s "hold a track button + turn master volume" per-track-volume gesture. Today it has to work around the lack of this flag by injecting a synthetic track-hold into Move's own firmware so Move's turn lands on the wrong target instead of master, and can only draw its own overlay while Shift is held (Move otherwise takes the OLED for the duration of the touch — see the design writeup: [`movy/plans/2026-08-24-track-volume-unification.md`](https://github.com/DimaDake/schwung-movy/blob/main/plans/2026-08-24-track-volume-unification.md)). With this flag, movy excludes Move outright and its overlay always shows, no Shift required.

## Testing

- `tests/host` (CI-gated suite): unchanged, all green.
- Device-verified end to end against movy: `shadow_set_overtake_suppress_master_volume` is called (confirmed via a `path=` tag movy logs), zero MIDI_IN injection occurs on this path, the dB-ladder gesture applies correctly, and the overlay renders with no Shift held (screen-grab confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)