### PR TITLE
anim: the store was never passed, so nothing has ever animated

### DIFF
--- a/src/modules/tools/file-browser/ui.js
+++ b/src/modules/tools/file-browser/ui.js
@@ -563,15 +563,6 @@ function drawList(items, selectedIdx, topY) {
     });
 }
 
-/* Draw item count indicator in header area */
-function drawItemCount(count, selectedIdx) {
-    if (count > MAX_VISIBLE) {
-        var countStr = (selectedIdx + 1) + "/" + count;
-        var w = text_width(countStr);
-        print(SCREEN_W - w - 2, 2, countStr, 1);
-    }
-}
-
 function drawRootPicker() {
     clear_screen();
     drawHeader("File Browser");
@@ -615,10 +606,17 @@ function drawBrowser() {
         return;
     }
 
-    /* Item count in header */
-    drawItemCount(browserState.items.length, browserState.selectedIndex);
-
-    /* Draw items */
+    /*
+     * NO ITEM COUNT. The shared list now draws a scrollbar, whose thumb reports
+     * position AND extent -- the same two facts "13/30" carried, in a column
+     * nothing else wants. Drawing both states it twice, and the header is the
+     * scarcer space: it holds the path, which truncates.
+     *
+     * Same argument that removed the scroll arrows. `drawItemCount` went with
+     * it rather than being left unused for a screen that might want it later:
+     * the root picker and the action sheets are short enough not to scroll, so
+     * that need does not exist today and a dead function is not a plan.
+     */
     drawList(browserState.items, browserState.selectedIndex, 15);
 
     /* Footer — shift+click works on everything */

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -36,6 +36,7 @@ import { renderPageMovy, drawFooter, drawHeader as drawHeaderMovy, drawBankBar,
          drawBrackets, drawPresetBody, displayValue, RULE_Y, LAYOUT_MOVY,
          MENU_LIST_X, MENU_LIST_Y, MENU_LIST_W } from "./render_page_movy.mjs";
 import { resolveViz, VIZ_SWITCH } from "./viz.mjs";
+import { createAnimState } from "./anim_state.mjs";
 import { drawMenuList } from "../menu_layout.mjs";
 
 export { LAYOUT_MOVY };
@@ -491,6 +492,9 @@ export function createController(io = {}) {
         (typeof io.trailingMenus === "function" ? (io.trailingMenus() || []) : []);
 
     const s = {
+        /* Per-controller, and it outlives a page change on purpose — see the
+         * `anim` field at the renderPageMovy call. */
+        anim: createAnimState(),
         slot: 0,
         component: "synth",
         prefix: "synth",
@@ -2753,6 +2757,27 @@ export function createController(io = {}) {
                  * the renderer, never the wiring.
                  */
                 triggerFiredAt: s.triggerFiredAt,
+                /*
+                 * THE WIDGET ANIMATION STORE, and its absence is why none of
+                 * them ever moved on hardware.
+                 *
+                 * `nowMs` alone is not enough: every animated widget guards on
+                 * `anim && typeof nowMs === "number"`, so an undefined store
+                 * silently draws the settled frame forever. createAnimState was
+                 * written, exported, unit-tested and never CALLED — the switch
+                 * fill, the waveform morph and the enum square's resize were all
+                 * inert from the day they shipped.
+                 *
+                 * Exactly the failure the note above `triggerFiredAt` describes,
+                 * one field away: the renderer tests hand these in directly, so
+                 * they prove the renderer and never the wiring. The trigger
+                 * flash had this bug, it was fixed, the note was written — and
+                 * the animations that arrived later reproduced it.
+                 *
+                 * One store per controller, so a page change does not restart
+                 * every transition and two slots do not share phase.
+                 */
+                anim: s.anim,
                 nowMs: now(),
                 footer,
             });

--- a/tests/host/test_anim_wiring.sh
+++ b/tests/host/test_anim_wiring.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# THE ANIMATIONS HAVE TO REACH THE RENDERER FROM THE CONTROLLER.
+#
+# Every animated widget guards on `anim && typeof nowMs === "number"`, so an
+# undefined store draws the settled frame forever -- silently, and identically
+# to a correct render of a value that is not moving. createAnimState was
+# written, exported, unit-tested and never CALLED: the switch fill, the waveform
+# morph and the enum square resize were all inert on hardware from the day they
+# shipped, and every test passed because the renderer tests hand `anim` in
+# DIRECTLY. They prove the renderer. Nothing proved the wiring.
+#
+# This drives the real controller and asserts that a value change produces a
+# DIFFERENT PICTURE part-way through than at rest. That cannot pass with the
+# store missing, and it does not care which widget or which easing.
+#
+# The trigger flash had this exact bug once, was fixed, and a note was left at
+# its call site. The animations that arrived later reproduced it one field away
+# from that note -- so the defence has to be a test, not a comment.
+#
+# NO APOSTROPHES inside the node script: single-quoted bash string.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the anim wiring test" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { createController, LAYOUT_MOVY }
+  from "./src/shared/param_pages/page_controller.mjs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
+
+let fail = 0;
+const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
+
+/* A switch (Off/On) and a waveform (5 shapes) -- the two viz widgets that
+   animate, so this fails if either loses its store. */
+const CHAIN_PARAMS = [
+  { key: "onoff", name: "Gate", type: "enum", options: ["Off", "On"] },
+  { key: "shape", name: "Shape", type: "enum",
+    options: ["Sine", "Tri", "Saw", "Square", "Noise"] },
+];
+const HIER = { modes: null, levels: { root: { label: "T",
+  knobs: ["onoff", "shape"], params: CHAIN_PARAMS.map((p) => ({ key: p.key })) } } };
+
+let clock = 1000;
+const store = { onoff: "0", shape: "0" };
+const ctl = createController({
+  getParam: (k) => {
+    const b = String(k).replace(/^[^:]+:/, "");
+    if (b === "ui_hierarchy") return JSON.stringify(HIER);
+    if (b === "chain_params") return JSON.stringify(CHAIN_PARAMS);
+    return b in store ? store[b] : "";
+  },
+  setParam: (k, v) => { store[String(k).replace(/^[^:]+:/, "")] = String(v); },
+  announce: () => {},
+  now: () => clock,
+});
+/* The MOVY grid, not the default LAYOUT_DIAL -- the animated widgets live in
+   that renderer alone, so a test on the default layout exercises none of them
+   and passes with the store missing. */
+ctl.setLayout(LAYOUT_MOVY);
+ctl.load({ prefix: "synth" });
+for (let i = 0; i < 12; i++) ctl.tick();
+
+const shot = () => {
+  const fb = createFramebuffer();
+  ctl.render(drawContext(fb));
+  return { fb, key: Buffer.from(fb.pixels).toString("base64") };
+};
+
+/* The store must exist at all. Checked first so a missing one reports as
+   itself rather than as "nothing animated". */
+ok(!!ctl.state.anim, "the controller owns an animation store");
+
+const slotOf = (k) => (ctl.page.keys || []).indexOf(k);
+const sw = slotOf("onoff");
+ok(sw >= 0, "the switch reached the page");
+
+const before = shot();
+/* Flip it. An enum is gated at 4 raw detents per option. */
+for (let i = 0; i < 6; i++) { clock += 20; ctl.onKnobTurn(sw, 1, clock); }
+
+/* Mid-flight and settled. The switch fill is 160ms, so 60ms in is inside it
+   and 600ms is well past. */
+clock += 60;
+const mid = shot();
+clock += 600;
+const settled = shot();
+
+ok(mid.key !== before.key, "the flip changed the picture at all");
+ok(mid.key !== settled.key,
+   "the frame 60ms into the flip differs from the settled one -- with no store " +
+   "wired through, every frame after a change is already the settled one");
+/* And it really does come to rest, rather than animating forever. */
+clock += 600;
+ok(shot().key === settled.key, "and it settles");
+
+process.exit(fail ? 1 : 0);
+'


### PR DESCRIPTION
## The animations have never run

`createAnimState` was written, exported, unit-tested and **never called**. Every
animated widget guards on `anim && typeof nowMs === "number"`, so with the store
undefined the switch fill, the waveform morph and the enum square resize all drew
the settled frame forever — silently, and identically to a correct render of a
value that is not moving.

Found by being asked whether switch animation had been implemented at all. It
had; it had just never run on hardware.

**The failure is already documented one field away from where it recurred.** The
comment above `triggerFiredAt`, at the same call site, says it outright: *"the
renderer is pure and reads the clock off `o`, so without them every button draws
in its idle phase forever — which is exactly what shipped, because the test
handed the renderer both directly and so only ever proved the renderer, never
the wiring."* The trigger flash had this bug, it was fixed, the note was left,
and the animations that arrived later reproduced it beside the note.

So the defence is a test. `test_anim_wiring` drives the real controller and
requires a frame 60ms into a flip to differ from the settled one. Deleting the
`anim:` field reproduces the shipped bug and fails it.

Two ways that test passed vacuously before it worked:

- The default layout is `LAYOUT_DIAL`. The animated widgets exist only in the
  movy renderer, so a test that never calls `setLayout` exercises none of them
  and is green with the store missing.
- It asserts a **difference between two frames**, not a particular picture — so
  it does not care which widget or which easing, and cannot rot when one is
  retuned.

## File browser: the item count goes

The shared list now draws a scrollbar whose thumb reports position and extent —
the same two facts `13/30` carried, in a column nothing else wants. The header is
the scarcer space; it holds a path that truncates. Same argument that removed the
scroll arrows.

`drawItemCount` is deleted rather than left unused for a screen that might want it
later: the root picker and action sheets do not scroll, so that need does not
exist and a dead function is not a plan.

Suite 141 pass, same 5 pre-existing. Built and verified on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SxmCg6xKKg7jeaAUdMfgye
