### PR TITLE
Fix overtake DSP MIDI injection into Move

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ Display: `host_flush_display`, `host_set_refresh_rate(hz)`, `host_get_refresh_ra
 
 Filesystem: `host_file_exists`, `host_read_file`, `host_write_file`, `host_http_download`, `host_extract_tar(_strip)`, `host_ensure_dir`, `host_remove_dir`.
 
-Tool lifecycle: `host_exit_module()`. MIDI injection: `move_midi_inject_to_move([type, status, d1, d2])`. Sampler: `host_sampler_start(path)`, `host_sampler_stop()`, `host_sampler_is_recording()`.
+Tool lifecycle: `host_exit_module()`. MIDI injection: `move_midi_inject_to_move([type, status, d1, d2])`. Overtake DSP `midi_inject_to_move` uses its own bounded queue so native Move output remains active without consuming the takeover test bus; UIs can detect this with `shadow_overtake_move_inject_active()`. Sampler: `host_sampler_start(path)`, `host_sampler_stop()`, `host_sampler_is_recording()`.
 
 CC 79 is the host volume knob by default. Modules can claim it via `capabilities.claims_master_knob: true`.
 

--- a/docs/ADDRESSING_MOVE_SYNTHS.md
+++ b/docs/ADDRESSING_MOVE_SYNTHS.md
@@ -141,6 +141,13 @@ internal prefix protocol (pads 68–99, steps 16–31, track CCs 40–43 —
 see `docs/SPI_PROTOCOL.md`) — injecting pitched notes there won't reach
 track instruments.
 
+Overtake DSPs use a dedicated bounded queue for this callback. It drains
+directly into Move's MIDI input while the takeover is active. The shared JS
+injection queue remains owned by the takeover test-bus publisher during that
+time, so DSP output cannot loop back into its own `on_midi` input. A tool UI
+can check for `shadow_overtake_move_inject_active()` when it needs to support
+older hosts where this separation is not available.
+
 ### 4. Timing from `render_block`
 
 `render_block` fires every 128-sample audio block (~2.9 ms at 44.1
@@ -276,5 +283,9 @@ Silent drains + no sound usually means either:
 - **`midi_inject_to_move` is NULL** — the host wasn't a shadow-mode
   Schwung host (check your test environment) or the overtake
   `host_api` wasn't wired for injection (fixed for all overtake DSPs
-  as of `3e307a66`; but custom host setups may need to wire
-  `shadow_chain_midi_inject` themselves).
+  as of `3e307a66`; current hosts wire overtake DSPs to
+  `shadow_overtake_midi_send`).
+- **Works only after leaving the takeover** — Schwung 0.12.0 and 0.12.1
+  diverted the shared inject queue to the takeover publisher. Upgrade to a
+  host exposing `shadow_overtake_move_inject_active()` so DSP output uses the
+  dedicated Move queue.

--- a/docs/API.md
+++ b/docs/API.md
@@ -261,6 +261,7 @@ shadow_load_ui_module(path)
 shadow_log(msg)
 shadow_control_restart()
 shadow_inbound_pad_midi_active()              // -> bool: host delivers Move's internal pad MIDI to the overtake DSP's on_midi hook
+shadow_overtake_move_inject_active()           // -> bool: overtake DSP midi_inject_to_move reaches Move while the takeover is active
 shadow_overtake_send_external_async_active()  // -> bool: overtake DSP's midi_send_external uses the audio-thread-safe async ring
 
 // Global setting bindings (shadow_ui only)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -242,6 +242,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_led_queue.c src/host/shadow_state.c \
     src/host/shadow_xmos_audio.c src/host/shadow_xmos_audio.h \
     src/host/shadow_midi.c src/host/shadow_midi_filter.c src/host/shadow_midi_filter.h \
+    src/host/shadow_overtake_midi.c src/host/shadow_overtake_midi.h \
     src/host/unified_log.c src/host/shim_worker.c \
     src/host/rt_thread_audit.c src/host/rt_thread_audit.h \
     src/host/shadow_shm_util.c src/host/schwung_trace.c src/host/shadow_test_stream.c src/host/shadow_test_stream.h \
@@ -276,6 +277,7 @@ if needs_rebuild build/schwung-shim.so \
         src/host/shadow_xmos_audio.c \
         src/host/shadow_midi.c \
         src/host/shadow_midi_filter.c \
+        src/host/shadow_overtake_midi.c \
         src/host/unified_log.c \
         src/host/shim_worker.c \
         src/host/rt_thread_audit.c \

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -531,6 +531,9 @@ typedef struct shadow_midi_dsp_t {
  *   - Shim:    schwung_shim.c overtake-entry "shift off"
  *   - Shim:    schwung_shim.c overtake-exit 4× CC release
  *   - Shim:    shadow_midi.c:shadow_chain_midi_inject (cable-2 forwarder)
+ * Overtake DSP midi_inject_to_move is intentionally separate; see
+ * shadow_overtake_midi.c. While overtake is active this shared queue has a
+ * different single consumer: the takeover test-bus publisher.
  *
  * Consumer (single, in shim's SPI thread, ~344 Hz):
  *   - shadow_midi.c:shadow_drain_midi_inject

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -7,6 +7,7 @@
 #include "shadow_midi.h"
 #include "shadow_midi_filter.h"   /* SHADOW_MIDI_IN_* geometry */
 #include "shadow_midi_inject_writer.h"
+#include "shadow_overtake_midi.h"
 #include "shadow_chain_mgmt.h"
 #include "shadow_led_queue.h"
 #include "shadow_overlay.h"  /* MIDI channel indicator globals */
@@ -197,6 +198,7 @@ void midi_routing_init(const midi_host_t *host)
     host_slot_fx_idle = host->slot_fx_idle;
     host_slot_fx_silence_frames = host->slot_fx_silence_frames;
 
+    shadow_overtake_midi_init();
     shadow_chain_transpose_reset();
 }
 
@@ -574,13 +576,16 @@ static void shadow_deliver_pending_to_move(uint8_t *midi_in, int stride, int max
     if (host_log) host_log("MIDI inject: delivered shim packet to Move MIDI_IN");
 }
 
-/* Drain MIDI inject buffer into Move's MIDI_IN (post-ioctl).
- * Copies USB-MIDI packets from SHM into empty slots in shadow_mailbox+MIDI_IN_OFFSET,
- * making Move process them as if they came from physical hardware.
- * Rate-limited to 16 packets per tick to avoid flooding. */
+/* Drain MIDI inject buffers into Move's MIDI_IN (post-ioctl).
+ * Active overtake DSP output uses a dedicated in-process ring so it can reach
+ * Move while the shared SHM ring is owned by the overtake test-bus publisher.
+ * Outside overtake, the dedicated ring drains first and the shared ring uses
+ * the remaining mailbox capacity. At most 31 packets fit in one frame. */
 void shadow_drain_midi_inject(void)
 {
     shadow_midi_inject_t *inject_shm = *host_shadow_midi_inject_shm;
+    shadow_control_t *sc = host_shadow_control ? *host_shadow_control : NULL;
+    int overtake_active = sc ? (int)sc->overtake_mode != 0 : 0;
     /* MIDI_IN events are 8 bytes each (4 USB-MIDI + 4 timestamp). Scanning
      * at 4-byte stride would land mid-event and corrupt Move's parse (Move
      * terminates the scan at the first zero slot, so any gap loses all
@@ -594,25 +599,6 @@ void shadow_drain_midi_inject(void)
      * the ring below belongs to someone else. */
     shadow_deliver_pending_to_move(host_shadow_mailbox + MIDI_IN_OFFSET,
                                    MIDI_IN_EVT_STRIDE, MIDI_IN_MAX_BYTES);
-
-    if (!inject_shm) return;
-
-    /* In OVERTAKE mode the queue belongs to the overtake publisher in
-     * schwung_shim.c, not to us.
-     *
-     * The two consumers are mutually exclusive by necessity: this ring is
-     * documented single-consumer, and popping from both would corrupt it. The
-     * split is also what makes injection reach an overtake module at all —
-     * this function writes into Move's MAILBOX MIDI_IN, which Move's firmware
-     * reads, while an overtake module is fed from the raw HARDWARE buffer. An
-     * injected packet written here could therefore never reach the module, and
-     * with the firmware suppressed during overtake it had nowhere useful to go
-     * either. Measured on device 2026-07-29: injected pads moved neither a
-     * parameter nor any of the 32 pad LEDs. */
-    {
-        shadow_control_t *sc = host_shadow_control ? *host_shadow_control : NULL;
-        if (sc && sc->overtake_mode != 0) return;
-    }
 
     /* Hold the inject drain for a few frames after an overtake module exits
      * (Back-to-suspend or full exit) before draining anything into Move's
@@ -636,7 +622,6 @@ void shadow_drain_midi_inject(void)
         static int prev_overtake_for_hold = 0;
         static int exit_hold_frames = 0;
         const int OVERTAKE_EXIT_HOLD_FRAMES = 3;  /* 2 also verified clean; 1 not */
-        shadow_control_t *sc = host_shadow_control ? *host_shadow_control : NULL;
         int cur_overtake = sc ? (int)sc->overtake_mode : 0;
         if (prev_overtake_for_hold != 0 && cur_overtake == 0)
             exit_hold_frames = OVERTAKE_EXIT_HOLD_FRAMES;
@@ -675,55 +660,15 @@ void shadow_drain_midi_inject(void)
         return;
     }
 
-    /* Peek the next published packet, place it in an empty MIDI_IN slot,
-     * and only then pop it. Packets we can't place this pass (MIDI_IN full,
-     * or hardware events appeared mid-drain) stay in the ring untouched and
-     * are retried next frame — no snapshot, no reset, no carryover writeback.
-     * The consumer touches only its own read_pos and the per-slot seq it
-     * frees; it never resets producer state or memsets the buffer. */
     uint8_t *midi_in = host_shadow_mailbox + MIDI_IN_OFFSET;
-    int hw_offset = 0;
-    int injected = 0;
-    uint8_t pkt[4];
-    /* Drain up to the MIDI_IN mailbox capacity (31 slots) per frame, not a
-     * fixed 16. A dense polyphonic burst (e.g. several ROUTE_MOVE tracks
-     * landing a chord on the same step) exceeds 16 simultaneous events; at
-     * the old cap the remainder dribbled out over later frames, smearing the
-     * chord's attack. 31 is the hardware slot count, so this cannot overflow,
-     * and the empty-slot / saw_existing race guard below is unchanged. */
-    while (injected < MIDI_IN_MAX_EVTS && shadow_midi_inject_peek(inject_shm, pkt)) {
-        /* Find an empty 8-byte slot (byte 0 == 0 means no cable/CIN, unused) */
-        int saw_existing = 0;
-        while (hw_offset < MIDI_IN_MAX_BYTES) {
-            if (midi_in[hw_offset] == 0) break;
-            saw_existing = 1;
-            hw_offset += MIDI_IN_EVT_STRIDE;
-        }
-        if (hw_offset >= MIDI_IN_MAX_BYTES) break;  /* MIDI_IN full — retry next frame */
-        /* If we'd have to write past pre-existing events, bail and leave the
-         * packet in the ring for next frame. The defer guard has a narrow
-         * race window: events can appear in MIDI_IN between the guard check
-         * and the write. Injecting alongside hardware events (at a non-zero
-         * offset) races Move's firmware MIDI read path and causes SIGABRT —
-         * empirically the crash always fires at a non-zero offset. */
-        if (saw_existing) break;
-
-        /* Write the 4-byte USB-MIDI packet + zero its 4-byte timestamp.
-         * Cable nibble in pkt[0] is preserved — callers choose cable:
-         * 0 for internal hardware (pads/buttons, Move-prefix protocol),
-         * 2 for external USB (general MIDI, routed to tracks by channel). */
-        memcpy(&midi_in[hw_offset], pkt, 4);
-        memset(&midi_in[hw_offset + 4], 0, 4);
-        hw_offset += MIDI_IN_EVT_STRIDE;
-        shadow_midi_inject_pop(inject_shm);   /* consume only after a successful inject */
-        injected++;
-    }
+    int injected = shadow_overtake_midi_drain(inject_shm, overtake_active,
+                                               midi_in, MIDI_IN_MAX_EVTS);
 
     if (host_log && injected > 0) {
         char dbg[128];
         snprintf(dbg, sizeof(dbg),
                  "MIDI inject: drained %d pkts at offset %d",
-                 injected, hw_offset - injected * MIDI_IN_EVT_STRIDE);
+                 injected, 0);
         host_log(dbg);
     }
 }
@@ -737,10 +682,9 @@ void shadow_drain_midi_inject(void)
  * instrument; cable 0 is reserved for Move's pad/button prefix protocol and
  * won't reach track instruments for pitched notes.
  *
- * The drain rate-limits to 8 packets/tick; callers should not burst more
- * than that per render block. Same-thread as the drain (both run in the
- * shim's SPI loop), so no extra synchronization is needed beyond the
- * existing ring pattern. */
+ * The shared queue is not drained into Move while overtake is active because
+ * its single consumer is then the overtake test-bus publisher. Overtake DSPs
+ * use shadow_overtake_midi_send instead. */
 int shadow_chain_midi_inject(const uint8_t *msg, int len)
 {
     if (!msg || len != 4) return 0;

--- a/src/host/shadow_overtake_midi.c
+++ b/src/host/shadow_overtake_midi.c
@@ -1,0 +1,53 @@
+#include <string.h>
+
+#include "shadow_midi_inject_writer.h"
+#include "shadow_overtake_midi.h"
+
+#define MIDI_IN_EVENT_STRIDE 8
+
+static shadow_midi_inject_t overtake_midi_ring;
+
+void shadow_overtake_midi_init(void)
+{
+    shadow_midi_inject_init(&overtake_midi_ring);
+}
+
+int shadow_overtake_midi_send(const uint8_t *msg, int len)
+{
+    if (!msg || len != 4) return 0;
+    return shadow_midi_inject_push(&overtake_midi_ring, msg) == 0 ? 4 : 0;
+}
+
+static int drain_ring(shadow_midi_inject_t *ring,
+                      uint8_t *midi_in,
+                      int first_event,
+                      int max_events)
+{
+    int copied = first_event;
+    uint8_t packet[4];
+
+    if (!ring) return copied;
+    while (copied < max_events && shadow_midi_inject_peek(ring, packet)) {
+        uint8_t *slot = &midi_in[copied * MIDI_IN_EVENT_STRIDE];
+        if (slot[0] != 0) break;
+        memcpy(slot, packet, 4);
+        memset(slot + 4, 0, 4);
+        shadow_midi_inject_pop(ring);
+        copied++;
+    }
+    return copied;
+}
+
+int shadow_overtake_midi_drain(shadow_midi_inject_t *shared,
+                               int overtake_active,
+                               uint8_t *midi_in,
+                               int max_events)
+{
+    int copied;
+
+    if (!midi_in || max_events <= 0) return 0;
+    copied = drain_ring(&overtake_midi_ring, midi_in, 0, max_events);
+    if (!overtake_active)
+        copied = drain_ring(shared, midi_in, copied, max_events);
+    return copied;
+}

--- a/src/host/shadow_overtake_midi.h
+++ b/src/host/shadow_overtake_midi.h
@@ -1,0 +1,22 @@
+/* Dedicated overtake-DSP MIDI path into Move's native MIDI_IN mailbox. */
+
+#ifndef SHADOW_OVERTAKE_MIDI_H
+#define SHADOW_OVERTAKE_MIDI_H
+
+#include <stdint.h>
+
+#include "shadow_constants.h"
+
+void shadow_overtake_midi_init(void);
+
+/* Host API callback for an active overtake DSP. Returns 4 when queued. */
+int shadow_overtake_midi_send(const uint8_t *msg, int len);
+
+/* Drain dedicated DSP packets first. The shared inject queue is drained only
+ * when no overtake owns its test-bus consumer. Returns packets copied. */
+int shadow_overtake_midi_drain(shadow_midi_inject_t *shared,
+                               int overtake_active,
+                               uint8_t *midi_in,
+                               int max_events);
+
+#endif /* SHADOW_OVERTAKE_MIDI_H */

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -62,6 +62,7 @@
 #include "host/shadow_state.h"
 #include "host/shadow_xmos_audio.h"
 #include "host/shadow_midi.h"
+#include "host/shadow_overtake_midi.h"
 #include "host/shadow_midi_filter.h"
 #include "host/fx_midi_filter.h"
 #include "host/shadow_shm_util.h"
@@ -1688,7 +1689,7 @@ static void overtake_dsp_load_body(void) {
     overtake_host_api.midi_send_external = overtake_midi_send_external;
     overtake_host_api.get_bpm = shim_get_bpm;
     overtake_host_api.get_beat_position = shadow_transport_beat_position;
-    overtake_host_api.midi_inject_to_move = shadow_chain_midi_inject;
+    overtake_host_api.midi_inject_to_move = shadow_overtake_midi_send;
 
     /* Extract module directory from dsp path */
     char module_dir[256];

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -239,6 +239,14 @@ static JSValue js_shadow_inbound_pad_midi_active(JSContext *ctx, JSValueConst th
     return JS_NewInt32(ctx, 1);
 }
 
+/* shadow_overtake_move_inject_active() -> int
+ * Capability sentinel: an overtake DSP's midi_inject_to_move callback uses a
+ * dedicated queue that continues into Move while the takeover is active. */
+static JSValue js_shadow_overtake_move_inject_active(JSContext *ctx, JSValueConst this_val, int argc, JSValueConst *argv) {
+    (void)this_val; (void)argc; (void)argv;
+    return JS_NewInt32(ctx, 1);
+}
+
 /* shadow_overtake_send_external_async_active() -> int
  * Returns 1 if this build of the shim performs the ROUTE_EXTERNAL SPI
  * ioctl off the audio thread (Phase 2 worker). Capability sentinel for
@@ -2755,6 +2763,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
     JS_SetPropertyStr(ctx, global_obj, "shadow_get_ui_flags", JS_NewCFunction(ctx, js_shadow_get_ui_flags, "shadow_get_ui_flags", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_clear_ui_flags", JS_NewCFunction(ctx, js_shadow_clear_ui_flags, "shadow_clear_ui_flags", 1));
     JS_SetPropertyStr(ctx, global_obj, "shadow_inbound_pad_midi_active", JS_NewCFunction(ctx, js_shadow_inbound_pad_midi_active, "shadow_inbound_pad_midi_active", 0));
+    JS_SetPropertyStr(ctx, global_obj, "shadow_overtake_move_inject_active", JS_NewCFunction(ctx, js_shadow_overtake_move_inject_active, "shadow_overtake_move_inject_active", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_overtake_send_external_async_active", JS_NewCFunction(ctx, js_shadow_overtake_send_external_async_active, "shadow_overtake_send_external_async_active", 0));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_begin", JS_NewCFunction(ctx, js_shadow_corun_begin, "shadow_corun_begin", 3));
     JS_SetPropertyStr(ctx, global_obj, "shadow_corun_end", JS_NewCFunction(ctx, js_shadow_corun_end, "shadow_corun_end", 0));

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -15,6 +15,7 @@ LDFLAGS = -lpthread
 BUILD_DIR = ../../build/tests/host
 
 TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
+	$(BUILD_DIR)/test_overtake_midi_route \
 	$(BUILD_DIR)/test_overtake_native_led_repaint \
 	$(BUILD_DIR)/test_shadow_midi_filter \
 	$(BUILD_DIR)/test_midi_in_compact \
@@ -43,6 +44,9 @@ $(BUILD_DIR)/%: %.c | $(BUILD_DIR)
 
 $(BUILD_DIR)/test_overtake_native_led_repaint: test_overtake_native_led_repaint.c ../../src/host/shadow_led_queue.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L $(INCLUDES) $^ -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/test_overtake_midi_route: test_overtake_midi_route.c ../../src/host/shadow_overtake_midi.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_shadow_midi_filter: test_shadow_midi_filter.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)

--- a/tests/host/test_overtake_midi_route.c
+++ b/tests/host/test_overtake_midi_route.c
@@ -1,0 +1,87 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "shadow_midi_inject_writer.h"
+#include "shadow_overtake_midi.h"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } \
+} while (0)
+
+static void test_active_overtake_uses_only_dedicated_queue(void)
+{
+    shadow_midi_inject_t shared;
+    uint8_t midi_in[31 * 8];
+    uint8_t shared_pkt[4] = { 0x29, 0x90, 72, 100 };
+    uint8_t dsp_on[4] = { 0x29, 0x90, 60, 100 };
+    uint8_t dsp_off[4] = { 0x28, 0x80, 60, 0 };
+    uint8_t peek[4];
+
+    shadow_midi_inject_init(&shared);
+    shadow_overtake_midi_init();
+    memset(midi_in, 0, sizeof(midi_in));
+
+    CHECK(shadow_midi_inject_push(&shared, shared_pkt) == 0,
+          "shared test-bus packet queued");
+    CHECK(shadow_overtake_midi_send(dsp_on, 4) == 4,
+          "overtake note-on queued");
+    CHECK(shadow_overtake_midi_send(dsp_off, 4) == 4,
+          "overtake note-off queued");
+
+    CHECK(shadow_overtake_midi_drain(&shared, 1, midi_in, 31) == 2,
+          "active overtake drains both dedicated packets");
+    CHECK(memcmp(&midi_in[0], dsp_on, 4) == 0,
+          "dedicated note-on is first");
+    CHECK(memcmp(&midi_in[8], dsp_off, 4) == 0,
+          "dedicated note-off is second");
+    CHECK(midi_in[4] == 0 && midi_in[12] == 0,
+          "injected timestamps are zero");
+    CHECK(shadow_midi_inject_peek(&shared, peek) == 1
+              && memcmp(peek, shared_pkt, 4) == 0,
+          "active overtake leaves shared queue for its publisher");
+
+    memset(midi_in, 0, sizeof(midi_in));
+    CHECK(shadow_overtake_midi_drain(&shared, 0, midi_in, 31) == 1,
+          "inactive mode resumes the shared queue");
+    CHECK(memcmp(&midi_in[0], shared_pkt, 4) == 0,
+          "shared packet reaches Move after overtake exits");
+    CHECK(shadow_midi_inject_peek(&shared, peek) == 0,
+          "shared packet is consumed only after it is copied");
+}
+
+static void test_full_queue_preserves_fifo(void)
+{
+    uint8_t midi_in[8];
+    uint8_t packet[4] = { 0x29, 0x90, 0, 100 };
+
+    shadow_overtake_midi_init();
+    for (int i = 0; i < SHADOW_MIDI_INJECT_SLOTS; i++) {
+        packet[2] = (uint8_t)i;
+        CHECK(shadow_overtake_midi_send(packet, 4) == 4,
+              "dedicated ring accepts every available slot");
+    }
+    packet[2] = 127;
+    CHECK(shadow_overtake_midi_send(packet, 4) == 0,
+          "dedicated ring rejects a packet when full");
+
+    memset(midi_in, 0, sizeof(midi_in));
+    CHECK(shadow_overtake_midi_drain(NULL, 1, midi_in, 1) == 1,
+          "bounded drain copies only the requested packet count");
+    CHECK(midi_in[2] == 0,
+          "ring overflow does not disturb the oldest packet");
+}
+
+int main(void)
+{
+    test_active_overtake_uses_only_dedicated_queue();
+    test_full_queue_preserves_fifo();
+
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    printf("PASS: overtake DSP MIDI reaches Move without consuming the shared test bus\n");
+    return 0;
+}

--- a/tests/host/test_overtake_move_inject_contract.sh
+++ b/tests/host/test_overtake_move_inject_contract.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+UI="$ROOT/src/shadow/shadow_ui.c"
+SHIM="$ROOT/src/schwung_shim.c"
+API="$ROOT/docs/API.md"
+GUIDE="$ROOT/docs/ADDRESSING_MOVE_SYNTHS.md"
+
+grep -q 'js_shadow_overtake_move_inject_active' "$UI"
+grep -q '"shadow_overtake_move_inject_active"' "$UI"
+grep -q 'midi_inject_to_move = shadow_overtake_midi_send' "$SHIM"
+
+if grep -q 'midi_inject_to_move = shadow_chain_midi_inject' "$SHIM"; then
+    echo "FAIL: overtake DSP output is wired back to the shared inject queue" >&2
+    exit 1
+fi
+
+grep -q 'shadow_overtake_move_inject_active()' "$API"
+grep -q 'dedicated.*queue' "$GUIDE"
+
+echo "PASS: overtake Move-injection capability and ownership contract"


### PR DESCRIPTION
## Problem

Since #190, `/schwung-midi-inject` is consumed by the overtake publisher while a takeover is active. Overtake DSPs still receive `host_api.midi_inject_to_move = shadow_chain_midi_inject`, so their generated MIDI loops back into the takeover input instead of reaching Move. The shared packets drain to Move only after the takeover is suspended or exited.

This is visible in Chord Finder: native/external MIDI is silent while its screen is open, then Move receives the queued notes after Back.

## Fix

- add a bounded in-process MPSC queue dedicated to overtake DSP output
- wire only the overtake DSP `midi_inject_to_move` callback to that queue
- drain dedicated packets into Move during active takeover while leaving the shared test-bus/JS queue to the overtake publisher
- outside takeover, drain the dedicated queue first and use remaining mailbox capacity for the shared queue
- expose `shadow_overtake_move_inject_active()` so tool UIs can distinguish fixed hosts from 0.12.0/0.12.1
- document queue ownership and the compatibility symptom

The plugin ABI and `/schwung-midi-inject` SHM ABI are unchanged. The realtime send path remains bounded and performs no allocation, logging, locks, or syscalls.

## Tests

- new compiled regression test covers active/inactive ownership, note order, bounded draining, and ring-full behavior
- new shell contract prevents rewiring the DSP callback to the shared queue and verifies the capability sentinel/docs
- `make -C tests/host test`
- every `tests/host/*.sh` contract test
- `DISABLE_SCREEN_READER=1 ./scripts/build.sh` (aarch64 host and shim)

## Device validation

Installed the local build over Schwung 0.12.1 on Move. With Chord Finder 0.4.3 active (`overtake_mode=2`), a right-pad chord produced an immediate 3-packet note-on drain and 3-packet note-off drain while the takeover remained visible. Installed shim/UI hashes matched the local aarch64 build, and existing Chord Finder settings were preserved.
