### PR TITLE
shadow ui: a timed-out read must not empty a chain position or blank an editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -930,6 +930,44 @@ shared `saveMasterFxChainConfig()` sink (derived from the routing table, never
 hand-listed), a key-specific saver welded to the assignment, or backend-owned.
 Stored values are **not** indexes — `resample_bridge` stores 0 and **2**.
 
+### A timed-out read empties NOTHING, and latches nothing
+
+`loadChainConfigFromSlot`'s `readPosition` was `moduleId && moduleId !== ""`,
+which puts `null` (the read did not complete) in the same branch as `""` (the
+position is empty) — the comment there said so, having considered only the
+unserved case. Loading a module blocks the SPI callback (the thread that also
+serves param requests) and `applyComponentSelectionConfirmed` re-syncs
+**immediately after its fire-and-forget module write**, i.e. inside that
+window. So the position read `null`, was recorded as EMPTY, and
+`chainConfigFresh[slot] = true` declared it authoritative — *"clean by
+definition once it returns"* was true of the call, not of the answer.
+
+An empty box in the diagram is a `+`, so the position the user had just filled
+opened the **module picker** instead of the editor.
+
+**It takes a SECOND defect to make that permanent**, and this is the part worth
+remembering: the module signature is a separate set of reads taken milliseconds
+later, and they straddled the end of the load. The config read stale-empty; the
+signature read the real module. `applySlotModuleSignature` reloads the config
+only when the signature **changes** — so the *correct* read is what did the
+damage, by matching, and a correct signature never changes again. Osirus logged
+a clean 124 ms load at 13:48:53.700–.824 and the editor still drew the position
+empty fifteen seconds later, while slot settings — same key, different path —
+said "Synth Virus".
+
+Now: a failed read keeps the position it had, leaves the slot **un-fresh** so
+the next frame re-reads, and `getSlotModuleSignature` answers **null** rather
+than inventing an empty chain (`applySlotModuleSignature` refuses null). A
+failed `*_count` keeps the section length — 0 from a timeout truncates the whole
+section, not one position.
+
+Falling out of it for free: the picker writes the chosen module into
+`chainConfigs` **before** the DSP write, so "what we already had" during the
+load window *is* the module just picked — the box shows it throughout, and
+there is no loading state to maintain. `tests/host/test_chain_config_read_failure.sh`
+lifts the real functions and drives that sequence, reads failing on frame 1 and
+landing on frame 2.
+
 ### A component editor WAITS; it does not decide from one read
 
 Opening a component's editor used to be one read of `<prefix>:ui_hierarchy` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -930,6 +930,46 @@ shared `saveMasterFxChainConfig()` sink (derived from the routing table, never
 hand-listed), a key-specific saver welded to the assignment, or backend-owned.
 Stored values are **not** indexes — `resample_bridge` stores 0 and **2**.
 
+### A component editor WAITS; it does not decide from one read
+
+Opening a component's editor used to be one read of `<prefix>:ui_hierarchy` and
+`if (!hierarchy) enterComponentEditFallback(...)` — which is the three-answers
+defect one layer above the controller that solves it, and the fallback is
+irreversible. For MiniJV and Osirus, the two slowest things in the fleet to
+come up, that drew an editor with **nothing in it**: neither ships a
+`ui_chain.js`, so the fallback lands on the bare preset browser, and the preset
+reads it makes there fail for the same reason the hierarchy read did.
+
+What made the entry the wrong place to give up is that **everything which knows
+how to wait is behind it** — the grid's `Loading...` hold, its bounded contract
+retry, its ten-second recovery probe, the list editor's `is_loading` re-fetch.
+
+`src/shared/component_load_gate.mjs` answers **ENTER / HOLD / FALLBACK**, and
+`openComponentEditor` (`shadow_ui.js`) is the one gate both editors — slot
+chain and Master FX — enter through. HOLD raises `VIEWS.COMPONENT_LOADING`
+("Loading...", `Back: exit`) and asks again: ~0.5 s apart for ~20 s, then every
+ten seconds for as long as the screen is up. **There is no give-up-and-show-the
+-fallback ending**, on purpose — a blank editor is the failure being fixed.
+
+**The empty answer needs a second question.** A module that declares no
+hierarchy and a position whose module has not finished arriving BOTH answer
+`""`. `<prefix>_module` separates them: the chain host publishes the name only
+after `create_instance` returns (`chain_host.c:504`). Named + no hierarchy
+falls back **immediately**, so the well-behaved fleet never sees the hold, and
+entering still costs the one read it always did (`module` and `is_loading` are
+read lazily, on the ambiguous branch only).
+
+The wait is view-agnostic — it sits in front of the destination choice, so it
+works with Param View on Knobs or List and with the screen reader on — and it
+is drawn and serviced on **both** draw paths, main and co-run. The probe runs
+*before* the dispatch, so a probe that lands opens the editor on that frame.
+`tests/host/test_component_load_hold_wiring.sh` pins all of that from source;
+`test_component_load_gate.sh` unit-tests the decision, including that a named
+module with no hierarchy is **not** held.
+
+Not a regression: the old gate is byte-identical at `v0.11.6`. What changed is
+how long these two modules take to answer.
+
 ### Shortcuts
 
 Shadow UI access gated by **Global Settings → Shortcuts → Shadow UI Trigger** (`shadow_ui_trigger` in `features.json`): `Both` (default) / `Long Press` / `Shift+Vol`.

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -4724,11 +4724,44 @@ function loadChainConfigFromSlot(slotIndex) {
 
     /* Read current patch configuration from DSP
      * Note: get_param uses underscores (synth_module), set_param uses colons (synth:module) */
-    /* An unserved key answers "" rather than null, which reads the same as an
-     * empty position — both mean "nothing loaded here". */
-    const readPosition = (id) => {
+    /*
+     * A POSITION READ HAS THREE ANSWERS, and only two of them are news about
+     * the chain:
+     *
+     *   "<id>"  a module is loaded here
+     *   ""      the position is empty
+     *   null    the read did not complete
+     *
+     * This used to be `moduleId && moduleId !== ""`, which put null in the same
+     * branch as "" — the comment here even said so, having considered only the
+     * unserved case. So a read that merely TIMED OUT emptied the position, and
+     * the freshness latch below then declared that authoritative.
+     *
+     * Not hypothetical, and not a flicker. Loading Osirus blocks the SPI
+     * callback — the thread that also serves param requests — for the ~124 ms
+     * of dlopen + create_instance, and applyComponentSelectionConfirmed
+     * re-syncs immediately after its fire-and-forget module write, i.e. inside
+     * that window. Captured on device 2026-08-26: the load logged clean at
+     * 13:48:53.700-.824, and fifteen seconds later the chain editor still drew
+     * the synth position EMPTY and its picker announced "Select Synth, None",
+     * while the slot-settings screen, reading the same key on a different path,
+     * correctly said "Synth Virus".
+     *
+     * A failed read therefore keeps the position we already had. Stale-but-
+     * right beats an emptiness we were never told about — and because the
+     * picker puts the chosen module into chainConfigs BEFORE writing it to the
+     * DSP, "what we already had" during that window is exactly the module the
+     * user just picked. `incomplete` stops the latch, so the next frame reads
+     * again instead of believing this one.
+     */
+    let incomplete = false;
+    const readPosition = (id, previous) => {
         const moduleId = getSlotParam(slotIndex, `${id}_module`);
-        return moduleId && moduleId !== ""
+        if (moduleId === null || moduleId === undefined) {
+            incomplete = true;
+            return previous || null;
+        }
+        return moduleId !== ""
             ? { module: moduleId.toLowerCase(), params: {} } : null;
     };
     /*
@@ -4740,9 +4773,14 @@ function loadChainConfigFromSlot(slotIndex) {
      * on every frame at ~2.8ms per IPC round trip, which is more per frame than
      * rendering the entire page. An unserved key answers "", and Number("") is
      * 0, so the parse is explicit about its fallback.
+     *
+     * A COUNT read fails the same way a position read does, and a count of 0
+     * from a timeout truncates the whole section — every FX in the slot gone,
+     * not just one. Keep the length we already had.
      */
-    const readCount = (key, cap) => {
+    const readCount = (key, cap, previous) => {
         const raw = getSlotParam(slotIndex, key);
+        if (raw === null || raw === undefined) { incomplete = true; return previous; }
         const n = parseInt(raw, 10);
         return (isNaN(n) || n < 0) ? 0 : Math.min(n, cap);
     };
@@ -4760,19 +4798,22 @@ function loadChainConfigFromSlot(slotIndex) {
      * A legacy patch with a hole therefore draws its hole, once, and closes it
      * the first time the user changes the order.
      */
-    const readSection = (idAt, count) => {
+    const readSection = (idAt, count, prevList) => {
         const list = [];
-        for (let i = 0; i < count; i++) list.push(readPosition(idAt(i)));
+        for (let i = 0; i < count; i++) list.push(readPosition(idAt(i), prevList[i]));
         while (list.length && !list[list.length - 1]) list.pop();
         return list;
     };
 
     const oldFx = cfg.fx;
+    const oldMidiFx = cfg.midiFx;
 
-    cfg.synth = readPosition("synth");
+    cfg.synth = readPosition("synth", cfg.synth);
     cfg.midiFx = readSection((i) => `midi_fx${i + 1}`,
-                             readCount("midi_fx_count", CHAIN_CAP.midiFx));
-    cfg.fx = readSection((i) => `fx${i + 1}`, readCount("fx_count", CHAIN_CAP.fx));
+                             readCount("midi_fx_count", CHAIN_CAP.midiFx, oldMidiFx.length),
+                             oldMidiFx);
+    cfg.fx = readSection((i) => `fx${i + 1}`,
+                         readCount("fx_count", CHAIN_CAP.fx, oldFx.length), oldFx);
 
     /* Clear display_name cache when FX modules change (prevents stale
      * announcement on swap). Also drop the poll backoff: a different module may
@@ -4789,9 +4830,18 @@ function loadChainConfigFromSlot(slotIndex) {
     }
 
     chainConfigs[slotIndex] = cfg;
-    /* This IS the reload every other path invalidates towards, so the slot is
-     * clean by definition once it returns. */
-    chainConfigFresh[slotIndex] = true;
+    /*
+     * This IS the reload every other path invalidates towards — but only when
+     * it actually READ the chain. "Clean by definition once it returns" was
+     * true of the call and not of the answer: a load in which every read timed
+     * out latched the slot as authoritative, and nothing re-read it until the
+     * module signature happened to change again.
+     *
+     * Leaving it stale costs one more pass on the next frame, which is what
+     * drawChainEdit already does for an invalidated slot, and only for as long
+     * as the channel is refusing.
+     */
+    chainConfigFresh[slotIndex] = !incomplete;
     return cfg;
 }
 
@@ -5201,10 +5251,33 @@ function withPendingChainInsert(choice, pending) {
  * Length comes from the published counts, so a slot holding nothing is three
  * reads rather than a walk of the cap.
  */
+/*
+ * Returns null when ANY of its reads failed.
+ *
+ * The signature's whole job is to say "the chain changed, reload the config",
+ * so a signature built from timeouts is the one input that must never be
+ * believed: `|| ""` turned a failed read into "this position is empty", which
+ * is a perfectly well-formed signature describing a chain that does not exist.
+ *
+ * That is the second half of the Osirus blank-position bug — see the note in
+ * loadChainConfigFromSlot. The config reads and these reads are taken
+ * milliseconds apart and straddled the end of the load: the config read
+ * stale-empty, the signature read the real "osirus". It was the FRESH one that
+ * did the damage, by MATCHING — applySlotModuleSignature reloads the config
+ * only when the signature changes, and a signature that is already correct
+ * never changes again.
+ */
 function getSlotModuleSignature(slotIndex) {
-    const read = (id) => getSlotParam(slotIndex, `${id}_module`) || "";
+    let failed = false;
+    const read = (id) => {
+        const v = getSlotParam(slotIndex, `${id}_module`);
+        if (v === null || v === undefined) { failed = true; return ""; }
+        return v;
+    };
     const count = (key, cap) => {
-        const n = parseInt(getSlotParam(slotIndex, key), 10);
+        const raw = getSlotParam(slotIndex, key);
+        if (raw === null || raw === undefined) { failed = true; return 0; }
+        const n = parseInt(raw, 10);
         return (isNaN(n) || n < 0) ? 0 : Math.min(n, cap);
     };
     const parts = [read("synth")];
@@ -5215,7 +5288,7 @@ function getSlotModuleSignature(slotIndex) {
     parts.push("/");
     const nFx = count("fx_count", CHAIN_CAP.fx);
     for (let i = 0; i < nFx; i++) parts.push(read(`fx${i + 1}`));
-    return parts.join("|");
+    return failed ? null : parts.join("|");
 }
 
 /* Refresh module signature for a slot and invalidate knob cache on changes */
@@ -5237,6 +5310,11 @@ function refreshSlotModuleSignature(slotIndex) {
  */
 function applySlotModuleSignature(slotIndex, signature) {
     if (slotIndex < 0 || slotIndex >= SHADOW_UI_SLOTS) return false;
+    /* null is "we could not read the chain", not "the chain is different".
+     * Latching it would compare every later signature against a non-answer —
+     * and declaring NO change is what this function does for a signature that
+     * matches, which is how a stale config survives. */
+    if (signature === null || signature === undefined) return false;
     if (signature !== lastSlotModuleSignatures[slotIndex]) {
         lastSlotModuleSignatures[slotIndex] = signature;
         loadChainConfigFromSlot(slotIndex);
@@ -10064,9 +10142,25 @@ function applyComponentSelectionConfirmed(slotIndex, paramKey, moduleId, comp, c
     /* Force sync chainConfigs from DSP and reset caches after module change.
      * Without this, the knob overlay can show the old module's name and params
      * because the periodic refreshSlotModuleSignature (every 30 ticks) hasn't
-     * run yet to sync the in-memory state with DSP. */
+     * run yet to sync the in-memory state with DSP.
+     *
+     * THIS RE-SYNC RACES THE LOAD IT IS SYNCING, and cannot not: the module
+     * write above is fire-and-forget, and the DSP applies it by blocking the
+     * SPI callback for as long as the dlopen + create_instance takes (~124 ms
+     * for Osirus). So these reads land inside that window and come back null.
+     *
+     * Both halves are null-safe now — loadChainConfigFromSlot keeps the
+     * position and leaves the slot un-fresh, getSlotModuleSignature answers
+     * null — but the SIGNATURE must also not be latched: a latched null
+     * compares unequal to every real signature forever, which would make the
+     * periodic refresh reload the config on every single pass. Latch nothing,
+     * and the next refresh compares a real signature against the pre-write one,
+     * differs, and reloads exactly once. */
     loadChainConfigFromSlot(slotIndex);
-    lastSlotModuleSignatures[slotIndex] = getSlotModuleSignature(slotIndex);
+    {
+        const sig = getSlotModuleSignature(slotIndex);
+        if (sig !== null) lastSlotModuleSignatures[slotIndex] = sig;
+    }
     invalidateKnobContextCache();
     /* A removal shortened the list, so the remembered index can now point past
      * its end — and the CHAIN_EDIT handlers read `comps[selection].key` without

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -83,6 +83,10 @@ import { runDrawBench } from '/data/UserData/schwung/shared/draw_bench.mjs';
 import { installParamTally, paramTallyTick, paramTallyArmed } from '/data/UserData/schwung/shared/param_tally.mjs';
 import { knobInit, knobStep } from '/data/UserData/schwung/shared/knob_engine.mjs';
 import {
+    decideComponentEntry, holdProbeIntervalTicks,
+    ENTRY_ENTER, ENTRY_HOLD,
+} from '/data/UserData/schwung/shared/component_load_gate.mjs';
+import {
     formatParamValue as ufFormatParamValue,
     formatParamForSet as ufFormatParamForSet,
 } from '/data/UserData/schwung/shared/param_format.mjs';
@@ -397,7 +401,8 @@ const VIEWS = {
     ANALYTICS_PROMPT: "analyticsprompt",       // First-run analytics opt-out prompt
     LFO_TARGET_COMPONENT: "lfotargetcomp",    // LFO target picker step 1: component
     LFO_TARGET_PARAM: "lfotargetparam",       // LFO target picker step 2: parameter
-    ENUM_PICKER: "enumpick"                   // Option list for an enum param
+    ENUM_PICKER: "enumpick",                  // Option list for an enum param
+    COMPONENT_LOADING: "comploading"          // "Loading..." while a component's contract arrives
 };
 
 /* ==== CO-RUN VIEW ADDRESSING ====
@@ -11580,13 +11585,152 @@ function enterHierarchyEditor(slotIndex, componentKey) {
     const mfx = masterFxIndexFromComponentKey(componentKey);
     if (mfx >= 0) { enterMasterFxHierarchyEditor(mfx); return; }
 
-    const hierarchy = getComponentHierarchy(slotIndex, componentKey);
-    if (!hierarchy) {
-        /* No hierarchy - fall back to simple preset browser */
-        enterComponentEditFallback(slotIndex, componentKey);
+    openComponentEditor(slotIndex, componentKey, -1);
+}
+
+/* ============================================================
+ * The component-editor entry gate, and the hold in front of it
+ * ============================================================ */
+
+/*
+ * A component whose contract has not arrived yet.
+ *
+ *   { slot, componentKey, mfxIndex, attempts, ticks }
+ *
+ * Non-null only while VIEWS.COMPONENT_LOADING is up. `attempts` is what slows
+ * the probe down (holdProbeIntervalTicks); `ticks` counts toward the next one.
+ */
+let componentLoadHold = null;
+
+/*
+ * The three RAW wire values the gate may consult, read lazily.
+ *
+ * Raw, deliberately: `null` (the read did not complete) and `""` (served, but
+ * nothing there) are different answers and the gate is the last place that can
+ * still tell them apart. `getComponentHierarchy` collapses them, which is
+ * exactly the bug this gate exists to stop repeating — so it is not used here.
+ */
+function componentEntryReader(slotIndex, componentKey, mfxIndex) {
+    if (mfxIndex >= 0) {
+        const fxKey = masterFxComponentKey(mfxIndex);
+        return {
+            hierarchy: () => chainTargetGetParam(MASTER_CHAIN_TARGET, fxKey, "ui_hierarchy"),
+            /* The get spelling, which for Master FX is the colon form — see
+             * getHierarchyActiveModuleId, whose two spellings these mirror. */
+            module: () => getSlotParam(MASTER_CHAIN_TARGET.slot, `master_fx:${fxKey}:module`),
+            isLoading: () => chainTargetGetParam(MASTER_CHAIN_TARGET, fxKey, "is_loading"),
+        };
+    }
+    const target = slotChainTarget(slotIndex);
+    const prefix = getComponentParamPrefix(componentKey);
+    return {
+        hierarchy: () => chainTargetGetParam(target, componentKey, "ui_hierarchy"),
+        /* get_param uses underscores (synth_module); set_param uses colons. */
+        module: () => (prefix ? getSlotParam(slotIndex, `${prefix}_module`) : ""),
+        isLoading: () => chainTargetGetParam(target, componentKey, "is_loading"),
+    };
+}
+
+/*
+ * Open a component's editor, or wait until it can be opened.
+ *
+ * Both editors (slot chain and Master FX) enter through here, and both of the
+ * destinations behind it — the knob grid and the list — are chosen further in,
+ * by enterHierarchyEditorWith. So the wait is view-agnostic: it works the same
+ * with Param View on Knobs or on List, and with the screen reader on.
+ *
+ * Re-entrant by design: the hold's probe calls this again, and an ENTER or a
+ * FALLBACK from that call is what ends the hold.
+ */
+function openComponentEditor(slotIndex, componentKey, mfxIndex) {
+    const decision = decideComponentEntry(
+        componentEntryReader(slotIndex, componentKey, mfxIndex),
+        (json) => { try { return JSON.parse(json); } catch (e) { return null; } });
+
+    if (decision.action === ENTRY_HOLD) {
+        holdForComponentLoad(slotIndex, componentKey, mfxIndex, decision.reason);
         return;
     }
-    enterHierarchyEditorWith(slotIndex, componentKey, hierarchy);
+
+    componentLoadHold = null;
+
+    if (decision.action === ENTRY_ENTER) {
+        if (mfxIndex >= 0) enterMasterFxHierarchyEditorWith(mfxIndex, decision.hierarchy);
+        else enterHierarchyEditorWith(slotIndex, componentKey, decision.hierarchy);
+        return;
+    }
+
+    /* FALLBACK — the module is in and declares no hierarchy. Unchanged
+     * behaviour for both editors, including Master FX's "do nothing, the
+     * module selection is still available". */
+    if (mfxIndex >= 0) return;
+    enterComponentEditFallback(slotIndex, componentKey);
+}
+
+function componentLoadHoldLabel() {
+    if (!componentLoadHold) return "";
+    const h = componentLoadHold;
+    if (h.mfxIndex >= 0) return `MFX ${h.mfxIndex + 1}`;
+    const cfg = chainConfigs[h.slot];
+    const moduleData = cfg ? getChainComponentModule(cfg, h.componentKey) : null;
+    /* From the in-memory config, never a fresh read: the channel this screen is
+     * waiting on is the one that would have to serve it. */
+    return moduleData && moduleData.module
+        ? getModuleAbbrev(moduleData.module)
+        : String(h.componentKey || "").toUpperCase();
+}
+
+function holdForComponentLoad(slotIndex, componentKey, mfxIndex, reason) {
+    const same = componentLoadHold &&
+                 componentLoadHold.slot === slotIndex &&
+                 componentLoadHold.componentKey === componentKey &&
+                 componentLoadHold.mfxIndex === mfxIndex;
+    if (!same) {
+        componentLoadHold = { slot: slotIndex, componentKey, mfxIndex, attempts: 0, ticks: 0 };
+        debugLog(`openComponentEditor: holding slot=${slotIndex} component=${componentKey} (${reason})`);
+        announce(`${componentLoadHoldLabel()}, loading`);
+    }
+    setView(VIEWS.COMPONENT_LOADING);
+    needsRedraw = true;
+}
+
+/*
+ * Ask again, on the cadence the gate publishes.
+ *
+ * Costs one read per interval and only while the screen is up, so a component
+ * that answers on the first probe costs nothing at all. The probe SLOWS rather
+ * than stopping — see the note in component_load_gate.mjs — so a module that
+ * takes far longer than expected still opens on its own rather than needing the
+ * user to back out and come in again.
+ */
+function serviceComponentLoadHold() {
+    if (!componentLoadHold || view !== VIEWS.COMPONENT_LOADING) return;
+    const h = componentLoadHold;
+    h.ticks++;
+    if (h.ticks < holdProbeIntervalTicks(h.attempts)) return;
+    h.ticks = 0;
+    h.attempts++;
+    openComponentEditor(h.slot, h.componentKey, h.mfxIndex);
+}
+
+/* Back out of the wait. The component is left exactly as it was — nothing has
+ * been written, and nothing was loaded on the way in. */
+function cancelComponentLoadHold() {
+    const wasMasterFx = componentLoadHold && componentLoadHold.mfxIndex >= 0;
+    componentLoadHold = null;
+    setView(wasMasterFx ? VIEWS.MASTER_FX : VIEWS.CHAIN_EDIT);
+    needsRedraw = true;
+}
+
+function drawComponentLoading() {
+    clear_screen();
+    const label = componentLoadHoldLabel();
+    drawHeader(label ? `${label}` : "Module");
+    const msg = "Loading...";
+    print(Math.max(0, (SCREEN_WIDTH - text_width(msg)) >> 1), 28, msg, 1);
+    /* The canon spelling — see the other drawFooter sites and
+     * tests/shadow/test_footer_verb_consistency.sh. */
+    drawFooter(["Back: exit"]);
 }
 
 /*
@@ -11824,12 +11968,15 @@ function enterHierarchyEditorWith(slotIndex, componentKey, hierarchy) {
 /* Enter hierarchy-based parameter editor for a Master FX slot */
 function enterMasterFxHierarchyEditor(fxSlot) {
     if (fxSlot < 0 || fxSlot >= MASTER_FX_SLOTS) return;
+    /* Through the same gate as the slot chain — a Master FX position holds the
+     * same modules and comes up just as slowly. openComponentEditor calls back
+     * into enterMasterFxHierarchyEditorWith once the contract has arrived. */
+    openComponentEditor(MASTER_CHAIN_TARGET.slot, masterFxComponentKey(fxSlot), fxSlot);
+}
 
-    const hierarchy = getMasterFxHierarchy(fxSlot);
-    if (!hierarchy) {
-        /* No hierarchy - just return, module selection is available */
-        return;
-    }
+function enterMasterFxHierarchyEditorWith(fxSlot, hierarchy) {
+    if (fxSlot < 0 || fxSlot >= MASTER_FX_SLOTS) return;
+    if (!hierarchy) return;
 
     dismissOverlayForHierarchyEntry();
 
@@ -16250,6 +16397,15 @@ function handleBack() {
             announce("Chain Editor");
             needsRedraw = true;
             break;
+        case VIEWS.COMPONENT_LOADING:
+            /* Stop waiting. Nothing was written on the way in, so there is
+             * nothing to unwind — the module carries on loading regardless. */
+            {
+                const wasMasterFx = componentLoadHold && componentLoadHold.mfxIndex >= 0;
+                cancelComponentLoadHold();
+                announce(wasMasterFx ? "Master FX" : "Chain Editor");
+            }
+            break;
         case VIEWS.FILEPATH_BROWSER:
             closeHierarchyFilepathBrowser();
             {
@@ -18332,6 +18488,9 @@ function runCoRunChainEdit(fn) {
  * draw function. drawSlots() only renders the top-level slot LIST — we must
  * dispatch every reachable view explicitly. */
 function dispatchCoRunDraw() {
+    /* Same reason as the main draw path: probe before dispatching, so a
+     * component that becomes readable is drawn on this frame. */
+    serviceComponentLoadHold();
     switch (view) {
         /* Addressable-view overlay roots (CORUN_ENTRIES) — the co-run draw path
          * must render these too, not just the chain-editor subtree. */
@@ -18356,6 +18515,7 @@ function dispatchCoRunDraw() {
             drawComponentEdit();
             break;
         case VIEWS.HIERARCHY_EDITOR:     drawHierarchyEditor(); break;
+        case VIEWS.COMPONENT_LOADING:    drawComponentLoading(); break;
         /* The grid draws grids; every other page kind it plans (preset
          * browser, items list, mode select, child selector) belongs to the
          * list editor, which drawParamPages declines by returning false. */
@@ -19397,6 +19557,11 @@ globalThis.tick = function() {
      * staying on the view the grid left. See maybeReturnToComponentGrid. */
     if (view === VIEWS.CHAIN_EDIT) maybeReturnToComponentGrid();
 
+    /* Probe a component we are waiting on BEFORE the switch, not inside its
+     * draw case: a probe that lands changes `view`, and doing it here means the
+     * editor it opens is drawn on this frame rather than one frame later. */
+    serviceComponentLoadHold();
+
     /* Guarded: a throw in any draw function would otherwise repeat every
      * frame — frozen screen with no recovery, since the C loop keeps
      * calling tick() regardless. (The OVERTAKE_MODULE case has its own
@@ -19445,6 +19610,9 @@ globalThis.tick = function() {
                 /* Fall back to simple preset browser */
                 drawComponentEdit();
             }
+            break;
+        case VIEWS.COMPONENT_LOADING:
+            drawComponentLoading();
             break;
         case VIEWS.HIERARCHY_EDITOR:
             drawHierarchyEditor();

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -989,6 +989,13 @@ function setView(newView, customLabel) {
      * already down on a knob it knows about. */
     knobCardClose();
     knobTouched.fill(false);
+    /* A wait belongs to the screen it is drawn on. Leaving by ANY route — Back,
+     * the gate opening the editor, or a dismiss that drops straight to
+     * VIEWS.SLOTS — ends it, so a stale hold cannot be resurrected by a later
+     * arrival and cannot go on probing behind a screen nobody is looking at. */
+    if (view === VIEWS.COMPONENT_LOADING && newView !== VIEWS.COMPONENT_LOADING) {
+        componentLoadHold = null;
+    }
     view = newView;
     needsRedraw = true;
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -4753,9 +4753,21 @@ function loadChainConfigFromSlot(slotIndex) {
      * DSP, "what we already had" during that window is exactly the module the
      * user just picked. `incomplete` stops the latch, so the next frame reads
      * again instead of believing this one.
+     *
+     * ONCE IT HAS REFUSED, STOP ASKING. A refusing channel has nothing further
+     * to tell us this pass, and every read costs its full timeout — so the
+     * first failure short-circuits the rest and the whole pass keeps what it
+     * had for one read instead of `3 + chain length` of them.
+     *
+     * That is not an optimisation, it is the fix for a delay this very change
+     * introduced: keeping the previous COUNT (rather than the old truncate-to-
+     * zero) made readSection issue that many more reads, all of them timing
+     * out, in the handler that runs between picking a module and returning to
+     * the chain editor. Reported from the device as exactly that pause.
      */
     let incomplete = false;
     const readPosition = (id, previous) => {
+        if (incomplete) return previous || null;
         const moduleId = getSlotParam(slotIndex, `${id}_module`);
         if (moduleId === null || moduleId === undefined) {
             incomplete = true;
@@ -4779,6 +4791,7 @@ function loadChainConfigFromSlot(slotIndex) {
      * not just one. Keep the length we already had.
      */
     const readCount = (key, cap, previous) => {
+        if (incomplete) return previous;
         const raw = getSlotParam(slotIndex, key);
         if (raw === null || raw === undefined) { incomplete = true; return previous; }
         const n = parseInt(raw, 10);
@@ -5268,13 +5281,18 @@ function withPendingChainInsert(choice, pending) {
  * never changes again.
  */
 function getSlotModuleSignature(slotIndex) {
+    /* Short-circuits on the first refusal, for the same reason
+     * loadChainConfigFromSlot does: the answer is already null, and this runs
+     * in the handler between picking a module and returning to the editor. */
     let failed = false;
     const read = (id) => {
+        if (failed) return "";
         const v = getSlotParam(slotIndex, `${id}_module`);
         if (v === null || v === undefined) { failed = true; return ""; }
         return v;
     };
     const count = (key, cap) => {
+        if (failed) return 0;
         const raw = getSlotParam(slotIndex, key);
         if (raw === null || raw === undefined) { failed = true; return 0; }
         const n = parseInt(raw, 10);

--- a/src/shared/component_load_gate.mjs
+++ b/src/shared/component_load_gate.mjs
@@ -1,0 +1,118 @@
+/*
+ * WHETHER A COMPONENT EDITOR MAY OPEN YET.
+ *
+ * Opening a component's editor starts with one read of `<prefix>:ui_hierarchy`,
+ * and that read has THREE answers, not two (see the note of the same name in
+ * CLAUDE.md, and page_controller.mjs's `load`):
+ *
+ *   JSON   the component declared a hierarchy
+ *   ""     the channel served us and the key produced nothing
+ *   null   the read did not complete — claim refused, or the response timed out
+ *
+ * The entry gate used to collapse all three into `if (!hierarchy)` and commit,
+ * irreversibly, to the preset-browser fallback. For a module that has no
+ * `ui_chain.js` and whose preset reads are failing for the same reason the
+ * hierarchy read failed, that fallback draws an editor with nothing in it —
+ * and nothing ever retries, so it stays that way until the user navigates away
+ * and back. Reported from the device for MiniJV and Osirus, the two slowest
+ * things in the fleet to come up.
+ *
+ * What makes that gate the wrong place to give up is that everything which
+ * knows how to WAIT lives behind it: the knob grid's "Loading..." hold, its
+ * bounded contract retry and its ten-second recovery probe, and the list
+ * editor's `is_loading` re-fetch. None of them get a chance, because the
+ * decision to show the fallback was already made.
+ *
+ * So the gate stops deciding from one read. It answers ENTER / HOLD / FALLBACK,
+ * and HOLD means "ask again shortly" rather than "this module has nothing".
+ *
+ * The reason the empty answer needs a second question is that "" is genuinely
+ * ambiguous — a module that declares no hierarchy and a position whose module
+ * has not finished arriving BOTH answer "". `<prefix>_module` separates them:
+ * the chain host only publishes the name after `create_instance` returns
+ * (chain_host.c:504), so an occupied position that cannot name its module is
+ * one that is still loading. A module that IS named and declares no hierarchy
+ * falls back immediately, exactly as before — the well-behaved fleet never
+ * sees the hold.
+ */
+
+export const ENTRY_ENTER = "enter";
+export const ENTRY_HOLD = "hold";
+export const ENTRY_FALLBACK = "fallback";
+
+/*
+ * Probe cadence while held.
+ *
+ * The fast phase matches the knob grid's contract retry (page_controller.mjs)
+ * because it is waiting on the same thing: ~0.5 s apart for ~20 s. That covers
+ * a dlopen of a large plugin and a fork-and-boot like Osirus's.
+ *
+ * After it, the probe does not stop — it slows. Giving up entirely is what the
+ * grid's CONTRACT_RECOVER_INTERVAL_TICKS exists to undo, and it costs one read
+ * every ten seconds to make a screen heal itself instead of needing the user to
+ * back out and come in again. There is no "give up and show the fallback"
+ * ending here on purpose: a blank editor is the failure being fixed, and Back
+ * is on screen the whole time for anyone who does not want to wait.
+ */
+export const HOLD_FAST_INTERVAL_TICKS = 30;
+export const HOLD_FAST_LIMIT = 40;
+export const HOLD_SLOW_INTERVAL_TICKS = 600;
+
+/** Ticks to wait before the next probe, given how many have already been made. */
+export function holdProbeIntervalTicks(attempts) {
+    return attempts < HOLD_FAST_LIMIT ? HOLD_FAST_INTERVAL_TICKS : HOLD_SLOW_INTERVAL_TICKS;
+}
+
+/**
+ * Decide what opening this component's editor should do right now.
+ *
+ * `read` supplies the three raw wire values LAZILY — `module` and `isLoading`
+ * are only consulted on the ambiguous branch, so the ordinary case where the
+ * hierarchy answers costs exactly the one read it always did. Each must return
+ * the RAW value: null for a failed read, "" for an unserved key. Branching on
+ * the raw value is the whole point; by the time it is parsed, `parse(null)` and
+ * `parse("")` are both null and the distinction is gone.
+ *
+ * `parse` is injected so the caller keeps ownership of what a hierarchy is.
+ * Unparseable JSON still falls back, which is what it did before — a truncated
+ * declaration is a broken module, not a slow one.
+ *
+ * Returns { action, hierarchy?, reason }.
+ */
+export function decideComponentEntry(read, parse) {
+    const rawHierarchy = read.hierarchy();
+
+    if (rawHierarchy === null || rawHierarchy === undefined) {
+        return { action: ENTRY_HOLD, reason: "hierarchy-read-failed" };
+    }
+
+    if (rawHierarchy !== "") {
+        const hierarchy = parse(rawHierarchy);
+        if (hierarchy) return { action: ENTRY_ENTER, hierarchy, reason: "declared" };
+        return { action: ENTRY_FALLBACK, reason: "hierarchy-unparseable" };
+    }
+
+    /* "" — served, but empty. Who is in this position? */
+    const rawModule = read.module();
+    if (rawModule === null || rawModule === undefined) {
+        return { action: ENTRY_HOLD, reason: "module-read-failed" };
+    }
+    if (rawModule === "") {
+        /*
+         * An occupied position that cannot yet name its module.
+         *
+         * Not reachable for a genuinely empty one: an empty box in the chain
+         * diagram is a `+` and opens the picker, never the editor. So the only
+         * way here is a position the user watched fill and clicked into before
+         * the chain host finished putting the module in it.
+         */
+        return { action: ENTRY_HOLD, reason: "module-not-published" };
+    }
+
+    /* Named, so the module is in. Does it say it is still coming up? */
+    if (read.isLoading() === "1") {
+        return { action: ENTRY_HOLD, reason: "module-reports-loading" };
+    }
+
+    return { action: ENTRY_FALLBACK, reason: "declares-no-hierarchy" };
+}

--- a/tests/host/test_chain_config_read_failure.sh
+++ b/tests/host/test_chain_config_read_failure.sh
@@ -130,6 +130,34 @@ const loaded   = (k) => (k === "synth_module" ? "osirus"
         cfg.fx.length && cfg.fx[0].module, "freeverb");
 }
 
+/* ---- 4b. a refusing channel costs ONE read, not one per position ------ *
+ *
+ * Keeping the previous COUNT (rather than truncating to zero, which is what
+ * the collapsing version did by accident) makes readSection ask for that many
+ * positions -- and on a channel that is refusing, every one of those is a full
+ * timeout. In the handler that runs between picking a module and returning to
+ * the chain editor, that is a visible pause; reported from the device as one.
+ *
+ * So the first refusal short-circuits the pass. Asserted as a COUNT, because
+ * "it still works" is true of the slow version too.
+ */
+{
+  const w = world(allNull);
+  w.chainConfigs[0] = { synth: { module: "osirus", params: {} },
+                        midiFx: [{ module: "arp", params: {} }],
+                        fx: [{ module: "freeverb", params: {} },
+                             { module: "cloudseed", params: {} }] };
+  const cfg = w.load(0);
+  check("a refusing channel is asked exactly once", w.reads.length, 1);
+  check("...and the whole chain is kept anyway",
+        [cfg.synth.module, cfg.midiFx.length, cfg.fx.length], ["osirus", 1, 2]);
+
+  const w2 = world(allNull);
+  w2.sig(0);
+  check("the signature also asks a refusing channel exactly once",
+        w2.reads.length, 1);
+}
+
 /* ---- 5. the signature refuses to answer from a failed read ------------ */
 {
   check("a signature built from a failed read is null", world(allNull).sig(0), null);

--- a/tests/host/test_chain_config_read_failure.sh
+++ b/tests/host/test_chain_config_read_failure.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A failed read must not empty a chain POSITION, and must not latch.
+#
+# Captured on device 2026-08-26. Loading Osirus into slot 1:
+#
+#   13:48:53.700 [chain-v2] Loading synth: .../osirus/dsp.so
+#   13:48:53.824 [chain-v2] Synth v2 loaded: osirus (16 params)
+#   13:49:08.948 Screen reader: "Select Synth, None"      <-- 15s later
+#   13:49:11.906 Screen reader: "Slot 1, Synth Virus"     <-- same key, other path
+#
+# The load was clean and took 124 ms. Fifteen seconds later the chain editor
+# still drew the synth position EMPTY -- clicking it opened the module picker,
+# which announced the position as None -- while the slot-settings screen, which
+# reads the same `synth_module` on a different path, said Virus.
+#
+# Two causes, and it needs both to become permanent:
+#
+#   1. loadChainConfigFromSlot's readPosition was `moduleId && moduleId !== ""`,
+#      which puts null (the read did not complete) in the same branch as ""
+#      (the position is empty). Loading a module blocks the SPI callback -- the
+#      thread that also serves param requests -- and applyComponentSelectionConfirmed
+#      re-syncs immediately after its fire-and-forget module write, i.e. inside
+#      that window. So the position read null and was recorded as empty, and
+#      `chainConfigFresh[slot] = true` declared that authoritative.
+#
+#   2. the module SIGNATURE is a SECOND set of reads, taken milliseconds later.
+#      They straddled the end of the load: the config read stale-empty, the
+#      signature read the real "osirus". applySlotModuleSignature reloads the
+#      config only when the signature CHANGES -- and a signature that is already
+#      correct never changes again. The fresh read is what made the stale one
+#      permanent.
+#
+# So both halves are pinned here, and the last case drives the recorded
+# sequence end to end.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the chain-config read-failure tests" >&2
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+
+let failures = 0;
+const fail = (m) => { console.log("FAIL: " + m); failures++; };
+const check = (name, got, want) => {
+  if (JSON.stringify(got) !== JSON.stringify(want))
+    fail(`${name}: got ${JSON.stringify(got)}, want ${JSON.stringify(want)}`);
+  else console.log("ok: " + name);
+};
+
+function lift(name, deps) {
+  const at = src.indexOf("function " + name + "(");
+  if (at < 0) { fail(name + " is gone"); return null; }
+  const end = src.indexOf("\n}\n", at);
+  if (end < 0) { fail("could not find the end of " + name); return null; }
+  return new Function(...deps, src.slice(at, end + 2) + "\nreturn " + name + ";");
+}
+
+const CHAIN_CAP = { midiFx: 8, fx: 8 };
+const SHADOW_UI_SLOTS = 4;
+const createEmptyChainConfig = () => ({ synth: null, midiFx: [], fx: [] });
+
+/* A fake DSP whose answers we choose per key: a string is served, null is a
+   read that did not complete. */
+function world(answers) {
+  const chainConfigs = [];
+  const chainConfigFresh = [];
+  const reads = [];
+  const getSlotParam = (slot, key) => { reads.push(key); return answers(key); };
+  const caches = [{}, {}, {}];
+  const load = lift("loadChainConfigFromSlot",
+    ["chainConfigs", "chainConfigFresh", "getSlotParam", "CHAIN_CAP",
+     "createEmptyChainConfig", "fxDisplayNameCache", "fxDisplayNameSkip",
+     "fxDisplayNameBackoff"])(
+    chainConfigs, chainConfigFresh, getSlotParam, CHAIN_CAP,
+    createEmptyChainConfig, caches[0], caches[1], caches[2]);
+  const sig = lift("getSlotModuleSignature", ["getSlotParam", "CHAIN_CAP"])(
+    getSlotParam, CHAIN_CAP);
+  return { chainConfigs, chainConfigFresh, reads, load, sig };
+}
+
+/* Answer tables. "" is served-and-empty; null is a read that failed. */
+const allNull  = () => null;
+const allEmpty = () => "";
+const loaded   = (k) => (k === "synth_module" ? "osirus"
+                       : k === "fx_count" || k === "midi_fx_count" ? "0" : "");
+
+/* ---- 1. a failed read keeps the position ------------------------------ */
+{
+  const w = world(allNull);
+  w.chainConfigs[0] = { synth: { module: "osirus", params: {} }, midiFx: [], fx: [] };
+  const cfg = w.load(0);
+  check("a failed read keeps the module in the position",
+        cfg.synth && cfg.synth.module, "osirus");
+  check("a failed read leaves the slot NOT fresh, so the next frame re-reads",
+        w.chainConfigFresh[0], false);
+}
+
+/* ---- 2. served-and-empty still empties it ----------------------------- */
+{
+  const w = world(allEmpty);
+  w.chainConfigs[0] = { synth: { module: "osirus", params: {} }, midiFx: [], fx: [] };
+  const cfg = w.load(0);
+  check("\"\" still means the position is empty", cfg.synth, null);
+  check("a clean read latches the slot fresh", w.chainConfigFresh[0], true);
+}
+
+/* ---- 3. a served module lands, and latches ---------------------------- */
+{
+  const w = world(loaded);
+  const cfg = w.load(0);
+  check("a served module lands in the position", cfg.synth.module, "osirus");
+  check("a served read latches the slot fresh", w.chainConfigFresh[0], true);
+}
+
+/* ---- 4. a failed COUNT must not truncate the section ------------------ */
+{
+  const w = world((k) => (k === "fx_count" ? null : k === "midi_fx_count" ? "0"
+                        : k === "synth_module" ? "osirus" : null));
+  w.chainConfigs[0] = { synth: null, midiFx: [],
+                        fx: [{ module: "freeverb", params: {} }] };
+  const cfg = w.load(0);
+  check("a failed fx_count keeps the section rather than emptying it",
+        cfg.fx.length && cfg.fx[0].module, "freeverb");
+}
+
+/* ---- 5. the signature refuses to answer from a failed read ------------ */
+{
+  check("a signature built from a failed read is null", world(allNull).sig(0), null);
+  const good = world(loaded).sig(0);
+  if (typeof good !== "string" || !good.includes("osirus"))
+    fail(`a clean signature should be a string naming the module, got ${JSON.stringify(good)}`);
+  else console.log("ok: a clean read still produces a real signature");
+}
+
+/* ---- 6. and a null signature is never latched ------------------------- */
+{
+  const last = ["", "", "", ""];
+  let reloads = 0;
+  const apply = lift("applySlotModuleSignature",
+    ["SHADOW_UI_SLOTS", "lastSlotModuleSignatures", "loadChainConfigFromSlot",
+     "invalidateKnobContextCache", "needsRedraw"])(
+    SHADOW_UI_SLOTS, last, () => { reloads++; }, () => {}, false);
+  check("a null signature is not news", apply(0, null), false);
+  check("...and is not latched", last[0], "");
+  check("a real signature still reloads", apply(0, "osirus|/"), true);
+  check("...and is latched", last[0], "osirus|/");
+  check("the same signature twice reloads once", apply(0, "osirus|/"), false);
+  check("one reload, not two", reloads, 1);
+}
+
+/* ---- 7. THE RECORDED SEQUENCE, end to end ---------------------------- *
+ *
+ * The picker puts the chosen module into chainConfigs BEFORE writing it to the
+ * DSP (applyChainComponentPick), then applyComponentSelectionConfirmed
+ * re-syncs. Frame 1 is inside the load: every read fails. Frame 2 is after it:
+ * every read lands.
+ *
+ * The position must be drawn as Osirus THROUGHOUT -- never as the empty box
+ * whose click opens the module picker.
+ */
+{
+  let inLoad = true;
+  const w = world((k) => (inLoad ? null : loaded(k)));
+  /* what the picker left behind */
+  w.chainConfigs[0] = { synth: { module: "osirus", params: {} }, midiFx: [], fx: [] };
+
+  const f1 = w.load(0);                       /* the re-sync, mid-load */
+  check("frame 1: the position is not emptied by the load it is racing",
+        f1.synth && f1.synth.module, "osirus");
+  const sigDuring = w.sig(0);
+  check("frame 1: the signature declines to answer", sigDuring, null);
+  if (w.chainConfigFresh[0] !== false)
+    fail("frame 1: the slot was latched fresh, so nothing would ever re-read it");
+
+  inLoad = false;
+  const f2 = w.load(0);                       /* next frame, load finished */
+  check("frame 2: the position still reads Osirus",
+        f2.synth && f2.synth.module, "osirus");
+  check("frame 2: the slot is clean now", w.chainConfigFresh[0], true);
+}
+
+if (failures) { console.log(`FAILED: ${failures} check(s)`); process.exit(1); }
+console.log("PASS: chain config read failure — a timeout empties no position and latches nothing");
+'

--- a/tests/host/test_chain_edit_read_budget.sh
+++ b/tests/host/test_chain_edit_read_budget.sh
@@ -639,8 +639,18 @@ function loadSlot(w, opts) {
        the configs */
     const after = src.slice(m.index, m.index + 900);
     /* writeChainOrder counts: it invalidates for its callers, and B2 above
-       proves it does so even when it writes no module ids at all. */
-    const ok = /chainConfigFresh\[slotIndex\] = true/.test(after.slice(0, 300)) ||
+       proves it does so even when it writes no module ids at all.
+
+       The freshness assignment is matched on the LEFT-HAND SIDE only, not on
+       `= true`. The one in the loader is conditional now -- `= !incomplete` --
+       because a load whose reads timed out has not read the chain and must not
+       latch as authoritative (see loadChainConfigFromSlot). What this check is
+       for is a site that says NOTHING about the cache; a site that says "clean
+       only if it worked" is saying more than one that hardcodes true, not less.
+
+       It also uses the full window rather than 300 chars, since that reasoning
+       is written out between the assignment and the flag. */
+    const ok = /chainConfigFresh\[slotIndex\]\s*=/.test(after) ||
                /invalidateChainConfig\(/.test(after) ||
                /writeChainShape\(/.test(after.slice(0, 400));
     if (!ok) sites.push(lineNo + ": " + m[0].trim());

--- a/tests/host/test_component_load_gate.sh
+++ b/tests/host/test_component_load_gate.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Opening a component editor must not decide from one param read.
+#
+# Reported from the device: "MiniJV and Osirus sometimes do not appear in the
+# module editor after loading. A blank editor is unacceptable."
+#
+# The chain:
+#   1. enterHierarchyEditor read <prefix>:ui_hierarchy once and branched on
+#      `if (!hierarchy)`, which is true for BOTH "" (served, empty) and null
+#      (the read did not complete).
+#   2. null is what you get while the chain host is inside dlopen +
+#      create_instance on the SPI callback thread that also serves param
+#      requests, and while a plugin's boot thread — born SCHED_FIFO 90 — is
+#      starving it. MiniJV and Osirus are the two slowest of these.
+#   3. so the gate concluded "this module declares no hierarchy" and committed
+#      to enterComponentEditFallback. Neither module ships a ui_chain.js, and
+#      the preset reads that fallback makes were failing for the same reason,
+#      so it drew an editor with nothing in it.
+#   4. it stuck: everything that knows how to wait for a slow module — the knob
+#      grid's "Loading..." hold, its contract retry, its recovery probe, the
+#      list editor's is_loading re-fetch — lives BEHIND this gate.
+#
+# Both halves below are required. The first alone would be passed by a gate
+# that simply holds forever and never opens anything; the second alone by one
+# that never holds, which is the bug.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the component-load-gate tests" >&2
+  exit 1
+fi
+
+node -e '
+import("./src/shared/component_load_gate.mjs").then((M) => {
+  const { decideComponentEntry, holdProbeIntervalTicks,
+          ENTRY_ENTER, ENTRY_HOLD, ENTRY_FALLBACK,
+          HOLD_FAST_INTERVAL_TICKS, HOLD_FAST_LIMIT, HOLD_SLOW_INTERVAL_TICKS } = M;
+
+  let failed = 0;
+  const check = (name, got, want) => {
+    if (got !== want) { console.log(`FAIL: ${name}: got ${got}, want ${want}`); failed++; }
+    else { console.log(`ok: ${name}`); }
+  };
+
+  const parse = (s) => { try { return JSON.parse(s); } catch (e) { return null; } };
+  const HIER = JSON.stringify({ levels: { root: { label: "JV", params: [] } } });
+
+  // Counts reads so we can prove the ordinary path did not get more expensive.
+  const reader = (hierarchy, mod, loading) => {
+    const n = { hierarchy: 0, module: 0, isLoading: 0 };
+    return {
+      n,
+      io: {
+        hierarchy: () => { n.hierarchy++; return hierarchy; },
+        module: () => { n.module++; return mod; },
+        isLoading: () => { n.isLoading++; return loading; },
+      },
+    };
+  };
+
+  // ---- the bug: a failed read must HOLD, not fall back -------------------
+  check("null hierarchy holds",
+        decideComponentEntry(reader(null, null, null).io, parse).action, ENTRY_HOLD);
+
+  // "" from ui_hierarchy with a module that has not been published yet is the
+  // other shape of the same window — the chain host only names the module
+  // after create_instance returns.
+  check("empty hierarchy + unpublished module holds",
+        decideComponentEntry(reader("", "", "").io, parse).action, ENTRY_HOLD);
+
+  check("empty hierarchy + failed module read holds",
+        decideComponentEntry(reader("", null, null).io, parse).action, ENTRY_HOLD);
+
+  // A module that says so itself.
+  check("module reporting is_loading holds",
+        decideComponentEntry(reader("", "virus", "1").io, parse).action, ENTRY_HOLD);
+
+  // ---- and the gate must still OPEN, and still fall back -----------------
+  const enter = decideComponentEntry(reader(HIER, "jv880", "0").io, parse);
+  check("declared hierarchy enters", enter.action, ENTRY_ENTER);
+  check("declared hierarchy is handed back parsed",
+        enter.hierarchy && enter.hierarchy.levels && enter.hierarchy.levels.root.label, "JV");
+
+  // The well-behaved fleet: loaded, named, declares no hierarchy. Must reach
+  // its preset browser IMMEDIATELY — a hold here would put "Loading..." in
+  // front of every module that has presets and no ui_hierarchy.
+  check("named module with no hierarchy falls back at once",
+        decideComponentEntry(reader("", "sf2", "0").io, parse).action, ENTRY_FALLBACK);
+  check("named module that does not serve is_loading falls back at once",
+        decideComponentEntry(reader("", "sf2", "").io, parse).action, ENTRY_FALLBACK);
+
+  // A truncated / broken declaration is a broken module, not a slow one.
+  check("unparseable hierarchy falls back",
+        decideComponentEntry(reader("{\"levels\":", "x", "0").io, parse).action, ENTRY_FALLBACK);
+
+  // ---- the ordinary path must not have got more expensive ----------------
+  const r = reader(HIER, "jv880", "0");
+  decideComponentEntry(r.io, parse);
+  check("entering costs exactly one read", r.n.hierarchy, 1);
+  check("entering reads no module", r.n.module, 0);
+  check("entering reads no is_loading", r.n.isLoading, 0);
+
+  const r2 = reader(null, "jv880", "0");
+  decideComponentEntry(r2.io, parse);
+  check("a failed hierarchy read asks nothing further", r2.n.module, 0);
+
+  // ---- the probe slows down but never stops ------------------------------
+  check("first probes are fast", holdProbeIntervalTicks(0), HOLD_FAST_INTERVAL_TICKS);
+  check("last fast probe is fast", holdProbeIntervalTicks(HOLD_FAST_LIMIT - 1), HOLD_FAST_INTERVAL_TICKS);
+  check("probing continues, slowly, past the fast budget",
+        holdProbeIntervalTicks(HOLD_FAST_LIMIT), HOLD_SLOW_INTERVAL_TICKS);
+  check("probing never stops", holdProbeIntervalTicks(100000), HOLD_SLOW_INTERVAL_TICKS);
+  // The fast phase has to outlast a big dlopen and a fork-and-boot. At 60 Hz:
+  const fastSeconds = (HOLD_FAST_LIMIT * HOLD_FAST_INTERVAL_TICKS) / 60;
+  check("fast phase covers a slow module (>= 15s)", fastSeconds >= 15, true);
+
+  if (failed) { console.log(`FAILED: ${failed} check(s)`); process.exit(1); }
+  console.log("PASS: component load gate");
+}).catch((e) => { console.log("FAIL: " + e.stack); process.exit(1); });
+'

--- a/tests/host/test_component_load_hold_wiring.sh
+++ b/tests/host/test_component_load_hold_wiring.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Static checks on the shadow_ui.js side of the component-load hold.
+#
+# The decision itself is unit-tested in test_component_load_gate.sh. What that
+# cannot see is whether shadow_ui.js actually ASKS it — and a gate nobody calls
+# is exactly the shape the bug had: every piece of machinery that knows how to
+# wait for a slow module was already in the tree, sitting behind an entry point
+# that had already decided to show the fallback.
+#
+# So this pins the wiring: that the entry point routes through the gate rather
+# than branching on one read, that the wait is drawn, serviced and escapable on
+# BOTH draw paths (main and co-run), and that the reads it makes are raw.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the component-load-hold wiring tests" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cp src/shadow/shadow_ui.js "$TMP/shadow_ui.mjs"
+if ! node --check "$TMP/shadow_ui.mjs" 2>"$TMP/err"; then
+  echo "FAIL: shadow_ui.js does not parse:"; cat "$TMP/err"; exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const s = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+
+let failed = 0;
+const fail = (m) => { console.log("FAIL: " + m); failed++; };
+const want = (re, m) => { if (!re.test(s)) fail(m); };
+const bodyOf = (decl) => {
+  const at = s.indexOf(decl);
+  if (at < 0) return null;
+  const end = s.indexOf("\n}\n", at);
+  return s.slice(at, end < 0 ? s.length : end);
+};
+
+/* ---- the entry point must not decide from one read -------------------- */
+{
+  const body = bodyOf("function enterHierarchyEditor(slotIndex, componentKey) {");
+  if (body === null) fail("enterHierarchyEditor is gone");
+  else {
+    if (!/openComponentEditor\(/.test(body))
+      fail("enterHierarchyEditor does not go through the load gate");
+    /* The original bug, spelled out: one read, then an irreversible branch to
+     * the preset-browser fallback. `getComponentHierarchy` collapses null and
+     * "" into null, so it can no longer be what the entry decision rests on. */
+    if (/getComponentHierarchy\(/.test(body))
+      fail("enterHierarchyEditor is back to deciding from a collapsed read");
+    if (/enterComponentEditFallback\(/.test(body))
+      fail("enterHierarchyEditor falls back directly, bypassing the hold");
+  }
+}
+
+/* Master FX comes up just as slowly and holds the same modules. */
+{
+  const body = bodyOf("function enterMasterFxHierarchyEditor(fxSlot) {");
+  if (body === null) fail("enterMasterFxHierarchyEditor is gone");
+  else if (!/openComponentEditor\(/.test(body))
+    fail("Master FX skips the load gate — a slow module blanks its editor too");
+}
+
+/* ---- the gate is consulted, and HOLD is honoured ---------------------- */
+{
+  const body = bodyOf("function openComponentEditor(slotIndex, componentKey, mfxIndex) {");
+  if (body === null) fail("openComponentEditor is gone");
+  else {
+    if (!/decideComponentEntry\(/.test(body)) fail("openComponentEditor does not ask the gate");
+    if (!/ENTRY_HOLD/.test(body)) fail("openComponentEditor ignores a HOLD — the wait never happens");
+    if (!/ENTRY_ENTER/.test(body)) fail("openComponentEditor never opens anything");
+  }
+}
+
+/* ---- the reads must be RAW ------------------------------------------- *
+ *
+ * null (the read did not complete) and "" (served, nothing there) are
+ * different answers, and the reader is the last place that can tell them
+ * apart. Routing any of the three through a helper that collapses them
+ * (getComponentHierarchy, or a `|| ""`) puts the bug straight back.
+ */
+{
+  const body = bodyOf("function componentEntryReader(slotIndex, componentKey, mfxIndex) {");
+  if (body === null) fail("componentEntryReader is gone");
+  else {
+    if (/getComponentHierarchy\(/.test(body))
+      fail("componentEntryReader reads through the collapsing helper");
+    if (/getMasterFxHierarchy\(/.test(body))
+      fail("componentEntryReader reads Master FX through the collapsing helper");
+    if (/_module`\)\s*\|\|\s*""/.test(body) || /:module`\)\s*\|\|\s*""/.test(body))
+      fail("componentEntryReader defaults a failed module read to \"\" — null is not \"\"");
+    for (const k of ["ui_hierarchy", "is_loading"])
+      if (!body.includes(k)) fail(`componentEntryReader never reads ${k}`);
+  }
+}
+
+/* ---- the wait is drawn, serviced and escapable ------------------------ *
+ *
+ * On BOTH draw paths. The co-run path is a mirror of the main switch and has
+ * drifted from it before; a view drawn on one and not the other is a screen
+ * that goes blank the moment a tool is co-running — which is the failure this
+ * whole change is about.
+ */
+want(/COMPONENT_LOADING:\s*"comploading"/, "VIEWS.COMPONENT_LOADING is gone");
+
+{
+  const draws = s.match(/case VIEWS\.COMPONENT_LOADING:/g) || [];
+  if (draws.length < 3)
+    fail(`VIEWS.COMPONENT_LOADING is dispatched ${draws.length} time(s); want 3 ` +
+         "(main draw, co-run draw, Back)");
+}
+want(/drawComponentLoading\(\)/, "the wait is never drawn");
+want(/function drawComponentLoading\(\)/, "drawComponentLoading is gone");
+want(/cancelComponentLoadHold\(\)/, "Back cannot escape the wait");
+
+/* Serviced on both paths, and BEFORE the dispatch — a probe that lands
+ * changes the view, and servicing inside the draw case would show the
+ * "Loading..." frame once more after the module was already readable. */
+{
+  const calls = s.match(/serviceComponentLoadHold\(\);/g) || [];
+  if (calls.length < 2)
+    fail(`serviceComponentLoadHold is called ${calls.length} time(s); want 2 ` +
+         "(main tick and co-run dispatch)");
+  /* Not inside the case it would be servicing: the probe has to run before the
+   * dispatch, or a probe that lands still draws one more "Loading..." frame. */
+  const armsAt = [];
+  for (let at = s.indexOf("case VIEWS.COMPONENT_LOADING:"); at >= 0;
+       at = s.indexOf("case VIEWS.COMPONENT_LOADING:", at + 1)) {
+    armsAt.push(at);
+    const next = s.indexOf("case VIEWS.", at + 11);
+    if (/serviceComponentLoadHold\(/.test(s.slice(at, next < 0 ? at + 400 : next)))
+      fail("the probe runs inside the draw dispatch rather than before it");
+  }
+
+  /* Each of the two DRAW dispatches (the first arm is the Back handler) is
+   * preceded by a probe, with no other dispatch in between. */
+  const callAt = [];
+  for (let at = s.indexOf("serviceComponentLoadHold();"); at >= 0;
+       at = s.indexOf("serviceComponentLoadHold();", at + 1)) callAt.push(at);
+  for (const arm of armsAt.slice(1)) {
+    const before = callAt.filter((c) => c < arm);
+    if (!before.length) { fail("a draw dispatch of the wait has no probe before it"); continue; }
+    const nearest = before[before.length - 1];
+    /* Between the probe and the case there must be no OTHER draw dispatch of
+     * the wait — otherwise one probe would be credited to both switches. */
+    if (armsAt.some((a) => a > nearest && a < arm))
+      fail("one probe is being credited to two draw dispatches");
+  }
+}
+
+/* ---- the probe never stops ------------------------------------------- *
+ *
+ * A bounded budget that ends in the fallback would restore the blank editor
+ * with extra steps. Holding uses the gate published cadence, which slows but
+ * does not stop.
+ */
+{
+  const body = bodyOf("function serviceComponentLoadHold() {");
+  if (body === null) fail("serviceComponentLoadHold is gone");
+  else {
+    if (!/holdProbeIntervalTicks\(/.test(body))
+      fail("the hold does not use the published probe cadence");
+    if (!/openComponentEditor\(/.test(body))
+      fail("the hold never re-asks the gate, so it can never open");
+  }
+}
+
+if (failed) { console.log(`FAILED: ${failed} check(s)`); process.exit(1); }
+console.log("PASS: component load hold — entry gated, reads raw, wait drawn/serviced/escapable on both paths");
+'

--- a/tests/host/test_param_pages_wiring.sh
+++ b/tests/host/test_param_pages_wiring.sh
@@ -107,10 +107,18 @@ want(/suppressParamPagesOnce = false;/, "the guard is never cleared, so the grid
  * Checked INSIDE the master entry point, not as a file-wide count: a second
  * occurrence anywhere would satisfy a count while the master screen went on
  * ignoring the setting.
+ *
+ * "The master entry point" is now enterMasterFxHierarchyEditorWith. The outer
+ * enterMasterFxHierarchyEditor became the read half — it goes through
+ * openComponentEditor, which waits on a contract that has not arrived rather
+ * than deciding from one read — and hands the hierarchy to this function. The
+ * gate travelled with the part that opens a view, which is where it belongs.
+ * Note the name is a PREFIX of the outer one, so this must not be an indexOf
+ * of the shorter spelling: that finds the read half, whose body has no gate.
  */
 {
-  const at = s.indexOf("function enterMasterFxHierarchyEditor(");
-  if (at < 0) fail("enterMasterFxHierarchyEditor is gone");
+  const at = s.indexOf("function enterMasterFxHierarchyEditorWith(");
+  if (at < 0) fail("enterMasterFxHierarchyEditorWith is gone");
   const end = s.indexOf("\n}\n", at);
   const body = s.slice(at, end < 0 ? s.length : end);
   if (!/paramPagesEnabled\(\) && !suppressParamPagesOnce/.test(body))


### PR DESCRIPTION
Reported from the device: MiniJV and Osirus sometimes do not appear in the module editor after loading, and the chain position shows as an empty `+` box that opens the module picker.

Two separate instances of the same defect — a param read has **three** answers and the code branched as if it had two.

## 1. The chain position (the reported bug)

`loadChainConfigFromSlot`'s `readPosition` was `moduleId && moduleId !== ""`, which puts `null` (the read did not complete) in the same branch as `""` (the position is empty). Loading a module blocks the SPI callback — the thread that also serves param requests — and `applyComponentSelectionConfirmed` re-syncs *immediately after its fire-and-forget module write*, i.e. inside that window. So the position read `null`, was recorded EMPTY, and `chainConfigFresh[slot] = true` declared it authoritative. "Clean by definition once it returns" was true of the call, not of the answer.

An empty box in the diagram is a `+`, so the position the user had just filled opened the **module picker**.

**It takes a second defect to make that permanent.** The module signature is a separate set of reads taken milliseconds later, and they straddled the end of the load: the config read stale-empty, the signature read the real module. `applySlotModuleSignature` reloads the config only when the signature *changes* — so the **correct** read did the damage, by matching, and a correct signature never changes again.

Captured on device:

```
13:48:53.700 [chain-v2] Loading synth: .../osirus/dsp.so
13:48:53.824 [chain-v2] Synth v2 loaded: osirus (16 params)
13:49:08.948 Screen reader: "Select Synth, None"      <- 15s later
13:49:11.906 Screen reader: "Slot 1, Synth Virus"     <- same key, different path
```

Now: a failed read keeps the position it had, leaves the slot **un-fresh** so the next frame re-reads, and `getSlotModuleSignature` answers `null` rather than inventing an empty chain. A failed `*_count` keeps the section length — 0 from a timeout truncates the whole section, not one position.

Falls out for free: the picker writes the chosen module into `chainConfigs` *before* the DSP write, so "what we already had" during the load window is exactly the module just picked. The box shows it throughout, with no loading state to maintain.

**And once the channel refuses, stop asking it.** Keeping the previous count made `readSection` issue that many more reads, each costing the full 100 ms timeout, in the handler between the pick and the return to the chain editor — a visible pause, reported from the device during review of this branch. The first refusal now short-circuits the pass in both functions: one read instead of `3 + chain length`, same resulting config.

## 2. The component editor

`enterHierarchyEditor` opened from one read of `<prefix>:ui_hierarchy` and branched `if (!hierarchy)` into `enterComponentEditFallback`, irreversibly. For modules with no `ui_chain.js` that draws an editor with nothing in it, since the preset reads the fallback makes fail for the same reason.

What made the entry the wrong place to give up is that **everything which knows how to wait is behind it** — the grid's `Loading...` hold, its contract retry, its recovery probe, the list editor's `is_loading` re-fetch.

`src/shared/component_load_gate.mjs` now answers ENTER / HOLD / FALLBACK, and `openComponentEditor` is the single gate both editors (slot chain and Master FX) enter through. HOLD raises `VIEWS.COMPONENT_LOADING` and asks again — ~0.5 s apart for ~20 s, then every ten seconds. No give-up-to-fallback ending, on purpose; Back is on screen throughout.

`""` is disambiguated by `<prefix>_module` (the chain host publishes the name only after `create_instance` returns), so a named module that declares no hierarchy falls back **immediately** — the well-behaved fleet never sees the hold, and entering still costs the one read it always did.

## Not a regression from .11

`git show v0.11.6:src/shadow/shadow_ui.js` has both gates byte-identical. What changed is how long some modules take to answer.

## Testing

- `tests/host/test_chain_config_read_failure.sh` — lifts the real functions and drives the recorded sequence (reads failing on frame 1, landing on frame 2), and pins the refusing-channel read **count**, because "it still works" is true of the slow version too.
- `tests/host/test_component_load_gate.sh` — the decision, including that a named module with no hierarchy is *not* held, and that entering costs one read.
- `tests/host/test_component_load_hold_wiring.sh` — that shadow_ui actually asks the gate, that the reads are raw, and that the wait is drawn/serviced/escapable on both the main and co-run draw paths.
- All mutation-checked in both directions.
- 132/132 runnable host tests pass; `make -C tests/host test` all pass. (32 local failures are the pre-existing `rg`-not-installed set.)
- Verified on hardware across several load/pick cycles.

Two existing tests were updated to follow code that moved, not to accommodate a weaker invariant: `test_param_pages_wiring.sh` (the Param View gate travelled to `enterMasterFxHierarchyEditorWith`) and `test_chain_edit_read_budget.sh` (the freshness assignment is conditional now, so the predicate matches the left-hand side; a site that says *nothing* about the cache still fails).

## Known, out of scope

MiniJV loads ~4.5 MB of ROMs synchronously inside `create_instance` (`jv880_plugin.cpp:1485`), on the SPI callback — ~500 ms every load, warm or cold. Osirus does the same work on a boot thread and returns in 2 ms. That's a module-side fix in `schwung-jv880`; this branch makes the UI degrade gracefully through the window rather than blanking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GyhkGNM9W9FVJAjn1VD1Ji