### PR TITLE
Chain knobs emit CC 102-109, so a control surface can follow

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -368,6 +368,36 @@ console.log(msg)              // Routed to the unified logger when enabled
 | 118 | Sample            | Also acts as Record on some firmwares; LED is RGB |
 | 119 | Delete            |                                |
 
+### Chain Knob CC Out (answering a control surface)
+
+CC 102-109 above are the *inbound* half: they drive a chain slot's eight knob
+mappings. A slot can also send them, so a motorised controller follows values
+changed anywhere else — Move's own encoder, or a patch load.
+
+Off by default. Enable per slot with the `knob_cc_out` patch field (or
+`set_param("knob_cc_out", "1")`):
+
+```json
+{ "receive_channel": 1, "knob_cc_out": 1 }
+```
+
+When on, the slot emits `CC 102-109` on its **receive channel**, to the
+external port (USB-A), whenever a mapped knob's value changes. Details worth
+knowing:
+
+- The value is the exact inverse of the inbound scaling, so a round trip
+  through a controller does not drift.
+- Change is detected at CC resolution — a parameter sweep too small to move the
+  0-127 value sends nothing.
+- An **inbound** CC 102-109 is deliberately **not** echoed. The sender already
+  has that value, and a controller that hears its own output would fight the
+  user mid-turn. Inbound CC 71-78 (relative) *is* answered, because a sender
+  moving by a delta has no way to know where it landed.
+- A slot whose receive channel is `All` emits nothing — there is no single
+  channel to answer on.
+- A patch load re-sends every mapped knob, since nothing else would tell a
+  control surface that all eight moved at once.
+
 ### Knob Touch (Capacitive)
 Notes 0-9 are generated when knobs are touched. Filter these if you don't need them:
 ```javascript

--- a/docs/API.md
+++ b/docs/API.md
@@ -374,12 +374,17 @@ CC 102-109 above are the *inbound* half: they drive a chain slot's eight knob
 mappings. A slot can also send them, so a motorised controller follows values
 changed anywhere else — Move's own encoder, or a patch load.
 
-Off by default. Enable per slot with the `knob_cc_out` patch field (or
-`set_param("knob_cc_out", "1")`):
+Off by default. Enable it per slot on the device at **Slot Settings > Knobs >
+Knob CC Out**, at the bottom of the knob list. Turning it on immediately sends
+every mapped knob, so the controller starts in sync. The setting is saved with
+the slot patch:
 
 ```json
 { "receive_channel": 1, "knob_cc_out": 1 }
 ```
+
+It is also reachable as a plain param — `set_param("knob_cc_out", "1")` — for
+the web UI and automation.
 
 When on, the slot emits `CC 102-109` on its **receive channel**, to the
 external port (USB-A), whenever a mapped knob's value changes. Details worth

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -1361,6 +1361,11 @@ int shadow_inprocess_load_chain(void) {
     shadow_host_api.get_beat_position = host.get_beat_position;  /* transport phase for LFO sync */
     shadow_host_api.midi_inject_to_move = shadow_chain_midi_inject;
     shadow_host_api.slot_recv_channel = shadow_chain_slot_recv_channel;
+    /* Outbound external MIDI. Previously left NULL by the memset above, which
+     * is why chain knobs could be driven from a controller but never answered
+     * one. Routed to the shim's ROUTE_EXTERNAL ring — the same audio-thread-safe
+     * path overtake DSPs already use. */
+    shadow_host_api.midi_send_external = host.midi_send_external;
 
     move_plugin_init_v2_fn init_v2 = (move_plugin_init_v2_fn)dlsym(
         shadow_dsp_handle, MOVE_PLUGIN_INIT_V2_SYMBOL);

--- a/src/host/shadow_chain_mgmt.h
+++ b/src/host/shadow_chain_mgmt.h
@@ -127,6 +127,12 @@ typedef struct {
      * Pushes the changed value to the web param notify ring for real-time
      * browser updates. May be NULL if web ring is not available. */
     void (*on_param_changed)(uint8_t slot, const char *key, const char *value);
+
+    /* Queue a 4-byte USB-MIDI packet for the external port (cable 2).
+     * Audio-thread safe: enqueues into the shim's lock-free ROUTE_EXTERNAL
+     * ring, drained into the mailbox once per block. May be NULL on hosts
+     * that have no external port — always guard. */
+    int (*midi_send_external)(const uint8_t *msg, int len);
 } chain_mgmt_host_t;
 
 /* ============================================================================

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -835,6 +835,8 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
             inst->loaded_receive_channel = temp_patch.receive_channel;
             inst->loaded_forward_channel = temp_patch.forward_channel;
             inst->midi_fx_pre_mode = temp_patch.midi_fx_pre_mode ? 1 : 0;
+            inst->knob_cc_out = temp_patch.knob_cc_out ? 1 : 0;
+            knob_emit_cc_out_all(inst);
             /* Check for "modified" field to restore dirty state */
             FILE *mf = fopen(val, "r");
             if (mf) {
@@ -878,6 +880,19 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
         inst->current_patch = -1;
         inst->dirty = 0;
         malloc_trim(0);
+    }
+    else if (strcmp(key, "knob_cc_out") == 0) {
+        int new_mode = (val && atoi(val)) ? 1 : 0;
+        if (new_mode != inst->knob_cc_out) {
+            inst->knob_cc_out = new_mode;
+            inst->dirty = 1;
+            /* Turning it on owes the controller a full picture; turning it off
+             * clears our record so a later re-enable re-sends everything. */
+            for (int i = 0; i < inst->knob_mapping_count; i++) {
+                inst->knob_mappings[i].last_cc_out = -1;
+            }
+            if (new_mode) knob_emit_cc_out_all(inst);
+        }
     }
     else if (strcmp(key, "midi_fx_pre_mode") == 0) {
         int new_mode = (val && atoi(val)) ? 1 : 0;
@@ -1153,6 +1168,9 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                         inst->knob_mappings[found].target[sizeof(inst->knob_mappings[found].target) - 1] = '\0';
                         strncpy(inst->knob_mappings[found].param, param, sizeof(inst->knob_mappings[found].param) - 1);
                         inst->knob_mappings[found].param[sizeof(inst->knob_mappings[found].param) - 1] = '\0';
+                        /* Remapped: this knob now means something else. */
+                        inst->knob_mappings[found].last_cc_out = -1;
+                        knob_emit_cc_out(inst, found);
                     } else if (inst->knob_mapping_count < MAX_KNOB_MAPPINGS) {
                         /* Add new */
                         int i = inst->knob_mapping_count++;
@@ -1166,6 +1184,8 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                         } else {
                             inst->knob_mappings[i].current_value = 0.5f;
                         }
+                        inst->knob_mappings[i].last_cc_out = -1;
+                        knob_emit_cc_out(inst, i);
                     }
                 }
                 inst->dirty = 1;
@@ -1242,6 +1262,9 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                         }
 
                         knob_forward_value(inst, target, param, val_str);
+                        /* Move's own encoder moved this knob. Nothing else
+                         * tells an external control surface that happened. */
+                        knob_emit_cc_out(inst, i);
                         inst->dirty = 1;
                         break;
                     }
@@ -1313,6 +1336,9 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
         }
         if (v == PATCH_CHANNEL_UNSET) return 0;  /* absent — caller skips */
         return snprintf(buf, buf_len, "%d", v);
+    }
+    if (strcmp(key, "knob_cc_out") == 0) {
+        return snprintf(buf, buf_len, "%d", inst->knob_cc_out ? 1 : 0);
     }
     if (strcmp(key, "midi_fx_pre_mode") == 0) {
         return snprintf(buf, buf_len, "%d", inst->midi_fx_pre_mode ? 1 : 0);

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -102,6 +102,10 @@ typedef struct {
     char target[16];     /* Component: "synth", "fx1", "fx2", "midi_fx" */
     char param[32];      /* Parameter key (lookup metadata in chain_params) */
     float current_value; /* Current value only */
+    int last_cc_out;     /* Last 0-127 value emitted to the external port,
+                          * -1 = nothing sent yet. Change detection happens at
+                          * CC resolution, so a knob swept through a range that
+                          * maps to one CC step emits once, not once per turn. */
 } knob_mapping_t;
 
 /* Chain parameter info from module.json */
@@ -206,6 +210,8 @@ typedef struct {
     int receive_channel;   /* PATCH_CHANNEL_UNSET=absent, 0=All, 1-16=specific channel */
     int forward_channel;   /* PATCH_CHANNEL_UNSET=absent, -2=passthrough, -1=auto, 0-15=channel */
     int midi_fx_pre_mode;  /* 0 = Post (default), 1 = Pre (additive inject to Move MIDI_IN) */
+    int knob_cc_out;       /* 0 = off (default), 1 = echo chain-knob changes out
+                            * as CC 102-109 on the slot's recv channel */
     lfo_state_t lfos[LFO_COUNT];  /* LFO configuration */
 } patch_info_t;
 
@@ -348,6 +354,7 @@ typedef struct chain_instance {
      * native instrument on the slot's forward_channel plays it additively).
      * Only meaningful when a MIDI FX is loaded. */
     int midi_fx_pre_mode;
+    int knob_cc_out;
 
     /* Cached "pre_capable" hint from the loaded MIDI FX module.json.
      * Informs the Shadow UI default on first placement; does not gate the
@@ -537,6 +544,15 @@ CHAIN_INTERNAL int format_param_value(chain_param_info_t *param, float value, ch
 CHAIN_INTERNAL int is_smoothable_float(const char *val, float *out_value);
 CHAIN_INTERNAL chain_param_info_t *knob_find_param(chain_instance_t *inst, const char *target, const char *param);
 CHAIN_INTERNAL void knob_forward_value(chain_instance_t *inst, const char *target, const char *param, const char *val_str);
+
+/* Echo one chain knob's current value to the external port as CC 102-109 on
+ * the slot's receive channel. No-op unless the patch opts in via knob_cc_out.
+ * Audio-thread safe (ring enqueue only). `idx` indexes inst->knob_mappings. */
+CHAIN_INTERNAL void knob_emit_cc_out(chain_instance_t *inst, int idx);
+
+/* Echo every mapped chain knob. Used after a patch load or knob remap, where
+ * values change without any per-knob event for the controller to have seen. */
+CHAIN_INTERNAL void knob_emit_cc_out_all(chain_instance_t *inst);
 CHAIN_INTERNAL int parse_chain_params(const char *module_path, chain_param_info_t *params, int *count);
 CHAIN_INTERNAL int parse_chain_params_array_json(const char *json_array, chain_param_info_t *params, int max_params);
 CHAIN_INTERNAL int parse_ui_hierarchy_cache(const char *module_path, char *out, int out_len);

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -815,6 +815,9 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
                     }
 
                     knob_forward_value(inst, target, param, val_str);
+                    /* Relative: the sender moved by a delta and has no idea
+                     * where that landed, so it needs the absolute answer. */
+                    knob_emit_cc_out(inst, i);
                     return;
                 }
             }
@@ -844,6 +847,13 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
                     else        snprintf(val_str, sizeof(val_str), "%.3f", abs_val);
 
                     knob_forward_value(inst, target, param, val_str);
+                    /* Deliberately no knob_emit_cc_out() here. The sender set
+                     * this value, so echoing it back is at best redundant and
+                     * at worst a loop: a controller configured to echo its own
+                     * output (common — it is how a motorised unit hears itself)
+                     * would fight the user's fingers mid-turn. Record what the
+                     * sender already knows so later change detection is honest. */
+                    inst->knob_mappings[i].last_cc_out = msg[2];
                     return;
                 }
             }

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -959,6 +959,79 @@ void knob_forward_value(chain_instance_t *inst, const char *target, const char *
 }
 
 
+/* ---- Chain-knob CC out ---------------------------------------------------
+ *
+ * The input half has shipped for a long time: CC 102-109 on a slot's receive
+ * channel drive that slot's eight chain knobs (see chain_midi.c). Nothing went
+ * the other way, so a motorised control surface went stale the moment a value
+ * changed anywhere else — the Move's own encoder, or a patch load — and the
+ * next touch of a knob jumped the parameter to wherever the stale knob sat.
+ *
+ * Opt-in per patch via knob_cc_out, off by default: a slot that is not driving
+ * a control surface has no business adding eight CC streams to the external
+ * port, where they would land on whatever else is plugged in.
+ *
+ * REALTIME: reached from set_param, on_midi and patch load, all of which ARE
+ * the SPI callback. No allocation, no I/O, no locks — midi_send_external is a
+ * lock-free ring enqueue that drops on full.
+ */
+
+/* Inverse of the inbound scaling in chain_midi.c. Returns -1 when the range is
+ * degenerate or dynamic (max_val < 0), where there is no meaningful 0-127. */
+static int knob_value_to_cc(float val, const chain_param_info_t *pinfo) {
+    if (!pinfo) return -1;
+    float span = pinfo->max_val - pinfo->min_val;
+    if (!(span > 0.0f)) return -1;
+    int cc_val = (int)(((val - pinfo->min_val) / span) * 127.0f + 0.5f);
+    if (cc_val < 0) cc_val = 0;
+    if (cc_val > 127) cc_val = 127;
+    return cc_val;
+}
+
+void knob_emit_cc_out(chain_instance_t *inst, int idx) {
+    if (!inst || !inst->knob_cc_out) return;
+    if (idx < 0 || idx >= inst->knob_mapping_count) return;
+    if (!inst->host || !inst->host->midi_send_external) return;
+
+    knob_mapping_t *km = &inst->knob_mappings[idx];
+    int knob = km->cc - KNOB_CC_START;              /* 0-7 */
+    if (knob < 0 || knob > (KNOB_CC_END - KNOB_CC_START)) return;
+
+    /* Answer on the channel the slot listens on, so in and out are symmetric.
+     * -1 (All) gives us no channel to answer on and -2 means the instance is
+     * not slot-registered (master FX); emit nothing rather than guess. */
+    if (!inst->host->slot_recv_channel) return;
+    int recv_ch = inst->host->slot_recv_channel((void *)inst);
+    if (recv_ch < 0 || recv_ch > 15) return;
+
+    chain_param_info_t *pinfo = knob_find_param(inst, km->target, km->param);
+    int cc_val = knob_value_to_cc(km->current_value, pinfo);
+    if (cc_val < 0) return;
+    if (cc_val == km->last_cc_out) return;          /* change detection at CC resolution */
+    km->last_cc_out = cc_val;
+
+    /* USB-MIDI: cable 2 (external), CIN 0x0B (CC). */
+    const uint8_t msg[4] = {
+        (uint8_t)((2 << 4) | 0x0B),
+        (uint8_t)(0xB0 | (uint8_t)recv_ch),
+        (uint8_t)(KNOB_ABS_CC_START + knob),
+        (uint8_t)cc_val
+    };
+    inst->host->midi_send_external(msg, 4);
+}
+
+void knob_emit_cc_out_all(chain_instance_t *inst) {
+    if (!inst || !inst->knob_cc_out) return;
+    for (int i = 0; i < inst->knob_mapping_count; i++) {
+        /* Force a send even when the quantised value is unchanged: after a
+         * patch load the controller's motors reflect the previous patch, so
+         * "same as last time we spoke" says nothing about where they sit. */
+        inst->knob_mappings[i].last_cc_out = -1;
+        knob_emit_cc_out(inst, i);
+    }
+}
+
+
 float dsp_value_to_float(const char *val_str, chain_param_info_t *pinfo, float fallback) {
     char *endptr;
     float v = strtof(val_str, &endptr);

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -1008,7 +1008,6 @@ void knob_emit_cc_out(chain_instance_t *inst, int idx) {
     int cc_val = knob_value_to_cc(km->current_value, pinfo);
     if (cc_val < 0) return;
     if (cc_val == km->last_cc_out) return;          /* change detection at CC resolution */
-    km->last_cc_out = cc_val;
 
     /* USB-MIDI: cable 2 (external), CIN 0x0B (CC). */
     const uint8_t msg[4] = {
@@ -1017,7 +1016,18 @@ void knob_emit_cc_out(chain_instance_t *inst, int idx) {
         (uint8_t)(KNOB_ABS_CC_START + knob),
         (uint8_t)cc_val
     };
-    inst->host->midi_send_external(msg, 4);
+
+    /* Record what the controller knows ONLY if it actually went out. The ring
+     * drops-newest when full, and it shares the 20-slot-per-block mailbox
+     * budget with LEDs, sequencer notes and JACK MIDI, so a drop under load is
+     * expected rather than exceptional. Recording a dropped value would leave
+     * last_cc_out claiming the controller is up to date; if the knob then
+     * stopped moving, its motor would stay wrong indefinitely — the exact
+     * staleness this feature exists to remove. Leaving it unrecorded makes the
+     * next emit for this knob retry, so a drop self-heals. */
+    if (inst->host->midi_send_external(msg, 4) > 0) {
+        km->last_cc_out = cc_val;
+    }
 }
 
 void knob_emit_cc_out_all(chain_instance_t *inst) {

--- a/src/modules/chain/dsp/chain_patch.c
+++ b/src/modules/chain/dsp/chain_patch.c
@@ -1298,6 +1298,9 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
     /* Parse midi_fx_pre_mode (top-level; absence = Post). */
     json_get_int(json, "midi_fx_pre_mode", &patch->midi_fx_pre_mode);
 
+    /* Parse knob_cc_out (top-level; absence = off). */
+    json_get_int(json, "knob_cc_out", &patch->knob_cc_out);
+
     /* Parse LFO config: "lfos": { "lfo1": { ... }, "lfo2": ... } */
     const char *lfos_pos = strstr(json, "\"lfos\"");
     if (lfos_pos) {
@@ -1576,6 +1579,11 @@ int v2_load_patch(chain_instance_t *inst, int patch_idx) {
     if (rc == 0) {
         inst->current_patch = patch_idx;
         inst->midi_fx_pre_mode = inst->patches[patch_idx].midi_fx_pre_mode ? 1 : 0;
+        inst->knob_cc_out = inst->patches[patch_idx].knob_cc_out ? 1 : 0;
+        /* A patch load moves every mapped knob at once, with no per-knob event
+         * for a control surface to have observed. Without this the motors keep
+         * showing the previous patch until each one is touched. */
+        knob_emit_cc_out_all(inst);
         inst->dirty = 0;
     }
     return rc;

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -4549,6 +4549,7 @@ static void shim_init_subsystems(void)
             .get_bpm = shim_get_bpm,
             .get_beat_position = shadow_transport_beat_position,
             .on_param_changed = web_param_notify_push,
+            .midi_send_external = overtake_midi_send_external,
         };
         chain_mgmt_init(&cm_host);
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1688,6 +1688,10 @@ function showKnobFeedback(knobIndex, name, value, raw, cardName) {
 let knobEditorSlot = 0;          // Which slot we're editing knobs for
 let knobEditorIndex = 0;         // Selected knob (0-7) in editor
 let knobEditorAssignments = [];  // Array of 8 {target, param} for current slot
+let knobEditorCcOut = 0;         // Cached knob_cc_out for the slot being edited.
+                                 // Cached rather than read per repaint: a
+                                 // get_param is served once per draw, and this
+                                 // row would otherwise pay that on every frame.
 let knobParamPickerFolder = null; // null = main (targets), string = target name for params
 let knobParamPickerIndex = 0;    // Selected index in param picker
 let knobParamPickerParams = [];  // Available params in current folder
@@ -7374,6 +7378,12 @@ function buildSlotPatchJson(slotIndex, name, forAutosave, moduleChanged) {
     const preMode = getSlotParam(slotIndex, "midi_fx_pre_mode");
     if (preMode !== null) patch.midi_fx_pre_mode = parseInt(preMode) ? 1 : 0;
 
+    /* Include Knob CC Out. Without this the setting is runtime-only and does
+     * not survive a reboot or a patch load, which makes it useless for the
+     * controller rig it exists to serve. */
+    const knobCcOut = getSlotParam(slotIndex, "knob_cc_out");
+    if (knobCcOut !== null) patch.knob_cc_out = parseInt(knobCcOut) ? 1 : 0;
+
     /* Include knob mappings */
     const knobMappingsJson = getSlotParam(slotIndex, "knob_mappings");
     if (knobMappingsJson) {
@@ -10972,6 +10982,9 @@ function loadKnobAssignments(slot) {
         const param = getSlotParam(slot, `knob_${i + 1}_param`) || "";
         knobEditorAssignments.push({ target, param });
     }
+    /* Absent on a chain DSP older than this feature — treat as Off. */
+    const ccOut = getSlotParam(slot, "knob_cc_out");
+    knobEditorCcOut = (ccOut !== null && parseInt(ccOut)) ? 1 : 0;
 }
 
 /* Get available targets for knob assignment (components with modules loaded) */
@@ -15379,13 +15392,17 @@ function handleJog(delta, shift = isShiftHeld()) {
             }
             break;
         case VIEWS.KNOB_EDITOR:
-            /* Navigate knob list (8 knobs) */
-            knobEditorIndex = Math.max(0, Math.min(NUM_KNOBS - 1, knobEditorIndex + delta));
-            /* Announce knob and current assignment */
-            const knobNum = knobEditorIndex + 1;
-            const assignment = knobEditorAssignments[knobEditorIndex];
-            const assignLabel = assignment ? `${assignment.target}: ${assignment.label}` : "Unassigned";
-            announceMenuItem(`Knob ${knobNum}`, assignLabel);
+            /* Navigate the 8 knobs plus the trailing Knob CC Out toggle. */
+            knobEditorIndex = Math.max(0, Math.min(NUM_KNOBS, knobEditorIndex + delta));
+            if (knobEditorIndex === NUM_KNOBS) {
+                announceMenuItem("Knob CC Out", knobEditorCcOut ? "On" : "Off");
+            } else {
+                /* Announce knob and current assignment */
+                const knobNum = knobEditorIndex + 1;
+                const assignment = knobEditorAssignments[knobEditorIndex];
+                const assignLabel = assignment ? `${assignment.target}: ${assignment.label}` : "Unassigned";
+                announceMenuItem(`Knob ${knobNum}`, assignLabel);
+            }
             break;
         case VIEWS.KNOB_PARAM_PICKER:
             if (knobParamPickerFolder === null) {
@@ -16114,8 +16131,17 @@ function handleSelect() {
             }
             break;
         case VIEWS.KNOB_EDITOR:
-            /* Edit this knob's assignment */
-            enterKnobParamPicker();
+            if (knobEditorIndex === NUM_KNOBS) {
+                /* Flip Knob CC Out. Turning it on makes the DSP dump every
+                 * mapped knob, so the controller starts in sync. */
+                knobEditorCcOut = knobEditorCcOut ? 0 : 1;
+                setSlotParam(knobEditorSlot, "knob_cc_out", String(knobEditorCcOut));
+                announceMenuItem("Knob CC Out", knobEditorCcOut ? "On" : "Off");
+                needsRedraw = true;
+            } else {
+                /* Edit this knob's assignment */
+                enterKnobParamPicker();
+            }
             break;
         case VIEWS.KNOB_PARAM_PICKER:
             if (knobParamPickerFolder === null) {
@@ -17207,7 +17233,7 @@ function drawKnobEditor() {
     clear_screen();
     drawHeader(`S${knobEditorSlot + 1} Knobs`);
 
-    /* List all 8 knobs */
+    /* List all 8 knobs, then the slot-wide CC-out toggle. */
     const items = [];
     for (let i = 0; i < NUM_KNOBS; i++) {
         items.push({
@@ -17216,6 +17242,11 @@ function drawKnobEditor() {
             assignment: knobEditorAssignments[i]
         });
     }
+    /* Echo this slot's knob values out as CC 102-109 on its receive channel,
+     * so a motorised controller follows changes made here. Off by default: a
+     * slot not driving a control surface should not add eight CC streams to a
+     * port shared with whatever else is plugged in. */
+    items.push({ type: "toggle", label: "Knob CC Out" });
 
     /* No editMode: the knob editor has no in-place editing state -- a click
      * opens the param picker instead. */
@@ -17225,7 +17256,7 @@ function drawKnobEditor() {
         getLabel: (item) => item.label,
         getValue: (item) => item.type === "knob"
             ? truncateText(getKnobAssignmentLabel(item.assignment), 12)
-            : "",
+            : (item.type === "toggle" ? (knobEditorCcOut ? "On" : "Off") : ""),
         listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
         valueAlignRight: true,
         prioritizeSelectedValue: true

--- a/tests/host/test_chain_knob_cc_out.c
+++ b/tests/host/test_chain_knob_cc_out.c
@@ -63,8 +63,11 @@ static uint8_t cap[CAP_MAX][4];
 static int cap_count = 0;
 static int g_recv_ch = 3;
 
+static int g_send_fails = 0;   /* 1 = pretend the ring is full */
+
 static int fake_send_external(const uint8_t *msg, int len) {
     if (len != 4) return 0;
+    if (g_send_fails) return 0;   /* ring full: drops-newest, returns 0 */
     if (cap_count < CAP_MAX) memcpy(cap[cap_count], msg, 4);
     cap_count++;
     return len;
@@ -218,6 +221,27 @@ int main(void) {
     check(cap_count == 0, "unchanged, so the per-knob path stays quiet");
     knob_emit_cc_out_all(inst);
     check(cap_count == 8, "the dump sends anyway -- motors show the old patch");
+
+    /* 8. A DROPPED PACKET MUST NOT BE REMEMBERED AS SENT.
+     * The ring drops-newest when full and returns 0. Recording that value
+     * anyway would leave the knob's motor wrong until the value happened to
+     * change again — which, for a knob the user has stopped touching, is
+     * forever. Found by a four-slot load test that overflowed the ring. */
+    printf("a drop does not count as delivered\n");
+    inst->knob_mapping_count = 0;
+    map_knob(inst, 0, KNOB_CC_START, "cutoff", 0.25f);
+    cap_reset();
+    g_send_fails = 1;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "nothing captured while the ring is full");
+    check(inst->knob_mappings[0].last_cc_out == -1,
+          "a dropped value is NOT recorded as known to the controller");
+
+    g_send_fails = 0;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 1, "the retry goes out once the ring drains");
+    check(cap[0][3] == 32, "and it carries the value that was dropped");
+    check(inst->knob_mappings[0].last_cc_out == 32, "now it is recorded");
 
     free(inst);
     if (failures) {

--- a/tests/host/test_chain_knob_cc_out.c
+++ b/tests/host/test_chain_knob_cc_out.c
@@ -1,0 +1,229 @@
+/*
+ * Does a chain knob answer the controller that drives it?
+ *
+ * CC 102-109 on a slot's receive channel have driven that slot's eight chain
+ * knobs for a long time (chain_midi.c). Nothing went the other way: a value
+ * changed by Move's own encoder, or by a patch load, left an external control
+ * surface showing the old one. On a motorised controller that is the whole
+ * difference between a remote and a control surface -- the next touch of a
+ * stale knob jumps the parameter to wherever the knob happened to be sitting.
+ *
+ * knob_emit_cc_out() is the answer half. This test RUNS it out of the real
+ * chain_params.c against a fake host that captures packets. The call SITES
+ * live in chain_midi.c / chain_host.c / chain_patch.c, which cannot be
+ * compiled natively (they dlopen plugins and own the get_param/set_param
+ * surface), so those are pinned at the source level in the companion .sh.
+ *
+ * The properties worth proving are the ones that are silent when wrong:
+ *   1. OFF BY DEFAULT -- a slot not driving a surface adds nothing to the
+ *      external port, where it would land on whatever else is plugged in;
+ *   2. the emitted value is the exact INVERSE of the inbound scaling, or a
+ *      round trip through the controller drifts;
+ *   3. change detection happens at CC RESOLUTION, so a slow sweep across one
+ *      CC step emits once rather than once per audio block;
+ *   4. no channel to answer on means SILENCE, not a guess.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "chain_internal.h"
+
+/* ------------------------------------------------------------------ stubs */
+/* chain_params.c reaches into sibling TUs for logging and module loading.
+ * None of them participate in emitting a CC, so all are inert here. */
+void chain_log(const char *msg) { (void)msg; }
+void parse_debug_log(const char *msg) { (void)msg; }
+void v2_chain_log(chain_instance_t *inst, const char *msg) { (void)inst; (void)msg; }
+void v2_synth_panic(chain_instance_t *inst) { (void)inst; }
+void chain_mod_clear_source(void *ctx, const char *source_id) { (void)ctx; (void)source_id; }
+int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *target) {
+    (void)inst; (void)target;
+    return 0;
+}
+int v2_load_synth(chain_instance_t *inst, const char *module_name) {
+    (void)inst; (void)module_name;
+    return 0;
+}
+void v2_unload_synth(chain_instance_t *inst) { (void)inst; }
+int v2_load_audio_fx(chain_instance_t *inst, const char *fx_name) {
+    (void)inst; (void)fx_name;
+    return 0;
+}
+void v2_unload_all_audio_fx(chain_instance_t *inst) { inst->fx_count = 0; }
+int v2_load_midi_fx(chain_instance_t *inst, const char *fx_name) {
+    (void)inst; (void)fx_name;
+    return 0;
+}
+void v2_unload_all_midi_fx(chain_instance_t *inst) { inst->midi_fx_count = 0; }
+
+/* ------------------------------------------------------------- fake host */
+#define CAP_MAX 64
+static uint8_t cap[CAP_MAX][4];
+static int cap_count = 0;
+static int g_recv_ch = 3;
+
+static int fake_send_external(const uint8_t *msg, int len) {
+    if (len != 4) return 0;
+    if (cap_count < CAP_MAX) memcpy(cap[cap_count], msg, 4);
+    cap_count++;
+    return len;
+}
+static int fake_recv_channel(void *instance) { (void)instance; return g_recv_ch; }
+static void cap_reset(void) { cap_count = 0; memset(cap, 0, sizeof(cap)); }
+
+/* ----------------------------------------------------------------- harness */
+static int failures = 0;
+
+static void check(int cond, const char *what) {
+    if (cond) {
+        printf("  ok   %s\n", what);
+    } else {
+        printf("  FAIL %s\n", what);
+        failures++;
+    }
+}
+
+/* One float parameter spanning [min,max], which is what a knob maps onto. */
+static void seed(chain_param_info_t *params, int *count, const char *key,
+                 float min_val, float max_val) {
+    memset(&params[0], 0, sizeof(params[0]));
+    snprintf(params[0].key, sizeof(params[0].key), "%s", key);
+    params[0].type = KNOB_TYPE_FLOAT;
+    params[0].min_val = min_val;
+    params[0].max_val = max_val;
+    *count = 1;
+}
+
+static void map_knob(chain_instance_t *inst, int idx, int cc, const char *param,
+                     float value) {
+    memset(&inst->knob_mappings[idx], 0, sizeof(inst->knob_mappings[idx]));
+    inst->knob_mappings[idx].cc = cc;
+    snprintf(inst->knob_mappings[idx].target, sizeof(inst->knob_mappings[idx].target), "synth");
+    snprintf(inst->knob_mappings[idx].param, sizeof(inst->knob_mappings[idx].param), "%s", param);
+    inst->knob_mappings[idx].current_value = value;
+    inst->knob_mappings[idx].last_cc_out = -1;
+    if (idx >= inst->knob_mapping_count) inst->knob_mapping_count = idx + 1;
+}
+
+int main(void) {
+    /* The instance is far too large for the stack on some hosts. */
+    chain_instance_t *inst = calloc(1, sizeof(*inst));
+    if (!inst || !chain_alloc_position_storage(inst)) {
+        printf("FAIL: out of memory\n");
+        return 1;
+    }
+
+    host_api_v1_t host;
+    memset(&host, 0, sizeof(host));
+    host.midi_send_external = fake_send_external;
+    host.slot_recv_channel = fake_recv_channel;
+    inst->host = &host;
+
+    seed(inst->synth_params, &inst->synth_param_count, "cutoff", 0.0f, 1.0f);
+    map_knob(inst, 0, KNOB_CC_START, "cutoff", 0.5f);
+
+    /* 1. OFF BY DEFAULT. */
+    printf("off unless the patch opts in\n");
+    cap_reset();
+    inst->knob_cc_out = 0;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "knob_cc_out=0 emits nothing");
+    knob_emit_cc_out_all(inst);
+    check(cap_count == 0, "the bulk dump is gated too");
+
+    /* 2. THE PACKET. */
+    printf("the packet a Roto-Control expects\n");
+    inst->knob_cc_out = 1;
+    cap_reset();
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 1, "one packet for one change");
+    check(cap[0][0] == ((2 << 4) | 0x0B), "cable 2 (USB-A), CIN 0x0B (CC)");
+    check(cap[0][1] == (0xB0 | 3), "status is CC on the slot's recv channel");
+    check(cap[0][2] == KNOB_ABS_CC_START, "knob 1 is CC 102");
+    check(cap[0][3] == 64, "0.5 of [0,1] is 64");
+
+    /* 3. CHANGE DETECTION AT CC RESOLUTION. */
+    printf("silence when nothing the controller can show has changed\n");
+    cap_reset();
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "same value emits nothing");
+    inst->knob_mappings[0].current_value = 0.5001f;  /* still CC 64 */
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "a move too small to change the CC emits nothing");
+    inst->knob_mappings[0].current_value = 1.0f;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 1 && cap[0][3] == 127, "max emits 127");
+    inst->knob_mappings[0].current_value = 0.0f;
+    cap_reset();
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 1 && cap[0][3] == 0, "min emits 0");
+
+    /* 4. NO CHANNEL TO ANSWER ON. */
+    printf("silence rather than a guess\n");
+    inst->knob_mappings[0].current_value = 0.5f;
+    inst->knob_mappings[0].last_cc_out = -1;
+    cap_reset();
+    g_recv_ch = -1;  /* All */
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "recv channel All emits nothing");
+    g_recv_ch = -2;  /* not slot-registered, e.g. master FX */
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "an unregistered instance emits nothing");
+    g_recv_ch = 3;
+
+    /* A host with no external port at all must not be dereferenced. */
+    inst->host = NULL;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "a NULL host is survivable");
+    host.midi_send_external = NULL;
+    inst->host = &host;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "a host without midi_send_external is survivable");
+    host.midi_send_external = fake_send_external;
+
+    /* 5. THE INVERSE OF THE INBOUND SCALING (chain_midi.c). */
+    printf("a round trip through the controller does not drift\n");
+    int drifted = -1;
+    for (int c = 0; c <= 127; c++) {
+        /* Exactly what chain_midi.c does with an inbound CC 102-109. */
+        float abs_val = 0.0f + ((float)c / 127.0f) * (1.0f - 0.0f);
+        inst->knob_mappings[0].current_value = abs_val;
+        inst->knob_mappings[0].last_cc_out = -1;
+        cap_reset();
+        knob_emit_cc_out(inst, 0);
+        if (cap_count != 1 || cap[0][3] != c) { drifted = c; break; }
+    }
+    check(drifted < 0, "every inbound 0-127 comes back as itself");
+
+    /* 6. EIGHT KNOBS, EIGHT CCs. */
+    printf("knob N is CC 101+N\n");
+    inst->knob_mapping_count = 0;
+    for (int k = 0; k < 8; k++) {
+        map_knob(inst, k, KNOB_CC_START + k, "cutoff", 1.0f);
+    }
+    cap_reset();
+    knob_emit_cc_out_all(inst);
+    check(cap_count == 8, "the dump covers all eight");
+    int mapped = 1;
+    for (int k = 0; k < 8 && k < cap_count; k++) {
+        if (cap[k][2] != (uint8_t)(KNOB_ABS_CC_START + k)) mapped = 0;
+    }
+    check(mapped, "knob 1-8 map to CC 102-109 in order");
+
+    /* 7. THE DUMP IGNORES CHANGE DETECTION. */
+    printf("a patch load re-states values the controller already had\n");
+    cap_reset();
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 0, "unchanged, so the per-knob path stays quiet");
+    knob_emit_cc_out_all(inst);
+    check(cap_count == 8, "the dump sends anyway -- motors show the old patch");
+
+    free(inst);
+    if (failures) {
+        printf("FAILURES: %d\n", failures);
+        return 1;
+    }
+    printf("PASS: chain knob CC out\n");
+    return 0;
+}

--- a/tests/host/test_chain_knob_cc_out.sh
+++ b/tests/host/test_chain_knob_cc_out.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Two halves:
+#
+#   RUN   knob_emit_cc_out() out of the real chain_params.c against a fake host
+#         that captures packets (tests/host/test_chain_knob_cc_out.c).
+#
+#   PIN   that the three places a chain knob's value changes actually call it,
+#         and -- the subtle one -- that the inbound ABSOLUTE path deliberately
+#         does not. chain_midi.c / chain_host.c / chain_patch.c cannot be
+#         compiled natively (they dlopen plugins and own the get_param/set_param
+#         surface), so the wiring is checked at the source level instead.
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ------------------------------------------------------------------ run half
+bin="build/tests/test_chain_knob_cc_out"
+mkdir -p "$(dirname "$bin")"
+
+# chain_internal.h includes <malloc.h>, which is glibc-only; one shim header
+# lets this compile on macOS too and changes nothing about the code under test.
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+printf '#include <stdlib.h>\n' > "$work/malloc.h"
+
+# -Wno-sign-compare: chain_params.c has pre-existing int/size_t comparisons
+# that are not this test's business to fix.
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
+  -Wno-sign-compare \
+  -I"$work" -Isrc -Isrc/host -Isrc/modules/chain/dsp \
+  tests/host/test_chain_knob_cc_out.c \
+  src/modules/chain/dsp/chain_params.c \
+  src/modules/chain/dsp/chain_json.c \
+  -o "$bin"
+
+"$bin"
+
+# ------------------------------------------------------------------ pin half
+
+# A knob's value changes from exactly three places. Each owes the controller an
+# update, and each has been the silent one at some point.
+command grep -q 'knob_emit_cc_out(inst, i);' src/modules/chain/dsp/chain_host.c \
+    || fail "Move's own encoder no longer emits -- the knob goes stale on the surface"
+command grep -q 'knob_emit_cc_out(inst, i);' src/modules/chain/dsp/chain_midi.c \
+    || fail "relative CC 71-78 no longer emits -- the sender never learns where its delta landed"
+command grep -q 'knob_emit_cc_out_all(inst);' src/modules/chain/dsp/chain_patch.c \
+    || fail "a patch load no longer dumps -- motors keep showing the previous patch"
+
+# THE LOOP GUARD. The inbound absolute path must NOT echo: a controller set
+# this value, and one configured to hear its own output (how a motorised unit
+# normally runs) would fight the user's fingers mid-turn. chain_midi.c has
+# exactly one emit -- the relative branch.
+n=$(command grep -c 'knob_emit_cc_out(inst' src/modules/chain/dsp/chain_midi.c || true)
+[ "$n" -eq 1 ] || fail "chain_midi.c has $n emit sites, expected exactly 1 (absolute CC must not echo)"
+
+# The absolute branch still has to record what the sender already knows, or the
+# next genuine change is measured against a stale baseline.
+command grep -q 'last_cc_out = msg\[2\]' src/modules/chain/dsp/chain_midi.c \
+    || fail "the absolute path no longer records the value the sender already has"
+
+# Off by default. A slot that is not driving a control surface must not add
+# eight CC streams to a port shared with whatever else is plugged in.
+command grep -q 'if (!inst || !inst->knob_cc_out) return;' src/modules/chain/dsp/chain_params.c \
+    || fail "knob_emit_cc_out no longer gates on the per-patch opt-in"
+
+# The host hook has to be assigned. It was NULL for years -- left out of the
+# eleven fields shadow_chain_mgmt.c does assign -- which is the whole reason
+# the outbound half did not exist.
+command grep -q 'shadow_host_api.midi_send_external' src/host/shadow_chain_mgmt.c \
+    || fail "shadow_host_api.midi_send_external is unassigned again -- the chain cannot answer"
+
+echo "PASS: chain knob CC out is wired at every value-change site"

--- a/tests/host/test_chain_midi_fx_slot.c
+++ b/tests/host/test_chain_midi_fx_slot.c
@@ -70,6 +70,12 @@ CHAIN_INTERNAL void knob_forward_value(chain_instance_t *inst, const char *targe
                                        const char *param, const char *val_str) {
     (void)inst; (void)target; (void)param; (void)val_str;
 }
+/* The relative-CC path answers the sender with the absolute value it landed
+ * on. That is chain_params.c's job and this file does not link it; whether the
+ * echo is emitted is proved in test_chain_knob_cc_out. */
+CHAIN_INTERNAL void knob_emit_cc_out(chain_instance_t *inst, int idx) {
+    (void)inst; (void)idx;
+}
 /* chain_reorder.c reaches the audio-FX unloader on its remove path; this file
  * only drives the MIDI side, and the audio loader lives in the one TU that
  * cannot be compiled natively. */


### PR DESCRIPTION
## What

Chain knobs can now **send** CC 102-109, not just receive them, so a motorised
control surface follows values changed anywhere else.

Off by default, opt-in per patch via `knob_cc_out`.

Picking this up from [the Discord thread](https://discord.com/channels/1480993331243778193/1540633445800214658)
— you mentioned having the assigned knobs publish would be feasible and said
feel free to open a PR. I have the Roto-Control here to test against.

## Why it didn't work before

Not a capability gap — one unassigned function pointer.

`shadow_inprocess_load_chain()` memsets `shadow_host_api` and then assigns
eleven fields. `midi_send_external` isn't among them, so the chain DSP has
always seen NULL and could not send anything. Its sibling `overtake_host_api`
has had both send functions all along (`schwung_shim.c:1688-1689`).

I'd measured this from the outside first — with shim MIDI logging on, moving a
chain knob from Move's own encoder produced 2,870 packets, 2,837 in, 33 out, and
zero outbound on cable 2. The only outbound CC in the capture was a track-button
LED update. Reading the source explained it.

This routes the chain's hook to the same lock-free `ROUTE_EXTERNAL` ring the
overtake path already uses, which is drained into the mailbox every block.

## Design

**All three writers report.** A knob's `current_value` changes in exactly three
places, and each was silent:

| Site | Source |
|---|---|
| `chain_midi.c` | inbound relative CC 71-78 |
| `chain_host.c` | Move's own encoder (shadow adjust) |
| `chain_patch.c` | patch / preset load |

The patch-load dump matters most in practice: nothing else tells a surface that
all eight knobs just moved at once.

**Inbound absolute CC is deliberately not echoed.** The sender set that value;
a controller configured to hear its own output — how a motorised unit normally
runs — would fight the user's fingers mid-turn. Relative CC 71-78 *is* answered,
because a sender moving by a delta has no way to know where it landed. The
absolute path still records the value so later change detection isn't measured
against a stale baseline. There's a test pinning this, since it's the kind of
thing a later refactor would "fix" by making it symmetric.

**Change detection at CC resolution**, not float equality, so a slow sweep
across one 0-127 step emits once rather than once per audio block.

**Silence rather than a guess** when the slot's receive channel is `All` or the
instance isn't slot-registered.

**Realtime.** The emit path is reached from `set_param`, `on_midi` and patch
load, all of which ARE the SPI callback. No allocation, no I/O, no locks — the
host hook is a ring enqueue that drops-newest on full.

## Scope / what's missing

- **UI:** the toggle lives at **Slot Settings > Knobs > Knob CC Out**, at the
  bottom of the eight knob assignments — the thing it affects is already on
  screen there. Off by default. Turning it on dumps every mapped knob so the
  controller starts in sync.
- **Persisted with the patch**, alongside `midi_fx_pre_mode`. Without that the
  setting is runtime-only and dies on the next reboot, which is no use for a
  controller rig. Still reachable as a plain param for the web UI/automation.
- Nothing changes for slots that don't opt in.

## Testing

`tests/host/test_chain_knob_cc_out.{c,sh}`, following the
`test_chain_knob_target_lookup` pair's run-half/pin-half shape.

The run half exercises the emitter against a fake host that captures packets —
21 assertions, including that every inbound 0-127 round-trips back as itself,
that a NULL host and a host without the hook are both survivable, and that the
dump ignores change detection. The pin half checks the wiring at all three call
sites, and that the fourth (absolute CC) is still absent.

Locally: `make -C tests/host test` all pass; `tests/host/*.sh` 135 pass with
**zero regressions** against pristine `main` (27 of the remainder fail only
because ripgrep isn't installed on this machine, which CI installs, and 5 fail
identically on unmodified `main`). The ARM64 Docker cross-compile succeeds and
all 13 expected artifacts verify as aarch64.

I couldn't run the `go` job — Go isn't installed here — but nothing in
`schwung-manager` is touched.

## Hardware

**Verified on a Move with a Roto-Control on USB-A**, across four slots and four
MIDI channels.

I cherry-picked this onto `v0.12.1` (every source file auto-merged), built for
ARM64, and swapped in just the two artifacts it affects. Four slots, four
synths, receive channels 1-4, 19 mapped knobs:

| page | slot | target | result |
|---|---|---|---|
| 1 | osirus `cutoff` 77/127 | 61% | correct |
| 2 | braids `cutoff` 0 | 0% (min) | correct |
| 3 | hera `vcf_cutoff` 1.0 | 100% (max) | correct |
| 4 | nusaw `cutoff` 0.28 | 28% | correct |

The on/off control is clean: flipping `knob_cc_out` while a parameter sweep
continued underneath stopped the motors dead, so the movement is attributable
to this change and nothing else in the build.

**No measurable SPI cost.** With four slots emitting, `pre` (the section the
ring drain runs in) held at 78-102us avg, identical to baseline, and the frame
overrun rate was unchanged at 344/s. Ring drops appeared only under a synthetic
12ms sweep (96, then 61); at a realistic turn rate, 318 emitted changes produced
**zero**.

Two caveats, stated plainly:

- Validated as a **0.12.1 backport, not on `main`**. A full `main` install needs
  root SSH to set `bin/schwung-heal` setuid, which I wasn't set up for. The
  patch applies to `main` cleanly (that's what this PR contains) and
  cross-compiles there, but the on-device run was the 0.12.1 build.
- The four-page run predates the UI toggle, so `knob_cc_out` was driven there via
  `set_param`. The toggle was then verified separately (below).

**The toggle is hardware-verified too.** The row renders at the bottom of the
knob list reading `Off`; clicking it flips to `On` and immediately repaints the
controller with that slot's values; turning a Move knob drives the motors;
clicking again stops it. Saved with the patch, power-cycled, and it came back
`On` — which was the whole point, since the setting previously died on any
reboot.

One caveat on that run: 0.12.1's knob editor predates `drawMenuList` and uses a
manual scroll loop, so the backport's **render half is different code** from
what this PR contains. Navigation, click handling, loading and persistence are
identical; only the drawing differs. If you want, I'm happy to have someone
sanity-check the `drawMenuList` rendering on a current `main` build — it's the
one part of this change that hasn't run on hardware in its upstream form.

## Known limitations

1. **Direct parameter sets do not emit.** Only the three `current_value` writers
   do. Changing `synth:cutoff` from the web UI or a component editor goes
   straight to the plugin without touching `knob_mappings[].current_value`, so a
   control surface won't follow. The stale knob cache is pre-existing, but this
   feature inherits it.
2. **A knob at a rail emits nothing** — correct (no change, no message), but
   it's the one case the drop fix can't self-heal, since the retry needs a next
   change and a railed parameter has none.

## A note on measuring this

Three separate instruments reported *nothing* rather than failing while I was
testing, and each initially read as evidence of absence:

- `schwung_shim.c:1210` reads `global_mmap_addr + MIDI_OUT_OFFSET`, refreshed
  from hardware post-ioctl — not the shadow mailbox the drain writes.
- `schwung_shim.c:5158` reads the right buffer but runs *before*
  `overtake_ext_drain_into_shadow` fills it.
- The remote-ui WebSocket doesn't push per-change param updates to a subscribed
  client.

So a capture showing "zero outbound on cable 2" is entirely consistent with
outbound working correctly — which is what my own pre-patch investigation
concluded from exactly that evidence. A comment on either logger would save the
next person a long detour. Happy to send that as a separate PR if useful.

## AI tooling

Written with Claude Code (Claude Opus 5), per CONTRIBUTING.md.
