### PR TITLE
Link Audio: the ring was 46ms against a 92ms stall, and the build was hiding its own failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,28 @@ jobs:
             file "$f" | grep -q 'aarch64' || { echo "WRONG ARCH"; file "$f"; exit 1; }
             echo "ok"
           done
-          # Conditional: only built when the libs/link submodule is present
-          # (it is, because of `submodules: recursive` above).
-          test -f build/link-subscriber && \
-            file build/link-subscriber | grep -q 'aarch64' || \
-            { echo "WARN: link-subscriber not built (submodule missing?)"; }
+          # link-subscriber is the SOLE reception path for Move->Schwung
+          # audio, and this check used to be a warning:
+          #     ... || { echo "WARN: link-subscriber not built"; }
+          # It is not conditional here — `submodules: recursive` above
+          # guarantees libs/link — so a warning could only ever mean the build
+          # silently stopped producing it, which is exactly what happened.
+          # On a dev machine with an uninitialised submodule, build.sh printed
+          # "Warning: Link SDK not found ... skipping link-subscriber", exited
+          # 0, package.sh omitted it, and install.sh only ever KILLS it. The
+          # sidecar on the test device went unreplaced for weeks and rode
+          # through a three-version bisect as the one thing nobody varied.
+          # A soft check on the one file that can rot invisibly is no check.
+          printf '%-48s ' build/link-subscriber
+          test -f build/link-subscriber || { echo "MISSING"; exit 1; }
+          file build/link-subscriber | grep -q 'aarch64' || \
+            { echo "WRONG ARCH"; file build/link-subscriber; exit 1; }
+          echo "ok"
       - name: Verify packaged tarball
         run: |
           test -f schwung.tar.gz
           tar -tzf schwung.tar.gz | grep -q 'schwung$'
+          # package.sh adds the sidecar only "if it was built", so the tarball
+          # is where a silent skip actually reaches users.
+          tar -tzf schwung.tar.gz | grep -q 'schwung/link-subscriber$' || {
+            echo "tarball has no link-subscriber — Move->Schwung audio would be dead"; exit 1; }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,7 +365,35 @@ Move's per-track audio round-trips with ~5–14 ms unpredictable drift. Slot syn
 
 Toggle mid-playback → ~16 ms artifact (audio hole on OFF→ON, dup on ON→OFF) as ring resets.
 
-Telemetry: `touch /data/UserData/schwung/link_audio_avail_log_on` for 5 s slot avail logs; `touch /data/UserData/schwung/align_dump_trigger` for ~2.9 s of raw s16le PCM dumps in `/data/UserData/schwung/`.
+Telemetry: `touch /data/UserData/schwung/link_audio_avail_log_on` for 5 s slot avail logs. For raw audio, `echo 30 > /data/UserData/schwung/align_dump_trigger` writes that many seconds of s16le stereo to `slot0_move_track.pcm` (Move's Link Audio) and `slot0_synth_src.pcm` (the module's own output) — the two summands of a slot's mix, captured separately at the point they are combined. Score them with `tools/link-audio/analyze_capture.py`.
+
+**The capture is RT-safe and the dump length is not cosmetic.** It used to `fopen`/`fwrite` on the SPI callback for the whole capture, so the instrument could perturb the timing fault it was measuring; `src/host/align_capture.{c,h}` now memcpys into a preallocated buffer and the worker writes it. And 2.9 s was too short to tell signal from variance — the same configuration measured 5.61x, 1.84x, 1.01x, 2.58x and 2.94x across five consecutive snapshots.
+
+**A starved frame is captured as SILENCE, not skipped.** Skipping spliced the file across the gap, so a starve read as a waveform discontinuity indistinguishable from a real one.
+
+### The IN ring is sized for Move's jitter, not for symmetry
+
+`LINK_AUDIO_IN_RING_BLOCKS` was `LINK_AUDIO_PUB_SHM_BLOCKS` (16 blocks = 4096 stereo samples = **46 ms**), inherited from the publish side because the two sit next to each other in `link_audio.h`. The directions do not have the same problem: we write the pub ring on a metronome, one block per SPI frame; **Move writes this one in bursts.**
+
+Measured 2026-08-27 with the sidecar's `cb slot=N max_gap=... max_burst_run=...` telemetry, under a load that provoked it:
+
+```
+max_gap       = 92 ms       Move publishes nothing at all
+max_burst_run = 30 blocks   then 30 callbacks back-to-back (~85 ms)
+avail max     = 13128 stereo samples = 149 ms
+```
+
+All four channels stalled within 5 ms of each other — one shared stall in Move's publisher, not per-channel jitter. A 46 ms ring is empty less than halfway through a 92 ms stall and cannot hold the burst that follows, so the producer lapped the consumer. **~16% of frames had no Move audio at all.**
+
+Worse, catch-up was **fighting** the burst: the threshold was a bare `need * 12` at the call site (3072 samples ≈ 35 ms), chosen when "observed bursts were consistently <30 ms". Every refill that could have covered the next stall was discarded — ~76,000 stereo samples per 5 s window, ~17% of the audio — guaranteeing the next stall starved too. Starve, burst, discard, starve.
+
+Now 64 blocks (**186 ms**), with `LINK_AUDIO_IN_CATCHUP_SAMPLES` **derived** from the ring (3/4 of it) rather than written beside it, so a resize cannot leave the two disagreeing. This adds no steady-state latency — the consumer sets the pace, taking one block per SPI frame whatever the ring holds, so mean `avail` stays where Move's delivery puts it (~16 ms). It only changes what happens during a burst: absorbed instead of discarded. After: starve, catchup, would_overrun and la_starve_fallback all **zero**, and Move's own `max_gap` fell to 14–32 ms.
+
+**`LINK_AUDIO_IN_SHM_VERSION` must be bumped with any resize** (now 3). The struct grew 32 KB → 128 KB, so a segment left by an older sidecar is not merely stale, it is *too short* for the new mapping — and touching the tail of an undersized mapping is SIGBUS. `magic` and `version` must stay the **first two fields** so the version check itself can be read safely off a short segment. `tests/host/test_link_audio_ring_sizing.sh` pins the margins against the measured numbers, not the constants.
+
+### build.sh used to skip the sidecar silently
+
+`libs/link` is a submodule. Uninitialised, `build.sh` printed a warning, **exited 0**, `package.sh` added the sidecar only "if it was built", and `install.sh` only ever *kills* `link-subscriber` — it never installs one. So the copy on the device never changed, and rode through weeks of deploys and a three-host-version bisect of a Link Audio bug as the one component nobody was varying. It is a hard build failure now (`SCHWUNG_ALLOW_NO_LINK_SDK=1` to opt out), CI verifies the binary and the tarball entry rather than warning, and the moral is general: **a build step that can be skipped silently defeats every bisect that follows.**
 
 ## Signal Chain Module
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,6 @@ CMD set -e && \
     echo "=== Build Artifacts ===" && \
     file /build/build/schwung && \
     file /build/build/schwung-shim.so && \
-    file /build/build/modules/sf2/dsp.so 2>/dev/null || echo "SF2 module DSP: not found" && \
     echo "" && \
     echo "=== Package Created ===" && \
     ls -lh /build/schwung.tar.gz && \

--- a/docs/plans/2026-08-27-osirus-linkaudio-breakup-HANDOFF.md
+++ b/docs/plans/2026-08-27-osirus-linkaudio-breakup-HANDOFF.md
@@ -1,221 +1,167 @@
-# Move → Schwung audio breakup — MEASURED, and it is not osirus
+# Move → Schwung audio breakup — measured, half fixed, one-line repro
 
-**Status: root cause found. Move's Link Audio stream is spliced when a
-CPU-heavy module is loaded; the cause is total CPU capacity, not scheduling
-priority, and osirus is exonerated as a source of the artifact. The remedy is
-undecided (§6a).** Supersedes the 2026-08-27 morning version of this file,
-which framed it as an osirus/host bisect.
+**Status: still OPEN as an audible fault, but no longer mysterious.** One of the
+two mechanisms is found and fixed (PR #306). The other is reproducible in one
+command and is characterised below. Supersedes the 2026-08-27 morning version,
+which framed this as an osirus/host bisect.
 
 ---
 
-## 1. The one-line answer
-
-**When a CPU-heavy module is loaded, Move's Link Audio stream becomes spliced:
-~4% of its 125-frame blocks do not continue the previous one, ~15 times a
-second.** The `Move → Schwung` toggle does not create those splices — it
-decides whether you *listen* to them, because it switches the shim from passing
-Move's own mailbox mix to **rebuilding the mailbox from Link Audio**. Off, you
-hear Move's clean output. On, you hear the Link Audio reconstruction, splices
-included. With a cheap module in the slot there are no splices to hear (§6).
-
-That accounts for every fact the previous session could not:
-
-| Fact | Explained by |
-|---|---|
-| Fine until Move→Schwung is on | the toggle selects the LA reconstruction as the audio you hear |
-| Survives a cold boot | nothing accumulates; the stream is like this from the start |
-| Reproduces on main, PR #303 **and** v0.11.6 | none of them touch Move's publisher |
-| Reproduces on osirus 0.5.0 / 0.6.0 / 0.6.1 | osirus contributes none of it |
-| Only "osirus's" audio breaks up | in rebuild mode Move's track is **summed into the slot** before FX |
-| Muting the Move track fixes it | that removes the spliced source from the sum |
-| Happens with a synth pad too | it is not drum transients |
-
-## 2. The measurement — reproduce it in five minutes
-
-`align_dump_trigger` dumps the two inputs to the slot sum *separately*, at the
-exact point they are combined:
+## 1. THE REPRO — start here, it needs no module and no listening
 
 ```bash
-ssh ableton@move.local "cd /data/UserData/schwung && \
-  rm -f slot0_move_track.pcm slot0_synth_src.pcm && touch align_dump_trigger"
-# ~3 s later both files exist: s16le stereo 44.1k, 2.9 s each
+ssh root@move.local
+cat > /data/UserData/spin.sh <<'EOF'
+while :; do :; done
+EOF
+taskset 0x7 sh /data/UserData/spin.sh &
+chrt -f -p 20 $!          # FIFO 20, cores 0-2
 ```
 
-Then run the **phase test**, which is immune to the drum-transient confound
-that fooled the first pass here. For every candidate phase `p`, take the mean
-`|diff|` of samples at positions `≡ p (mod 125)`:
+**A busy loop that does nothing** takes Move's Link Audio delivery from
+`max_gap 8.7 ms / burst 2` to `max_gap 377 ms / burst 127`, and it reverts the
+instant you kill it. That is the whole fault, with no module involved.
 
-```
-slot0_move_track.pcm   BEST phase = 112   mean|diff| 5.61x overall
-                       every other phase  1.00 - 1.02x
-                       control period 128 -> 1.77x   (smear of the same spike)
-                       control period 127 -> 1.75x
-slot0_synth_src.pcm    BEST phase 1.05x, std 0.020   -> FLAT. CLEAN.
-```
+**DO NOT run the spinner at FIFO 70.** It starves `sshd` on cores 0-2 and the
+device has to be power-cycled. FIFO 20 reproduces it fine. (Learned the hard
+way; core 3 is free but sshd's threads are not pinned there.)
 
-A transient cannot prefer one phase-of-125. **125 frames is Move's Link Audio
-block** (`max_frames=125` on every telemetry line; 44100/125 = 352.8 blocks/s,
-which is exactly the observed `produced_count`).
+Watch it with the sidecar's continuity counter (see §3):
 
-Shape of the splice, at the boundary:
-
-```
-frame 7612:  2376 2328 2280 2233 2183 2138 2092 [1001] 1028 1056 1083
-             descending smoothly ................... ^ jumps AND reverses
-
-exact repeat of >=2 frames across boundary:   0 / 1022     -> not duplication
-median boundary step 36  vs  median local slope 34         -> 96% of boundaries clean
-boundaries with step > 3x local slope:        4.2%         -> ~15 / second
+```bash
+touch /data/UserData/schwung/debug_log_on   # ~100 s before the gate opens, see §6
+grep 'continuity slot' /data/UserData/schwung/debug.log
 ```
 
-Not a repeat, not clipping, not a level jump. Audio is **missing**.
+## 2. What it is NOT — every one of these was measured, do not re-test
 
-## 3. What is NOT the cause — do not re-test these
-
-| Variable | Evidence |
+| Suspect | Verdict |
 |---|---|
-| **osirus** | its own output measured **0 discontinuities**, phase-flat at 1.05x, max sample-to-sample delta 508 on a peak of 8100 |
-| osirus CPU | burns 82% of a core and reports `ur=0` for minutes at a time — it is not short of CPU |
-| osirus thread priority | tested at FIFO 70 **and** FIFO 20; see §4 |
-| our mixing / clipping | the splice is present in `slot0_move_track.pcm` **before** the sum; `synth_src` is clean |
-| our ring reader | the splice is locked to the producer's **125**-frame phase, not our 128-frame read |
-| the sidecar's writer | ring write → `__sync_synchronize()` → release-store `write_pos` is correct, and `produced_count` = 352.8/s means **no callback is missed** |
-| starve / catchup / would_overrun | all quiet during the measurement — this is not a ring-management fault |
-| the stale sidecar (§5) | the missing commit is **108 insertions, 0 deletions** — pure telemetry |
+| **osirus** | its own output is **clean in every configuration**: 1.02–1.07x phase-flat, 0 discontinuities, max sample delta 508 on a peak of 8100 |
+| osirus CPU starvation | burns 82% of a core and reports `ur=0` for minutes |
+| module thread priority | tested at FIFO **70**, FIFO **20**, and pinned to **core 3**. All equivalent |
+| core placement | pinning the module to core 3 made it **audibly worse** (core 3 is 42.6% busy, not idle; it went to 95%) |
+| **our sidecar's thread priority** | SCHED_OTHER vs **FIFO 45**: `breaks 0.61–1.46%` vs `0.32–1.18%`, `max_gap 282–366 ms` vs `359–478 ms`. **No help** |
+| raw CPU capacity | ~54% across four cores at the time of failure. Not saturated |
+| UDP / socket buffers | `Udp6InErrors=0`, `Udp6RcvbufErrors=0` under load. Nothing dropped in the kernel |
+| our ring management | since PR #306: starve, catchup, would_overrun, la_starve_fallback **all zero** |
+| our mixing | the artifact is present in `slot0_move_track.pcm` **before** the sum; `synth_src` is clean |
+| our ring reader | the artifact is locked to the producer's **125**-frame phase, not our 128-frame read |
+| the sidecar's writer | ring write → fence → release-store is correct, and `produced_count` = 352.8/s means no callback is missed |
 
-## 4. The priority hypothesis, and why it died
+**Three host versions and four osirus versions all reproduced it** because none
+of them changes CPU load on cores 0-2.
 
-osirus is fork-parallel. Its DSP child (`ppid` = MoveOriginal, `comm` inherited
-as `Audio Main/SPI`, worker thread named `DSP`) inherits scheduling from
-whatever forked it. Measured:
+## 3. The instrument that settled "us or them"
 
-```
-913   949  FF  35  10.5   Link Main          <- Move's LA publisher
-977   980  FF  70  79.7   DSP                <- osirus, ABOVE Link Main
-```
-
-That is a real contract violation and it is worth fixing on its own merits —
-it is also **the burn number §2.3 of the PR #303 handoff said had never been
-measured**: 16.3 s of CPU in 20 s, i.e. 81.5% of a core, at realtime priority.
-
-But it is not this bug:
-
-| | osirus underruns | LA starve | audible |
-|---|---|---|---|
-| FIFO 70, cores 0–3 | ~12 / 10 min | 44 starves, 1857 would-overrun | breakup |
-| FIFO 20, cores 0–2 | **88 / second** | ~1–2 / 15 s | **worse** |
-
-At FIFO 20 osirus starves itself (pitch/speed wobble, matching its `ur` counter
-and matching #303's note that SCHED_OTHER made this child audibly underrun).
-Neither rung removes the crackle, because the crackle is in the Link Audio data.
-
-**Why PR #303 "reproduced":** its deferred loader covers a `synth:module`
-*write* only. `v2_load_synth` is still used for "patch load, boot restore", so
-a module already in the slot at boot is loaded synchronously on the SPI
-callback and its children still inherit FIFO 70 on cores 0–3. Verified on
-device: after a cold boot on the #303 build there is **no `schwung-loader`
-thread at all** and the DSP child reads `FIFO 70, aff 0-3`. Re-pick the module
-in the UI and it becomes `FIFO 20, aff 0-2`. Both states were confirmed with
-`chrt -p` before listening.
-
-## 5. Build bug found on the way — the sidecar was never being shipped
-
-`libs/link` is an **uninitialised submodule**. Consequence chain:
+`link_cb_note_continuity` in `src/host/link_subscriber.cpp` compares the FIRST
+sample of each incoming buffer against the LAST of the previous one for the
+same slot, judged against the signal's own local slope. It runs **inside the
+source callback** — before our ring, before `read_pos`, before the mixer — so
+it observes Move's stream at the earliest point that exists.
 
 ```
-git submodule status  ->  -e9a2e414... libs/link      (leading '-')
-build.sh              ->  "Warning: Link SDK not found at libs/link/,
-                           skipping link-subscriber"     ... and exits 0
-package.sh            ->  only adds ./link-subscriber "if it was built"
-install.sh            ->  only KILLS link-subscriber; never installs it
+continuity slot=0  joins=1929  breaks=34  (1.76%)   <- Move track 1, playing
+continuity slot=1  joins=1929  breaks=9   (0.47%)
+continuity slot=2  joins=1929  breaks=0   (0.00%)   <- silent track
+continuity slot=3  joins=1929  breaks=0   (0.00%)   <- silent track
 ```
 
-So the Link Audio sidecar — the sole reception path for Move→Schwung audio —
-was frozen at whatever binary was placed on the device once, and rode
-unchanged through every deploy, including all three host versions bisected on
-2026-08-27. The deployed binary did not contain `max_burst_run` at all.
+The two silent tracks reading **0.00%** are the built-in control: the detector
+is not merely counting drum transients, or it would fire on everything.
 
-It is **not** the cause (the missing commit is pure telemetry) but it is why
-nobody could see this: the callback-delivery instrumentation added in
-`d0e90664` was never on the device. Fixed for this session by
-`git submodule update --init --recursive libs/link` and a rebuild; the tarball
-then contains `schwung/link-subscriber` and the deployed md5 matches.
+**Caveat on the word "upstream".** Breaks here prove the audio is already
+discontinuous when our callback receives it. They do **not** prove Move's
+firmware is at fault — the Link SDK's receiver runs **inside our own sidecar
+process**, so the socket options, the thread scheduling and the subscription
+are all ours. "Before our ring" is not "before anything we own", and conflating
+the two is how this got called an Ableton bug twice (see memory
+`link_audio_producer_burst_dropouts`, where the same wrong call was made and
+corrected).
 
-**This needs a real fix**: a silent skip that produces a working-looking
-tarball is the same class of failure as the empty `version.txt`. Either make
-the submodule a hard build requirement, or fail the build, or at minimum have
-`install.sh` refuse to proceed when the tarball has no sidecar.
+## 4. FIXED, and shipped in PR #306: the ring was 46 ms
 
-## 6. It is OURS: CPU capacity, not scheduling priority
+`LINK_AUDIO_IN_RING_BLOCKS` was `LINK_AUDIO_PUB_SHM_BLOCKS` — inherited from
+the publish side because they sit next to each other in the header. We write
+the pub ring on a metronome; **Move writes this one in bursts.** Against a
+measured 92 ms stall and 85 ms burst, a 46 ms ring is empty less than halfway
+through and cannot hold the refill. Catch-up made it worse by discarding at
+35 ms — below the burst — so every refill that could have covered the next
+stall was thrown away. Starve, burst, discard, starve.
 
-The controlling experiment was run. Same Move, same routing, same sidecar, same
-shim — only the module in slot 1 changed:
+Now 186 ms with the threshold derived from the ring. Result on hardware:
 
-```
-                    phase-125 lock     verdict
-osirus  move_track     5.61x           hard structural splice
-braids  move_track     1.02x           NONE
-either  synth_src      1.05x / 1.16x   the module itself is clean
-```
+| | before | after |
+|---|---|---|
+| Starved frames / 30 s | 145 runs, **2.53%** of audio missing | **0**, 0.095% |
+| osirus underruns / 30 s | 598 | **0** |
+| Move's own `max_gap` | 92 ms | 14–32 ms |
 
-**Swap osirus for braids and Move's Link Audio stream stops being spliced.** So
-Move's publisher is not inherently lossy; we are starving it.
+**This did not fix the audible fault** — the reporter reports it as no better —
+but it was a real bug and it was masking the other one.
 
-Read the **phase ratio**, not a splice count. Where there is no phase lock the
-`step > 3x local slope` fraction just counts ordinary transients at an
-arbitrary phase — `osirus: synth_src` scores "20.3/s" by that metric while
-being provably clean at 1.05x. That is the same trap as the absolute-threshold
-detector in §7.
+## 5. What is still open
 
-**The lever is not priority.** The osirus dump above was taken at **FIFO 20 on
-cores 0–2** — already below `Link Main` (FIFO 35), already off the SPI core —
-and it starved Move's publisher anyway. This corrects the mechanism recorded in
-memory `link_audio_producer_burst_dropouts` ("our DSP at 70 starves Link Main
-at 35"): the rung is not what matters. What matters is that osirus consumes
-~82% of one core out of four, and Move's audio engine cannot make its deadline
-alongside that. Cache/memory-bandwidth contention is a candidate mechanism that
-has NOT been measured.
+Move's publisher degrades under **any** sustained realtime CPU load on cores
+0-2, regardless of who holds it, at what priority, or what we run our own
+receiver at. Not yet tried:
 
-Note also that our own SPI-callback cost roughly doubles when routing comes on
-(`pre avg 160µs → 338µs`), all of it inside Move's FIFO-70 thread. That is a
-second, independent contribution that has not been separated from the module's.
+1. **Reduce the load.** dake's multi-core render split for osirus. Note it
+   spreads work across MORE cores, which may not help contention even though
+   it shortens total time — measure with the spinner rig before assuming.
+2. **Keep cores free.** The spinner used `taskset 0x7` (cores 0-2). Test
+   whether load confined to ONE core still breaks delivery — if Move's
+   publisher only needs one uncontended core, an affinity policy is a fix.
+3. **Look at how we subscribe.** `SourceProcessor` / channel-request TTL and
+   the socket options are ours. `d0e90664` tested the 5 s renewal theory and
+   disproved it, but the buffer sizes on the receive socket have never been
+   examined.
+4. **Admission control.** If we cannot keep Move's publisher healthy under
+   load, refuse to engage `rebuild_from_la` and stay on Move's own mailbox mix
+   with a visible reason. Degrades a feature instead of the audio.
 
-Prior art, and it is a **different** phenomenon — do not merge the two:
-`d0e90664`'s commit message recorded rare (~1 per 5–40 s) ~205 ms stalls on all
-four slots simultaneously with Move's `Link Main` showing a 172 ms continuous
-sleep, and placed those in Move's firmware publisher. This bug is constant
-~15/s block splices under load.
+## 6. Traps that cost real time today
 
-## 6a. What to do about it — not yet decided
+- **`unified_log` rechecks `debug_log_on` every 100 CALLS, not on a timer.**
+  For a subsystem logging once a second that is ~100 seconds of silence after
+  arming. Budget three minutes before concluding a flag is broken.
+- **An absolute click threshold cannot tell a splice from a kick drum.** Score
+  by PHASE mod 125 (`tools/link-audio/analyze_capture.py`). The first pass here
+  used `|diff| > 2000` and reported drums.
+- **Report phase ABSOLUTE, never per-window.** A 3 s window is 132300 samples
+  ≡ 50 (mod 125), so consecutive windows of the same steady artifact print
+  59, 122, 0, 0… and look like drift.
+- **The splice-rate percentage is meaningless without a phase lock.** With no
+  lock it counts ordinary transients — a provably clean `synth_src` scores
+  "20.3/s" that way.
+- **Three probes measured the wrong thing today**, each caught only by running
+  a control: an offset search that included `k=0` (comparing a segment to
+  itself, so it "proved" everything was contiguous); a junction-badness
+  detector that could not recover a KNOWN 3/11/40-sample cut; and the
+  absolute-threshold detector above. **Write the control first.** See memory
+  `probes_that_measured_the_wrong_thing`.
+- **A 2.9 s capture is too short.** The same configuration scored 5.61x, 1.84x,
+  1.01x, 2.58x and 2.94x across five consecutive snapshots. Captures are 30 s
+  now (`echo 30 > align_dump_trigger`).
+- **`chrt` and `taskset` need root** on the module's threads. `ssh root@` works.
+- **PR #303's deferred loader does not cover boot restore.** A module already
+  in the slot at boot loads synchronously on the SPI callback and its children
+  inherit FIFO 70 on cores 0-3. Verified with `chrt -p` on the `DSP` thread:
+  cold boot gives 70/0-3, re-picking the module in the UI gives 20/0-2. That
+  is why #303 looked like it changed nothing.
 
-Options, none tested:
+## 7. Related
 
-1. **Reduce osirus's cost.** A contributor (dake) reports a multi-core render
-   split with >2x improvement. It requires modules to have no shared mutable
-   statics between instances — that requirement needs writing into
-   `docs/MODULES.md`.
-2. **Admission control.** If total module CPU exceeds a threshold, refuse to
-   engage `rebuild_from_la` and stay on Move's clean mailbox mix, with a
-   visible reason. Degrades a feature rather than the audio.
-3. **Reduce our own per-frame SPI cost** in rebuild mode (the 160→338 µs).
-4. **Do nothing and document it** as a capacity limit of the platform.
+- PR **#306** — the ring fix, the RT-safe capture, and the build fixes below.
+- `docs/plans/2026-08-27-rt-safe-module-loading-handoff.md` — PR #303.
+- Memory `link_audio_producer_burst_dropouts` — the same bug, first recorded
+  2026-08-19, with the same wrong conclusion drawn and corrected.
 
-Measure before choosing: separate the module's contribution from the shim's by
-re-running §2 with osirus loaded but `rebuild_from_la` cost minimised.
-
-## 7. Instruments that work, and one that lies
-
-- `align_dump_trigger` — the decisive one. Separates the two summands.
-  **Caveat:** it only writes `move_track` when `have_move_track` is true, so a
-  starved frame is *skipped* and the file splices across it. Check both files
-  are the same length before trusting a discontinuity near a starve.
-- The **phase test** (§2), not an absolute-threshold click detector. The first
-  pass here used `|diff| > 2000` and could not distinguish a splice from a
-  kick drum. See memory `probes_that_measured_the_wrong_thing`.
-- `chrt -p <tid>` on the `DSP`-named thread — a version oracle that cannot lie
-  about whether a loader change took.
-- osirus's own `virus_debug.log` `ur=` counter — free, always on, and it is
-  what exonerated osirus.
-- **`unified_log` only rechecks `debug_log_on` every 100 CALLS**, not on a
-  timer. For a subsystem that logs once a second that is ~100 seconds of
-  silence after arming. Budget ~3 minutes before concluding a flag is broken.
+**Build bugs found underneath this, all fixed in #306:** `libs/link`
+uninitialised made `build.sh` warn and exit 0, `package.sh` omit the sidecar,
+and `install.sh` only ever kill it — so the sidecar was frozen on the device
+for weeks and rode through the whole bisect as the one thing nobody varied.
+And in the Dockerfile, a vestigial `file .../sf2/dsp.so || echo "not found"`
+for a module that left this repo long ago **always** failed, so the `||`
+**always** fired and masked the exit status of the entire build chain. Every
+build failure ever run was swallowed.

--- a/docs/plans/2026-08-27-osirus-linkaudio-breakup-HANDOFF.md
+++ b/docs/plans/2026-08-27-osirus-linkaudio-breakup-HANDOFF.md
@@ -100,25 +100,76 @@ Now 186 ms with the threshold derived from the ring. Result on hardware:
 **This did not fix the audible fault** — the reporter reports it as no better —
 but it was a real bug and it was masking the other one.
 
+## 4a. THE CONFIGURATION SPACE IS EXHAUSTED — it is a capacity wall
+
+Do not spend another session on priorities or affinities. Every combination was
+measured with the §1 spinner rig, and the result is a strict either/or.
+
+Load placement, measuring BOTH sides (Link Audio delivery and our own SPI path):
+
+```
+                     LinkAudio gap  burst   SPI frame max   SPI tx max   frames/s
+baseline                12,700 us      4       2,487 us       563 us       345
+load on cores 0-2      390,286 us    114       2,537 us       588 us       345
+load on CORE 3 ONLY     54,818 us      3      54,001 us    51,855 us       328
+load on cores 0-1      389,445 us    128            --            --        --
+load on core 0 ONLY  1.5-5.7 SEC     134            --            --        --
+load on cores 0-3      316-382 ms   93-114           --            --        --
+```
+
+- **cores 0-2** (current policy): our audio is FINE, Move's Link Audio collapses.
+  This is the shipped configuration and today's symptom.
+- **core 3**: Move's Link Audio is fine, **our SPI path collapses** — 54 ms
+  frames, 51.9 ms transfers, and frames/s falls 345 → 328, i.e. real dropped
+  audio frames.
+- **spreading to 0-3**: no better than 0-2.
+- **confining to one core**: much worse (1.5-5.7 s gaps).
+
+Scheduling priority, every axis:
+
+```
+module DSP at FIFO 70 / FIFO 20 / SCHED_OTHER      all equivalent
+sidecar at SCHED_OTHER / FIFO 25 / FIFO 45         all equivalent (340-400 ms)
+sidecar affinity 0-2 vs 0-3                        all equivalent
+```
+
+Also checked and clean: `sched_rt_runtime_us` = 950000/1000000 (RT throttling
+ON, 95%), `ksoftirqd` SCHED_OTHER on all four cores, NET_RX softirqs spread
+across all four, `lo` with **0 drops in 2.9M packets**, `Udp6InErrors` and
+`Udp6RcvbufErrors` both 0 under load.
+
+**Conclusion: the device cannot run a heavy realtime module and Move's Link
+Audio publishing at the same time.** There is no placement or priority that
+satisfies both. What remains is a product decision, not a scheduling fix.
+
+One trap worth naming: the two `MoveOriginal` threads restricted to cores 0-2
+(`FIFO 10` and `SCHED_OTHER`) are **ours** — `snap_worker_main` in
+`schwung_shim.c` and the shim worker. A thread inherits its parent's `comm`, so
+they report as `MoveOriginal` and look like Move firmware threads being
+starved. They are not. Every one of Move's own threads is `0-3`.
+
 ## 5. What is still open
 
 Move's publisher degrades under **any** sustained realtime CPU load on cores
 0-2, regardless of who holds it, at what priority, or what we run our own
 receiver at. Not yet tried:
 
-1. **Reduce the load.** dake's multi-core render split for osirus. Note it
-   spreads work across MORE cores, which may not help contention even though
-   it shortens total time — measure with the spinner rig before assuming.
-2. **Keep cores free.** The spinner used `taskset 0x7` (cores 0-2). Test
-   whether load confined to ONE core still breaks delivery — if Move's
-   publisher only needs one uncontended core, an affinity policy is a fix.
-3. **Look at how we subscribe.** `SourceProcessor` / channel-request TTL and
-   the socket options are ours. `d0e90664` tested the 5 s renewal theory and
-   disproved it, but the buffer sizes on the receive socket have never been
-   examined.
-4. **Admission control.** If we cannot keep Move's publisher healthy under
-   load, refuse to engage `rebuild_from_la` and stay on Move's own mailbox mix
-   with a visible reason. Degrades a feature instead of the audio.
+Given §4a, the remaining options are product decisions, not scheduling fixes:
+
+1. **Reduce module CPU.** dake's multi-core render split. **Measure it on the
+   spinner rig first** — it spreads work across cores 0-2, which is precisely
+   the placement that breaks Move's publisher, so a shorter total time may not
+   help and could hurt.
+2. **Admission control.** When total module load is high, decline to engage
+   `rebuild_from_la` and stay on Move's own mailbox mix, with a visible reason.
+   Degrades a feature instead of the audio. This is the only option that is
+   fully in our control and cannot make anything worse.
+3. **Document the limit** and let users choose between a heavy synth and
+   Move→Schwung.
+4. **Not yet examined:** the receive socket's buffer sizes (`SO_RCVBUF`) and
+   how we subscribe. `d0e90664` disproved the 5 s channel-request renewal
+   theory, but the socket options have never been looked at. Low expected
+   value given no UDP drops are recorded, but it is the one stone left.
 
 ## 6. Traps that cost real time today
 

--- a/docs/plans/2026-08-27-osirus-linkaudio-breakup-HANDOFF.md
+++ b/docs/plans/2026-08-27-osirus-linkaudio-breakup-HANDOFF.md
@@ -1,0 +1,221 @@
+# Move → Schwung audio breakup — MEASURED, and it is not osirus
+
+**Status: root cause found. Move's Link Audio stream is spliced when a
+CPU-heavy module is loaded; the cause is total CPU capacity, not scheduling
+priority, and osirus is exonerated as a source of the artifact. The remedy is
+undecided (§6a).** Supersedes the 2026-08-27 morning version of this file,
+which framed it as an osirus/host bisect.
+
+---
+
+## 1. The one-line answer
+
+**When a CPU-heavy module is loaded, Move's Link Audio stream becomes spliced:
+~4% of its 125-frame blocks do not continue the previous one, ~15 times a
+second.** The `Move → Schwung` toggle does not create those splices — it
+decides whether you *listen* to them, because it switches the shim from passing
+Move's own mailbox mix to **rebuilding the mailbox from Link Audio**. Off, you
+hear Move's clean output. On, you hear the Link Audio reconstruction, splices
+included. With a cheap module in the slot there are no splices to hear (§6).
+
+That accounts for every fact the previous session could not:
+
+| Fact | Explained by |
+|---|---|
+| Fine until Move→Schwung is on | the toggle selects the LA reconstruction as the audio you hear |
+| Survives a cold boot | nothing accumulates; the stream is like this from the start |
+| Reproduces on main, PR #303 **and** v0.11.6 | none of them touch Move's publisher |
+| Reproduces on osirus 0.5.0 / 0.6.0 / 0.6.1 | osirus contributes none of it |
+| Only "osirus's" audio breaks up | in rebuild mode Move's track is **summed into the slot** before FX |
+| Muting the Move track fixes it | that removes the spliced source from the sum |
+| Happens with a synth pad too | it is not drum transients |
+
+## 2. The measurement — reproduce it in five minutes
+
+`align_dump_trigger` dumps the two inputs to the slot sum *separately*, at the
+exact point they are combined:
+
+```bash
+ssh ableton@move.local "cd /data/UserData/schwung && \
+  rm -f slot0_move_track.pcm slot0_synth_src.pcm && touch align_dump_trigger"
+# ~3 s later both files exist: s16le stereo 44.1k, 2.9 s each
+```
+
+Then run the **phase test**, which is immune to the drum-transient confound
+that fooled the first pass here. For every candidate phase `p`, take the mean
+`|diff|` of samples at positions `≡ p (mod 125)`:
+
+```
+slot0_move_track.pcm   BEST phase = 112   mean|diff| 5.61x overall
+                       every other phase  1.00 - 1.02x
+                       control period 128 -> 1.77x   (smear of the same spike)
+                       control period 127 -> 1.75x
+slot0_synth_src.pcm    BEST phase 1.05x, std 0.020   -> FLAT. CLEAN.
+```
+
+A transient cannot prefer one phase-of-125. **125 frames is Move's Link Audio
+block** (`max_frames=125` on every telemetry line; 44100/125 = 352.8 blocks/s,
+which is exactly the observed `produced_count`).
+
+Shape of the splice, at the boundary:
+
+```
+frame 7612:  2376 2328 2280 2233 2183 2138 2092 [1001] 1028 1056 1083
+             descending smoothly ................... ^ jumps AND reverses
+
+exact repeat of >=2 frames across boundary:   0 / 1022     -> not duplication
+median boundary step 36  vs  median local slope 34         -> 96% of boundaries clean
+boundaries with step > 3x local slope:        4.2%         -> ~15 / second
+```
+
+Not a repeat, not clipping, not a level jump. Audio is **missing**.
+
+## 3. What is NOT the cause — do not re-test these
+
+| Variable | Evidence |
+|---|---|
+| **osirus** | its own output measured **0 discontinuities**, phase-flat at 1.05x, max sample-to-sample delta 508 on a peak of 8100 |
+| osirus CPU | burns 82% of a core and reports `ur=0` for minutes at a time — it is not short of CPU |
+| osirus thread priority | tested at FIFO 70 **and** FIFO 20; see §4 |
+| our mixing / clipping | the splice is present in `slot0_move_track.pcm` **before** the sum; `synth_src` is clean |
+| our ring reader | the splice is locked to the producer's **125**-frame phase, not our 128-frame read |
+| the sidecar's writer | ring write → `__sync_synchronize()` → release-store `write_pos` is correct, and `produced_count` = 352.8/s means **no callback is missed** |
+| starve / catchup / would_overrun | all quiet during the measurement — this is not a ring-management fault |
+| the stale sidecar (§5) | the missing commit is **108 insertions, 0 deletions** — pure telemetry |
+
+## 4. The priority hypothesis, and why it died
+
+osirus is fork-parallel. Its DSP child (`ppid` = MoveOriginal, `comm` inherited
+as `Audio Main/SPI`, worker thread named `DSP`) inherits scheduling from
+whatever forked it. Measured:
+
+```
+913   949  FF  35  10.5   Link Main          <- Move's LA publisher
+977   980  FF  70  79.7   DSP                <- osirus, ABOVE Link Main
+```
+
+That is a real contract violation and it is worth fixing on its own merits —
+it is also **the burn number §2.3 of the PR #303 handoff said had never been
+measured**: 16.3 s of CPU in 20 s, i.e. 81.5% of a core, at realtime priority.
+
+But it is not this bug:
+
+| | osirus underruns | LA starve | audible |
+|---|---|---|---|
+| FIFO 70, cores 0–3 | ~12 / 10 min | 44 starves, 1857 would-overrun | breakup |
+| FIFO 20, cores 0–2 | **88 / second** | ~1–2 / 15 s | **worse** |
+
+At FIFO 20 osirus starves itself (pitch/speed wobble, matching its `ur` counter
+and matching #303's note that SCHED_OTHER made this child audibly underrun).
+Neither rung removes the crackle, because the crackle is in the Link Audio data.
+
+**Why PR #303 "reproduced":** its deferred loader covers a `synth:module`
+*write* only. `v2_load_synth` is still used for "patch load, boot restore", so
+a module already in the slot at boot is loaded synchronously on the SPI
+callback and its children still inherit FIFO 70 on cores 0–3. Verified on
+device: after a cold boot on the #303 build there is **no `schwung-loader`
+thread at all** and the DSP child reads `FIFO 70, aff 0-3`. Re-pick the module
+in the UI and it becomes `FIFO 20, aff 0-2`. Both states were confirmed with
+`chrt -p` before listening.
+
+## 5. Build bug found on the way — the sidecar was never being shipped
+
+`libs/link` is an **uninitialised submodule**. Consequence chain:
+
+```
+git submodule status  ->  -e9a2e414... libs/link      (leading '-')
+build.sh              ->  "Warning: Link SDK not found at libs/link/,
+                           skipping link-subscriber"     ... and exits 0
+package.sh            ->  only adds ./link-subscriber "if it was built"
+install.sh            ->  only KILLS link-subscriber; never installs it
+```
+
+So the Link Audio sidecar — the sole reception path for Move→Schwung audio —
+was frozen at whatever binary was placed on the device once, and rode
+unchanged through every deploy, including all three host versions bisected on
+2026-08-27. The deployed binary did not contain `max_burst_run` at all.
+
+It is **not** the cause (the missing commit is pure telemetry) but it is why
+nobody could see this: the callback-delivery instrumentation added in
+`d0e90664` was never on the device. Fixed for this session by
+`git submodule update --init --recursive libs/link` and a rebuild; the tarball
+then contains `schwung/link-subscriber` and the deployed md5 matches.
+
+**This needs a real fix**: a silent skip that produces a working-looking
+tarball is the same class of failure as the empty `version.txt`. Either make
+the submodule a hard build requirement, or fail the build, or at minimum have
+`install.sh` refuse to proceed when the tarball has no sidecar.
+
+## 6. It is OURS: CPU capacity, not scheduling priority
+
+The controlling experiment was run. Same Move, same routing, same sidecar, same
+shim — only the module in slot 1 changed:
+
+```
+                    phase-125 lock     verdict
+osirus  move_track     5.61x           hard structural splice
+braids  move_track     1.02x           NONE
+either  synth_src      1.05x / 1.16x   the module itself is clean
+```
+
+**Swap osirus for braids and Move's Link Audio stream stops being spliced.** So
+Move's publisher is not inherently lossy; we are starving it.
+
+Read the **phase ratio**, not a splice count. Where there is no phase lock the
+`step > 3x local slope` fraction just counts ordinary transients at an
+arbitrary phase — `osirus: synth_src` scores "20.3/s" by that metric while
+being provably clean at 1.05x. That is the same trap as the absolute-threshold
+detector in §7.
+
+**The lever is not priority.** The osirus dump above was taken at **FIFO 20 on
+cores 0–2** — already below `Link Main` (FIFO 35), already off the SPI core —
+and it starved Move's publisher anyway. This corrects the mechanism recorded in
+memory `link_audio_producer_burst_dropouts` ("our DSP at 70 starves Link Main
+at 35"): the rung is not what matters. What matters is that osirus consumes
+~82% of one core out of four, and Move's audio engine cannot make its deadline
+alongside that. Cache/memory-bandwidth contention is a candidate mechanism that
+has NOT been measured.
+
+Note also that our own SPI-callback cost roughly doubles when routing comes on
+(`pre avg 160µs → 338µs`), all of it inside Move's FIFO-70 thread. That is a
+second, independent contribution that has not been separated from the module's.
+
+Prior art, and it is a **different** phenomenon — do not merge the two:
+`d0e90664`'s commit message recorded rare (~1 per 5–40 s) ~205 ms stalls on all
+four slots simultaneously with Move's `Link Main` showing a 172 ms continuous
+sleep, and placed those in Move's firmware publisher. This bug is constant
+~15/s block splices under load.
+
+## 6a. What to do about it — not yet decided
+
+Options, none tested:
+
+1. **Reduce osirus's cost.** A contributor (dake) reports a multi-core render
+   split with >2x improvement. It requires modules to have no shared mutable
+   statics between instances — that requirement needs writing into
+   `docs/MODULES.md`.
+2. **Admission control.** If total module CPU exceeds a threshold, refuse to
+   engage `rebuild_from_la` and stay on Move's clean mailbox mix, with a
+   visible reason. Degrades a feature rather than the audio.
+3. **Reduce our own per-frame SPI cost** in rebuild mode (the 160→338 µs).
+4. **Do nothing and document it** as a capacity limit of the platform.
+
+Measure before choosing: separate the module's contribution from the shim's by
+re-running §2 with osirus loaded but `rebuild_from_la` cost minimised.
+
+## 7. Instruments that work, and one that lies
+
+- `align_dump_trigger` — the decisive one. Separates the two summands.
+  **Caveat:** it only writes `move_track` when `have_move_track` is true, so a
+  starved frame is *skipped* and the file splices across it. Check both files
+  are the same length before trusting a discontinuity near a starve.
+- The **phase test** (§2), not an absolute-threshold click detector. The first
+  pass here used `|diff| > 2000` and could not distinguish a splice from a
+  kick drum. See memory `probes_that_measured_the_wrong_thing`.
+- `chrt -p <tid>` on the `DSP`-named thread — a version oracle that cannot lie
+  about whether a loader change took.
+- osirus's own `virus_debug.log` `ur=` counter — free, always on, and it is
+  what exonerated osirus.
+- **`unified_log` only rechecks `debug_log_on` every 100 CALLS**, not on a
+  timer. For a subsystem that logs once a second that is ~100 seconds of
+  silence after arming. Budget ~3 minutes before concluding a flag is broken.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -83,6 +83,7 @@ if [ -z "$CROSS_PREFIX" ] && [ ! -f "/.dockerenv" ]; then
         -e DISABLE_SCREEN_READER="$DISABLE_SCREEN_READER" \
         -e REQUIRE_SCREEN_READER="$REQUIRE_SCREEN_READER" \
         -e SCHWUNG_BUILD_TEST_MODULES="${SCHWUNG_BUILD_TEST_MODULES:-}" \
+        -e SCHWUNG_ALLOW_NO_LINK_SDK="${SCHWUNG_ALLOW_NO_LINK_SDK:-0}" \
         "$IMAGE_NAME"
 
     echo ""
@@ -246,6 +247,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/unified_log.c src/host/shim_worker.c \
     src/host/rt_thread_audit.c src/host/rt_thread_audit.h \
     src/host/spi_tally.c src/host/spi_tally.h \
+    src/host/align_capture.c src/host/align_capture.h \
     src/host/shadow_shm_util.c src/host/schwung_trace.c src/host/shadow_test_stream.c src/host/shadow_test_stream.h \
     $SHIM_TTS_SRC \
     src/host/shadow_constants.h src/host/shadow_midi_inject_writer.h src/host/shadow_midi.h src/host/shadow_sampler.h \
@@ -283,6 +285,7 @@ if needs_rebuild build/schwung-shim.so \
         src/host/shim_worker.c \
         src/host/rt_thread_audit.c \
         src/host/spi_tally.c \
+        src/host/align_capture.c \
         src/host/shadow_shm_util.c \
         src/host/schwung_trace.c \
         src/host/shadow_test_stream.c \
@@ -380,7 +383,31 @@ if [ -d "./libs/link/include/ableton" ]; then
         echo "Skipping Link Audio subscriber (up to date)"
     fi
 else
-    echo "Warning: Link SDK not found at libs/link/, skipping link-subscriber"
+    # A WARNING HERE IS NOT ENOUGH, and this is why.
+    #
+    # link-subscriber is the sole reception path for Move->Schwung audio.
+    # package.sh adds it only "if it was built", and install.sh only ever
+    # KILLS it — it never installs one. So an uninitialised libs/link submodule
+    # produced a working-looking tarball with no sidecar in it, and the copy on
+    # the device simply never changed. It sat there from July through weeks of
+    # deploys, and through a three-host-version bisect of a Link Audio bug as
+    # the one component nobody was varying. The build said so, once, in a line
+    # that scrolled past.
+    #
+    # Fail instead. SCHWUNG_ALLOW_NO_LINK_SDK=1 is the deliberate opt-out for
+    # anyone who really does want a build without it.
+    if [ "${SCHWUNG_ALLOW_NO_LINK_SDK:-0}" = "1" ]; then
+        echo "Warning: Link SDK not found at libs/link/, skipping link-subscriber"
+        echo "         (SCHWUNG_ALLOW_NO_LINK_SDK=1 — Move->Schwung audio will not work)"
+    else
+        echo "ERROR: Link SDK not found at libs/link/ — cannot build link-subscriber." >&2
+        echo "       Move->Schwung (Link Audio) has no reception path without it, and" >&2
+        echo "       the tarball would silently ship without one." >&2
+        echo "" >&2
+        echo "       Fix:  git submodule update --init --recursive libs/link" >&2
+        echo "       Or:   SCHWUNG_ALLOW_NO_LINK_SDK=1 ./scripts/build.sh" >&2
+        exit 1
+    fi
 fi
 
 # Build MIDI inject test tool

--- a/src/host/align_capture.c
+++ b/src/host/align_capture.c
@@ -1,0 +1,135 @@
+#include "align_capture.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ---- worker side ------------------------------------------------------- */
+
+void align_capture_abort(align_capture_t *ac)
+{
+    if (!ac) return;
+    /* Disarm FIRST, so a callback already inside align_capture_record cannot
+     * pick up a buffer we are about to free. The acquire-load of `armed` in
+     * record() pairs with this release-store. */
+    __atomic_store_n(&ac->armed, 0, __ATOMIC_RELEASE);
+    for (int i = 0; i < ALIGN_CAPTURE_MAX_STREAMS; i++) {
+        free(ac->streams[i].buf);
+        ac->streams[i].buf = NULL;
+    }
+    memset(ac->streams, 0, sizeof(ac->streams));
+    ac->stream_count = 0;
+}
+
+int align_capture_arm(align_capture_t *ac, const char *const *paths,
+                      int count, uint32_t samples_per_stream)
+{
+    if (!ac || !paths) return -1;
+    if (count <= 0 || count > ALIGN_CAPTURE_MAX_STREAMS) return -1;
+    if (samples_per_stream == 0) return -1;
+
+    /* Refuse rather than restart. A second trigger mid-capture would truncate
+     * the first, and a short file is indistinguishable from a starved one. */
+    if (__atomic_load_n(&ac->armed, __ATOMIC_ACQUIRE)) return -1;
+
+    if (samples_per_stream > ALIGN_CAPTURE_MAX_SAMPLES)
+        samples_per_stream = ALIGN_CAPTURE_MAX_SAMPLES;
+
+    memset(ac->streams, 0, sizeof(ac->streams));
+    ac->stream_count = count;
+
+    for (int i = 0; i < count; i++) {
+        if (!paths[i]) { align_capture_abort(ac); return -1; }
+        ac->streams[i].buf =
+            (int16_t *)malloc((size_t)samples_per_stream * sizeof(int16_t));
+        if (!ac->streams[i].buf) { align_capture_abort(ac); return -1; }
+        ac->streams[i].capacity = samples_per_stream;
+        ac->streams[i].filled   = 0;
+        ac->streams[i].done     = 0;
+        ac->streams[i].written  = 0;
+        snprintf(ac->streams[i].path, sizeof(ac->streams[i].path),
+                 "%s", paths[i]);
+    }
+
+    /* Publish last: everything above must be visible before the callback can
+     * observe armed != 0. */
+    __atomic_store_n(&ac->armed, 1, __ATOMIC_RELEASE);
+    return 0;
+}
+
+int align_capture_poll(align_capture_t *ac)
+{
+    if (!ac) return 0;
+    if (!__atomic_load_n(&ac->armed, __ATOMIC_ACQUIRE)) return 0;
+
+    int written_now = 0;
+    int all_written = 1;
+
+    for (int i = 0; i < ac->stream_count; i++) {
+        align_capture_stream_t *s = &ac->streams[i];
+        if (s->written) continue;
+
+        /* Acquire against the callback's release-store of `done`, so the
+         * samples it wrote are visible to us before we read them. */
+        if (!__atomic_load_n(&s->done, __ATOMIC_ACQUIRE)) {
+            all_written = 0;
+            continue;
+        }
+
+        FILE *f = fopen(s->path, "wb");
+        if (f) {
+            fwrite(s->buf, sizeof(int16_t), s->filled, f);
+            fclose(f);
+            written_now++;
+        }
+        /* Mark written even if fopen failed — retrying every 200 ms worker
+         * tick against a full or read-only filesystem would spin forever. */
+        s->written = 1;
+    }
+
+    if (all_written) align_capture_abort(ac);
+    return written_now;
+}
+
+/* ---- SPI callback side ------------------------------------------------- */
+/* Everything below runs on the audio thread. Bounds check + memcpy only. */
+
+int align_capture_record(align_capture_t *ac, int stream,
+                         const int16_t *samples, uint32_t n)
+{
+    if (!ac || !samples || n == 0) return 0;
+    if (!__atomic_load_n(&ac->armed, __ATOMIC_ACQUIRE)) return 0;
+    if (stream < 0 || stream >= ac->stream_count) return 0;
+
+    align_capture_stream_t *s = &ac->streams[stream];
+    if (!s->buf) return 0;
+    if (__atomic_load_n(&s->done, __ATOMIC_RELAXED)) return 0;
+
+    uint32_t room = s->capacity - s->filled;
+    if (n > room) {
+        /* Take the partial block rather than dropping it: a capture that ends
+         * mid-block is honest, one that silently omits the tail is not. */
+        n = room;
+    }
+    if (n) {
+        memcpy(s->buf + s->filled, samples, (size_t)n * sizeof(int16_t));
+        s->filled += n;
+    }
+
+    if (s->filled >= s->capacity) {
+        /* Release: the worker's acquire-load of `done` must see every sample
+         * written above. */
+        __atomic_store_n(&s->done, 1, __ATOMIC_RELEASE);
+    }
+    return n > 0;
+}
+
+int align_capture_complete(const align_capture_t *ac)
+{
+    if (!ac) return 0;
+    if (!__atomic_load_n(&ac->armed, __ATOMIC_ACQUIRE)) return 0;
+    for (int i = 0; i < ac->stream_count; i++) {
+        if (!__atomic_load_n(&ac->streams[i].done, __ATOMIC_ACQUIRE)) return 0;
+    }
+    return 1;
+}

--- a/src/host/align_capture.h
+++ b/src/host/align_capture.h
@@ -1,0 +1,114 @@
+/*
+ * align_capture — RT-safe multi-stream audio capture for the SPI callback.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The align/main-FX dumps in schwung_shim.c call fopen()/fwrite() directly on
+ * the SPI callback. That is a realtime violation on the one thread that must
+ * never block (see docs/REALTIME_SAFETY.md), and for a diagnostic it is worse
+ * than untidy: a 2.9 s dump does ~1000 buffered writes on the audio thread,
+ * so the instrument can perturb the very timing fault it is measuring. On
+ * 2026-08-27 the Move->Schwung splice ratio measured 5.61x, 1.84x, 1.01x,
+ * 2.58x and 2.94x across five consecutive single-shot dumps of the same
+ * configuration. That spread is not something to average over — it has to be
+ * removed as a suspect before any number here can be trusted.
+ *
+ * THE SPLIT
+ * ---------
+ *   SPI callback :  align_capture_record()  — bounds check + memcpy. Nothing
+ *                   else. No allocation, no I/O, no locks.
+ *   Worker thread:  align_capture_poll()    — notices a finished stream and
+ *                   writes it out.
+ *
+ * Allocation happens in align_capture_arm(), which the WORKER calls when it
+ * consumes the trigger file — never the callback.
+ *
+ * OWNERSHIP: single producer (SPI callback), single consumer (worker). The
+ * handoff is one release-store of `done` per stream against an acquire-load,
+ * which is why no lock appears anywhere in here.
+ */
+
+#ifndef ALIGN_CAPTURE_H
+#define ALIGN_CAPTURE_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Streams captured in parallel. Each gets its own buffer and its own file. */
+#define ALIGN_CAPTURE_MAX_STREAMS 4
+
+/* Longest capture we will allocate, per stream, in stereo int16 SAMPLES.
+ * 30 s @ 44.1 kHz stereo = 2,646,000 samples = 5.3 MB per stream. Four of
+ * those is 21 MB, which /data/UserData has room for and / does not — see the
+ * device-constraints note in CLAUDE.md about never writing to /tmp. */
+#define ALIGN_CAPTURE_MAX_SAMPLES (30u * 44100u * 2u)
+
+typedef struct {
+    int16_t  *buf;          /* owned; NULL when this stream is unused      */
+    uint32_t  capacity;     /* samples the buffer can hold                 */
+    uint32_t  filled;       /* samples written so far (callback-only)      */
+    int       done;         /* release-stored by callback, acquired by worker */
+    int       written;      /* worker-only: already flushed to disk        */
+    char      path[128];    /* destination file                            */
+} align_capture_stream_t;
+
+typedef struct {
+    align_capture_stream_t streams[ALIGN_CAPTURE_MAX_STREAMS];
+    int      stream_count;
+    int      armed;         /* release-stored by worker, acquired by callback */
+} align_capture_t;
+
+/*
+ * Arm a capture. WORKER THREAD ONLY — this allocates.
+ *
+ * `paths` holds `count` destination filenames; `samples_per_stream` is
+ * clamped to ALIGN_CAPTURE_MAX_SAMPLES. Returns 0 on success, -1 on bad
+ * arguments or allocation failure (in which case nothing is armed and any
+ * partial allocation is released).
+ *
+ * Arming while already armed is refused rather than silently restarted: a
+ * second trigger during a capture would otherwise truncate the first one and
+ * produce a short file that looks like a starve.
+ */
+int align_capture_arm(align_capture_t *ac, const char *const *paths,
+                      int count, uint32_t samples_per_stream);
+
+/*
+ * Append one block to a stream. SPI-CALLBACK-SAFE: bounds check + memcpy.
+ *
+ * Returns 1 if the samples were stored, 0 if they were not (not armed, bad
+ * stream index, stream already full). A 0 is not an error the caller can do
+ * anything about on the audio thread — it means the capture has ended.
+ *
+ * A stream that fills marks itself done; the worker takes it from there.
+ */
+int align_capture_record(align_capture_t *ac, int stream,
+                         const int16_t *samples, uint32_t n);
+
+/*
+ * True once every armed stream has filled. Cheap; callback-safe.
+ */
+int align_capture_complete(const align_capture_t *ac);
+
+/*
+ * Write out any finished-but-unwritten stream and, once all are written,
+ * free the buffers and disarm. WORKER THREAD ONLY — this does file I/O.
+ *
+ * Returns the number of files written by this call (0 is the common case).
+ */
+int align_capture_poll(align_capture_t *ac);
+
+/*
+ * Release everything without writing. Safe to call unarmed. WORKER ONLY.
+ */
+void align_capture_abort(align_capture_t *ac);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ALIGN_CAPTURE_H */

--- a/src/host/link_audio.h
+++ b/src/host/link_audio.h
@@ -155,9 +155,75 @@ typedef struct {
 /* Use the same block size as the pub side for symmetry. */
 #define LINK_AUDIO_IN_BLOCK_FRAMES   LINK_AUDIO_PUB_BLOCK_FRAMES
 #define LINK_AUDIO_IN_BLOCK_SAMPLES  LINK_AUDIO_PUB_BLOCK_SAMPLES
-#define LINK_AUDIO_IN_RING_BLOCKS    LINK_AUDIO_PUB_SHM_BLOCKS
+
+/*
+ * THE IN RING IS SIZED FOR MOVE'S JITTER, NOT FOR SYMMETRY WITH THE PUB RING.
+ *
+ * It used to be `LINK_AUDIO_PUB_SHM_BLOCKS` (16 blocks = 4096 stereo samples =
+ * 46 ms), inherited from the publish side because the two sit next to each
+ * other in this header. The two directions do not have the same problem. We
+ * write the pub ring on a metronome — one block per SPI frame. Move writes
+ * this one in bursts.
+ *
+ * Measured on hardware 2026-08-27 with the sidecar's own delivery telemetry
+ * (`cb slot=N max_gap=... max_burst_run=...`), under a load that made it
+ * misbehave — osirus in a slot, drum kit on the Move track:
+ *
+ *     max_gap        = 92 ms      Move publishes nothing at all
+ *     max_burst_run  = 30 blocks  then 30 callbacks back to back (~85 ms)
+ *     avail max      = 13128 stereo samples = 149 ms
+ *
+ * All four channels stalled within 5 ms of each other, so it is one shared
+ * stall in Move's publisher rather than per-channel jitter.
+ *
+ * A 46 ms ring cannot absorb a 92 ms stall — it is empty less than halfway
+ * through — and it cannot hold the 85 ms burst that follows, so the producer
+ * laps the consumer (`would_overrun` was ~51 per 5 s window). The result was
+ * ~16% of frames with no Move audio at all.
+ *
+ * 64 blocks = 16384 stereo samples = 8192 frames = 186 ms, which is ~2x the
+ * worst observed stall and ~1.25x the worst observed `avail`. Cost is 4 slots
+ * x 32 KB = 128 KB of SHM, up from 32 KB.
+ *
+ * This does NOT add steady-state latency. The consumer sets the pace: it takes
+ * one block per SPI frame whatever the ring holds, so mean `avail` stays where
+ * Move's delivery puts it (~16 ms measured). A deeper ring only changes what
+ * happens during a burst — absorbed instead of discarded.
+ *
+ * MUST stay a power of two: LINK_AUDIO_IN_RING_MASK is used as `& mask` by
+ * both the sidecar's writer and the shim's reader.
+ */
+#define LINK_AUDIO_IN_RING_BLOCKS    64
 #define LINK_AUDIO_IN_RING_SAMPLES   (LINK_AUDIO_IN_BLOCK_SAMPLES * LINK_AUDIO_IN_RING_BLOCKS)
 #define LINK_AUDIO_IN_RING_MASK      (LINK_AUDIO_IN_RING_SAMPLES - 1)
+
+/* The mask is only a valid substitute for a modulo if the ring is a power of
+ * two, and this is the kind of constant somebody rounds to 50 later. */
+#if (LINK_AUDIO_IN_RING_SAMPLES & LINK_AUDIO_IN_RING_MASK) != 0
+#error "LINK_AUDIO_IN_RING_SAMPLES must be a power of two (see LINK_AUDIO_IN_RING_MASK)"
+#endif
+
+/*
+ * Catch-up threshold: how far the producer may get ahead before the reader
+ * gives up on the backlog and jumps to the newest block, dropping whatever
+ * sat between. Every catch-up is an audible discontinuity.
+ *
+ * DERIVED from the ring, never written as a literal, because the two have to
+ * move together: a threshold above the ring can never fire (the producer laps
+ * us first and the data is already corrupt), and one far below the burst size
+ * discards the very refill that was about to cover the next stall. The old
+ * value was a bare `need * 12` at the call site, which is how it came to be
+ * calibrated for a 30 ms burst and left there when bursts reached 85 ms.
+ *
+ * 3/4 of the ring: high enough to absorb Move's measured burst, low enough
+ * that a runaway producer is still caught before it laps the reader.
+ */
+#define LINK_AUDIO_IN_CATCHUP_SAMPLES \
+    (LINK_AUDIO_IN_RING_SAMPLES - (LINK_AUDIO_IN_RING_SAMPLES / 4))
+
+#if LINK_AUDIO_IN_CATCHUP_SAMPLES >= LINK_AUDIO_IN_RING_SAMPLES
+#error "catch-up threshold must sit inside the ring, or it can never fire"
+#endif
 
 /* Slots 0-3: per-track audio from Move. Slot 4 (Main) is reserved but
  * unsubscribed by link_subscriber to keep Move's Audio Worker threads free
@@ -186,13 +252,33 @@ typedef struct {
     uint32_t          _stats_pad[1];            /* keep 8-byte alignment */
 } link_audio_in_slot_t;
 
+/*
+ * `magic` and `version` MUST stay the first two fields.
+ *
+ * The shim maps `sizeof(link_audio_in_shm_t)` from a segment the sidecar
+ * owns. If a sidecar from an older build is still running, that segment is
+ * SMALLER than the mapping, and touching the tail of an undersized mapping is
+ * SIGBUS, not a read of zeroes. Reading offsets 0 and 4 is always safe (page
+ * zero exists either way), so the version check below can reject the segment
+ * and munmap before anything reaches `slots[]`. Move these fields to the end
+ * and a sidecar/shim version skew becomes a crash loop instead of a warning.
+ */
 typedef struct {
     volatile uint32_t magic;    /* 0x4C41494E = "LAIN" */
-    volatile uint32_t version;  /* 2 */
+    volatile uint32_t version;
     link_audio_in_slot_t slots[LINK_AUDIO_IN_SLOT_COUNT];
 } link_audio_in_shm_t;
 
 #define LINK_AUDIO_IN_SHM_MAGIC   0x4C41494E
-#define LINK_AUDIO_IN_SHM_VERSION 2
+
+/*
+ * BUMP THIS WHENEVER THE LAYOUT OR THE RING SIZE CHANGES.
+ *
+ * 3: LINK_AUDIO_IN_RING_BLOCKS 16 -> 64 (46 ms -> 186 ms). The struct grew
+ *    from 32 KB to 128 KB, so a v2 segment left behind by an old sidecar is
+ *    not merely stale, it is too short for the new mapping.
+ * 2: earlier layout.
+ */
+#define LINK_AUDIO_IN_SHM_VERSION 3
 
 #endif /* LINK_AUDIO_H */

--- a/src/host/link_subscriber.cpp
+++ b/src/host/link_subscriber.cpp
@@ -96,6 +96,64 @@ static std::atomic<uint32_t> g_cb_count[LINK_AUDIO_IN_SLOT_COUNT];
 static std::atomic<uint32_t> g_cb_gap_seq[LINK_AUDIO_IN_SLOT_COUNT];
 static std::atomic<uint32_t> g_cb_gap_us[LINK_AUDIO_IN_SLOT_COUNT];
 
+/* ---- continuity of Move's OWN stream, measured before our ring exists -----
+ *
+ * The question this settles: does Move hand us audio whose consecutive
+ * buffers do not join, or do we damage joined audio somewhere downstream?
+ *
+ * Everything else is measured after the ring, so it cannot tell those apart.
+ * This compares the FIRST sample of each incoming buffer against the LAST
+ * sample of the previous one for the same slot, and counts the joins where
+ * that step dwarfs the signal's own local slope. It is the earliest possible
+ * observation point — before the ring, before read_pos, before the mixer.
+ *
+ * RT-safe: a handful of loads and one comparison per callback. No allocation,
+ * no logging, no locks; the 5 s report is drained on the main loop.
+ */
+static std::atomic<int32_t>  g_cont_last[LINK_AUDIO_IN_SLOT_COUNT];   /* last sample */
+static std::atomic<int32_t>  g_cont_slope[LINK_AUDIO_IN_SLOT_COUNT];  /* |diff| avg x16 */
+static std::atomic<uint32_t> g_cont_joins[LINK_AUDIO_IN_SLOT_COUNT];  /* joins seen */
+static std::atomic<uint32_t> g_cont_breaks[LINK_AUDIO_IN_SLOT_COUNT]; /* joins that broke */
+static std::atomic<uint32_t> g_cont_seen[LINK_AUDIO_IN_SLOT_COUNT];   /* has a previous */
+
+static inline void link_cb_note_continuity(int slot, const int16_t *samples,
+                                           size_t num_frames)
+{
+    if (num_frames < 4) return;
+    /* Left channel only; the two are interleaved and a break shows in both. */
+    const int32_t first = samples[0];
+    const int32_t last  = samples[(num_frames - 1) * 2];
+
+    /* Local slope INSIDE this buffer, as the scale to judge the join against.
+     * Averaged over 8 steps: cheap, and enough to separate a transient from a
+     * splice without an absolute threshold (an absolute one cannot tell a kick
+     * drum from a dropout — that mistake cost a day). */
+    int32_t slope = 0;
+    for (int i = 1; i <= 8 && (size_t)i < num_frames; i++) {
+        int32_t d = (int32_t)samples[i * 2] - (int32_t)samples[(i - 1) * 2];
+        slope += (d < 0) ? -d : d;
+    }
+    slope /= 8;
+    if (slope < 1) slope = 1;
+
+    if (g_cont_seen[slot].load(std::memory_order_relaxed)) {
+        const int32_t prev = g_cont_last[slot].load(std::memory_order_relaxed);
+        int32_t step = first - prev;
+        if (step < 0) step = -step;
+        /* Judge against the larger of this buffer's slope and the previous
+         * one's, so a join into a genuinely loud attack is not counted. */
+        int32_t prev_slope = g_cont_slope[slot].load(std::memory_order_relaxed);
+        int32_t scale = (slope > prev_slope) ? slope : prev_slope;
+        g_cont_joins[slot].fetch_add(1, std::memory_order_relaxed);
+        if (step > scale * 4) {
+            g_cont_breaks[slot].fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    g_cont_last[slot].store(last, std::memory_order_relaxed);
+    g_cont_slope[slot].store(slope, std::memory_order_relaxed);
+    g_cont_seen[slot].store(1, std::memory_order_relaxed);
+}
+
 static inline void link_cb_note_delivery(int slot)
 {
     struct timespec ts;
@@ -485,6 +543,9 @@ int main()
                                 if (num_frames == 0) return;
                                 if (!samples) return;
 
+                                link_cb_note_continuity(slot_idx_cap,
+                                                        samples, num_frames);
+
                                 link_audio_in_slot_t *slot =
                                     &in_shm_cap->slots[slot_idx_cap];
 
@@ -686,6 +747,16 @@ int main()
                 LOG_INFO(LINK_SUB_LOG_SOURCE,
                          "cb slot=%d n=%u max_gap=%u us (%.1f ms) max_burst_run=%u",
                          i, n, max_gap, (double)max_gap / 1000.0, max_run);
+                uint32_t joins  = g_cont_joins[i].exchange(0, std::memory_order_relaxed);
+                uint32_t breaks = g_cont_breaks[i].exchange(0, std::memory_order_relaxed);
+                if (joins) {
+                    LOG_INFO(LINK_SUB_LOG_SOURCE,
+                             "continuity slot=%d joins=%u breaks=%u (%.2f%%) "
+                             "-- breaks here mean MOVE's stream is discontinuous, "
+                             "upstream of our ring",
+                             i, joins, breaks,
+                             100.0 * (double)breaks / (double)joins);
+                }
             }
         }
 

--- a/src/host/shadow_link_audio.c
+++ b/src/host/shadow_link_audio.c
@@ -136,14 +136,30 @@ int link_audio_read_channel_shm(link_audio_in_shm_t *shm, int slot_idx,
         return 0;
     }
 
-    /* Catch-up: if producer got ahead by more than 12 blocks (~70 ms), jump
-     * to the most recent block. Every catch-up is an audible drop, so the
-     * threshold has to tolerate real producer-thread jitter — the Link audio
-     * SDK thread can pause ~25 ms and then flush buffered audio. Raised from
-     * need*4 (1024 samples) to need*12 (3072) after instrumentation showed
-     * observed bursts were consistently <30 ms. If true long-term drift
-     * exists, max_avail_seen will rise steadily and surface in the logger. */
-    if (avail > need * 12) {
+    /* Catch-up: if the producer gets far enough ahead, jump to the most recent
+     * block. Every catch-up is an audible drop, so the threshold has to
+     * tolerate real producer jitter.
+     *
+     * THE THRESHOLD MUST EXCEED THE BURST, OR IT DISCARDS THE FIX FOR THE
+     * STALL. It was `need * 12` = 3072 samples = 35 ms, chosen when
+     * "observed bursts were consistently <30 ms". That stopped being true.
+     * Measured 2026-08-27 (see link_audio.h for the full numbers): Move stalls
+     * ~92 ms on all four channels at once, then delivers ~30 blocks back to
+     * back. So the ring drained, the burst refilled it past 35 ms, and
+     * catch-up threw the refill away — ~76,000 stereo samples per 5 s window,
+     * about 17% of the audio — which guaranteed the next stall starved too.
+     * Starve, burst, discard, starve.
+     *
+     * LINK_AUDIO_IN_CATCHUP_SAMPLES is derived from the ring rather than
+     * written as a number, so resizing the ring cannot leave the two
+     * disagreeing. At 64 blocks it is 12288 samples = 139 ms: above the worst
+     * observed `avail` (149 ms is a lapped producer, not a burst we can keep)
+     * while still bounded well inside the ring, so a genuinely runaway
+     * producer is still caught.
+     *
+     * If true long-term drift exists, max_avail_seen rises steadily and
+     * surfaces in the logger. */
+    if (avail > LINK_AUDIO_IN_CATCHUP_SAMPLES) {
         uint32_t new_rp = wp - need;
         __atomic_fetch_add(&slot->catchup_samples_dropped,
                            (new_rp - rp), __ATOMIC_RELAXED);

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -378,12 +378,17 @@ static void align_capture_tick(void) {
     unlink(ALIGN_CAPTURE_TRIGGER_PATH);
     if (seconds <= 0) seconds = ALIGN_CAPTURE_DEFAULT_SECONDS;
 
-    static const char *const paths[2] = {
+    /* Four streams: the two summands, the slot's post-FX output, and the
+     * finished mailbox. Inputs alone cannot tell "Move sent bad audio" from
+     * "we damaged good audio" — capture the chain, not its ends. */
+    static const char *const paths[4] = {
         "/data/UserData/schwung/slot0_move_track.pcm",
         "/data/UserData/schwung/slot0_synth_src.pcm",
+        "/data/UserData/schwung/slot0_post_fx.pcm",
+        "/data/UserData/schwung/mailbox_out.pcm",
     };
     uint32_t samples = (uint32_t)seconds * 44100u * 2u;
-    if (align_capture_arm(&g_align_capture, paths, 2, samples) == 0) {
+    if (align_capture_arm(&g_align_capture, paths, 4, samples) == 0) {
         unified_log("shim", LOG_LEVEL_INFO,
                     "align capture armed: %d s per stream", seconds);
     } else {

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -15,6 +15,7 @@
 #include "shim_worker.h"
 #include "rt_thread_audit.h"
 #include "spi_tally.h"
+#include "align_capture.h"
 #include "shadow_set_pages.h"
 #include "unified_log.h"
 #include "usbc_out_gate.h"
@@ -100,7 +101,6 @@ static const flag_spec_t FLAGS[] = {
     { "/data/UserData/schwung/log_xmos_sysex_on",    SHIM_FLAG_XMOS_LOG,     0 },
     { "/data/UserData/schwung/spi_midi_log_on",      SHIM_FLAG_SPI_MIDI_LOG, 0 },
     { "/data/UserData/schwung/slot_fx_dump_trigger", SHIM_FLAG_SLOT_FX_DUMP, 1 },
-    { "/data/UserData/schwung/align_dump_trigger",   SHIM_FLAG_ALIGN_DUMP,   1 },
     { "/data/UserData/schwung/main_fx_dump_trigger", SHIM_FLAG_MAIN_FX_DUMP, 1 },
     { "/data/UserData/schwung/rt_thread_audit_on",   SHIM_FLAG_RT_AUDIT,     0 },
     { "/data/UserData/schwung/spi_tally_on",         SHIM_FLAG_SPI_TALLY,    0 },
@@ -345,6 +345,54 @@ static void rt_audit_tick(void)
  * do; correctness does not depend on when the change is observed. */
 extern int shim_touch_trace_on;
 void shim_touch_trace_drain(void);
+
+/* ---- align capture ---------------------------------------------------- */
+
+/* The align dump is armed HERE, not on the SPI callback, because arming
+ * allocates. The callback only memcpys (align_capture_record); this side does
+ * the malloc, the fopen and the fwrite. See align_capture.h.
+ *
+ * The trigger file's contents are the capture length in seconds; empty or
+ * unparseable means ALIGN_CAPTURE_DEFAULT_SECONDS. A single 2.9 s snapshot was
+ * too short to tell a real signal from run-to-run variance — the measured
+ * splice ratio moved between 1.01x and 5.61x across five consecutive captures
+ * of the same configuration.
+ */
+#define ALIGN_CAPTURE_TRIGGER_PATH "/data/UserData/schwung/align_dump_trigger"
+#define ALIGN_CAPTURE_DEFAULT_SECONDS 30
+
+extern align_capture_t g_align_capture;
+
+static void align_capture_tick(void) {
+    /* Finish any capture already in flight before starting another. */
+    align_capture_poll(&g_align_capture);
+
+    if (access(ALIGN_CAPTURE_TRIGGER_PATH, F_OK) != 0) return;
+
+    int seconds = 0;
+    FILE *f = fopen(ALIGN_CAPTURE_TRIGGER_PATH, "r");
+    if (f) {
+        if (fscanf(f, "%d", &seconds) != 1) seconds = 0;
+        fclose(f);
+    }
+    unlink(ALIGN_CAPTURE_TRIGGER_PATH);
+    if (seconds <= 0) seconds = ALIGN_CAPTURE_DEFAULT_SECONDS;
+
+    static const char *const paths[2] = {
+        "/data/UserData/schwung/slot0_move_track.pcm",
+        "/data/UserData/schwung/slot0_synth_src.pcm",
+    };
+    uint32_t samples = (uint32_t)seconds * 44100u * 2u;
+    if (align_capture_arm(&g_align_capture, paths, 2, samples) == 0) {
+        unified_log("shim", LOG_LEVEL_INFO,
+                    "align capture armed: %d s per stream", seconds);
+    } else {
+        /* Almost always "a capture is already running" — say so rather than
+         * leaving the user to wonder why the trigger did nothing. */
+        unified_log("shim", LOG_LEVEL_WARN,
+                    "align capture NOT armed (already running, or out of memory)");
+    }
+}
 
 static void poll_flags(void) {
     shim_touch_trace_on =
@@ -606,6 +654,7 @@ static void *worker_main(void *arg) {
         if (tick % 5 == 0) poll_flags();          /* ~1 Hz */
         if (tick % 5 == 0) rt_audit_tick();       /* ~1 Hz, no-op unless armed */
         if (tick % 5 == 0) spi_tally_tick();      /* ~1 Hz, no-op unless armed */
+        align_capture_tick();                    /* 5 Hz: arm on trigger, drain when full */
         if (tick % 7 == 0) shadow_poll_current_set(); /* ~1.4 s FS scan */
         tick++;
     }

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -29,7 +29,10 @@
 /* One-shot flags: worker unlinks the trigger file and sets the bit; the
  * RT consumer clears it with shim_debug_flag_consume(). */
 #define SHIM_FLAG_SLOT_FX_DUMP   (1u << 8)  /* slot_fx_dump_trigger */
-#define SHIM_FLAG_ALIGN_DUMP     (1u << 9)  /* align_dump_trigger */
+/* (1u << 9) was SHIM_FLAG_ALIGN_DUMP. The align dump moved off the SPI
+ * callback entirely — the worker arms and drains it (align_capture.h), so
+ * there is nothing for the RT side to consume. Left as a hole on purpose:
+ * reusing the bit would make a stale build read one trigger as another. */
 #define SHIM_FLAG_MAIN_FX_DUMP   (1u << 10) /* main_fx_dump_trigger */
 
 extern volatile uint32_t shim_debug_flags;

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -55,6 +55,11 @@
 #include "host/shadow_dbus.h"
 #include "host/shadow_chain_mgmt.h"
 #include "host/shadow_link_audio.h"
+#include "host/align_capture.h"
+
+/* Defined further down with the other shim globals; used from the mixer,
+ * which sits above that block. */
+extern align_capture_t g_align_capture;
 #include "host/shadow_process.h"
 #include "host/shadow_resample.h"
 #include "host/shadow_overlay.h"
@@ -2357,43 +2362,34 @@ static void shadow_inprocess_mix_from_buffer(void) {
                     synth_src = synth_delayed;
                 }
 
-                /* Latency alignment dump (slot 0 only). Touch
-                 * /data/UserData/schwung/align_dump_trigger to arm;
-                 * captures 300 blocks (~870 ms) of:
+                /* Latency alignment capture (slot 0 only). Touch
+                 * /data/UserData/schwung/align_dump_trigger to arm; the file's
+                 * contents are the duration in seconds (default 30, clamped by
+                 * ALIGN_CAPTURE_MAX_SAMPLES). Produces:
                  *   slot0_move_track.pcm  — Move Link Audio (post-nudge)
                  *   slot0_synth_src.pcm   — Schwung synth (post-delay if
                  *                            comp active)
-                 * Both s16le stereo @44.1k. Cross-correlate them to
-                 * measure the actual sample offset between Move and
-                 * Schwung audio paths. */
+                 * Both s16le stereo @44.1k, sample-aligned with each other.
+                 *
+                 * This is memcpy ONLY. It used to fopen/fwrite right here, on
+                 * the SPI callback — a realtime violation for the whole length
+                 * of the capture, which meant the instrument could perturb the
+                 * timing fault it was measuring. See align_capture.h. Arming
+                 * and writing both live on the worker now.
+                 *
+                 * A starved frame writes SILENCE into move_track rather than
+                 * skipping it. Skipping spliced the file across the gap, so a
+                 * starve appeared as a waveform discontinuity indistinguishable
+                 * from a real one — which cost real time on 2026-08-27 before
+                 * the equal file lengths gave it away. */
                 if (s == 0) {
-                    static FILE *align_move_f  = NULL;
-                    static FILE *align_synth_f = NULL;
-                    static int align_dump_frames = 0;
-                    if (align_dump_frames == 0 &&
-                        shim_debug_flag_consume(SHIM_FLAG_ALIGN_DUMP)) {
-                        /* Worker already unlinked the trigger file. */
-                        align_move_f = fopen(
-                            "/data/UserData/schwung/slot0_move_track.pcm", "wb");
-                        align_synth_f = fopen(
-                            "/data/UserData/schwung/slot0_synth_src.pcm", "wb");
-                        align_dump_frames = 1000;  /* ~2.9 s */
-                    }
-                    if (align_dump_frames > 0) {
-                        if (align_move_f && have_move_track) {
-                            fwrite(move_track, sizeof(int16_t),
-                                   FRAMES_PER_BLOCK * 2, align_move_f);
-                        }
-                        if (align_synth_f) {
-                            fwrite(synth_src, sizeof(int16_t),
-                                   FRAMES_PER_BLOCK * 2, align_synth_f);
-                        }
-                        align_dump_frames--;
-                        if (align_dump_frames == 0) {
-                            if (align_move_f)  { fclose(align_move_f);  align_move_f = NULL; }
-                            if (align_synth_f) { fclose(align_synth_f); align_synth_f = NULL; }
-                        }
-                    }
+                    static const int16_t align_silence[FRAMES_PER_BLOCK * 2] = {0};
+                    align_capture_record(&g_align_capture, 0,
+                                         have_move_track ? move_track
+                                                         : align_silence,
+                                         FRAMES_PER_BLOCK * 2);
+                    align_capture_record(&g_align_capture, 1, synth_src,
+                                         FRAMES_PER_BLOCK * 2);
                 }
 
                 /* Active slot: combine synth + Link Audio, run through FX */
@@ -4959,6 +4955,10 @@ static volatile spi_timing_snapshot_t spi_snap = {0};
 
 /* Link Audio path-flip counters (single-writer from SPI path, single-reader
  * from the background logger thread). Declared extern where incremented. */
+/* Audio capture for the align dump. Armed and drained by the worker;
+ * the SPI callback only memcpys into it. See align_capture.h. */
+align_capture_t g_align_capture;
+
 volatile uint32_t shim_la_rebuild_flip_count = 0;
 volatile uint32_t shim_la_starve_fallback_count = 0;
 

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2438,6 +2438,18 @@ static void shadow_inprocess_mix_from_buffer(void) {
                     shadow_chain_process_fx(shadow_chain_slots[s].instance,
                                             fx_buf, MOVE_FRAMES_PER_BLOCK);
 
+                    /* Stream 2: slot 0 AFTER its FX chain. Streams 0 and 1 are
+                     * the two things summed INTO this, so an artifact present
+                     * here but in neither of them was introduced by the sum or
+                     * by the FX chain — i.e. by us. Capturing only the inputs
+                     * cannot distinguish "Move sent us bad audio" from "we
+                     * damaged good audio", and on 2026-08-27 a whole session
+                     * measured only inputs. */
+                    if (s == 0) {
+                        align_capture_record(&g_align_capture, 2, fx_buf,
+                                             FRAMES_PER_BLOCK * 2);
+                    }
+
                     if (main_dump_frames > 0) {
                         if (mpost_f[s])
                             fwrite(fx_buf, sizeof(int16_t),
@@ -2797,6 +2809,12 @@ skip_la_rebuild:
             speaker_eq_process(mailbox_audio, FRAMES_PER_BLOCK);
         }
     }
+
+    /* Stream 3: the finished mailbox — master volume and speaker EQ applied,
+     * i.e. what actually goes to the DAC. The last stop where an artifact can
+     * be introduced without appearing in any of streams 0-2. */
+    align_capture_record(&g_align_capture, 3, mailbox_audio,
+                         FRAMES_PER_BLOCK * 2);
 
     /* Poll sampler commands from shadow UI (via shared memory) */
     if (shadow_control) {

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -21,7 +21,8 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_rt_thread_audit \
 	$(BUILD_DIR)/test_master_fx_slot_routing \
 	$(BUILD_DIR)/test_master_fx_saved_state \
-	$(BUILD_DIR)/test_spi_tally
+	$(BUILD_DIR)/test_spi_tally \
+	$(BUILD_DIR)/test_align_capture
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
 # the routing test covers whatever range Master FX actually runs with. Raising
@@ -55,6 +56,9 @@ $(BUILD_DIR)/test_rt_thread_audit: test_rt_thread_audit.c ../../src/host/rt_thre
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_spi_tally: test_spi_tally.c ../../src/host/spi_tally.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/test_align_capture: test_align_capture.c ../../src/host/align_capture.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_master_fx_slot_routing: test_master_fx_slot_routing.c ../../src/host/master_fx_key.h ../../src/host/shadow_chain_mgmt.h | $(BUILD_DIR)

--- a/tests/host/test_align_capture.c
+++ b/tests/host/test_align_capture.c
@@ -1,0 +1,291 @@
+/*
+ * Unit tests for align_capture — the RT-safe replacement for the shim's
+ * fwrite-on-the-SPI-callback audio dumps.
+ *
+ * The properties worth pinning are the ones that make it safe to call from
+ * the audio thread, plus the two failure shapes that would make a capture
+ * lie about what it recorded:
+ *
+ *   - a partial final block is KEPT, not dropped (a short honest file beats
+ *     one silently missing its tail)
+ *   - a second arm during a capture is REFUSED, not restarted (a restart
+ *     truncates the first file, and a short file is indistinguishable from
+ *     a starved one — which is exactly the misreading this whole module
+ *     exists to prevent)
+ */
+
+#include "align_capture.h"
+
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int failures = 0;
+
+#define CHECK(cond, msg) do {                                   \
+    if (!(cond)) { printf("  FAIL: %s\n", (msg)); failures++; } \
+    else         { printf("  ok:   %s\n", (msg)); }             \
+} while (0)
+
+static char tmpdir[256];
+
+static void make_tmpdir(void)
+{
+    snprintf(tmpdir, sizeof(tmpdir), "/tmp/align_capture_test_%d", (int)getpid());
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "mkdir -p %s", tmpdir);
+    if (system(cmd) != 0) { printf("mkdir failed\n"); exit(1); }
+}
+
+static void rm_tmpdir(void)
+{
+    char cmd[512];
+    snprintf(cmd, sizeof(cmd), "rm -rf %s", tmpdir);
+    if (system(cmd) != 0) { /* best effort */ }
+}
+
+static long file_size(const char *p)
+{
+    FILE *f = fopen(p, "rb");
+    if (!f) return -1;
+    fseek(f, 0, SEEK_END);
+    long n = ftell(f);
+    fclose(f);
+    return n;
+}
+
+/* ---------------------------------------------------------------------- */
+
+static void test_basic_roundtrip(void)
+{
+    printf("basic capture round-trip\n");
+    align_capture_t ac;
+    memset(&ac, 0, sizeof(ac));
+
+    char p0[320], p1[320];
+    snprintf(p0, sizeof(p0), "%s/a.pcm", tmpdir);
+    snprintf(p1, sizeof(p1), "%s/b.pcm", tmpdir);
+    const char *paths[2] = { p0, p1 };
+
+    CHECK(align_capture_arm(&ac, paths, 2, 1000) == 0, "arm succeeds");
+    CHECK(align_capture_complete(&ac) == 0, "not complete when just armed");
+
+    int16_t block[100];
+    for (int i = 0; i < 100; i++) block[i] = (int16_t)i;
+
+    /* Nothing is written to disk until the worker polls. */
+    for (int k = 0; k < 10; k++) {
+        CHECK(align_capture_record(&ac, 0, block, 100) == 1, "record stream 0");
+        CHECK(align_capture_record(&ac, 1, block, 100) == 1, "record stream 1");
+    }
+    CHECK(align_capture_complete(&ac) == 1, "complete once both filled");
+    CHECK(align_capture_record(&ac, 0, block, 100) == 0, "record refused when full");
+
+    CHECK(align_capture_poll(&ac) == 2, "poll writes both files");
+    CHECK(file_size(p0) == 2000, "stream 0 is 1000 int16 = 2000 bytes");
+    CHECK(file_size(p1) == 2000, "stream 1 is 1000 int16 = 2000 bytes");
+    CHECK(ac.armed == 0, "disarmed after everything is written");
+    CHECK(ac.streams[0].buf == NULL, "buffers freed after write");
+
+    /* Content survived the round trip. */
+    FILE *f = fopen(p0, "rb");
+    assert(f);
+    int16_t back[1000];
+    size_t got = fread(back, sizeof(int16_t), 1000, f);
+    fclose(f);
+    CHECK(got == 1000, "read back 1000 samples");
+    CHECK(back[0] == 0 && back[99] == 99 && back[100] == 0,
+          "content matches what was recorded");
+}
+
+static void test_partial_block_is_kept(void)
+{
+    printf("a partial final block is kept, not dropped\n");
+    align_capture_t ac;
+    memset(&ac, 0, sizeof(ac));
+
+    char p0[320];
+    snprintf(p0, sizeof(p0), "%s/partial.pcm", tmpdir);
+    const char *paths[1] = { p0 };
+
+    /* Capacity deliberately not a multiple of the block size. */
+    CHECK(align_capture_arm(&ac, paths, 1, 250) == 0, "arm 250");
+
+    int16_t block[100];
+    for (int i = 0; i < 100; i++) block[i] = (int16_t)(i + 1);
+
+    CHECK(align_capture_record(&ac, 0, block, 100) == 1, "block 1");
+    CHECK(align_capture_record(&ac, 0, block, 100) == 1, "block 2");
+    /* Only 50 samples of room left. The block must be truncated, not lost. */
+    CHECK(align_capture_record(&ac, 0, block, 100) == 1, "block 3 truncated but accepted");
+    CHECK(align_capture_complete(&ac) == 1, "complete");
+
+    CHECK(align_capture_poll(&ac) == 1, "written");
+    CHECK(file_size(p0) == 500, "exactly 250 samples on disk, tail kept");
+}
+
+static void test_rearm_is_refused(void)
+{
+    printf("re-arming during a capture is refused\n");
+    align_capture_t ac;
+    memset(&ac, 0, sizeof(ac));
+
+    char p0[320], p1[320];
+    snprintf(p0, sizeof(p0), "%s/first.pcm", tmpdir);
+    snprintf(p1, sizeof(p1), "%s/second.pcm", tmpdir);
+    const char *first[1]  = { p0 };
+    const char *second[1] = { p1 };
+
+    CHECK(align_capture_arm(&ac, first, 1, 1000) == 0, "first arm ok");
+    int16_t block[100] = {0};
+    align_capture_record(&ac, 0, block, 100);
+
+    CHECK(align_capture_arm(&ac, second, 1, 1000) == -1, "second arm REFUSED");
+    CHECK(strcmp(ac.streams[0].path, p0) == 0, "first capture untouched");
+    CHECK(ac.streams[0].filled == 100, "first capture kept its samples");
+
+    align_capture_abort(&ac);
+    CHECK(file_size(p1) == -1, "refused arm wrote no file");
+}
+
+static void test_unarmed_is_inert(void)
+{
+    printf("an unarmed capture is inert and never crashes\n");
+    align_capture_t ac;
+    memset(&ac, 0, sizeof(ac));
+
+    int16_t block[16] = {0};
+    CHECK(align_capture_record(&ac, 0, block, 16) == 0, "record on unarmed = 0");
+    CHECK(align_capture_complete(&ac) == 0, "complete on unarmed = 0");
+    CHECK(align_capture_poll(&ac) == 0, "poll on unarmed = 0");
+    align_capture_abort(&ac);
+    CHECK(1, "abort on unarmed does not crash");
+
+    /* Out-of-range stream indices must be rejected by the COUNT check, not by
+     * happening to find a NULL buffer.
+     *
+     * Arm every stream, so all buffers are non-NULL. Now the only thing
+     * standing between `record(ac, ALIGN_CAPTURE_MAX_STREAMS, ...)` and a read
+     * off the end of the array is `stream >= ac->stream_count`. Arming just
+     * ONE stream hides that: streams[1..3] are zeroed by arm(), so the
+     * `!s->buf` early-out catches an in-range index and the bound looks
+     * redundant when it is not. Deleting the bound survives that weaker test,
+     * which is how this one came to be written. */
+    char pf[ALIGN_CAPTURE_MAX_STREAMS][320];
+    const char *full[ALIGN_CAPTURE_MAX_STREAMS];
+    for (int i = 0; i < ALIGN_CAPTURE_MAX_STREAMS; i++) {
+        snprintf(pf[i], sizeof(pf[i]), "%s/inert%d.pcm", tmpdir, i);
+        full[i] = pf[i];
+    }
+    CHECK(align_capture_arm(&ac, full, ALIGN_CAPTURE_MAX_STREAMS, 100) == 0,
+          "arm all streams");
+    CHECK(align_capture_record(&ac, -1, block, 16) == 0, "stream -1 rejected");
+    CHECK(align_capture_record(&ac, ALIGN_CAPTURE_MAX_STREAMS, block, 16) == 0,
+          "stream at max rejected with every buffer non-NULL");
+    CHECK(align_capture_record(&ac, ALIGN_CAPTURE_MAX_STREAMS + 3, block, 16) == 0,
+          "stream well past max rejected");
+    /* Nothing above should have disturbed a real stream. */
+    CHECK(ac.streams[0].filled == 0, "no in-range stream was written by a bad index");
+    align_capture_abort(&ac);
+
+    /* And with a partial arm, an index inside the array but past the count is
+     * still refused. */
+    const char *one[1];
+    char p0[320];
+    snprintf(p0, sizeof(p0), "%s/inert.pcm", tmpdir);
+    one[0] = p0;
+    align_capture_arm(&ac, one, 1, 100);
+    CHECK(align_capture_record(&ac, 1, block, 16) == 0, "stream past count rejected");
+    align_capture_abort(&ac);
+}
+
+static void test_arm_validates(void)
+{
+    printf("arm rejects bad arguments\n");
+    align_capture_t ac;
+    memset(&ac, 0, sizeof(ac));
+    char p0[320];
+    snprintf(p0, sizeof(p0), "%s/v.pcm", tmpdir);
+    const char *paths[1] = { p0 };
+
+    CHECK(align_capture_arm(&ac, paths, 0, 100) == -1, "count 0 rejected");
+    CHECK(align_capture_arm(&ac, paths, ALIGN_CAPTURE_MAX_STREAMS + 1, 100) == -1,
+          "count over max rejected");
+    CHECK(align_capture_arm(&ac, paths, 1, 0) == -1, "zero samples rejected");
+    CHECK(align_capture_arm(&ac, NULL, 1, 100) == -1, "NULL paths rejected");
+    CHECK(ac.armed == 0, "still unarmed after every rejection");
+
+    /* Over-long requests clamp rather than fail. */
+    CHECK(align_capture_arm(&ac, paths, 1, ALIGN_CAPTURE_MAX_SAMPLES * 2) == 0,
+          "oversized request is clamped, not refused");
+    CHECK(ac.streams[0].capacity == ALIGN_CAPTURE_MAX_SAMPLES, "clamped to max");
+    align_capture_abort(&ac);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Producer/consumer handoff: the callback fills while the worker polls.   */
+
+typedef struct {
+    align_capture_t *ac;
+    volatile int stop;
+} producer_arg_t;
+
+static void *producer(void *v)
+{
+    producer_arg_t *a = (producer_arg_t *)v;
+    int16_t block[128];
+    for (int i = 0; i < 128; i++) block[i] = (int16_t)i;
+    while (!a->stop) {
+        if (!align_capture_record(a->ac, 0, block, 128)) break;
+    }
+    return NULL;
+}
+
+static void test_concurrent_handoff(void)
+{
+    printf("producer fills while consumer polls\n");
+    align_capture_t ac;
+    memset(&ac, 0, sizeof(ac));
+
+    char p0[320];
+    snprintf(p0, sizeof(p0), "%s/concurrent.pcm", tmpdir);
+    const char *paths[1] = { p0 };
+    const uint32_t cap = 128u * 500u;
+    CHECK(align_capture_arm(&ac, paths, 1, cap) == 0, "arm");
+
+    producer_arg_t arg = { &ac, 0 };
+    pthread_t th;
+    pthread_create(&th, NULL, producer, &arg);
+
+    /* Poll like the worker does, ~200 ms cadence compressed. */
+    int wrote = 0;
+    for (int i = 0; i < 2000 && !wrote; i++) {
+        wrote = align_capture_poll(&ac);
+        usleep(500);
+    }
+    arg.stop = 1;
+    pthread_join(th, NULL);
+
+    CHECK(wrote == 1, "worker wrote exactly one file");
+    CHECK(file_size(p0) == (long)cap * 2, "file is the full capacity");
+    CHECK(ac.armed == 0, "disarmed after the handoff");
+}
+
+int main(void)
+{
+    make_tmpdir();
+    printf("align_capture tests\n\n");
+    test_basic_roundtrip();
+    test_partial_block_is_kept();
+    test_rearm_is_refused();
+    test_unarmed_is_inert();
+    test_arm_validates();
+    test_concurrent_handoff();
+    rm_tmpdir();
+
+    printf("\n%s\n", failures ? "FAILED" : "all align_capture tests passed");
+    return failures ? 1 : 0;
+}

--- a/tests/host/test_link_audio_ring_sizing.sh
+++ b/tests/host/test_link_audio_ring_sizing.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# The Move→shim Link Audio ring must be sized for MOVE'S MEASURED JITTER, and
+# the catch-up threshold must sit above the burst it is meant to absorb.
+#
+# Why this test exists
+# --------------------
+# Both numbers were wrong at once on 2026-08-27, and each made the other
+# invisible:
+#
+#   - the ring was 16 blocks (46 ms) because it was aliased to the PUB ring's
+#     size "for symmetry". Move stalls ~92 ms — twice the whole ring.
+#   - catch-up fired above 3072 samples (35 ms), a value calibrated when
+#     "observed bursts were consistently <30 ms". Bursts are now ~85 ms, so
+#     every refill that could have covered the next stall was discarded:
+#     ~76,000 stereo samples per 5 s window, ~17% of the audio.
+#
+# Result was ~16% of frames with no Move audio at all — audible as repeated
+# gaps, and diagnosed for a whole session as everything except a buffer size.
+#
+# So this pins the ENGINEERING MARGINS against the measured hardware numbers,
+# not the constants themselves. Changing 64 to 128 passes. Changing it back to
+# 16 fails, and says why.
+#
+# The measured numbers are recorded in src/host/link_audio.h.
+
+set -u
+cd "$(dirname "$0")/../.."
+
+fail=0
+ok()   { echo "  ok:   $1"; }
+bad()  { echo "  FAIL: $1"; fail=1; }
+
+HDR=src/host/link_audio.h
+SRC=src/host/shadow_link_audio.c
+
+# --- measured hardware behaviour these margins must cover -------------------
+MEASURED_STALL_MS=92     # cb max_gap, all four channels together
+MEASURED_BURST_MS=85     # cb max_burst_run = 30 blocks of 125 frames
+RATE=44100
+
+# --- resolve the macros by asking the compiler, not by regex ----------------
+# A regex over #defines gets the arithmetic wrong the moment one of them is
+# expressed in terms of another, which all of these are.
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/probe.c" <<'EOF'
+#include <stdio.h>
+#include "link_audio.h"
+int main(void) {
+    printf("%d %d %d %d\n",
+           LINK_AUDIO_IN_RING_SAMPLES,
+           LINK_AUDIO_IN_RING_MASK,
+           LINK_AUDIO_IN_CATCHUP_SAMPLES,
+           LINK_AUDIO_IN_BLOCK_SAMPLES);
+    return 0;
+}
+EOF
+
+if ! cc -I src/host -o "$TMP/probe" "$TMP/probe.c" 2>"$TMP/err"; then
+    echo "  FAIL: could not compile the macro probe:"
+    sed 's/^/        /' "$TMP/err"
+    exit 1
+fi
+
+read -r RING MASK CATCHUP BLOCK < <("$TMP/probe")
+
+ring_ms=$(( RING * 1000 / 2 / RATE ))
+catchup_ms=$(( CATCHUP * 1000 / 2 / RATE ))
+
+echo "link audio IN ring sizing"
+echo "  ring    = $RING stereo samples (${ring_ms} ms)"
+echo "  catchup = $CATCHUP stereo samples (${catchup_ms} ms)"
+echo
+
+# --- 1. power of two, or the mask silently corrupts the wrap ----------------
+if [ $(( RING & MASK )) -eq 0 ] && [ $(( RING )) -gt 0 ]; then
+    ok "ring is a power of two (the mask is used as & instead of %)"
+else
+    bad "ring $RING is NOT a power of two — LINK_AUDIO_IN_RING_MASK is broken"
+fi
+
+# --- 2. the ring must outlast the stall, with margin ------------------------
+# Bare equality is not enough: the ring has to hold the stall AND the burst
+# that follows it, or the producer laps the consumer on the way back up.
+if [ "$ring_ms" -ge $(( MEASURED_STALL_MS * 2 )) ]; then
+    ok "ring ${ring_ms}ms covers 2x the measured ${MEASURED_STALL_MS}ms stall"
+else
+    bad "ring ${ring_ms}ms is under 2x the measured ${MEASURED_STALL_MS}ms stall — a stall will empty it"
+fi
+
+# --- 3. catch-up must NOT discard the burst --------------------------------
+if [ "$catchup_ms" -gt "$MEASURED_BURST_MS" ]; then
+    ok "catch-up at ${catchup_ms}ms is above the measured ${MEASURED_BURST_MS}ms burst"
+else
+    bad "catch-up at ${catchup_ms}ms would DISCARD the measured ${MEASURED_BURST_MS}ms burst — starve/burst/discard loop"
+fi
+
+# --- 4. ...but must still fire before the producer laps us ------------------
+if [ "$CATCHUP" -lt "$RING" ]; then
+    ok "catch-up sits inside the ring, so a runaway producer is still caught"
+else
+    bad "catch-up ($CATCHUP) >= ring ($RING) — it can never fire"
+fi
+
+# --- 5. the IN ring must not be aliased to the PUB ring again ---------------
+# This is how it got the wrong size in the first place: the two sit next to
+# each other in the header and one was defined in terms of the other. They
+# have different producers with different timing and must be sized apart.
+if grep -qE '^#define[[:space:]]+LINK_AUDIO_IN_RING_BLOCKS[[:space:]]+LINK_AUDIO_PUB' "$HDR"; then
+    bad "LINK_AUDIO_IN_RING_BLOCKS is aliased to the PUB ring again — that IS the bug"
+else
+    ok "IN ring has its own size, not the PUB ring's"
+fi
+
+# --- 6. a layout change must bump the SHM version ---------------------------
+# The struct grew from 32 KB to 128 KB. A v2 segment left by an older sidecar
+# is SHORTER than the shim's mapping, and touching the tail of an undersized
+# mapping is SIGBUS. The version check is the only thing that rejects it, and
+# it only works if the number actually moved.
+VER=$(grep -E '^#define[[:space:]]+LINK_AUDIO_IN_SHM_VERSION' "$HDR" | awk '{print $3}')
+if [ "${VER:-0}" -ge 3 ]; then
+    ok "SHM version is $VER (>= 3, bumped for the ring resize)"
+else
+    bad "SHM version is ${VER:-unset} — the ring grew, so an old sidecar's segment is too SHORT for our mapping (SIGBUS). Bump it."
+fi
+
+# magic/version must remain the first two fields, or the version check itself
+# reads off the end of an undersized mapping.
+if grep -A3 'typedef struct {' "$HDR" | grep -B1 'volatile uint32_t version;' | grep -q 'volatile uint32_t magic;'; then
+    ok "magic/version are still the first fields (safe to read on a short mapping)"
+else
+    bad "magic/version are no longer first — a short-segment check would SIGBUS before it could reject"
+fi
+
+# --- 7. the threshold must be DERIVED, not a literal at the call site -------
+# The old value was a bare `need * 12` inside link_audio_read_channel_shm, so
+# resizing the ring left it behind. Nothing in the reader may re-introduce a
+# hand-written multiple of `need`.
+if grep -qE 'avail > need \* [0-9]+' "$SRC"; then
+    bad "reader compares avail against a literal multiple of need again — resize the ring and this is stale"
+else
+    ok "reader uses the derived LINK_AUDIO_IN_CATCHUP_SAMPLES"
+fi
+
+if grep -q 'LINK_AUDIO_IN_CATCHUP_SAMPLES' "$SRC"; then
+    ok "reader references the derived threshold"
+else
+    bad "reader does not use LINK_AUDIO_IN_CATCHUP_SAMPLES"
+fi
+
+echo
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: link audio ring is sized for the measured jitter"
+else
+    echo "FAIL: link audio ring sizing"
+fi
+exit "$fail"

--- a/tools/link-audio/analyze_capture.py
+++ b/tools/link-audio/analyze_capture.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Score an align capture for Link Audio splices, starves and module cleanliness.
+
+    tools/link-audio/analyze_capture.py move_track.pcm [synth_src.pcm]
+
+Input is raw s16le stereo @44.1k, as written by the shim's align capture
+(`echo 30 > /data/UserData/schwung/align_dump_trigger`).
+
+WHAT IT MEASURES, AND WHY NOT SOMETHING SIMPLER
+-----------------------------------------------
+The obvious detector — "flag any sample-to-sample jump over N" — does not
+work here, and believing it cost real time on 2026-08-27. A drum transient
+has a huge legitimate jump, so an absolute threshold reports a kick drum and
+a dropout identically.
+
+What separates them is WHERE. Move publishes Link Audio in 125-frame blocks
+(44100/125 = 352.8 blocks/s, which is exactly the observed `produced_count`,
+and `max_frames=125` on every telemetry line). A splice between blocks lands
+at a fixed offset mod 125. A drum cannot prefer one phase-of-125.
+
+So the score is a PHASE RATIO: mean |diff| at the worst phase, over mean
+|diff| everywhere. 1.0 means no phase structure at all. Measured values:
+
+    module clean (synth_src, every run)      1.02 - 1.07
+    braids in the slot   (move_track)        1.02
+    osirus in the slot   (move_track)        1.73 - 5.61
+
+TWO TRAPS THIS TOOL EXISTS TO AVOID
+-----------------------------------
+1. Phase is reported ABSOLUTE, never relative to a window. A 3 s window is
+   132300 samples = 50 (mod 125), so consecutive windows of the SAME steady
+   artifact print phases 59, 122, 0, 0, ... if you forget to add the window
+   offset back. That looks like the lock is drifting when it is rock solid.
+
+2. The "fraction of boundaries with a big step" number is only meaningful
+   ONCE A PHASE LOCK EXISTS. With no lock it just counts ordinary transients
+   at an arbitrary phase — a provably clean synth_src scores "20.3/s" by that
+   metric. It is reported, but gated behind the ratio.
+"""
+
+import sys
+import numpy as np
+
+RATE = 44100
+LA_BLOCK = 125          # Move's Link Audio block, in frames
+LOCK_THRESHOLD = 1.25   # below this, treat "best phase" as noise, not a lock
+
+
+def load(path):
+    a = np.fromfile(path, dtype="<i2")
+    if a.size % 2:
+        a = a[:-1]
+    return a.reshape(-1, 2).astype(np.float64)
+
+
+def phase_profile(mono, offset=0):
+    """Mean |diff| per phase-of-125, with phase reported ABSOLUTE."""
+    d = np.abs(np.diff(mono))
+    if d.size == 0:
+        return None
+    overall = d.mean()
+    if overall == 0:
+        return None
+    idx = (np.arange(d.size) + offset) % LA_BLOCK
+    means = np.array([d[idx == p].mean() if (idx == p).any() else 0.0
+                      for p in range(LA_BLOCK)])
+    best = int(np.argmax(means))
+    return {"best_phase": best,
+            "ratio": means[best] / overall,
+            "overall": overall,
+            "means": means}
+
+
+def splice_fraction(mono, phase):
+    """Fraction of block boundaries whose step dwarfs the local slope."""
+    steps, locs = [], []
+    for s in range(phase, len(mono) - 200, LA_BLOCK):
+        if s < 9:
+            continue
+        steps.append(abs(mono[s + 1] - mono[s]))
+        locs.append(np.mean(np.abs(np.diff(mono[s - 8:s + 1]))) + 1e-9)
+    if not steps:
+        return 0.0, 0
+    steps = np.array(steps)
+    locs = np.array(locs)
+    return float(np.mean(steps / locs > 3)), len(steps)
+
+
+def starve_report(mono):
+    """A starved frame is written as SILENCE by the shim, so it is visible."""
+    z = (mono == 0)
+    if not z.any():
+        return 0, 0
+    edges = np.diff(np.concatenate(([0], z.view(np.int8), [0])))
+    starts = np.where(edges == 1)[0]
+    ends = np.where(edges == -1)[0]
+    runs = ends - starts
+    return int((runs >= LA_BLOCK).sum()), int(z.sum())
+
+
+def report(path, label):
+    a = load(path)
+    mono = a[:, 0]
+    secs = len(mono) / RATE
+    prof = phase_profile(mono)
+    print(f"\n{label}  ({path})")
+    print(f"  {secs:.2f}s   peak={int(np.abs(mono).max())}   "
+          f"rms={int(np.sqrt((mono ** 2).mean()))}")
+    if prof is None:
+        print("  SILENT — nothing to score")
+        return
+    ratio = prof["ratio"]
+    locked = ratio >= LOCK_THRESHOLD
+    print(f"  phase-{LA_BLOCK} lock: best phase {prof['best_phase']:3d} "
+          f"= {ratio:.2f}x overall   -> {'SPLICED' if locked else 'clean'}")
+    if locked:
+        frac, n = splice_fraction(mono, prof["best_phase"])
+        print(f"  spliced boundaries: {frac * 100:.1f}% of {n}  "
+              f"({frac * RATE / LA_BLOCK:.1f}/s)")
+    else:
+        print("  (splice rate not reported — with no phase lock it would "
+              "just count transients)")
+    runs, samples = starve_report(mono)
+    print(f"  starved frames (silence): {runs} runs, {samples} samples "
+          f"({100 * samples / len(mono):.3f}%)")
+
+    # Windowed, with the absolute-phase correction applied.
+    W = 3 * RATE
+    n_win = len(mono) // W
+    if n_win >= 2:
+        print("  per-3s windows (ABSOLUTE phase):")
+        row = []
+        for k in range(n_win):
+            seg = mono[k * W:(k + 1) * W]
+            p = phase_profile(seg, offset=k * W)
+            if p:
+                row.append(f"{p['best_phase']:3d}@{p['ratio']:.2f}")
+        print("    " + "  ".join(row))
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        return 1
+    report(sys.argv[1], "MOVE TRACK (Link Audio input)")
+    if len(sys.argv) > 2:
+        report(sys.argv[2], "SYNTH SRC (the module's own output)")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Partial fix for the open "audio breaks up whenever Move→Schwung is on" bug, plus two build bugs found underneath it.

**This does not close the audible fault.** It fixes one of two, verified from four counters, and the reporter still hears dropouts. `docs/plans/2026-08-27-osirus-linkaudio-breakup-HANDOFF.md` records what is measured and what is still open.

## What was wrong

The Move→shim Link Audio ring was **46 ms**, because `LINK_AUDIO_IN_RING_BLOCKS` was defined as `LINK_AUDIO_PUB_SHM_BLOCKS` — inherited from the publish side because the two sit next to each other in the header. The directions do not have the same problem: we write the pub ring on a metronome, one block per SPI frame; **Move writes this one in bursts.**

Measured on hardware with the sidecar's own delivery telemetry:

```
max_gap       = 92 ms      Move publishes nothing at all
max_burst_run = 30 blocks  then 30 callbacks back-to-back (~85 ms)
avail max     = 149 ms
```

All four channels stalled within 5 ms of each other — one shared stall upstream, not per-channel jitter.

And catch-up was **fighting** the burst instead of absorbing it: a bare `need * 12` (35 ms) at the call site, chosen when *"observed bursts were consistently <30 ms"*. Every refill that could have covered the next stall was discarded — ~17% of the audio — guaranteeing the next stall starved too.

## Results on hardware

| | before | after |
|---|---|---|
| Starved frames / 30 s | 145 runs, **2.53%** of audio missing | **0 runs**, 0.095% |
| osirus underruns / 30 s | 598 | **0** |
| starve / catchup / would_overrun / fallback | all nonzero | **all zero** |
| Move's own `max_gap` | 92 ms | 14–32 ms |

## The build was hiding its own failures

```
libs/link uninitialised  ->  build.sh warned and EXITED 0
package.sh               ->  adds the sidecar only "if it was built"
install.sh               ->  only ever KILLS link-subscriber, never installs one
```

The sidecar — the **sole reception path** for Move→Schwung audio — was frozen on the test device since July and rode unchanged through a three-host-version bisect as the one component nobody varied. It is also why the callback telemetry above appeared to produce nothing: added 2026-08-19, never deployed.

Underneath that, in the Dockerfile:

```dockerfile
file /build/build/modules/sf2/dsp.so 2>/dev/null || echo "not found" && \
```

`sf2` left this repo long ago, so that `file` **always** failed, so the `||` **always** fired — and with `&&`/`||` left-associative it masked the exit status of the entire preceding chain. **Every build failure, on every build ever run, was swallowed**, leaving stale artifacts in the tarball. Deleted.

## Also here

- `src/host/align_capture.{c,h}` — the align dump used to `fopen`/`fwrite` on the SPI callback for the whole capture, so the instrument could perturb the fault it measured. Now memcpy on the callback, worker writes. 30 s captures instead of 2.9 s, which matters: the same configuration scored 5.61x / 1.84x / 1.01x / 2.58x / 2.94x across five consecutive snapshots.
- A starved frame is captured as **silence**, not skipped — skipping spliced the file across the gap and made a starve indistinguishable from a real discontinuity.
- `tools/link-audio/analyze_capture.py` — scores a capture by **phase**, not by an absolute click threshold, which cannot tell a splice from a kick drum.

## Testing

- `tests/host/test_link_audio_ring_sizing.sh` pins the **margins against the measured hardware numbers**, not the constants — widening the ring passes, reverting it fails with the reason. Mutation-checked: reverting to 16 blocks, re-aliasing to the PUB ring, restoring the `need * 12` literal, and dropping catch-up below the burst each fail with a distinct message.
- `tests/host/test_align_capture.c` — host-tested and mutation-checked. The one mutation that survives portably (deleting the array bound is UB that happens to return 0) is caught by ASan in CI instead, and that is noted in the workflow.
- CI now verifies the sidecar binary **and** its tarball entry instead of warning.
- 174/174 `tests/host/*.sh` and all C units green.

## Risk

`LINK_AUDIO_IN_SHM_VERSION` 2 → 3. The struct grew 32 KB → 128 KB, so a segment left by an older sidecar is not merely stale, it is **too short** for the new mapping — touching the tail of an undersized mapping is SIGBUS. The version check rejects it; `magic`/`version` stay the first two fields so that check is itself safe to read off a short segment, and a test pins that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MchAFN22rbUngQGbm2vWNs