### PR TITLE
shim: SPI frame tally — and the frame budget is ~2370µs, not ~900µs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,9 +79,12 @@ JS: `console.log()` (auto-routed) or import `shared/logger.mjs`. C: `LOG_DEBUG("
 default) reports at ~1 Hz:
 
 ```
-spi-tally: 44 frames / 44 irq  tx avg 312us (max 1904us)  headroom 2590us  backlog 0
-spi-tally: LATE 3 irq(s) arrived while busy — frames queued, not dropped (backlog 3, worst window 3)
+spi-tally: 345 frames / 345 irq  tx avg 389us (max 447us)  headroom 2513us  backlog 8
+spi-tally: LATE 1 irq(s) arrived while busy — frames queued, not dropped (backlog 8, worst window 1)
 ```
+
+(345/s is right: the block rate is **344.5 Hz**, not 44 — 128 frames per block
+at 44.1 kHz, 2.902 ms per block.)
 
 Both numbers come from ablspi itself, which ships in Ableton's GPL source drop
 (see `docs/SPI_PROTOCOL.md`). `tx` is the driver's own `spi_tx_time`, stamped
@@ -97,15 +100,23 @@ never appears as a gap; it appears as a **burst**, which is exactly the shape
 that gets attributed to somebody else's producer misbehaving. `backlog` is that
 queue. Point it at the Link Audio dropouts before blaming Move's `Link Main`.
 
-`headroom` is nominal period (2.902 ms) minus measured transfer, i.e. what is
-actually left for our work — **measure it before quoting the "~900µs" budget
-below**, which predates any measurement of the transfer itself.
+**Measured 2026-08-26, and it corrects the budget below.** The ioctl takes
+2569µs but only **389µs of that is the transfer** — the other ~2180µs is
+`wait_event_interruptible` blocking for the next XMOS IRQ, i.e. frame pacing,
+not work and not the wire. With ~140µs of our own compute (`pre` 97 + `post`
+43), real slack is **~2370µs, not ~900µs**. See docs/REALTIME_SAFETY.md.
+
+A corollary worth holding: **`total_us` is not a load signal.** Our work
+growing shrinks the driver's wait by the same amount, so the loop total sits
+near the period whatever we do. The old overrun counter compared it against
+2000µs — below the 2902µs period — and so counted *every* frame: 43,986
+"overruns" in two minutes on an idle device. Now `OVERRUN_THRESHOLD_US`.
 
 Pure accumulator in `src/host/spi_tally.c` (no I/O, so `spi_tally_record` is
 SPI-callback-safe and the whole thing is host-tested by
 `tests/host/test_spi_tally.c`); `/proc` read and reporting in `shim_worker.c`.
 The IRQ delta is a **32-bit** subtraction on purpose — that counter is printed
-from an `int`, goes negative past 2^31 (~13.5 h) and wraps at 2^32, and only
+from an `int`, goes negative past 2^31 (~72 days) and wraps at 2^32, and only
 modular arithmetic survives both. Widening it is the regression the test fails on.
 
 **When the UI feels slow, check the tick rate FIRST.** The shadow UI loop is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,9 @@ near the period whatever we do. The old overrun counter compared it against
 Pure accumulator in `src/host/spi_tally.c` (no I/O, so `spi_tally_record` is
 SPI-callback-safe and the whole thing is host-tested by
 `tests/host/test_spi_tally.c`); `/proc` read and reporting in `shim_worker.c`.
+**Arming gotchas, the measured table, and the two experiments still owed are in
+`docs/plans/2026-08-26-spi-tally-followups.md`** — read it before re-measuring;
+the tally stays silent for ~20 s after arming, which looks like a broken build.
 The IRQ delta is a **32-bit** subtraction on purpose — that counter is printed
 from an `int`, goes negative past 2^31 (~72 days) and wraps at 2^32, and only
 modular arithmetic survives both. Widening it is the regression the test fails on.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,39 @@ JS: `console.log()` (auto-routed) or import `shared/logger.mjs`. C: `LOG_DEBUG("
   draws << ticks means something gates the redraw; draws == ticks and both low
   means the tick is slow or its pacing is wrong.
 
+**SPI frame tally** (`touch /data/UserData/schwung/spi_tally_on`, off by
+default) reports at ~1 Hz:
+
+```
+spi-tally: 44 frames / 44 irq  tx avg 312us (max 1904us)  headroom 2590us  backlog 0
+spi-tally: LATE 3 irq(s) arrived while busy — frames queued, not dropped (backlog 3, worst window 3)
+```
+
+Both numbers come from ablspi itself, which ships in Ableton's GPL source drop
+(see `docs/SPI_PROTOCOL.md`). `tx` is the driver's own `spi_tx_time`, stamped
+after every transfer into `struct ablspi_sys_info` at the END of the mmap'd page
+— one aligned 8-byte load of memory the shim already maps, no syscall. `irq` is
+`/proc/ableton/ablspi0.0/irq_count`, read on the worker because it is file I/O.
+
+**The gap between them is the point, and it exists because ablspi's IRQ is a
+counting semaphore rather than a flag** (`atomic_inc` in the ISR, `atomic_dec`
+in the wait). Overrun the budget and the frame is **not dropped** — it queues,
+and the next waits return immediately, replaying back-to-back. So a late frame
+never appears as a gap; it appears as a **burst**, which is exactly the shape
+that gets attributed to somebody else's producer misbehaving. `backlog` is that
+queue. Point it at the Link Audio dropouts before blaming Move's `Link Main`.
+
+`headroom` is nominal period (2.902 ms) minus measured transfer, i.e. what is
+actually left for our work — **measure it before quoting the "~900µs" budget
+below**, which predates any measurement of the transfer itself.
+
+Pure accumulator in `src/host/spi_tally.c` (no I/O, so `spi_tally_record` is
+SPI-callback-safe and the whole thing is host-tested by
+`tests/host/test_spi_tally.c`); `/proc` read and reporting in `shim_worker.c`.
+The IRQ delta is a **32-bit** subtraction on purpose — that counter is printed
+from an `int`, goes negative past 2^31 (~13.5 h) and wraps at 2^32, and only
+modular arithmetic survives both. Widening it is the regression the test fails on.
+
 **When the UI feels slow, check the tick rate FIRST.** The shadow UI loop is
 paced to an absolute deadline (60 Hz); it previously slept a fixed 16 ms
 *after* the work, making the real rate `1/(work + 16ms)` — so every parameter

--- a/docs/REALTIME_SAFETY.md
+++ b/docs/REALTIME_SAFETY.md
@@ -122,6 +122,22 @@ Sources removed:
 
 Frame budget: 2900µs (128 frames @ 44.1kHz).
 
+**The "SPI ioctl baseline ~2ms" row above is inherited, not measured**, and it
+is the number the ~900µs budget is derived from. 768 bytes at 20 MHz is ~307µs
+of wire time, so the two disagree by roughly 6×. ablspi stamps the real
+per-transfer duration into the mmap'd page on every frame — arm the SPI frame
+tally (`touch /data/UserData/schwung/spi_tally_on`, see CLAUDE.md) and read
+`tx avg` / `headroom` rather than re-quoting either figure.
+
+**An overrun does not drop a frame — it queues.** ablspi's IRQ is a counting
+semaphore (`atomic_inc` in the ISR, `atomic_dec` in the wait), so frames that
+fire while we are busy are serviced back-to-back afterwards. Two consequences
+worth holding onto when reading the table above and the module-load section
+below: "232 consecutive dropped frames" is really 232 frames of *deferral* that
+Move then works off in a burst; and a burst arriving at a downstream consumer
+(Link Audio, the JACK bridge) is evidence *for* one of our own overruns, not
+against it. `backlog` in the tally is that queue, measured.
+
 ## What NOT to do
 
 - Never call unified_log from the SPI callback path

--- a/docs/REALTIME_SAFETY.md
+++ b/docs/REALTIME_SAFETY.md
@@ -122,12 +122,28 @@ Sources removed:
 
 Frame budget: 2900µs (128 frames @ 44.1kHz).
 
-**The "SPI ioctl baseline ~2ms" row above is inherited, not measured**, and it
-is the number the ~900µs budget is derived from. 768 bytes at 20 MHz is ~307µs
-of wire time, so the two disagree by roughly 6×. ablspi stamps the real
-per-transfer duration into the mmap'd page on every frame — arm the SPI frame
-tally (`touch /data/UserData/schwung/spi_tally_on`, see CLAUDE.md) and read
-`tx avg` / `headroom` rather than re-quoting either figure.
+### The "~2ms transfer" is mostly the shim sitting idle — MEASURED 2026-08-26
+
+The "SPI ioctl baseline ~2ms" row above is the *ioctl call*, not the transfer,
+and the ~900µs budget derived from it is wrong. ablspi stamps the real transfer
+duration into the mmap'd page every frame; reading it (`spi_tally_on`) against
+the existing `[spi_timing]` line, on an idle device with three empty slots:
+
+| | µs |
+|---|---|
+| Frame period (128 @ 44.1 kHz, **344.5 Hz** block rate) | 2902 |
+| `ioctl` call, as the shim measures it | 2569 |
+| …of which **actual transfer** (ablspi `spi_tx_time`) | **389** (max 447) |
+| …of which **blocked in `wait_event_interruptible`** | **~2180** |
+| Our compute (`pre` 97 + `post` 43) | ~140 |
+| **Real slack** | **~2370** |
+
+Most of that ioctl is the driver waiting for the *next* XMOS IRQ — it is the
+frame pacing, not work and not the wire. So the budget is ~2.4 ms, not ~900 µs.
+
+`total_us` is pinned near the period for the same reason: our work growing
+shrinks the wait by the same amount. **It is not a load signal** — use
+`mix_buf`/`render` in `[spi_timing] Pre/Post`, or the tally's `backlog`.
 
 **An overrun does not drop a frame — it queues.** ablspi's IRQ is a counting
 semaphore (`atomic_inc` in the ISR, `atomic_dec` in the wait), so frames that

--- a/docs/SPI_PROTOCOL.md
+++ b/docs/SPI_PROTOCOL.md
@@ -2,6 +2,12 @@
 
 Reverse-engineered from Ableton's JACK Move driver (`jack2.move-move/linux/move/move-spi/`) and RNBO's `jack_move.so`.
 
+The **driver side** is no longer reverse-engineered: `ablspi` ships in Ableton's
+GPL source release for Move, as `drivers/spi/ablspi-{core,gpio,proc}.c` inside
+the patched `linux-raspberrypi-5.15.92-rt57` tree (`CONFIG_ABLSPI=m`, device
+tree `arch/arm64/boot/dts/overlays/ablspi-overlay.dts`, IRQ on GPIO 3). Anything
+below marked *(driver)* is read from that source rather than inferred.
+
 ## SPI Transfer
 
 - Device: `/dev/ablspi0.0`
@@ -25,9 +31,36 @@ INPUT (RX) — mmap offset 2048:
   2048    248     MIDI IN: 31 × 8-byte AblSpiMidiEvent
   2296    4       Display status word
   2304    512     Audio IN: 128 frames × 2 channels × int16
+
+KERNEL (driver-written) — end of the page:
+  4088    8       struct ablspi_sys_info { u64 spi_tx_time; }
 ```
 
 Audio: 44100 Hz, 128 frames/block, stereo interleaved int16, little-endian.
+
+**RX is not a clean 2048 bytes** *(driver)*. `ablspi_open` splits the page in
+half — `tx_buffer` at 0, `rx_buffer` at `PAGE_SIZE/2` — and then places
+`sysinfo` at `PAGE_SIZE - sizeof(struct ablspi_sys_info)`, i.e. **inside the
+tail of the RX half**. RX is therefore safely 2040 bytes, not 2048. Harmless at
+Move's 768-byte frames, which reach nowhere near it, but a larger transfer would
+have the driver overwrite its own telemetry.
+
+### spi_tx_time — free per-frame transfer timing *(driver)*
+
+The driver stamps the real duration of each transfer, in nanoseconds:
+
+```c
+s64 then = trace_clock_local();
+ablspi_send_message(spidev, spi, arg);
+wait_for_completion(&spidev->dma_transfer_finished);
+spidev->sysinfo->spi_tx_time = trace_clock_local() - then;
+```
+
+It is written before the ioctl returns, so by the time `shim_post_transfer` runs
+the value describes the frame that just completed. Reading it costs one aligned
+8-byte load of memory the shim already maps — no syscall, nothing on the wire.
+`SCHWUNG_OFF_SPI_TX_TIME` in `src/lib/schwung_spi_lib.h`; consumed by
+`src/host/spi_tally.c`. The field reads 0 until the first transfer completes.
 
 ## MIDI Event Formats
 
@@ -99,6 +132,39 @@ enum IoctlCommands {
     ABLSPI_GET_SPEED = 12
 };
 ```
+
+**Only 6, 7, 10, 11 and 12 exist in the driver** *(driver)* — the others above
+are ours and the kernel implements nothing for them. Dispatch is on
+`_IOC_NR(cmd)`, so the direction/size/type bits are ignored and Move passes the
+bare integers (which is what lets the shim's `ioctl` hook compare `request`
+directly). Constraints the driver enforces:
+
+- `WAIT_AND_SEND_MESSAGE_WITH_SIZE`: `arg` is the transfer size, and must be
+  128 … `PAGE_SIZE/2`. Rejected with `-EINVAL` if a transfer is already in
+  flight, or if the IRQ GPIO never probed.
+- `SET_SPEED`: 5 MHz … 25 MHz. 5 MHz is the driver default; Move selects 20, so
+  there is headroom.
+- Only **one** process may hold the device — a second `open` gets `-EBUSY`.
+  This is why the shim has to be an `LD_PRELOAD` inside MoveOriginal rather
+  than a second reader.
+- `read()` and `write()` are stubs that return 0. All I/O is mmap + ioctl.
+
+### The IRQ is a counting semaphore, not a flag *(driver)*
+
+`ablspi_gpio_isr` does `atomic_inc(&spidev->irq_arrived)`;
+`ablspi_wait_for_interrupt` does `atomic_dec`. So **an overrun does not drop a
+frame — it queues.** If we miss our budget, the IRQs that fired meanwhile are
+still counted, and the next waits return immediately, replaying back-to-back.
+
+The consequence for diagnosis is large: a late frame is invisible as a gap and
+shows up as a **burst**, which is easy to attribute to some other producer
+misbehaving. `/proc/ableton/ablspi0.0/irq_count` (bumped by the ISR regardless
+of whether we serviced it) minus our own frame count is exactly that queue —
+see "SPI frame tally" in CLAUDE.md.
+
+`/proc/ableton/ablspi0.0/` also carries `spi_tx_time` (same value as the mmap
+field) and `failed_send_count`, which **nothing in the driver ever increments**
+— it is always 0 and means nothing.
 
 ## Key Constants
 

--- a/docs/plans/2026-08-26-spi-tally-followups.md
+++ b/docs/plans/2026-08-26-spi-tally-followups.md
@@ -1,0 +1,136 @@
+# SPI frame tally — what it measured, and the two tests still owed
+
+2026-08-26. Companion to PR #296. The tool is `spi_tally_on`; this file is the
+part that is *not* in the code: what was measured, what it invalidated, and the
+two experiments that were not run.
+
+## Arm it
+
+```bash
+ssh ableton@move.local "touch /data/UserData/schwung/debug_log_on"
+ssh ableton@move.local "touch /data/UserData/schwung/spi_tally_on"
+ssh ableton@move.local "tail -f /data/UserData/schwung/debug.log | grep spi-tally"
+```
+
+**Both flags are required** and the order matters in practice: `unified_log`
+only starts accepting after it notices `debug_log_on`, and it rechecks every 100
+calls. The tally refuses to measure into a log that is still dropping writes
+(same rule as `rt_thread_audit`), so for the first several seconds after arming
+you get *nothing* — which looks exactly like a broken build. Wait ~20 s before
+concluding anything. This cost a cycle the first time.
+
+Disarm both when done. `debug_log_on` writes ~270 B/s with the tally up, and
+leaving it armed has previously caused the dropouts it was hunting.
+
+## Reading a line
+
+```
+spi-tally: 345 frames / 345 irq  tx avg 389us (max 464us)  headroom 2513us  backlog 6
+spi-tally: LATE 1 irq(s) arrived while busy — frames queued, not dropped (backlog 6, worst window 1)
+```
+
+- **345/s is correct.** The block rate is 344.5 Hz — 128 frames per block at
+  44.1 kHz, 2.902 ms per block. Not 44. (I got this wrong first time and it is
+  an easy mistake: "128 frames" is the block size, not the rate.)
+- **`backlog` is cumulative since arming**, not a level. It only rises.
+- `frames > irqs` in a window is the queue *draining* and is reported as clean.
+- `max` is the worst transfer since arming and never resets per-window — a
+  spike once an hour is the finding, and a per-window max throws it away.
+
+## What it measured — idle device, three empty slots
+
+| | µs |
+|---|---|
+| Frame period (344.5 Hz block rate) | 2902 |
+| `ioctl`, as `[spi_timing]` measures it | 2569 |
+| …of which **actual transfer** (ablspi `spi_tx_time`) | **389** (max 464) |
+| …of which **blocked in `wait_event_interruptible`** | **~2180** |
+| Our compute (`pre` 97 + `post` 43) | ~140 |
+| **Real slack** | **~2370** |
+
+Backlog at idle creeps ~1 per 10 s, each a single-frame lateness.
+
+### Two things this invalidated
+
+1. **The ~900 µs frame budget.** It was derived from "SPI ioctl baseline ~2ms",
+   which is the *ioctl*, not the transfer — most of it is the driver waiting for
+   the next XMOS IRQ. Real slack is ~2370 µs. Every "X% of budget" figure
+   against 900 µs is ~2.6× too pessimistic.
+2. **`total_us` as a load signal.** It is not one. The loop is paced by the
+   blocking ioctl, so our work growing shrinks the wait by exactly as much and
+   the total stays pinned near the period whatever we do. Use `mix_buf` /
+   `render` from `[spi_timing] Pre/Post`, or `backlog`.
+
+That second point is why the old overrun counter tested `total_us > 2000` — below
+the 2902 µs period — and counted **43,986 overruns in two minutes on an idle
+device**, while sitting on the same log line as `ioctl avg=2568` looking like
+corroboration. Fixed; verified 43,986 → 1.
+
+## Test 1 — the loaded reading (the one that matters)
+
+**Not run.** Doing it would have meant loading modules into a live set.
+
+Question: when Link Audio stalls, is `backlog` climbing in the same windows?
+
+Method: reproduce the dropouts per
+`memory/link_audio_producer_burst_dropouts.md` (minijv + keydetect +
+airwindows was the configuration that did it, ~1 stall per 4–40 s), arm the
+tally alongside the sidecar's `max_gap` / `max_burst_run` logging, and line the
+timestamps up.
+
+- **Backlog climbs with the stalls** → our own frame overruns are implicated,
+  and the tally is a far cheaper probe than the `[spi_timing] mix_buf`
+  instrumentation currently used to watch the load knob.
+- **Backlog stays flat through them** → our SPI servicing is fine and the stall
+  is entirely Move-side (`Link Main` at FIFO 35 missing its timer, then
+  `SinkProcessor` draining its 128-slot queue in one greedy burst). That is the
+  standing diagnosis and this would corroborate it independently.
+
+**Do not conflate the two queues.** ablspi's IRQ semaphore and Move's sink
+queue *both* turn a delay into a catch-up burst. Two burst-shaped phenomena in
+one system is exactly how you talk yourself into the wrong one.
+
+## Test 2 — re-derive the tapedelay instance ceiling
+
+`memory/tapedelay_cpu_two_instances.md` says Tape Echo 2 is 41% of budget and
+only two instances fit. The per-instance measurement (0.36–0.37 ms/block) is
+unaffected by any of this; the **denominator** was 900 µs. Against ~2370 µs it
+is ~15%.
+
+Naively that is ~6 instances. **Do not publish that number from division.**
+Re-run `tools/bench_instances.cpp`. The slack has other claimants — all four
+slots, master FX, mixing — and `Link Main` starving at FIFO 35 is a ceiling that
+has nothing to do with arithmetic. The memory is flagged superseded-in-part
+rather than rewritten, deliberately.
+
+## Things worth knowing before extending this
+
+- **`spi_tally_record` runs on the SPI callback.** `src/host/spi_tally.c` is
+  pure — no I/O, allocation or locks — and must stay that way. `/proc` reading
+  and logging live on the worker.
+- **The handoff takes deltas of cumulative counters** rather than draining a
+  window the producer is still filling. Draining would lose whichever sample
+  landed between the read and the reset, and the sample most worth keeping is
+  the outlier.
+- **The IRQ delta must stay a 32-bit subtraction of 32-bit operands.** Signed
+  vs unsigned is irrelevant (two's complement); the **width** is what makes it
+  modular. Widening `prev_irqs` / `spi_tally_sample_t::irqs` "for consistency
+  with `frames`" turns the counter's 2^32 wrap (~72 days at 344.5 Hz) into a
+  4-billion-IRQ window. `tests/host/test_spi_tally.c` fails on exactly that;
+  the signedness mutation is *equivalent* and will not fail it, which is worth
+  knowing before you go hunting for why.
+- **`failed_send_count`** in `/proc/ableton/ablspi0.0/` is always 0. Nothing in
+  the driver ever increments it. Do not build anything on it.
+
+## Source
+
+The driver is not reverse-engineered any more — `ablspi` ships in Ableton's GPL
+source release for Move, in the patched `linux-raspberrypi-5.15.92-rt57` tree:
+
+```
+drivers/spi/ablspi-{core,gpio,proc}.c, ablspi{,-ioctl}.h
+arch/arm64/boot/dts/overlays/ablspi-overlay.dts     # IRQ on GPIO 3
+.kernel-meta/configs/rpi4-ablspi.cfg                # CONFIG_ABLSPI=m
+```
+
+Driver-derived facts are marked *(driver)* in `docs/SPI_PROTOCOL.md`.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -244,6 +244,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_midi.c src/host/shadow_midi_filter.c src/host/shadow_midi_filter.h \
     src/host/unified_log.c src/host/shim_worker.c \
     src/host/rt_thread_audit.c src/host/rt_thread_audit.h \
+    src/host/spi_tally.c src/host/spi_tally.h \
     src/host/shadow_shm_util.c src/host/schwung_trace.c src/host/shadow_test_stream.c src/host/shadow_test_stream.h \
     $SHIM_TTS_SRC \
     src/host/shadow_constants.h src/host/shadow_midi_inject_writer.h src/host/shadow_midi.h src/host/shadow_sampler.h \
@@ -279,6 +280,7 @@ if needs_rebuild build/schwung-shim.so \
         src/host/unified_log.c \
         src/host/shim_worker.c \
         src/host/rt_thread_audit.c \
+        src/host/spi_tally.c \
         src/host/shadow_shm_util.c \
         src/host/schwung_trace.c \
         src/host/shadow_test_stream.c \

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -14,6 +14,7 @@
 
 #include "shim_worker.h"
 #include "rt_thread_audit.h"
+#include "spi_tally.h"
 #include "shadow_set_pages.h"
 #include "unified_log.h"
 
@@ -98,7 +99,86 @@ static const flag_spec_t FLAGS[] = {
     { "/data/UserData/schwung/align_dump_trigger",   SHIM_FLAG_ALIGN_DUMP,   1 },
     { "/data/UserData/schwung/main_fx_dump_trigger", SHIM_FLAG_MAIN_FX_DUMP, 1 },
     { "/data/UserData/schwung/rt_thread_audit_on",   SHIM_FLAG_RT_AUDIT,     0 },
+    { "/data/UserData/schwung/spi_tally_on",         SHIM_FLAG_SPI_TALLY,    0 },
 };
+
+/* ---- SPI frame tally --------------------------------------------------- */
+
+/* Pairs the kernel's per-transfer spi_tx_time (accumulated on the SPI callback,
+ * see spi_tally.h) with /proc/ableton/<dev>/irq_count, which only the worker
+ * may read — it is file I/O. Off unless armed:
+ *     touch /data/UserData/schwung/spi_tally_on
+ */
+
+#define ABLSPI_IRQ_COUNT_PATH "/proc/ableton/ablspi0.0/irq_count"
+
+/* Returns 0 and fills *out on success. The counter is printed from an int that
+ * only ever increments, so it eventually prints negative; parse it wide, then
+ * narrow to exactly 32 bits so spi_tally_fold's modular subtraction sees the
+ * same width the kernel counts in. */
+static int ablspi_irq_count_read(uint32_t *out)
+{
+    FILE *f = fopen(ABLSPI_IRQ_COUNT_PATH, "r");
+    if (!f) return -1;
+    long v = 0;
+    int got = (fscanf(f, "%ld", &v) == 1);
+    fclose(f);
+    if (!got) return -1;
+    *out = (uint32_t)v;
+    return 0;
+}
+
+static void spi_tally_tick(void)
+{
+    static spi_tally_state_t state;
+    static int armed = 0;
+
+    if (!(shim_debug_flags & SHIM_FLAG_SPI_TALLY)) {
+        /* Disarmed: drop the accumulator so a later session does not inherit
+         * this one's peak transfer time or backlog. */
+        if (armed) {
+            spi_tally_reset(&shim_spi_tally, &state);
+            armed = 0;
+        }
+        return;
+    }
+
+    /* Same rule as the RT-thread audit: do not start measuring into a log that
+     * is still dropping writes, or the whole session reads as "armed, nothing
+     * found" — which is indistinguishable from a clean result. */
+    if (!unified_log_enabled()) return;
+
+    if (!armed) {
+        spi_tally_reset(&shim_spi_tally, &state);
+        armed = 1;
+    }
+
+    uint32_t irqs = 0;
+    if (ablspi_irq_count_read(&irqs) != 0) {
+        /* A tally that cannot read the counter must SAY so — reporting frames
+         * with no IRQ side would look like a clean zero-backlog result while
+         * measuring only half of the comparison that is the entire point. */
+        static int moaned = 0;
+        if (!moaned) {
+            moaned = 1;
+            unified_log("shim", LOG_LEVEL_ERROR,
+                        "spi-tally: armed but " ABLSPI_IRQ_COUNT_PATH
+                        " is unreadable — NO backlog measurement is running");
+        }
+        return;
+    }
+
+    spi_tally_sample_t s;
+    spi_tally_fold(&state, &shim_spi_tally, irqs, &s);
+
+    char line[256];
+    if (s.late) {
+        spi_tally_format_late(&s, line, sizeof(line));
+        unified_log("shim", LOG_LEVEL_WARN, line);
+    }
+    spi_tally_format(&s, line, sizeof(line));
+    unified_log("shim", LOG_LEVEL_INFO, line);
+}
 
 /* ---- realtime-thread audit ------------------------------------------- */
 
@@ -476,6 +556,7 @@ static void *worker_main(void *arg) {
 
         if (tick % 5 == 0) poll_flags();          /* ~1 Hz */
         if (tick % 5 == 0) rt_audit_tick();       /* ~1 Hz, no-op unless armed */
+        if (tick % 5 == 0) spi_tally_tick();      /* ~1 Hz, no-op unless armed */
         if (tick % 7 == 0) shadow_poll_current_set(); /* ~1.4 s FS scan */
         tick++;
     }

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -24,6 +24,7 @@
 #define SHIM_FLAG_XMOS_LOG       (1u << 1)  /* log_xmos_sysex_on */
 #define SHIM_FLAG_SPI_MIDI_LOG   (1u << 2)  /* spi_midi_log_on */
 #define SHIM_FLAG_RT_AUDIT       (1u << 3)  /* rt_thread_audit_on */
+#define SHIM_FLAG_SPI_TALLY      (1u << 4)  /* spi_tally_on */
 
 /* One-shot flags: worker unlinks the trigger file and sets the bit; the
  * RT consumer clears it with shim_debug_flag_consume(). */

--- a/src/host/spi_tally.c
+++ b/src/host/spi_tally.c
@@ -1,0 +1,109 @@
+/* spi_tally.c — see spi_tally.h. Pure: no I/O, no allocation, no locks. */
+
+#include "spi_tally.h"
+
+#include <stdio.h>
+#include <string.h>
+
+spi_tally_t shim_spi_tally;
+
+void spi_tally_record(spi_tally_t *t, uint32_t tx_ns)
+{
+    if (!t || tx_ns == 0u) return;
+    t->frames++;
+    t->tx_ns_sum += tx_ns;
+    t->tx_ns_last = tx_ns;
+    if (tx_ns > t->tx_ns_max) t->tx_ns_max = tx_ns;
+}
+
+void spi_tally_reset(spi_tally_t *t, spi_tally_state_t *s)
+{
+    if (t) {
+        t->frames = 0;
+        t->tx_ns_sum = 0;
+        t->tx_ns_max = 0;
+        t->tx_ns_last = 0;
+    }
+    if (s) memset(s, 0, sizeof(*s));
+}
+
+void spi_tally_fold(spi_tally_state_t *s, const spi_tally_t *t, uint32_t irqs,
+                    spi_tally_sample_t *out)
+{
+    if (!s || !t || !out) return;
+
+    /* Read the producer's counters ONCE each. They are cumulative and only
+     * ever rise, so a frame landing between these loads shifts one sample into
+     * the next window rather than corrupting either. */
+    uint64_t frames    = t->frames;
+    uint64_t tx_ns_sum = t->tx_ns_sum;
+
+    memset(out, 0, sizeof(*out));
+    out->max_ns       = t->tx_ns_max;
+    out->backlog      = s->backlog;
+    out->backlog_peak = s->backlog_peak;
+
+    if (!s->have_prev) {
+        out->first = 1;
+        s->prev_frames    = frames;
+        s->prev_tx_ns_sum = tx_ns_sum;
+        s->prev_irqs      = irqs;
+        s->have_prev      = 1;
+        return;
+    }
+
+    out->frames = frames - s->prev_frames;
+    /* Deliberately a 32-bit subtraction of 32-bit operands: that is what makes
+     * it modular, and modular is what survives the /proc counter's sign flip
+     * at 2^31 and its wrap at 2^32. Do NOT widen either side. See spi_tally.h. */
+    out->irqs   = irqs - s->prev_irqs;
+
+    uint64_t ns_delta = tx_ns_sum - s->prev_tx_ns_sum;
+    if (out->frames > 0) out->avg_ns = (uint32_t)(ns_delta / out->frames);
+
+    out->headroom_ns = (out->avg_ns < SPI_TALLY_PERIOD_NS)
+                     ? (SPI_TALLY_PERIOD_NS - out->avg_ns) : 0u;
+
+    /* An IRQ that fired while we were busy is one the semaphore queued. Only a
+     * POSITIVE difference is news: irqs < frames just means the window
+     * boundaries caught a queued frame being worked off, which is the backlog
+     * draining, not going negative. */
+    if ((uint64_t)out->irqs > out->frames) {
+        out->late = (uint32_t)((uint64_t)out->irqs - out->frames);
+        s->backlog += out->late;
+        if (out->late > s->backlog_peak) s->backlog_peak = out->late;
+    }
+
+    out->backlog      = s->backlog;
+    out->backlog_peak = s->backlog_peak;
+
+    s->prev_frames    = frames;
+    s->prev_tx_ns_sum = tx_ns_sum;
+    s->prev_irqs      = irqs;
+}
+
+int spi_tally_format(const spi_tally_sample_t *s, char *buf, int len)
+{
+    if (!s || !buf || len <= 0) return 0;
+    if (s->first)
+        return snprintf(buf, (size_t)len, "spi-tally: armed — baseline taken");
+
+    return snprintf(buf, (size_t)len,
+                    "spi-tally: %llu frames / %u irq  tx avg %uus (max %uus)  "
+                    "headroom %uus  backlog %llu",
+                    (unsigned long long)s->frames, s->irqs,
+                    s->avg_ns / 1000u, s->max_ns / 1000u,
+                    s->headroom_ns / 1000u,
+                    (unsigned long long)s->backlog);
+}
+
+int spi_tally_format_late(const spi_tally_sample_t *s, char *buf, int len)
+{
+    if (!s || !buf || len <= 0) return 0;
+    return snprintf(buf, (size_t)len,
+                    "spi-tally: LATE %u irq(s) arrived while busy — "
+                    "frames queued, not dropped (backlog %llu, worst window %llu)",
+                    s->late,
+                    (unsigned long long)s->backlog,
+                    (unsigned long long)s->backlog_peak);
+}

--- a/src/host/spi_tally.h
+++ b/src/host/spi_tally.h
@@ -99,7 +99,7 @@ void spi_tally_reset(spi_tally_t *t, spi_tally_state_t *s);
 /* Fold one worker sample. `irqs` is the raw /proc counter.
  *
  * That counter is printed from an `int` that only ever increments, so it goes
- * NEGATIVE past 2^31 (~13.5 h at 44 Hz) and wraps at 2^32.
+ * NEGATIVE past 2^31 (~72 days at the 344.5 Hz block rate) and wraps at 2^32.
  *
  * What makes the delta survive both is the WIDTH, not the signedness: the
  * subtraction has to happen in exactly 32 bits, matching the counter. Two's

--- a/src/host/spi_tally.h
+++ b/src/host/spi_tally.h
@@ -1,0 +1,122 @@
+/* spi_tally.h — SPI frame telemetry from the kernel's own counters.
+ *
+ * Two numbers ablspi already maintains, that nothing was reading:
+ *
+ *   spi_tx_time   `struct ablspi_sys_info` at the END of the mmap'd page
+ *                 (PAGE_SIZE - 8). The driver stamps it after every transfer:
+ *
+ *                     s64 then = trace_clock_local();
+ *                     ablspi_send_message(...);
+ *                     wait_for_completion(&dma_transfer_finished);
+ *                     sysinfo->spi_tx_time = trace_clock_local() - then;
+ *
+ *                 So it is the REAL wire+DMA time of the frame we just did, in
+ *                 nanoseconds, for the cost of one aligned 8-byte load. The
+ *                 shim already maps the whole page, and the post-transfer
+ *                 hw→shadow memcpy already copies those bytes.
+ *
+ *   irq_count     /proc/ableton/ablspi0.0/irq_count — bumped by the GPIO ISR
+ *                 on every XMOS frame, whether or not we serviced it.
+ *
+ * The difference between irq_count and our own frame count is the useful part,
+ * and it needs one fact about the driver to read correctly: **ablspi's IRQ is a
+ * counting semaphore, not a flag.** The ISR does `atomic_inc(&irq_arrived)`;
+ * `ABLSPI_WAIT_AND_SEND_MESSAGE_WITH_SIZE` does `atomic_dec`. So when we
+ * overrun our budget the frame is NOT dropped — it queues, and the next wait
+ * returns immediately, replaying back-to-back. An overrun is therefore
+ * invisible as a gap and shows up as a BURST, which is exactly the signature
+ * that has been read as somebody else's producer misbehaving.
+ *
+ * `irqs - frames` over a window is that queue's change: the number of XMOS
+ * frames that fired while we were still busy with an earlier one.
+ *
+ * This file is pure — no I/O, no allocation, no locks — so `spi_tally_record`
+ * is safe on the SPI callback and the whole thing is host-testable
+ * (tests/host/test_spi_tally.c). Reading /proc and logging live on the worker.
+ */
+
+#ifndef SPI_TALLY_H
+#define SPI_TALLY_H
+
+#include <stdint.h>
+
+/* 128 frames at 44100 Hz = the SPI frame period Move runs at, in ns.
+ * Used only to express how much of each period the transfer itself consumed;
+ * it is nominal, not measured. */
+#define SPI_TALLY_PERIOD_NS 2902494u
+
+/* Written by the SPI callback, read by the worker. Single writer, aligned,
+ * monotonic — so no atomics and no lock. Nothing here is ever reset by the
+ * reader, which is what keeps the handoff race-free: the worker takes
+ * DELTAS of cumulative counters rather than draining a window the producer is
+ * still filling (which would lose whichever sample landed in between, and the
+ * sample most worth keeping is the outlier). */
+typedef struct {
+    volatile uint64_t frames;      /* completed transfers observed */
+    volatile uint64_t tx_ns_sum;   /* sum of spi_tx_time */
+    volatile uint32_t tx_ns_max;   /* worst single transfer since arming */
+    volatile uint32_t tx_ns_last;  /* most recent, for a spot check */
+} spi_tally_t;
+
+/* Worker-owned. Carries the previous sample so deltas can be taken. */
+typedef struct {
+    uint64_t prev_frames;
+    uint64_t prev_tx_ns_sum;
+    uint32_t prev_irqs;
+    int      have_prev;
+    uint64_t backlog;       /* cumulative late IRQs since arming */
+    uint64_t backlog_peak;  /* worst single window */
+} spi_tally_state_t;
+
+/* One window's worth of answer. */
+typedef struct {
+    uint64_t frames;        /* frames this window */
+    uint32_t irqs;          /* IRQs this window */
+    uint32_t avg_ns;        /* mean transfer time this window */
+    uint32_t max_ns;        /* worst transfer since arming */
+    uint32_t headroom_ns;   /* SPI_TALLY_PERIOD_NS - avg_ns, floored at 0 */
+    uint32_t late;          /* IRQs that arrived while busy, this window */
+    uint64_t backlog;       /* cumulative late IRQs since arming */
+    uint64_t backlog_peak;  /* worst single window */
+    int      first;         /* 1 = no previous sample; deltas not meaningful */
+} spi_tally_sample_t;
+
+/* The shim's single instance: written by the SPI callback in
+ * shim_post_transfer, read by the worker's ~1 Hz tick. It lives here rather
+ * than in either of them so neither has to reach into the other's statics. */
+extern spi_tally_t shim_spi_tally;
+
+/* SPI-callback safe. Call once per completed transfer with the kernel's
+ * spi_tx_time. A zero tx_ns is ignored — the driver leaves the field
+ * untouched until the first transfer completes, and folding that zero in
+ * would drag the mean down and pin the minimum at zero forever. */
+void spi_tally_record(spi_tally_t *t, uint32_t tx_ns);
+
+/* Drop both the accumulator and the window state. Called on the rising edge of
+ * arming so a second session does not inherit the first one's peak. */
+void spi_tally_reset(spi_tally_t *t, spi_tally_state_t *s);
+
+/* Fold one worker sample. `irqs` is the raw /proc counter.
+ *
+ * That counter is printed from an `int` that only ever increments, so it goes
+ * NEGATIVE past 2^31 (~13.5 h at 44 Hz) and wraps at 2^32.
+ *
+ * What makes the delta survive both is the WIDTH, not the signedness: the
+ * subtraction has to happen in exactly 32 bits, matching the counter. Two's
+ * complement makes signed and unsigned 32-bit subtraction produce the same
+ * bits, so `(int32_t)a - (int32_t)b` is equally correct — but widen either
+ * operand to 64 bits first and the arithmetic stops being modular, so the
+ * wrap reads as a 4-billion-IRQ window instead of a 44-IRQ one. That is why
+ * `prev_irqs` and `spi_tally_sample_t::irqs` are uint32_t and must stay that
+ * way; widening them "for consistency with frames" is the regression, and
+ * tests/host/test_spi_tally.c fails on exactly it. */
+void spi_tally_fold(spi_tally_state_t *s, const spi_tally_t *t, uint32_t irqs,
+                    spi_tally_sample_t *out);
+
+/* Steady-state line. Returns the length written. */
+int spi_tally_format(const spi_tally_sample_t *s, char *buf, int len);
+
+/* Overrun line — only meaningful when s->late is nonzero. */
+int spi_tally_format_late(const spi_tally_sample_t *s, char *buf, int len);
+
+#endif /* SPI_TALLY_H */

--- a/src/lib/schwung_spi_lib.h
+++ b/src/lib/schwung_spi_lib.h
@@ -50,6 +50,20 @@
 #define SCHWUNG_OFF_IN_DISP_STAT   (SCHWUNG_OFF_IN_BASE + 248)
 #define SCHWUNG_OFF_IN_AUDIO       (SCHWUNG_OFF_IN_BASE + 256)
 
+// Kernel-maintained transfer telemetry — `struct ablspi_sys_info`, which
+// ablspi_open() places at the very END of the page:
+//
+//     spidev->sysinfo = page_address(buffer) + PAGE_SIZE - sizeof(struct ablspi_sys_info);
+//     struct ablspi_sys_info { u64 spi_tx_time; };
+//
+// The driver stamps spi_tx_time (nanoseconds, trace_clock_local) after each
+// completed transfer. Note it OVERLAPS the last 8 bytes of the nominal RX
+// region — rx_buffer is PAGE_SIZE/2 long but the sysinfo block sits inside its
+// tail, so RX is only safely (PAGE_SIZE/2 - 8) bytes. Harmless at Move's
+// 768-byte frames, which reach nowhere near it.
+#define SCHWUNG_OFF_SYSINFO        (SCHWUNG_PAGE_SIZE - 8)
+#define SCHWUNG_OFF_SPI_TX_TIME    SCHWUNG_OFF_SYSINFO
+
 // MIDI limits
 #define SCHWUNG_MIDI_IN_MAX        31
 #define SCHWUNG_MIDI_OUT_MAX       20
@@ -57,7 +71,14 @@
 // Display
 #define SCHWUNG_DISPLAY_SIZE       1024
 
-// ioctl command numbers
+// ioctl command numbers.
+//
+// ablspi dispatches on `_IOC_NR(cmd)` and defines only these five:
+//   6 GET_STATE, 7 CAN_SEND, 10 WAIT_AND_SEND_MESSAGE_WITH_SIZE,
+//   11 SET_SPEED, 12 GET_SPEED.
+// The rest below are ours and are not driver commands — nothing may assume the
+// kernel implements them. Speed range is 5 MHz (the driver default) to 25 MHz;
+// Move selects 20.
 enum schwung_ioctl_cmd {
     SCHWUNG_IOCTL_FILL_TX        = 0,
     SCHWUNG_IOCTL_FILL_RX        = 1,

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -8183,8 +8183,24 @@ post_timing:
     if (ioctl_us > spi_ioctl_max) spi_ioctl_max = ioctl_us;
     if (post_us > spi_post_max) spi_post_max = post_us;
 
-    /* Track overruns (no I/O — just update snapshot) */
-    if (total_us > 2000) {
+    /* Track overruns (no I/O — just update snapshot).
+     *
+     * The threshold is the frame PERIOD, not some fraction of it. `total_us` is
+     * the whole loop iteration and the loop is paced by the blocking ioctl, so
+     * it sits at the period (~2710-2830 us measured) no matter how much or how
+     * little work we do — our work grows, the wait inside the ioctl shrinks by
+     * the same amount. It only exceeds the period when we genuinely blew it.
+     *
+     * The old threshold here was 2000 us, i.e. BELOW the 2902 us period, so it
+     * counted every frame as an overrun: 43,986 of them in two minutes on an
+     * idle device with three empty slots. A counter that fires on 100% of
+     * frames reads as catastrophic and carries no information. Matches
+     * OVERRUN_THRESHOLD_US, which was already calibrated this way (2850 =
+     * "98% of budget", where budget means the period).
+     *
+     * Arm the SPI frame tally for the number this one cannot give you: how
+     * much of the period is the transfer, and whether IRQs are queueing. */
+    if (total_us > OVERRUN_THRESHOLD_US) {
         static uint32_t hook_overrun_count = 0;
         hook_overrun_count++;
         spi_snap.overrun_count = hook_overrun_count;

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -51,6 +51,7 @@
 #include "host/shadow_transport.h"
 #include "host/shadow_set_pages.h"
 #include "host/shim_worker.h"
+#include "host/spi_tally.h"
 #include "host/shadow_dbus.h"
 #include "host/shadow_chain_mgmt.h"
 #include "host/shadow_link_audio.h"
@@ -6340,6 +6341,20 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
 
     /* Root span for the post-ioctl half of the SPI frame. */
     TRACE_SCOPE("spi.post");
+
+    /* SPI frame telemetry from the kernel's own counters. One aligned 8-byte
+     * load of the transfer time ablspi already stamped at the end of the page
+     * (see spi_tally.h) — no syscall, no /proc, nothing added to the wire.
+     * The worker pairs it with irq_count and reports at ~1 Hz.
+     * Dormant unless /data/UserData/schwung/spi_tally_on exists. */
+    if ((shim_debug_flags & SHIM_FLAG_SPI_TALLY) && hw) {
+        uint64_t tx_ns;
+        memcpy(&tx_ns, hw + SCHWUNG_OFF_SPI_TX_TIME, sizeof(tx_ns));
+        /* Clamp rather than truncate: a bogus wide value must not alias to a
+         * plausible-looking microsecond figure. */
+        spi_tally_record(&shim_spi_tally,
+                         tx_ns > 0xFFFFFFFFull ? 0xFFFFFFFFu : (uint32_t)tx_ns);
+    }
 
     /*
      * Knob-touch ground truth, UNCONDITIONALLY.

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -20,7 +20,8 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_midi_in_compact \
 	$(BUILD_DIR)/test_rt_thread_audit \
 	$(BUILD_DIR)/test_master_fx_slot_routing \
-	$(BUILD_DIR)/test_master_fx_saved_state
+	$(BUILD_DIR)/test_master_fx_saved_state \
+	$(BUILD_DIR)/test_spi_tally
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
 # the routing test covers whatever range Master FX actually runs with. Raising
@@ -51,6 +52,9 @@ $(BUILD_DIR)/test_midi_in_compact: test_midi_in_compact.c ../../src/host/shadow_
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_rt_thread_audit: test_rt_thread_audit.c ../../src/host/rt_thread_audit.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/test_spi_tally: test_spi_tally.c ../../src/host/spi_tally.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_master_fx_slot_routing: test_master_fx_slot_routing.c ../../src/host/master_fx_key.h ../../src/host/shadow_chain_mgmt.h | $(BUILD_DIR)

--- a/tests/host/test_spi_tally.c
+++ b/tests/host/test_spi_tally.c
@@ -1,0 +1,278 @@
+/* Unit test: SPI frame tally — kernel transfer time + IRQ backlog.
+ *
+ * The thing being measured is a COMPARISON between two counters that come from
+ * different places and wrap differently, so most of these tests are about the
+ * ways the comparison can lie:
+ *
+ *   - the /proc counter is printed from an int and goes negative past 2^31, so
+ *     a signed delta invents a multi-billion backlog roughly once a day;
+ *   - the driver leaves spi_tx_time at zero until the first transfer, so
+ *     folding that in pins the mean low;
+ *   - `irqs < frames` is the backlog DRAINING, not a negative backlog, and an
+ *     unsigned subtraction there underflows to ~2^32.
+ *
+ * Each of those produces a plausible-looking number rather than an error,
+ * which is why they are pinned individually.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "spi_tally.h"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } \
+} while (0)
+
+/* Advance the accumulator by `n` frames each costing `ns`. */
+static void run_frames(spi_tally_t *t, int n, uint32_t ns)
+{
+    for (int i = 0; i < n; i++) spi_tally_record(t, ns);
+}
+
+static void test_a_zero_transfer_time_is_not_a_sample(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_reset(&t, &s);
+
+    /* ablspi does not touch sysinfo->spi_tx_time until a transfer completes,
+     * so the field reads 0 on the very first frames. Counting those as
+     * zero-nanosecond transfers drags the mean toward zero and makes the
+     * headroom look like a full period. */
+    spi_tally_record(&t, 0);
+    spi_tally_record(&t, 0);
+    CHECK(t.frames == 0, "zero tx_ns must not count as a frame");
+    CHECK(t.tx_ns_sum == 0, "zero tx_ns must not enter the sum");
+
+    spi_tally_record(&t, 300000);
+    CHECK(t.frames == 1, "a real sample counts");
+    CHECK(t.tx_ns_max == 300000, "max tracks the first real sample");
+}
+
+static void test_max_is_the_worst_since_arming(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_reset(&t, &s);
+
+    spi_tally_record(&t, 300000);
+    spi_tally_record(&t, 1900000);
+    spi_tally_record(&t, 310000);
+
+    CHECK(t.tx_ns_max == 1900000, "max keeps the outlier, not the latest");
+    CHECK(t.tx_ns_last == 310000, "last is the latest");
+
+    /* The peak is deliberately NOT per-window: a spike that happens once an
+     * hour is the whole finding, and a per-window max hands it to whichever
+     * one-second bucket it landed in and then throws it away. */
+    spi_tally_sample_t out;
+    spi_tally_fold(&s, &t, 3, &out);          /* baseline */
+    run_frames(&t, 10, 300000);
+    spi_tally_fold(&s, &t, 13, &out);
+    CHECK(out.max_ns == 1900000, "the peak survives a window boundary");
+}
+
+static void test_the_first_fold_is_a_baseline(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_sample_t out;
+    spi_tally_reset(&t, &s);
+
+    run_frames(&t, 44, 300000);
+    spi_tally_fold(&s, &t, 1000, &out);
+
+    CHECK(out.first == 1, "the first fold reports itself as a baseline");
+    CHECK(out.frames == 0, "no frame delta is claimed from one sample");
+    CHECK(out.late == 0, "no backlog is claimed from one sample");
+
+    /* Arming mid-session means the counters already hold hours of history.
+     * Reporting that history as one window's work would read as a colossal
+     * overrun on the very first line. */
+    spi_tally_fold(&s, &t, 1000, &out);
+    CHECK(out.first == 0, "the second fold is a real window");
+    CHECK(out.frames == 0, "…and it measures from the baseline, not from zero");
+}
+
+static void test_a_clean_window_has_no_backlog(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_sample_t out;
+    spi_tally_reset(&t, &s);
+
+    spi_tally_fold(&s, &t, 500, &out);        /* baseline */
+    run_frames(&t, 44, 300000);
+    spi_tally_fold(&s, &t, 544, &out);
+
+    CHECK(out.frames == 44, "frame delta");
+    CHECK(out.irqs == 44, "irq delta");
+    CHECK(out.late == 0, "serviced every IRQ — nothing late");
+    CHECK(out.backlog == 0, "backlog stays clean");
+    CHECK(out.avg_ns == 300000, "mean is over this window's frames");
+    CHECK(out.headroom_ns == SPI_TALLY_PERIOD_NS - 300000, "headroom");
+}
+
+static void test_an_overrun_queues_rather_than_drops(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_sample_t out;
+    spi_tally_reset(&t, &s);
+
+    spi_tally_fold(&s, &t, 0, &out);          /* baseline */
+
+    /* 44 IRQs fired, we only got through 41. ablspi's irq_arrived is a
+     * counting semaphore, so those 3 are queued and will be replayed
+     * back-to-back — the burst that reads as somebody else's producer
+     * misbehaving. */
+    run_frames(&t, 41, 300000);
+    spi_tally_fold(&s, &t, 44, &out);
+    CHECK(out.late == 3, "three IRQs arrived while busy");
+    CHECK(out.backlog == 3, "backlog accumulates");
+    CHECK(out.backlog_peak == 3, "peak tracks the worst window");
+
+    run_frames(&t, 43, 300000);
+    spi_tally_fold(&s, &t, 88, &out);
+    CHECK(out.late == 1, "one more");
+    CHECK(out.backlog == 4, "backlog is cumulative");
+    CHECK(out.backlog_peak == 3, "peak keeps the WORSE earlier window");
+}
+
+static void test_draining_the_queue_is_not_a_negative_backlog(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_sample_t out;
+    spi_tally_reset(&t, &s);
+
+    spi_tally_fold(&s, &t, 0, &out);          /* baseline */
+    run_frames(&t, 41, 300000);
+    spi_tally_fold(&s, &t, 44, &out);         /* 3 queued */
+    CHECK(out.backlog == 3, "precondition: 3 queued");
+
+    /* Now we work off the backlog: 47 frames against 44 IRQs. `irqs - frames`
+     * is negative here, and the counters are unsigned — done naively that is
+     * ~2^32 late IRQs and a backlog that never recovers. */
+    run_frames(&t, 47, 300000);
+    spi_tally_fold(&s, &t, 88, &out);
+    CHECK(out.late == 0, "draining the queue is not lateness");
+    CHECK(out.backlog == 3, "backlog does not underflow");
+    CHECK(out.frames == 47, "frames still counted correctly");
+}
+
+static void test_the_proc_counter_wrapping_is_not_a_spike(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_sample_t out;
+
+    /* The irq_count file under /proc/ableton is printed from an `int` that
+     * only ever increments, so at ~44 Hz it crosses 2^31 after ~13.5 hours and
+     * prints negative from then on, then wraps 2^32 -> 0. Both transitions
+     * must read as an ordinary 44-IRQ window. */
+    const uint32_t sign_flip = 0x7FFFFFFFu;   /* INT_MAX, next print is negative */
+    spi_tally_reset(&t, &s);
+    spi_tally_fold(&s, &t, sign_flip - 22u, &out);   /* baseline */
+    run_frames(&t, 44, 300000);
+    spi_tally_fold(&s, &t, sign_flip + 22u, &out);
+    CHECK(out.irqs == 44, "crossing INT_MAX is a 44-irq window, not a spike");
+    CHECK(out.late == 0, "…and produces no phantom backlog");
+
+    const uint32_t wrap = 0xFFFFFFFFu;
+    spi_tally_reset(&t, &s);
+    spi_tally_fold(&s, &t, wrap - 22u, &out);        /* baseline */
+    run_frames(&t, 44, 300000);
+    spi_tally_fold(&s, &t, (uint32_t)(wrap + 22u), &out);
+    CHECK(out.irqs == 44, "wrapping 2^32 is a 44-irq window, not a spike");
+    CHECK(out.late == 0, "…and produces no phantom backlog");
+}
+
+static void test_headroom_floors_at_zero(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_sample_t out;
+    spi_tally_reset(&t, &s);
+
+    spi_tally_fold(&s, &t, 0, &out);          /* baseline */
+    /* A transfer longer than the nominal period. Unsigned subtraction would
+     * report several thousand microseconds of headroom at the exact moment
+     * there is none. */
+    run_frames(&t, 4, SPI_TALLY_PERIOD_NS + 500000u);
+    spi_tally_fold(&s, &t, 4, &out);
+    CHECK(out.headroom_ns == 0, "headroom cannot go below zero");
+}
+
+static void test_reset_drops_the_previous_session(void)
+{
+    spi_tally_t t;
+    spi_tally_state_t s;
+    spi_tally_sample_t out;
+    spi_tally_reset(&t, &s);
+
+    spi_tally_fold(&s, &t, 0, &out);
+    run_frames(&t, 41, 1900000);
+    spi_tally_fold(&s, &t, 44, &out);
+    CHECK(out.backlog == 3 && out.max_ns == 1900000, "precondition");
+
+    /* Disarming and re-arming must not inherit the old peak or backlog —
+     * otherwise a fresh measurement opens by reporting an overrun that
+     * happened before the user started looking. */
+    spi_tally_reset(&t, &s);
+    spi_tally_fold(&s, &t, 44, &out);
+    CHECK(out.first == 1, "re-arming takes a fresh baseline");
+    CHECK(out.backlog == 0, "backlog is dropped");
+    CHECK(out.max_ns == 0, "peak is dropped");
+}
+
+static void test_format_never_overruns(void)
+{
+    spi_tally_sample_t out;
+    memset(&out, 0, sizeof(out));
+    out.frames = 18446744073709551615ull;
+    out.irqs = 0xFFFFFFFFu;
+    out.avg_ns = 0xFFFFFFFFu;
+    out.max_ns = 0xFFFFFFFFu;
+    out.headroom_ns = 0xFFFFFFFFu;
+    out.late = 0xFFFFFFFFu;
+    out.backlog = 18446744073709551615ull;
+    out.backlog_peak = 18446744073709551615ull;
+
+    char small[16];
+    memset(small, 0x7F, sizeof(small));
+    spi_tally_format(&out, small, (int)sizeof(small));
+    CHECK(small[sizeof(small) - 1] == '\0', "format NUL-terminates within len");
+
+    memset(small, 0x7F, sizeof(small));
+    spi_tally_format_late(&out, small, (int)sizeof(small));
+    CHECK(small[sizeof(small) - 1] == '\0', "format_late NUL-terminates within len");
+
+    char big[256];
+    out.first = 1;
+    spi_tally_format(&out, big, (int)sizeof(big));
+    CHECK(strstr(big, "baseline") != NULL, "the baseline line says so");
+}
+
+int main(void)
+{
+    test_a_zero_transfer_time_is_not_a_sample();
+    test_max_is_the_worst_since_arming();
+    test_the_first_fold_is_a_baseline();
+    test_a_clean_window_has_no_backlog();
+    test_an_overrun_queues_rather_than_drops();
+    test_draining_the_queue_is_not_a_negative_backlog();
+    test_the_proc_counter_wrapping_is_not_a_spike();
+    test_headroom_floors_at_zero();
+    test_reset_drops_the_previous_session();
+    test_format_never_overruns();
+
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    printf("PASS: spi tally — irq backlog survives the /proc counter's wrap, "
+           "and draining is not a negative backlog\n");
+    return 0;
+}

--- a/tests/host/test_spi_tally.c
+++ b/tests/host/test_spi_tally.c
@@ -5,7 +5,8 @@
  * ways the comparison can lie:
  *
  *   - the /proc counter is printed from an int and goes negative past 2^31, so
- *     a signed delta invents a multi-billion backlog roughly once a day;
+ *     the delta must stay a 32-bit subtraction of 32-bit operands; widening
+ *     either side turns the wrap into a 4-billion-IRQ window;
  *   - the driver leaves spi_tx_time at zero until the first transfer, so
  *     folding that in pins the mean low;
  *   - `irqs < frames` is the backlog DRAINING, not a negative backlog, and an
@@ -168,10 +169,10 @@ static void test_the_proc_counter_wrapping_is_not_a_spike(void)
     spi_tally_state_t s;
     spi_tally_sample_t out;
 
-    /* The irq_count file under /proc/ableton is printed from an `int` that
-     * only ever increments, so at ~44 Hz it crosses 2^31 after ~13.5 hours and
-     * prints negative from then on, then wraps 2^32 -> 0. Both transitions
-     * must read as an ordinary 44-IRQ window. */
+    /* The irq_count file under /proc/ableton is printed from an `int` that only
+     * ever increments. At Move's 344.5 Hz block rate it crosses 2^31 after ~72
+     * days and prints negative from then on, then wraps 2^32 -> 0. Both
+     * transitions must read as an ordinary window. */
     const uint32_t sign_flip = 0x7FFFFFFFu;   /* INT_MAX, next print is negative */
     spi_tally_reset(&t, &s);
     spi_tally_fold(&s, &t, sign_flip - 22u, &out);   /* baseline */


### PR DESCRIPTION
Reads two counters ablspi already maintains that nothing here was looking at, and in doing so corrects a number several other conclusions rest on.

`ablspi` ships in Ableton's GPL source drop for Move (`drivers/spi/ablspi-*.c` in the patched `linux-raspberrypi-5.15.92-rt57` tree), so the driver side is no longer reverse-engineered. Facts taken from it are marked *(driver)* in `docs/SPI_PROTOCOL.md`.

## The instrument

```
touch /data/UserData/schwung/spi_tally_on

spi-tally: 345 frames / 345 irq  tx avg 389us (max 464us)  headroom 2513us  backlog 6
spi-tally: LATE 1 irq(s) arrived while busy — frames queued, not dropped (backlog 6, worst window 1)
```

- **`tx`** is the driver's own `spi_tx_time`, stamped into `struct ablspi_sys_info` at the end of the mmap'd page after every transfer. One aligned 8-byte load of memory the shim already maps — no syscall, nothing on the wire.
- **`irq`** is `/proc/ableton/ablspi0.0/irq_count`, read on the worker because it is file I/O.

**The gap between them is the point, because ablspi's IRQ is a counting semaphore, not a flag** (`atomic_inc` in the ISR, `atomic_dec` in the wait). Overrun the budget and the frame is *not dropped* — it queues, and the next waits replay back-to-back. A late frame never appears as a gap; it appears as a **burst**, which is the shape that gets attributed to somebody else's producer misbehaving. `backlog` is that queue. Worth pointing at the Link Audio dropouts.

## What it found, on hardware

| | µs |
|---|---|
| Frame period (block rate **344.5 Hz**) | 2902 |
| `ioctl`, as `[spi_timing]` measures it | 2569 |
| …of which **actual transfer** | **389** (max 464) |
| …of which **blocked waiting for the next IRQ** | **~2180** |
| Our compute (pre 97 + post 43) | ~140 |
| **Real slack** | **~2370** |

The "~2 ms transfer" in `docs/REALTIME_SAFETY.md` was never the transfer — it is the ioctl, and most of it is the driver idling until the XMOS says go. **The ~900 µs budget derived from it is wrong by ~2.6×.**

Corollary: **`total_us` is not a load signal.** Our work growing shrinks the driver's wait by exactly as much, so the loop total is pinned near the period whatever we do.

Which is exactly the trap the second commit fixes. The overrun counter tested `total_us > 2000` — *below* the 2902 µs period — so it counted every frame:

```
overruns=43986      ← two minutes, idle device, three empty slots
```

...while sitting on the same log line as `ioctl avg=2568`, reading like corroboration for a transfer time that was really 389. Repointed at `OVERRUN_THRESHOLD_US` (2850, already correctly calibrated against the period). **Verified on device: 43,986 → 1.**

## Shape

`src/host/spi_tally.c` is pure — no I/O, allocation or locks — so `spi_tally_record` is SPI-callback-safe and the logic is host-tested; `/proc` reading and logging live on the worker. Follows `shadow_xmos_audio` and `rt_thread_audit` respectively. Zero hot-path cost disarmed.

The producer/consumer handoff takes **deltas of cumulative counters** rather than draining a window the producer is still filling — which would lose whichever sample landed in between, and the sample most worth keeping is the outlier.

## Tests

`tests/host/test_spi_tally.c`, mutation-checked. Two pins matter because both failure modes produce a plausible-looking number rather than an error:

- **The IRQ delta must stay a 32-bit subtraction of 32-bit operands.** Signed vs unsigned makes no difference (two's complement) — I originally credited signedness and mutation testing showed that mutation is *equivalent*; the real protection is the **width**. Widening the fields "for consistency with `frames`" turns the counter's wrap into a 4-billion-IRQ window, and the test fails on exactly that.
- **`irqs < frames` is the queue draining, not a negative backlog.** Unguarded unsigned subtraction underflows to ~2^32 and never recovers. Killed by mutation.

## Docs

- `docs/SPI_PROTOCOL.md` — driver-derived facts, marked: the real ioctl set (only 6/7/10/11/12 exist, dispatched on `_IOC_NR`), the 5–25 MHz speed range (Move uses 20), single-opener `-EBUSY` (which is *why* the shim must be an LD_PRELOAD), and that RX is safely 2040 bytes because `sysinfo` overlaps its tail.
- `docs/REALTIME_SAFETY.md` — the measured budget table above.
- `CLAUDE.md` — how to arm it and how to read `backlog`.

## Verification

- `make -C tests/host test` — green, including the new test.
- ARM cross-compile clean; symbols linked into `schwung-shim.so`.
- Deployed to hardware twice; device shim md5 confirmed matching the local build before trusting any reading.
- Diagnostics disarmed on the device afterwards.

## Not done

No reading taken with modules loaded — that is the one that matters for the Link Audio dropouts, and it needs a deliberate session rather than disturbing a live set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QngBPVQH9SRyeV3pgJwtja