### PR TITLE
usbc out: the boot gate was a deadline racing Move's assert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1009,11 +1009,30 @@ nothing to correct and nothing goes on the wire.
 
 Two behaviours worth knowing:
 
-- **Persistence is gated for ~7 s after boot.** Move asserts its Mic default at
-  ~0.6 s, and the shim observes its *own* replay too (emit runs earlier in the
-  same `pre_transfer` than scan). Persisting either would clobber the stored
-  preference on every reboot. Trade-off: a change made in the first ~7 s of boot
-  is not persisted.
+- **Persistence is gated CAUSALLY, not on a deadline** (`src/host/usbc_out_gate.c`).
+  Move asserts its Mic default at ~0.6 s, and the shim observes its *own* replay
+  too (emit runs earlier in the same `pre_transfer` than scan) — neither carries
+  user intent and persisting either clobbers the stored preference.
+
+  This was a ~7 s deadline, and **that deadline was a bug**. The worker's clock
+  starts when MoveOriginal opens the SPI device; Move's assert floats with boot
+  load. A slow boot put the assert on the trusting side of the line, so Mic was
+  written over a stored Main Out — reverting in session *and* forgetting across
+  the reboot, one mechanism producing both halves of the symptom, intermittent
+  by construction. Confirmed on hardware: one boot logging `USB-C out: boot
+  re-assert Main Out` and the state file later reading `0` with no user action.
+
+  The discriminator is not time. **We only ever re-assert Main Out, so during
+  the boot window an observed Mic can only have come from Move.** The gate
+  stays closed until Move has had its say *and* we have re-asserted over it —
+  pre-replay observations are recorded but never persisted; while defending, an
+  observed Mic is countered (bounded by `USBC_GATE_MAX_REPLAYS`) rather than
+  believed; an observed Main Out only settles the gate once Move has actually
+  asserted Mic this boot, so our own echo cannot settle it early on a slow boot.
+  A ~60 s `usbc_gate_force_settle` backstop covers a boot where Move never
+  speaks (opening the gate persists nothing by itself). Trade-off, unchanged in
+  kind but now bounded by events: a change made before the ~5 s re-assert is not
+  persisted. Unit tests: `tests/host/test_usbc_out_gate.sh`.
 - **Move's own Settings screen keeps reading "Mic"** even when the hardware is on
   Main Out — Move doesn't adopt the replayed value into its UI state. The audio
   is correct; the screen is not. Selecting "Main Out" there is harmless;
@@ -1032,7 +1051,10 @@ before the ~5 s replay and the restore needs no runtime propagation.
 Impl: `src/host/shadow_xmos_audio.c` (pure codec — no I/O, allocation or locks,
 so it is both SPI-callback-safe and host-testable; unit tests in
 `tests/host/test_xmos_audio.sh`), observed and emitted in `schwung_shim.c`'s
-pre-transfer callback, persisted and armed in `src/host/shim_worker.c`.
+pre-transfer callback, persisted and armed in `src/host/shim_worker.c`. The
+boot arbitration is split out as `src/host/usbc_out_gate.c` — also pure state,
+with no clock of its own, which is what makes the boot orderings testable
+without a device.
 
 `xmos_audio_emit` is also the only sanctioned way to put SysEx into MIDI_OUT: it
 requires a **contiguous** run of free slots, refuses while any cable-0 SysEx is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1001,6 +1001,28 @@ Out reaches USB-C (the XMOS mutes the speakers while it's set, to prevent
 feedback). `37 14` is the dedicated out-source bit. This resolves open question
 Q2 in the movesniff findings doc, which listed `0x14` as unreversed.
 
+**Move's sampling page emits a LONE `37 12`, and it clears bit1.** Captured
+2026-08-26: changing the sampling source sent `37 12 01` then `37 12 00`, with
+no `37 14` anywhere near either. The original 2026-08-18 capture recorded bit0
+as `0` throughout and concluded "the pair is atomic" — true of the *out-source*
+control, false of the sampling page, which that capture never exercised.
+Because bit1 is what actually routes Main Out to USB-C, a sampling-source
+change silently reverted USB-C out to Mic while `37 14` still read Main Out, so
+nothing re-asserted. That is the **in-session** half of "sometimes reverts to
+the microphone"; the boot gate below is the across-reboot half.
+
+`xmos_audio_state_t.monitor` therefore tracks bit1 in its own right (it is
+deliberately NOT folded into `scan`'s `changed` return — that flag means "the
+out-source selection moved", and this is not a selection), and
+`usbc_gate_tick_monitor` re-asserts on `usbc_out == 1 && monitor == 0`. The
+`37 14` half of that test is what keeps it off a deliberate Mic selection,
+which moves both. **The debounce is load-bearing**: the pair can split across
+SPI frames (16 of 20 MIDI_OUT slots), so acting on a single tick would fight
+the leading half of a split Mic selection. Two consecutive worker ticks
+(~400 ms) against ~3 ms frames settles that. Verified on hardware — Move's
+`37 12 01` at f75529, our `37 12 03` at f75635 (**bit0 preserved, bit1
+restored**), then quiet.
+
 Flow: the SPI pre-transfer callback scans MIDI_OUT via `xmos_audio_scan`; the
 worker persists the value to `/data/UserData/schwung/usbc_out_state`; ~5 s after
 boot the worker arms a replay, which the SPI callback emits one message per

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -241,6 +241,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/shadow_resample.c src/host/shadow_overlay.c src/host/shadow_pin_scanner.c \
     src/host/shadow_led_queue.c src/host/shadow_state.c \
     src/host/shadow_xmos_audio.c src/host/shadow_xmos_audio.h \
+    src/host/usbc_out_gate.c src/host/usbc_out_gate.h \
     src/host/shadow_midi.c src/host/shadow_midi_filter.c src/host/shadow_midi_filter.h \
     src/host/unified_log.c src/host/shim_worker.c \
     src/host/rt_thread_audit.c src/host/rt_thread_audit.h \
@@ -275,6 +276,7 @@ if needs_rebuild build/schwung-shim.so \
         src/host/shadow_led_queue.c \
         src/host/shadow_state.c \
         src/host/shadow_xmos_audio.c \
+        src/host/usbc_out_gate.c \
         src/host/shadow_midi.c \
         src/host/shadow_midi_filter.c \
         src/host/unified_log.c \

--- a/src/host/shadow_xmos_audio.c
+++ b/src/host/shadow_xmos_audio.c
@@ -69,6 +69,13 @@ int xmos_audio_scan(const uint8_t *midi_out, int len, xmos_audio_state_t *st) {
         if (st->rx_buf[7] == XMOS_AUDIO_KEY_ROUTE) {
             memcpy(st->route, st->rx_buf, XMOS_AUDIO_MSG_LEN);
             st->have_route = 1;
+            /* Track bit1 separately. It is not redundant with usbc_out: Move's
+             * sampling page sends a LONE 37 12 to set bit0 and carries bit1
+             * from its own stale "Mic" state, which clears monitoring and so
+             * reverts the hardware to Mic with no 37 14 to show for it.
+             * Deliberately NOT folded into `changed` — that flag means "the
+             * out-source selection moved", and this is not a selection. */
+            st->monitor = (st->rx_buf[8] & XMOS_AUDIO_ROUTE_BIT_MONITOR) ? 1 : 0;
         } else if (st->rx_buf[7] == XMOS_AUDIO_KEY_OUT_SRC) {
             int8_t out = (st->rx_buf[8] & 0x01) ? 1 : 0;
             if (st->usbc_out != out) {

--- a/src/host/shadow_xmos_audio.h
+++ b/src/host/shadow_xmos_audio.h
@@ -33,6 +33,14 @@ typedef struct {
     uint8_t  route[XMOS_AUDIO_MSG_LEN]; /* last observed 37 12 envelope */
     uint8_t  have_route;                /* 1 once route[] is populated */
     int8_t   usbc_out;                  /* -1 unknown, 0 = Mic, 1 = Main Out */
+    /* Bit1 of the last observed 37 12, tracked separately from usbc_out
+     * because Move's sampling page emits a LONE 37 12 to set bit0 (the USB-C
+     * input select) and carries bit1 from its own permanently-stale "Mic" UI
+     * state. Observed on hardware 2026-08-26: `37 12 01` then `37 12 00`, with
+     * no 37 14 in the frame or anywhere near it. That clears monitoring — and
+     * monitoring is *how* Main Out reaches USB-C — so the hardware reverts to
+     * Mic while usbc_out still reads 1 and nothing re-asserts. -1 = unknown. */
+    int8_t   monitor;
     uint32_t seq;                       /* bumped on every usbc_out change */
 
     /* Reassembly state. Persisted here (not on the call stack) because a
@@ -48,7 +56,7 @@ typedef struct {
  * state reads usbc_out == 0, which is indistinguishable from an observed Mic
  * selection and would suppress the first real change. Always init state with
  * this macro rather than {0} or memset. */
-#define XMOS_AUDIO_STATE_INIT { .usbc_out = -1 }
+#define XMOS_AUDIO_STATE_INIT { .usbc_out = -1, .monitor = -1 }
 
 /* Scan a MIDI_OUT region (len bytes, 4-byte USB-MIDI slots) and fold any
  * audio-IO envelopes into st. Only cable-0 packets (Move's own firmware)

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -17,6 +17,8 @@
 #include "spi_tally.h"
 #include "shadow_set_pages.h"
 #include "unified_log.h"
+#include "usbc_out_gate.h"
+#include "shadow_resample.h"   /* usbc_out_persist_enabled */
 
 volatile uint32_t shim_debug_flags = 0;
 volatile int shim_pending_sysex_inject = -1;
@@ -498,8 +500,14 @@ static void *worker_main(void *arg) {
     int last_persisted = boot_jack;
     int boot_reasserted = 0;
 
-    int boot_usbc_out = usbc_out_state_read();  /* -1 if never persisted */
-    int last_usbc_out = boot_usbc_out;
+    /* USB-C audio-out arbitration. The gate decides what is Move's boot
+     * default and what is the user; see usbc_out_gate.h for why that cannot be
+     * a deadline. `usbc_last_fed` is the edge detector for the level the RT
+     * path publishes — it only ever writes on a change, so feeding the gate
+     * once per distinct value is exactly one call per real transition. */
+    usbc_gate_t usbc_gate;
+    usbc_gate_init(&usbc_gate, usbc_out_state_read());  /* -1 if never persisted */
+    int usbc_last_fed = -1;
 
     for (;;) {
         usleep(200 * 1000);             /* 200 ms cadence */
@@ -513,24 +521,37 @@ static void *worker_main(void *arg) {
             jack_state_write(jp);
         }
 
-        /* Persist the USB-C audio-out source when the RT path reports a change —
-         * but only once the boot window has fully settled. Two things put
-         * unintended values on the wire early: (1) Move's own firmware asserts
-         * its Mic default at ~0.6 s into every boot, regardless of what the
-         * user last chose; (2) our own boot re-assert (armed below, ~5 s) is
-         * itself observed by the same scan() that feeds this variable, since
-         * the shim's SysEx emit runs earlier in the same pre_transfer than its
-         * scan (see the scan call site in schwung_shim.c). Persisting either
-         * would silently clobber the stored preference on every reboot. Gate
-         * on tick >= 35 (~7 s) — after both Move's assert and our own replay
-         * echo — so only genuine post-boot user changes are written. Known,
-         * accepted trade-off: a setting change made in the first ~7 s of boot
-         * is not persisted. */
+        /* Feed the USB-C arbitration gate. Two things put values on the wire
+         * that carry no user intent: Move's own Mic default at boot, and our
+         * re-assert echoing back (the shim's SysEx emit runs earlier in the
+         * same pre_transfer than its scan, so scan cannot tell our bytes from
+         * Move's). Neither may reach the state file.
+         *
+         * This used to be a ~7 s deadline, which raced Move's assert: the
+         * worker's clock starts when MoveOriginal opens the SPI device, while
+         * Move's assert floats with boot load, so a slow boot landed it on the
+         * trusting side and wrote Mic over a stored Main Out — reverting in
+         * session and forgetting across the reboot. The gate replaces the
+         * deadline with the one thing that genuinely separates the two: we
+         * only ever re-assert Main Out, so during the boot window an observed
+         * Mic can only have come from Move. */
         int up = shim_usbc_out_persist;
-        if (tick >= 35 && up >= 0 && up != last_usbc_out) {
-            last_usbc_out = up;
-            usbc_out_state_write(up);
+        if (up >= 0 && up != usbc_last_fed) {
+            usbc_last_fed = up;
+            usbc_gate_out_t act = {0};
+            usbc_gate_observe(&usbc_gate, up, &act);
+            if (act.replay) {
+                shim_usbc_out_replay = act.replay_value;
+                unified_log("shim", LOG_LEVEL_DEBUG,
+                            "USB-C out: Move asserted Mic over a stored Main Out — re-asserting");
+            }
+            if (act.persist) usbc_out_state_write(act.persist_value);
         }
+
+        /* Backstop: on a boot where Move never asserts at all, the gate would
+         * otherwise stay closed and silently swallow every user change for the
+         * rest of the session. Opening it persists nothing by itself. */
+        if (tick == 300) usbc_gate_force_settle(&usbc_gate);   /* ~60 s */
 
         /* Re-assert jack state to Move once, ~5 s after start (Move's firmware
          * is up by then). Prefer the value XMOS actually reported THIS boot
@@ -542,16 +563,24 @@ static void *worker_main(void *arg) {
             int v = (shim_jack_persist >= 0) ? shim_jack_persist : boot_jack;
             if (v >= 0) shim_inject_boot_jack = v;
 
-            /* Re-assert the USB-C audio-out source too. Skip entirely when the
-             * stored value is Mic — that's Move's own boot default, so there is
-             * nothing to correct and no reason to put SysEx on the wire. */
-            if (boot_usbc_out == 1) shim_usbc_out_replay = 1;
-
-            /* Discard anything observed during the boot window before the
-             * persistence gate (tick >= 35) opens — Move's own boot-default
-             * assert and, shortly, our own replay echo have no user intent
-             * behind them and must not be queued up to write the file. */
-            shim_usbc_out_persist = -1;
+            /* Re-assert the USB-C audio-out source too. The gate puts nothing
+             * on the wire when the stored value is Mic — that's Move's own
+             * boot default, so there is nothing to correct.
+             *
+             * With restore switched off in Global Settings the shim drops the
+             * replay, so defending would mean guarding a re-assert that never
+             * reaches the wire: the gate would spend its whole budget on
+             * Move's assert and stay shut meanwhile. Restore-off still
+             * *remembers* (the setting governs only whether we re-assert), so
+             * open the gate instead and let the ordinary differs-from-stored
+             * test run from the start. */
+            if (usbc_out_persist_enabled) {
+                usbc_gate_out_t act = {0};
+                usbc_gate_boot_replay(&usbc_gate, &act);
+                if (act.replay) shim_usbc_out_replay = act.replay_value;
+            } else {
+                usbc_gate_force_settle(&usbc_gate);
+            }
         }
 
         if (tick % 5 == 0) poll_flags();          /* ~1 Hz */

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -26,6 +26,8 @@ volatile int shim_inject_boot_jack = -1;
 volatile int shim_jack_persist = -1;
 volatile int shim_usbc_out_persist = -1;
 volatile int shim_usbc_out_replay = -1;
+volatile int shim_usbc_out_level = -1;
+volatile int shim_usbc_monitor = -1;
 
 /* Persisted jack state (last CC 115 value). Survives reboot so the worker can
  * re-assert it to Move at boot — XMOS doesn't report jack-in at boot, so an
@@ -543,9 +545,27 @@ static void *worker_main(void *arg) {
             if (act.replay) {
                 shim_usbc_out_replay = act.replay_value;
                 unified_log("shim", LOG_LEVEL_DEBUG,
-                            "USB-C out: Move asserted Mic over a stored Main Out — re-asserting");
+                            "USB-C out: Move asserted Mic over a stored Main Out (boot) — re-asserting");
             }
             if (act.persist) usbc_out_state_write(act.persist_value);
+        }
+
+        /* Defend against Move's sampling page clearing monitoring behind our
+         * back. It emits a lone 37 12 to set bit0 (the USB-C input select) and
+         * carries bit1 from its own stale "Mic" UI state, which reverts the
+         * hardware while 37 14 still reads Main Out — so there is no edge for
+         * the observe path above to see. Debounced inside the gate so the
+         * leading half of a split 37 12 / 37 14 Mic selection is not mistaken
+         * for it. */
+        {
+            usbc_gate_out_t act = {0};
+            usbc_gate_tick_monitor(&usbc_gate, shim_usbc_out_level,
+                                   shim_usbc_monitor, &act);
+            if (act.replay && usbc_out_persist_enabled) {
+                shim_usbc_out_replay = act.replay_value;
+                unified_log("shim", LOG_LEVEL_DEBUG,
+                            "USB-C out: monitoring cleared by a lone 37 12 — re-asserting Main Out");
+            }
         }
 
         /* Backstop: on a boot where Move never asserts at all, the gate would

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -64,6 +64,14 @@ extern volatile int shim_usbc_out_persist;
  * then); the RT consumer emits the SysEx pair and swaps it back to -1. */
 extern volatile int shim_usbc_out_replay;
 
+/* Live view of the two bits that together decide whether Main Out actually
+ * reaches USB-C, republished by the RT path every frame (-1 until observed).
+ * Unlike shim_usbc_out_persist these are levels, not edges: the worker polls
+ * them to notice Move's sampling page clearing monitoring behind our back with
+ * a lone 37 12. See usbc_gate_tick_monitor. */
+extern volatile int shim_usbc_out_level;   /* 37 14: 0 = Mic, 1 = Main Out */
+extern volatile int shim_usbc_monitor;     /* 37 12 bit1: monitoring engaged */
+
 /* Deferred events (RT-safe to post; worker executes within ~200 ms). */
 #define SHIM_EVT_OVERTAKE_EXIT_HOOK 1
 #define SHIM_EVT_RESTART_MOVE       2

--- a/src/host/usbc_out_gate.c
+++ b/src/host/usbc_out_gate.c
@@ -1,0 +1,111 @@
+/* usbc_out_gate.c - Boot arbitration for the USB-C audio-out preference.
+ * See usbc_out_gate.h for the model and why it is causal rather than timed. */
+
+#include "usbc_out_gate.h"
+
+static void gate_persist(usbc_gate_t *g, usbc_gate_out_t *out, int v)
+{
+    out->persist = 1;
+    out->persist_value = (int8_t)v;
+    /* Track what we wrote. Without this a value would be written on every
+     * repeat, and a change back to the original would compare equal to a
+     * stale `stored` and be dropped as "no change". */
+    g->stored = (int8_t)v;
+}
+
+static void gate_replay(usbc_gate_t *g, usbc_gate_out_t *out)
+{
+    g->replays_left--;
+    out->replay = 1;
+    out->replay_value = 1;   /* we only ever re-assert Main Out */
+}
+
+void usbc_gate_init(usbc_gate_t *g, int stored)
+{
+    g->stored = (int8_t)stored;
+    g->phase = USBC_GATE_PHASE_PRE_REPLAY;
+    g->replays_left = USBC_GATE_MAX_REPLAYS;
+    g->saw_mic_assert = 0;
+}
+
+void usbc_gate_boot_replay(usbc_gate_t *g, usbc_gate_out_t *out)
+{
+    if (g->phase != USBC_GATE_PHASE_PRE_REPLAY) return;
+
+    /* Only a stored Main Out needs defending. A stored Mic agrees with Move's
+     * own boot default, so there is nothing to put on the wire and nothing to
+     * arbitrate — open the gate and let the ordinary differs-from-stored test
+     * do the rest. Same for an absent preference. */
+    if (g->stored != 1) {
+        g->phase = USBC_GATE_PHASE_SETTLED;
+        return;
+    }
+
+    g->phase = USBC_GATE_PHASE_DEFENDING;
+    gate_replay(g, out);
+}
+
+void usbc_gate_observe(usbc_gate_t *g, int observed, usbc_gate_out_t *out)
+{
+    int v = observed ? 1 : 0;
+
+    switch (g->phase) {
+    case USBC_GATE_PHASE_PRE_REPLAY:
+        /* Nothing before our re-assert can be attributed to the user with any
+         * confidence, so nothing here is persisted. We do record whether Move
+         * has asserted its Mic default yet — that is the fact the defending
+         * phase needs, and the whole reason a fast boot behaves differently
+         * from a slow one. */
+        if (v == 0) g->saw_mic_assert = 1;
+        return;
+
+    case USBC_GATE_PHASE_DEFENDING:
+        if (v == 0) {
+            /* We never replay Mic, so during the boot window a 0 can only have
+             * come from Move. This is the observation the old wall-clock gate
+             * mistook for a user choice and wrote to the file. Counter it. */
+            g->saw_mic_assert = 1;
+            if (g->replays_left > 0) {
+                gate_replay(g, out);
+            } else {
+                /* Out of attempts. Open the gate rather than keep defending —
+                 * staying shut would swallow every user change for the rest of
+                 * the session, which is a worse failure than losing the
+                 * argument about the boot default.
+                 *
+                 * Adopt Mic as the in-memory value but do NOT write it. That
+                 * is the whole point: the file keeps the user's Main Out, so
+                 * the next boot tries again, while we stop re-writing a value
+                 * we never agreed with. Settling without this line would let
+                 * the very next observation persist the Mic we just failed to
+                 * override — reintroducing the bug at the bottom of the
+                 * fallback path. Cost, in a path that needs Move to assert its
+                 * default USBC_GATE_MAX_REPLAYS times in one boot: a genuine
+                 * user Mic choice later in this session compares equal and is
+                 * not written. */
+                g->phase = USBC_GATE_PHASE_SETTLED;
+                g->stored = 0;
+            }
+        } else {
+            /* Main Out is live. Settle only once Move has actually asserted
+             * its default this boot — otherwise this is just our own replay
+             * echoing back on a slow boot, and settling on it would leave us
+             * open to exactly the late assert we are here to defend against. */
+            if (g->saw_mic_assert) g->phase = USBC_GATE_PHASE_SETTLED;
+        }
+        return;
+
+    case USBC_GATE_PHASE_SETTLED:
+    default:
+        if (v != g->stored) gate_persist(g, out, v);
+        return;
+    }
+}
+
+void usbc_gate_force_settle(usbc_gate_t *g)
+{
+    /* Permits future writes; deliberately performs none. Whatever we were
+     * defending stays the stored preference. */
+    if (g->phase != USBC_GATE_PHASE_SETTLED)
+        g->phase = USBC_GATE_PHASE_SETTLED;
+}

--- a/src/host/usbc_out_gate.c
+++ b/src/host/usbc_out_gate.c
@@ -26,6 +26,9 @@ void usbc_gate_init(usbc_gate_t *g, int stored)
     g->phase = USBC_GATE_PHASE_PRE_REPLAY;
     g->replays_left = USBC_GATE_MAX_REPLAYS;
     g->saw_mic_assert = 0;
+    g->last_monitor = -1;
+    g->monitor_pending = 0;
+    g->monitor_replays_left = USBC_GATE_MAX_REPLAYS;
 }
 
 void usbc_gate_boot_replay(usbc_gate_t *g, usbc_gate_out_t *out)
@@ -100,6 +103,50 @@ void usbc_gate_observe(usbc_gate_t *g, int observed, usbc_gate_out_t *out)
         if (v != g->stored) gate_persist(g, out, v);
         return;
     }
+}
+
+void usbc_gate_tick_monitor(usbc_gate_t *g, int usbc_out, int monitor,
+                            usbc_gate_out_t *out)
+{
+    /* Boot arbitration owns the wire until it settles — it is already
+     * re-asserting on its own budget, and two defences bidding at once would
+     * double-spend. */
+    if (g->phase != USBC_GATE_PHASE_SETTLED || g->stored != 1) {
+        g->monitor_pending = 0;
+        return;
+    }
+
+    if (monitor != g->last_monitor) {
+        g->last_monitor = (int8_t)monitor;
+        g->monitor_pending = 0;
+        /* A fresh loss is a new event and gets a full budget — otherwise the
+         * fourth sampling-source change of a session would go undefended
+         * because the first three drained the counter. */
+        if (monitor == 0) g->monitor_replays_left = USBC_GATE_MAX_REPLAYS;
+    }
+
+    /* A deliberate Mic selection moves 37 14 as well, and is not ours to
+     * fight. Only "37 14 still says Main Out but monitoring is gone" is the
+     * lone-37-12 signature. */
+    if (usbc_out != 1 || monitor != 0) {
+        g->monitor_pending = 0;
+        return;
+    }
+
+    /* Hysteresis: the pair can split across SPI frames, so one tick of
+     * agreement is not enough to tell a lone 37 12 from the leading half of a
+     * split Mic selection. Frames are ~3 ms against a 200 ms tick, so a split
+     * has always resolved by the second. */
+    if (g->monitor_pending < USBC_GATE_MONITOR_DEBOUNCE - 1) {
+        g->monitor_pending++;
+        return;
+    }
+    g->monitor_pending = 0;
+
+    if (g->monitor_replays_left == 0) return;
+    g->monitor_replays_left--;
+    out->replay = 1;
+    out->replay_value = 1;
 }
 
 void usbc_gate_force_settle(usbc_gate_t *g)

--- a/src/host/usbc_out_gate.h
+++ b/src/host/usbc_out_gate.h
@@ -1,0 +1,93 @@
+/* usbc_out_gate.h - Boot arbitration for the USB-C audio-out preference.
+ *
+ * THE PROBLEM THIS SOLVES
+ *
+ * Move's firmware forgets the USB-C audio-out source across reboots and
+ * asserts its own Mic default on every boot. Schwung remembers the user's
+ * preference and re-asserts it a few seconds in. Both arrive on the wire as
+ * the same `37 14` envelope, so nothing in the bytes says which is which.
+ *
+ * The original gate separated them by wall clock: ignore everything for the
+ * first ~7 s, trust everything after. That races a variable-latency firmware
+ * event with a fixed deadline. The worker's clock starts when MoveOriginal
+ * opens the SPI device; Move's default assert floats with boot load. When a
+ * slow boot pushed the assert past the deadline, the observed Mic was taken
+ * for a user choice and written to the state file — so the preference both
+ * reverted in that session AND was forgotten on the next boot. One mechanism,
+ * both halves of the reported symptom, intermittent by construction.
+ *
+ * THE SIGNAL THAT ACTUALLY SEPARATES THEM
+ *
+ * We only ever re-assert Main Out (1) — replaying Mic would be pointless,
+ * since Mic is Move's own boot default. So during the boot window an observed
+ * **0 can only have come from Move**, never from us. That, not elapsed time,
+ * is the discriminator.
+ *
+ * The gate therefore stays closed until Move has had its say AND we have
+ * re-asserted over it:
+ *
+ *   phase 0  pre-replay   observations recorded, never persisted
+ *   phase 1  defending    an observed 0 is Move's default -> re-assert, never
+ *                         persist; an observed 1 settles us, but only once
+ *                         Move has actually asserted 0 this boot
+ *   phase 2  settled      ordinary operation: persist anything that differs
+ *
+ * A slow boot now lands in phase 1 with `saw_mic_assert` still clear, so our
+ * own replay echo cannot settle the gate prematurely; Move's late assert is
+ * countered rather than believed.
+ *
+ * Everything here is pure state — no I/O, no allocation, no locks, no clock —
+ * so the worker can call it and the host suite can compile it directly.
+ * Timekeeping stays with the caller, which is what makes this testable.
+ */
+#ifndef USBC_OUT_GATE_H
+#define USBC_OUT_GATE_H
+
+#include <stdint.h>
+
+/* Bounded so a Move that re-asserts its default repeatedly cannot start a
+ * replay war with us. Three attempts is well past any observed boot. */
+#define USBC_GATE_MAX_REPLAYS 3
+
+typedef enum {
+    USBC_GATE_PHASE_PRE_REPLAY = 0,
+    USBC_GATE_PHASE_DEFENDING  = 1,
+    USBC_GATE_PHASE_SETTLED    = 2,
+} usbc_gate_phase_t;
+
+typedef struct {
+    int8_t  stored;          /* the persisted preference: -1 unknown, 0 Mic, 1 Main Out */
+    uint8_t phase;           /* usbc_gate_phase_t */
+    uint8_t replays_left;
+    uint8_t saw_mic_assert;  /* Move has asserted Mic at least once this boot */
+} usbc_gate_t;
+
+/* What the caller must do as a result of a gate call. Both may be set. */
+typedef struct {
+    int    persist;          /* 1 = write persist_value to the state file */
+    int8_t persist_value;
+    int    replay;           /* 1 = put replay_value on the wire */
+    int8_t replay_value;
+} usbc_gate_out_t;
+
+/* `stored` is the persisted preference, or -1 if the file is absent/unreadable. */
+void usbc_gate_init(usbc_gate_t *g, int stored);
+
+/* Call once, when the caller judges Move's firmware ready to accept SysEx
+ * (the existing ~5 s mark). Arms the boot re-assert when the stored
+ * preference is Main Out; otherwise settles immediately, because a stored Mic
+ * needs no defending — it agrees with Move's own default, and the ordinary
+ * differs-from-stored test is enough from that point on. */
+void usbc_gate_boot_replay(usbc_gate_t *g, usbc_gate_out_t *out);
+
+/* Call whenever the wire reports a value (0 = Mic, 1 = Main Out). */
+void usbc_gate_observe(usbc_gate_t *g, int observed, usbc_gate_out_t *out);
+
+/* Backstop: force the gate open. The caller applies this on a generous
+ * deadline so that a boot where Move never speaks at all cannot leave the
+ * gate closed forever, silently swallowing every later user change. Nothing
+ * has been persisted wrongly by that point — settling only permits future
+ * writes, it does not perform one. */
+void usbc_gate_force_settle(usbc_gate_t *g);
+
+#endif /* USBC_OUT_GATE_H */

--- a/src/host/usbc_out_gate.h
+++ b/src/host/usbc_out_gate.h
@@ -55,11 +55,21 @@ typedef enum {
     USBC_GATE_PHASE_SETTLED    = 2,
 } usbc_gate_phase_t;
 
+/* Ticks the monitor-loss condition must hold before we act. One tick of
+ * hysteresis, i.e. ~400 ms at the worker's 200 ms cadence. See
+ * usbc_gate_tick_monitor. */
+#define USBC_GATE_MONITOR_DEBOUNCE 2
+
 typedef struct {
     int8_t  stored;          /* the persisted preference: -1 unknown, 0 Mic, 1 Main Out */
     uint8_t phase;           /* usbc_gate_phase_t */
     uint8_t replays_left;
     uint8_t saw_mic_assert;  /* Move has asserted Mic at least once this boot */
+
+    /* Monitor-loss defence, independent of the boot budget above. */
+    int8_t  last_monitor;
+    uint8_t monitor_pending;
+    uint8_t monitor_replays_left;
 } usbc_gate_t;
 
 /* What the caller must do as a result of a gate call. Both may be set. */
@@ -82,6 +92,30 @@ void usbc_gate_boot_replay(usbc_gate_t *g, usbc_gate_out_t *out);
 
 /* Call whenever the wire reports a value (0 = Mic, 1 = Main Out). */
 void usbc_gate_observe(usbc_gate_t *g, int observed, usbc_gate_out_t *out);
+
+/* Call once per worker tick with the last values seen on the wire (-1 =
+ * unknown): `usbc_out` from 37 14, `monitor` from bit1 of 37 12.
+ *
+ * Defends against a second, separate way the preference is lost. Move's
+ * sampling page emits a **lone 37 12** to set bit0 (the USB-C input select)
+ * and carries bit1 from its own permanently-stale "Mic" UI state. Observed on
+ * hardware 2026-08-26: `37 12 01` then `37 12 00`, with no 37 14 anywhere near
+ * either. Monitoring is *how* Main Out reaches USB-C, so clearing it reverts
+ * the hardware — while 37 14 still says Main Out, so nothing re-asserts and
+ * the revert is silent. Changing the sampling source therefore killed USB-C
+ * out, which is the in-session half of the original bug report.
+ *
+ * `usbc_out == 1 && monitor == 0` is what separates this from a deliberate Mic
+ * selection, where 37 14 moves too. The pair CAN split across SPI frames
+ * (16 of 20 MIDI_OUT slots — concurrent LED traffic forces a split), so acting
+ * on the first frame of a split Mic selection would fight the user. Hence the
+ * USBC_GATE_MONITOR_DEBOUNCE hysteresis: frames are ~3 ms and the worker ticks
+ * every 200 ms, so a split resolves long before two consecutive ticks agree.
+ *
+ * Bounded like the boot replay, and re-armed on each fresh 1->0 transition so
+ * a fourth sampling-source change is still defended. */
+void usbc_gate_tick_monitor(usbc_gate_t *g, int usbc_out, int monitor,
+                            usbc_gate_out_t *out);
 
 /* Backstop: force the gate open. The caller applies this on a generous
  * deadline so that a boot where Move never speaks at all cannot leave the

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -5118,8 +5118,13 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
                 xmos_audio_build(&xmos_audio_observed, replay, pending[0], pending[1]);
                 pending_count = 2;
                 pending_next = 0;
-                shadow_log(replay ? "USB-C out: boot re-assert Main Out"
-                                  : "USB-C out: boot re-assert Mic");
+                /* Neutral wording on purpose: this path serves the boot replay
+                 * AND the monitor-loss defence, and the shim cannot tell them
+                 * apart — the worker arms both through the same variable. It
+                 * logs the specific reason before arming, so saying "boot"
+                 * here mislabelled every mid-session re-assert. */
+                shadow_log(replay ? "USB-C out: re-asserting Main Out"
+                                  : "USB-C out: re-asserting Mic");
             } else if (shim_pending_sysex_inject >= 0) {
                 int val_byte = shim_pending_sysex_inject;
                 shim_pending_sysex_inject = -1;
@@ -5289,6 +5294,14 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
      * observed change (see shim_worker.c's tick >= 35 gate). */
     if (xmos_audio_scan(shadow + MIDI_OUT_OFFSET, 80, &xmos_audio_observed))
         shim_usbc_out_persist = xmos_audio_observed.usbc_out;
+
+    /* Republish both bits as levels every frame. scan() only reports an
+     * out-source EDGE, and Move's sampling page changes nothing about the out
+     * source — it emits a lone 37 12 that clears monitoring, which reverts the
+     * hardware to Mic with no edge to report. Two stores; the worker polls
+     * them at 5 Hz and decides (see usbc_gate_tick_monitor). */
+    shim_usbc_out_level = xmos_audio_observed.usbc_out;
+    shim_usbc_monitor   = xmos_audio_observed.monitor;
 
     /* Ensure subsystems are initialized on first call */
     if (!shim_subsystems_initialized) {

--- a/tests/host/test_usbc_out_gate.c
+++ b/tests/host/test_usbc_out_gate.c
@@ -1,0 +1,201 @@
+/* Unit test for the USB-C audio-out boot gate.
+ *
+ * The bug this pins: a stored Main Out preference was being overwritten with
+ * Mic whenever Move's own boot-default assert landed after the old fixed ~7 s
+ * deadline. The device evidence was a state file that had gone 1 -> 0 between
+ * boots with no user action — one boot logging "boot re-assert Main Out", the
+ * next not logging it at all.
+ *
+ * Build/run: bash tests/host/test_usbc_out_gate.sh
+ */
+#include <stdio.h>
+#include <string.h>
+#include "usbc_out_gate.h"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { \
+    if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } \
+} while (0)
+
+/* Every call clears its output first, so a test that expects "no action" is
+ * checking the gate stayed silent rather than inheriting a stale struct. */
+static usbc_gate_out_t OUT;
+static void clr(void) { memset(&OUT, 0, sizeof OUT); }
+
+static void observe(usbc_gate_t *g, int v) { clr(); usbc_gate_observe(g, v, &OUT); }
+static void boot_replay(usbc_gate_t *g)    { clr(); usbc_gate_boot_replay(g, &OUT); }
+
+/* ---- the regression itself ------------------------------------------- */
+
+/* Move's default assert lands AFTER our re-assert. Under the old wall-clock
+ * gate this was read as a user choice and written to the file. */
+static void test_late_move_assert_does_not_clobber(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 1);            /* stored: Main Out */
+
+    boot_replay(&g);
+    CHECK(OUT.replay == 1 && OUT.replay_value == 1, "late: boot arms a Main Out replay");
+    CHECK(OUT.persist == 0, "late: arming a replay persists nothing");
+
+    observe(&g, 1);                   /* our own replay echoing back */
+    CHECK(OUT.persist == 0, "late: our own echo is never persisted");
+
+    observe(&g, 0);                   /* Move's default, arriving late */
+    CHECK(OUT.persist == 0, "late: Move's late default must NOT be persisted");
+    CHECK(OUT.replay == 1 && OUT.replay_value == 1,
+          "late: Move's late default is countered by another re-assert");
+
+    observe(&g, 1);                   /* the counter-assert lands */
+    CHECK(OUT.persist == 0, "late: counter-assert echo is not persisted");
+
+    /* Gate is now open; a genuine user choice must get through. */
+    observe(&g, 0);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 0,
+          "late: a user Mic choice after settling IS persisted");
+}
+
+/* The fast boot that used to work: Move asserts before we replay. */
+static void test_early_move_assert(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 1);
+
+    observe(&g, 0);                   /* Move's default, pre-replay */
+    CHECK(OUT.persist == 0, "early: pre-replay observations are never persisted");
+    CHECK(OUT.replay == 0, "early: nothing is put on the wire before boot_replay");
+
+    boot_replay(&g);
+    CHECK(OUT.replay == 1 && OUT.replay_value == 1, "early: replay armed");
+
+    observe(&g, 1);                   /* echo; Move has already spoken */
+    CHECK(OUT.persist == 0, "early: echo not persisted");
+
+    observe(&g, 0);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 0,
+          "early: user Mic choice persists once settled");
+}
+
+/* ---- stored Mic / unknown -------------------------------------------- */
+
+static void test_stored_mic_settles_immediately(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 0);
+
+    boot_replay(&g);
+    CHECK(OUT.replay == 0, "mic: nothing to re-assert when Mic is stored");
+
+    observe(&g, 0);
+    CHECK(OUT.persist == 0, "mic: Move's default matches stored, no write");
+
+    observe(&g, 1);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 1, "mic: user Main Out persists");
+
+    observe(&g, 1);
+    CHECK(OUT.persist == 0, "mic: repeat of the same value writes nothing");
+}
+
+static void test_unknown_stored_records_first_value(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, -1);           /* no state file yet */
+
+    boot_replay(&g);
+    CHECK(OUT.replay == 0, "unknown: no replay without a stored preference");
+
+    observe(&g, 0);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 0, "unknown: first value is recorded");
+}
+
+/* ---- bounds and backstops -------------------------------------------- */
+
+/* A Move that keeps re-asserting must not start an unbounded replay war. */
+static void test_replays_are_bounded(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 1);
+
+    /* The cap counts every re-assert this boot, the one boot_replay puts on
+     * the wire included — not just the ones Move provokes afterwards. */
+    boot_replay(&g);
+    int replays = OUT.replay ? 1 : 0;
+
+    for (int i = 0; i < USBC_GATE_MAX_REPLAYS + 5; i++) {
+        observe(&g, 0);
+        CHECK(OUT.persist == 0, "bounded: a defended Mic is never persisted");
+        if (OUT.replay) replays++;
+    }
+    CHECK(replays == USBC_GATE_MAX_REPLAYS, "bounded: re-asserts stop at the cap");
+
+    /* Having given up, the gate must be open — otherwise user changes would be
+     * swallowed for the rest of the session. */
+    observe(&g, 1);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 1,
+          "bounded: gate opens after giving up so user changes still persist");
+}
+
+/* If Move never speaks at all this boot, the gate must not stay shut forever. */
+static void test_force_settle_backstop(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 1);
+    boot_replay(&g);
+
+    observe(&g, 1);
+    CHECK(OUT.persist == 0, "backstop: still defending before the deadline");
+
+    usbc_gate_force_settle(&g);
+
+    observe(&g, 0);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 0,
+          "backstop: forcing the gate open lets user changes through");
+}
+
+/* force_settle only permits future writes; it must never itself persist. */
+static void test_force_settle_writes_nothing(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 1);
+    boot_replay(&g);
+    observe(&g, 0);                   /* defended */
+    usbc_gate_force_settle(&g);
+    observe(&g, 1);
+    CHECK(OUT.persist == 0,
+          "backstop: settling does not retroactively persist the defended value");
+}
+
+/* The stored value must track what we write, or a value would be written twice
+ * and — worse — a return to the original would look like "no change". */
+static void test_stored_tracks_writes(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 0);
+    boot_replay(&g);
+
+    observe(&g, 1);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 1, "tracks: first change written");
+    observe(&g, 0);
+    CHECK(OUT.persist == 1 && OUT.persist_value == 0, "tracks: change back is written");
+    observe(&g, 0);
+    CHECK(OUT.persist == 0, "tracks: no redundant write");
+}
+
+int main(void)
+{
+    test_late_move_assert_does_not_clobber();
+    test_early_move_assert();
+    test_stored_mic_settles_immediately();
+    test_unknown_stored_records_first_value();
+    test_replays_are_bounded();
+    test_force_settle_backstop();
+    test_force_settle_writes_nothing();
+    test_stored_tracks_writes();
+
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    printf("PASS\n");
+    return 0;
+}

--- a/tests/host/test_usbc_out_gate.c
+++ b/tests/host/test_usbc_out_gate.c
@@ -181,6 +181,125 @@ static void test_stored_tracks_writes(void)
     CHECK(OUT.persist == 0, "tracks: no redundant write");
 }
 
+/* ---- monitor-loss defence -------------------------------------------- */
+
+static void mon(usbc_gate_t *g, int usbc_out, int monitor)
+{
+    clr();
+    usbc_gate_tick_monitor(g, usbc_out, monitor, &OUT);
+}
+
+/* Drive a gate to SETTLED with Main Out stored and monitoring live, the way
+ * the wire does. */
+static void settle_main_out(usbc_gate_t *g)
+{
+    usbc_gate_init(g, 1);
+    observe(g, 0);        /* Move's boot default */
+    boot_replay(g);
+    observe(g, 1);        /* our re-assert lands -> settled */
+    mon(g, 1, 1);         /* monitoring live */
+}
+
+/* The hardware case: sampling-source change emits a lone 37 12 with bit1
+ * clear, so monitor drops while 37 14 still says Main Out. */
+static void test_monitor_loss_triggers_reassert(void)
+{
+    usbc_gate_t g;
+    settle_main_out(&g);
+
+    mon(&g, 1, 0);
+    CHECK(OUT.replay == 0, "monloss: does not fire on the first tick (debounce)");
+
+    mon(&g, 1, 0);
+    CHECK(OUT.replay == 1 && OUT.replay_value == 1,
+          "monloss: re-asserts Main Out once the condition holds");
+    CHECK(OUT.persist == 0, "monloss: re-asserting persists nothing");
+}
+
+/* A deliberate Mic selection moves 37 14 too. If the pair splits across SPI
+ * frames we may see monitor=0 one tick before usbc_out=0 — that must never
+ * become a re-assert, or we would fight the user. */
+static void test_split_mic_selection_is_not_fought(void)
+{
+    usbc_gate_t g;
+    settle_main_out(&g);
+
+    mon(&g, 1, 0);        /* first frame of the split pair */
+    CHECK(OUT.replay == 0, "split: no action on the first tick");
+
+    observe(&g, 0);       /* 37 14 00 arrives -> user really chose Mic */
+    mon(&g, 0, 0);
+    CHECK(OUT.replay == 0, "split: a real Mic selection is never fought");
+
+    mon(&g, 0, 0);
+    CHECK(OUT.replay == 0, "split: still not fought on later ticks");
+}
+
+static void test_monitor_healthy_does_nothing(void)
+{
+    usbc_gate_t g;
+    settle_main_out(&g);
+    for (int i = 0; i < 5; i++) {
+        mon(&g, 1, 1);
+        CHECK(OUT.replay == 0 && OUT.persist == 0, "healthy: monitoring live, no action");
+    }
+}
+
+static void test_monitor_loss_not_defended_when_mic_stored(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 0);
+    boot_replay(&g);      /* stored Mic settles immediately */
+    for (int i = 0; i < 4; i++) {
+        mon(&g, 1, 0);
+        CHECK(OUT.replay == 0, "mic-stored: nothing to defend");
+    }
+}
+
+/* Boot arbitration owns the wire; the monitor defence must not cut in. */
+static void test_monitor_defence_inert_before_settling(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, 1);
+    for (int i = 0; i < 4; i++) {
+        mon(&g, 1, 0);
+        CHECK(OUT.replay == 0, "pre-settle: monitor defence is inert");
+    }
+    boot_replay(&g);
+    for (int i = 0; i < 4; i++) {
+        mon(&g, 1, 0);
+        CHECK(OUT.replay == 0, "defending: monitor defence is inert");
+    }
+}
+
+static void test_monitor_reasserts_are_bounded(void)
+{
+    usbc_gate_t g;
+    settle_main_out(&g);
+
+    int replays = 0;
+    for (int i = 0; i < (USBC_GATE_MAX_REPLAYS + 5) * USBC_GATE_MONITOR_DEBOUNCE; i++) {
+        mon(&g, 1, 0);
+        if (OUT.replay) replays++;
+    }
+    CHECK(replays == USBC_GATE_MAX_REPLAYS, "monbound: re-asserts stop at the cap");
+}
+
+/* A fourth sampling-source change must still be defended, so the budget
+ * re-arms on each fresh 1->0 transition rather than draining for the session. */
+static void test_monitor_budget_rearms_on_fresh_loss(void)
+{
+    usbc_gate_t g;
+    settle_main_out(&g);
+
+    for (int round = 0; round < 4; round++) {
+        mon(&g, 1, 1);                     /* our re-assert took effect */
+        mon(&g, 1, 0);                     /* fresh loss: debounce tick */
+        mon(&g, 1, 0);
+        CHECK(OUT.replay == 1, "rearm: every fresh monitor loss is defended");
+    }
+}
+
 int main(void)
 {
     test_late_move_assert_does_not_clobber();
@@ -191,6 +310,13 @@ int main(void)
     test_force_settle_backstop();
     test_force_settle_writes_nothing();
     test_stored_tracks_writes();
+    test_monitor_loss_triggers_reassert();
+    test_split_mic_selection_is_not_fought();
+    test_monitor_healthy_does_nothing();
+    test_monitor_loss_not_defended_when_mic_stored();
+    test_monitor_defence_inert_before_settling();
+    test_monitor_reasserts_are_bounded();
+    test_monitor_budget_rearms_on_fresh_loss();
 
     if (fails) {
         fprintf(stderr, "%d check(s) failed\n", fails);

--- a/tests/host/test_usbc_out_gate.sh
+++ b/tests/host/test_usbc_out_gate.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+bin="build/tests/test_usbc_out_gate"
+mkdir -p "$(dirname "$bin")"
+
+cc -std=gnu11 -Wall -Wextra -Isrc/host \
+  tests/host/test_usbc_out_gate.c \
+  src/host/usbc_out_gate.c \
+  -o "$bin"
+
+"$bin"

--- a/tests/host/test_xmos_audio.c
+++ b/tests/host/test_xmos_audio.c
@@ -407,6 +407,61 @@ static void test_emit_byte_exact_against_capture(void) {
     CHECK(memcmp(buf, expected, sizeof expected) == 0, "emit byte-exact: matches captured framing");
 }
 
+/* Bit1 of 37 12 is monitoring — the mechanism that actually routes Main Out to
+ * USB-C — so it has to be tracked in its own right, not inferred from 37 14. */
+static void test_monitor_bit_tracked_from_route(void) {
+    uint8_t buf[MIDI_OUT_LEN];
+    xmos_audio_state_t st = XMOS_AUDIO_STATE_INIT;
+    int slot;
+
+    CHECK(st.monitor == -1, "monitor: starts unknown, not 0");
+
+    memset(buf, 0, sizeof buf); slot = 0;
+    put_msg(buf, &slot, XMOS_AUDIO_KEY_ROUTE, 0x02);   /* monitor on */
+    xmos_audio_scan(buf, MIDI_OUT_LEN, &st);
+    CHECK(st.monitor == 1, "monitor: 37 12 02 sets monitor");
+
+    memset(buf, 0, sizeof buf); slot = 0;
+    put_msg(buf, &slot, XMOS_AUDIO_KEY_ROUTE, 0x00);   /* monitor off */
+    xmos_audio_scan(buf, MIDI_OUT_LEN, &st);
+    CHECK(st.monitor == 0, "monitor: 37 12 00 clears monitor");
+
+    /* bit0 set, bit1 clear — the exact byte Move's sampling page sent. */
+    memset(buf, 0, sizeof buf); slot = 0;
+    put_msg(buf, &slot, XMOS_AUDIO_KEY_ROUTE, 0x01);
+    xmos_audio_scan(buf, MIDI_OUT_LEN, &st);
+    CHECK(st.monitor == 0, "monitor: bit0 alone does not read as monitoring");
+
+    memset(buf, 0, sizeof buf); slot = 0;
+    put_msg(buf, &slot, XMOS_AUDIO_KEY_ROUTE, 0x03);   /* both bits */
+    xmos_audio_scan(buf, MIDI_OUT_LEN, &st);
+    CHECK(st.monitor == 1, "monitor: bit1 read independently of bit0");
+}
+
+/* The hardware capture, 2026-08-26: changing the sampling source emits a LONE
+ * 37 12 with bit1 clear. usbc_out must not move (nothing said anything about
+ * the out source) while monitor must — that difference is the whole signal. */
+static void test_lone_route_clears_monitor_without_touching_usbc_out(void) {
+    uint8_t buf[MIDI_OUT_LEN];
+    xmos_audio_state_t st = XMOS_AUDIO_STATE_INIT;
+    int slot;
+
+    /* Establish Main Out the way the wire does: 37 12 02 then 37 14 01. */
+    memset(buf, 0, sizeof buf); slot = 0;
+    put_msg(buf, &slot, XMOS_AUDIO_KEY_ROUTE, 0x02);
+    put_msg(buf, &slot, XMOS_AUDIO_KEY_OUT_SRC, 0x01);
+    xmos_audio_scan(buf, MIDI_OUT_LEN, &st);
+    CHECK(st.usbc_out == 1 && st.monitor == 1, "lone: Main Out established");
+
+    /* Sampling page selects the USB-C input: 37 12 01, no 37 14. */
+    memset(buf, 0, sizeof buf); slot = 0;
+    put_msg(buf, &slot, XMOS_AUDIO_KEY_ROUTE, 0x01);
+    int changed = xmos_audio_scan(buf, MIDI_OUT_LEN, &st);
+    CHECK(st.usbc_out == 1, "lone: a lone 37 12 must not move usbc_out");
+    CHECK(st.monitor == 0, "lone: a lone 37 12 DOES clear monitoring");
+    CHECK(changed == 0, "lone: no usbc_out change is reported");
+}
+
 int main(void) {
     test_main_out();
     test_mic();
@@ -429,6 +484,8 @@ int main(void) {
     test_emit_refuses_when_free_slots_not_contiguous();
     test_emit_refuses_when_unterminated_sysex_present();
     test_emit_byte_exact_against_capture();
+    test_monitor_bit_tracked_from_route();
+    test_lone_route_clears_monitor_without_touching_usbc_out();
 
     if (fails) {
         fprintf(stderr, "%d check(s) failed\n", fails);


### PR DESCRIPTION
## The bug

USB-C audio-out reverts to Mic and isn't remembered across reboots — intermittently.

Move forgets the setting every boot and asserts its Mic default; Schwung re-asserts the stored preference ~5 s in. Both arrive as the same `37 14` envelope, so the worker separated them **by wall clock**: ignore everything for ~7 s, trust everything after.

That clock starts when MoveOriginal opens the SPI device (`shim_spi_init`), while Move's assert floats with boot load. On a slow boot the assert lands on the *trusting* side of the line, is taken for a user choice, and is written to the state file:

| t | fast boot | slow boot |
|---|---|---|
| 0.6 s | Move asserts Mic → discarded, pre-gate | — |
| 5 s | our replay asserts Main Out | our replay asserts Main Out |
| 7 s | gate opens; `up == last` → no write ✓ | gate opens |
| 9 s | — | **Move finally asserts Mic** → hardware reverts, gate is open → **writes 0 over the stored 1** |

One mechanism produces **both** halves of the symptom: it flips to the microphone in that session, *and* the next boot starts on Mic with no replay.

**Not a regression** — `shadow_xmos_audio.c` and its wiring have been byte-identical since the feature landed (`6e5602c3`, `86efd261`) the day before v0.12.1. It shipped intermittent; slower boots as the module set grew made it surface.

### Hardware evidence

- an earlier boot logging `USB-C out: boot re-assert Main Out` — so the file held `1`
- the file now reading `0`, with no user action
- this boot logging no re-assert at all

## The fix

The discriminator is not time. **We only ever re-assert Main Out, so during the boot window an observed Mic can only have come from Move.** `src/host/usbc_out_gate.c` uses that:

- **pre-replay** — observations recorded, never persisted
- **defending** — an observed Mic is *countered*, never believed (bounded by `USBC_GATE_MAX_REPLAYS`, so Move can't start a replay war); an observed Main Out settles the gate **only once Move has actually asserted this boot**, so our own echo can't settle it early on a slow boot
- **settled** — ordinary differs-from-stored persistence

Two edges worth calling out:

- **Giving up after the replay cap adopts Mic in memory but deliberately does not write it** — the file keeps the user's preference so the next boot tries again. Settling without that let the next observation persist the very Mic we'd failed to override, reintroducing the bug at the bottom of the fallback path. (Caught by the test, not by review.)
- **Restore-off settles immediately** rather than defending a re-assert the shim drops before it reaches the wire. The setting governs only whether we re-assert; it still remembers.

A ~60 s `force_settle` backstop covers a boot where Move never speaks (opening the gate persists nothing by itself).

The gate is pure state with **no clock of its own** — which is what makes the boot orderings testable without a device.

## Verification

- `tests/host/test_usbc_out_gate.sh` — new, 8 cases; written first, failed against a stub for the right reason, then green. Pins the late-assert regression directly, plus fast boot, stored-Mic, unknown-stored, replay bounds, and both backstop properties.
- `tests/host/test_xmos_audio.sh` — green (codec untouched).
- `make -C tests/host test` — all green.
- ARM64 cross-compile green; all four `usbc_gate_*` symbols confirmed in `schwung-shim.so`, no warnings on the changed files.
- 32 `tests/host/*.sh` fail locally for the known missing-`rg` reason, on this branch and every other; CI has `rg`.

**Not yet verified on hardware** — the decisive check is a reboot with a stored Main Out, confirming the preference survives and `usbc_out_state` stays `1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AxgUkEvmFBVbTqBKUo5d7m