### PR TITLE
overtake: power button reaches Move's own shutdown prompt

### DIFF
--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -6604,6 +6604,11 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
          * immediately behind it at +248; at the 256 bound the last iteration
          * read that word as a 32nd event and, whenever it looked like a
          * filtered control, ZEROED it. */
+        /* Power-button SysEx run-length: set when the lookahead below matches
+         * the message's first packet, decremented as its remaining 3 packets
+         * are walked. Function-local and re-zeroed every call (one SPI frame
+         * each), so it only ever spans packets within a single frame. */
+        int power_sysex_remaining = 0;
         for (int j = 0; j < SHADOW_MIDI_IN_BYTES; j += 8) {
             uint8_t cin = hw_midi[j] & 0x0F;
             uint8_t cable = (hw_midi[j] >> 4) & 0x0F;
@@ -6611,6 +6616,34 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
             uint8_t type = status & 0xF0;
             uint8_t d1 = hw_midi[j + 2];
             uint8_t d2 = hw_midi[j + 3];
+
+            /* Power button: F0 00 21 1D 01 01 3A <id> <val> 00 F7, four USB-MIDI
+             * packets (cin 0x4, 0x4, 0x4, 0x6). Unlike every other overtake
+             * button, this one is not a routable CC/note (docs/CORUN.md) — it
+             * only shows up as this SysEx, and the mode-2/mode-1 "status>=0x80"
+             * suppression below zeroes its lead packet (0xF0 counts as a
+             * status byte here) same as it would any other cable-0 SysEx,
+             * corrupting the one message Move's own shutdown-prompt flow needs
+             * intact. The id byte at offset 17 varies (observed 0x2A on a tap,
+             * 0x3A on a ~1.5-2s hold); match on the fixed header + subcommand
+             * only. Lookahead, not a stateful match at the subcommand packet,
+             * because a corrective *retroactive* un-filter of already-written
+             * sh_midi slots would need to special-case every filter site
+             * above instead of the one line below. */
+            int power_sysex_hit = 0;
+            if (power_sysex_remaining > 0) {
+                power_sysex_remaining--;
+                power_sysex_hit = 1;
+            } else if (cable == 0x00 && cin == 0x04 &&
+                       status == 0xF0 && d1 == 0x00 && d2 == 0x21 &&
+                       j + 24 < SHADOW_MIDI_IN_BYTES &&
+                       (hw_midi[j + 8] & 0x0F) == 0x04 &&
+                       hw_midi[j + 9] == 0x1D && hw_midi[j + 10] == 0x01 && hw_midi[j + 11] == 0x01 &&
+                       (hw_midi[j + 16] & 0x0F) == 0x04 && hw_midi[j + 17] == 0x3A &&
+                       (hw_midi[j + 24] & 0x0F) == 0x06) {
+                power_sysex_hit = 1;
+                power_sysex_remaining = 3;
+            }
 
             int filter = 0;
 
@@ -6716,6 +6749,10 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                     }
                 }
             }
+
+            /* Let the power-button SysEx through intact regardless of which
+             * overtake-mode branch above ran — see the lookahead comment. */
+            if (power_sysex_hit) filter = 0;
 
             if (filter) {
                 /* Zero the packet dword in the shadow buffer (slot becomes
@@ -7711,6 +7748,16 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                 if (cin < 0x08 || cin > 0x0E) continue;
                 if (cable != 0x00) continue;  /* Only internal cable 0 (Move hardware) */
             }
+            /* Cable 14 ("system") carries internal signaling — e.g. the power
+             * button's CC, whose value on a long hold (0x3A = 58) happens to
+             * collide with Move's own Loop-button CC number. It was never
+             * meant to reach a module's regular MIDI dispatch as an ordinary
+             * button press (movy's onMidiMessageInternal receives [status,
+             * d1, d2] with no cable byte to tell the two apart, per
+             * docs/MODULES.md's module contract), so it never should have.
+             * Confirmed on-device: a power-button hold entered movy's Loop
+             * mode via this path. */
+            if (cable == 0x0E) continue;
 
             uint8_t status = src[j + 1];
             uint8_t type = status & 0xF0;


### PR DESCRIPTION
## What

Two related fixes to the overtake MIDI filter, found while investigating why the power button does nothing while an overtake module (e.g. movy) is open:

1. **The power button's SysEx now survives the overtake filter.** The mode-1/mode-2 filter's blanket `status >= 0x80 → suppress` rule (there to block Move's own button CCs) also zeroes the lead packet of *every* cable-0 SysEx in full overtake — including the power button's `F0 00 21 1D 01 01 3A <id> <val> 00 F7`, identified on-device via the existing `spi_midi_log_on` raw-capture facility. A small lookahead at the message's first packet exempts all four of its USB-MIDI packets when the fixed header + subcommand match (the `<id>` byte varies between presses — observed `0x2A` on a tap, `0x3A` on a hold — and is intentionally not matched on).

2. **Cable 14 ("system") is now excluded from the overtake module MIDI-dispatch loop.** The power button also emits a matching CC on cable 14, which was being forwarded to the loaded module's regular MIDI dispatch with no cable check. Its value on some presses (`0x3A` = 58) collides with Move's own Loop-button CC number — so a power press was entering a loaded module's Loop mode. Cable 14 was never meant to reach a module as an ordinary button press; a module's MIDI contract (`[status, d1, d2]`) has no cable byte to tell it apart from a real CC.

## Why

Move's own shutdown-confirm handler (`shadow_dbus_handle_text()`, `shadow_dbus.c`) only fires off the D-Bus screen-reader announcement of "Press wheel to shut down" — which requires Move to have actually rendered that prompt. With the SysEx corrupted, Move never got a complete message and never showed it, so the handler's trigger never occurred. Full investigation (including why the SysEx even matters, once traced through `shim_post_transfer`'s `hw`→`shadow` buffer copy) is in movy's plan doc: [`movy/plans/2026-08-24-power-off-dialog.md`](https://github.com/DimaDake/schwung-movy/blob/main/plans/2026-08-24-power-off-dialog.md).

## Testing

- `tests/host` (CI-gated suite): unchanged, all green.
- Device-verified: Move's real "Press wheel to shut down" prompt now appears; Back dismisses it safely with no accidental shutdown; the Loop-mode false-trigger from cable 14 is gone.

## Known follow-up (not fixed here)

The overtake module isn't automatically restored to the foreground after Back dismisses the prompt — the user has to reselect it from Move's Tools menu — and its pad LEDs don't recover until the next interaction. Two auto-resume approaches were tried and reverted as ineffective (schwung's own `overtake_mode` clearing on this path fires non-deterministically for the same physical gesture, which defeated both attempts at detecting "the prompt is gone"). Full writeup of what was tried and what to investigate next is in the same plan doc, "Two more attempts made and reverted" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)