### PR TITLE
Add Ruminant frequency-shifting delay to catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -169,6 +169,17 @@
       "min_host_version": "0.7.13"
     },
     {
+      "id": "ruminant",
+      "name": "Ruminant",
+      "description": "Frequency-shifting feedback delay for metallic echoes, phasing, flanging, and inharmonic dub textures",
+      "author": "mestela",
+      "component_type": "audio_fx",
+      "github_repo": "mestela/schwung-ruminant",
+      "default_branch": "main",
+      "asset_name": "ruminant-module.tar.gz",
+      "min_host_version": "0.12.1"
+    },
+    {
       "id": "junologue-chorus",
       "name": "Junologue Chorus",
       "description": "Junologue Chorus - Juno-60 chorus emulation (I, I+II, II modes)",


### PR DESCRIPTION
Adds **Ruminant** to the module catalog — an original frequency-shifting feedback delay for metallic echoes, phasing, flanging, and inharmonic dub textures.

**Repo:** https://github.com/mestela/schwung-ruminant  
**Latest release:** https://github.com/mestela/schwung-ruminant/releases/tag/v0.1.0

**Highlights:**
- Upper/lower single-sideband frequency shifting with ring modulation at the centre
- 1–1000 ms fractional delay with feedback and tone damping
- Dry/wet mix and stereo phase spread
- Smooth live parameter changes, saved state, and continuous delay tails
- Native ARM64 DSP measured at about 142 microseconds per block on Move

**Validation:**
- Built and tested on Schwung v0.12.1
- 16 module DSP tests pass
- Catalog JSON parses with unique module IDs
- Schwung store regression tests pass
- Public `release.json` and v0.1.0 asset names match the catalog entry

`min_host_version` is set to `0.12.1`, the version used for development and hardware testing.