### PR TITLE
param pages: the string keyboard returns through the shared helper, and a test can see it

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2780,14 +2780,21 @@ function openHierarchyParamEditor(selectedKey, meta, forceOpen) {
                  * a preset from a Save cell left them sitting in a list of
                  * rows, on a page they did not navigate to, with the grid they
                  * were working on gone.
+                 *
+                 * Through the SHARED helper rather than an inline copy of it.
+                 * This is the fourth own-view editor to want this branch, and
+                 * the third was missed precisely because it was open-coded --
+                 * see closeOwnViewEditorToCaller. The keyboard is not a view,
+                 * so it has no close function of its own to fix; its two
+                 * callbacks ARE its exits, and they are what the test drives.
                  */
-                if (paramEditorOpenedFromGrid) returnToParamPagesFromEditor();
+                closeOwnViewEditorToCaller();
             },
             onCancel: () => {
                 needsRedraw = true;
                 /* Cancel returns the same way: backing out of the keyboard
                  * should undo the hand-off, not complete it. */
-                if (paramEditorOpenedFromGrid) returnToParamPagesFromEditor();
+                closeOwnViewEditorToCaller();
             }
         });
         return;

--- a/tests/host/test_editor_returns_to_caller.sh
+++ b/tests/host/test_editor_returns_to_caller.sh
@@ -132,6 +132,85 @@ if (clickFromList.length !== 0) {
     bad++;
 }
 
+/*
+ * The FOURTH door: a STRING cell opens the on-screen keyboard, and the keyboard
+ * is not a view either -- it is an overlay whose onConfirm / onCancel ARE its
+ * two exits. So there is no close function to drive; the test reaches in
+ * through openTextEntry, keeps the options object it was handed, and fires the
+ * callbacks itself.
+ *
+ * Both exits return, including CANCEL: backing out of the keyboard undoes the
+ * hand-off rather than completing it, so it lands where confirm lands.
+ *
+ * setView is spied even though the helper never calls it, so that a future
+ * rewrite which sends the keyboard to the hierarchy list directly fails here
+ * rather than passing for want of an assertion.
+ */
+function runStringEditor(which, openedFromGrid) {
+    const log = [];
+    let opts = null;
+    const deps = {
+        hierEditorEditMode: false,
+        hierEditorSlot: 0,
+        paramEditorOpenedFromGrid: openedFromGrid,
+        buildHierarchyParamKey: (k) => "synth:" + k,
+        getSlotParam: () => "before",
+        setSlotParam: () => log.push("write"),
+        refreshHierarchyVisibility: () => {},
+        announceParameter: () => {},
+        announce: () => {},
+        openTextEntry: (o) => { opts = o; },
+        setView: (v) => log.push("view:" + v),
+        VIEWS: { HIERARCHY_EDITOR: "hierarch" },
+        returnToParamPagesFromEditor: () => log.push("grid"),
+        needsRedraw: false,
+    };
+    const names = Object.keys(deps);
+    const preamble = names.map((n, i) => "let " + n + " = __d[" + i + "];").join("\n");
+    const f = new Function("__d", "__box",
+        preamble + "\n" + lift("closeOwnViewEditorToCaller") + "\n" +
+        lift("openHierarchyParamEditor") + "\n" +
+        "openHierarchyParamEditor(\"preset_name\", { type: \"string\", name: \"Name\" }, true);");
+    try {
+        f(names.map(n => deps[n]), null);
+        if (!opts) { log.push("no-keyboard"); return log; }
+        if (which === "confirm") opts.onConfirm("typed");
+        else opts.onCancel();
+    } catch (e) { log.push("threw:" + e.message); }
+    return log;
+}
+
+for (const which of ["confirm", "cancel"]) {
+    const fromGrid = runStringEditor(which, true);
+    if (!fromGrid.includes("grid")) {
+        console.log("FAIL: string " + which + " from the grid did not return to it: " +
+                    JSON.stringify(fromGrid));
+        bad++;
+    }
+    if (fromGrid.includes("view:hierarch")) {
+        console.log("FAIL: string " + which + " from the grid ALSO fell into the list: " +
+                    JSON.stringify(fromGrid));
+        bad++;
+    }
+    const fromList = runStringEditor(which, false);
+    if (fromList.includes("grid")) {
+        console.log("FAIL: string " + which + " from the list teleported to the grid: " +
+                    JSON.stringify(fromList));
+        bad++;
+    }
+}
+
+/* Confirm still WRITES -- a return that skipped the write would satisfy every
+ * assertion above and lose the text the user typed. */
+if (!runStringEditor("confirm", true).includes("write")) {
+    console.log("FAIL: string confirm returned to the grid without writing the value");
+    bad++;
+}
+if (runStringEditor("cancel", true).includes("write")) {
+    console.log("FAIL: string cancel wrote a value");
+    bad++;
+}
+
 if (bad === 0) console.log("PASS: own-view editors return to their caller");
 process.exit(bad === 0 ? 0 : 1);
 ' || FAIL=1


### PR DESCRIPTION
Follow-up to #281, which is merged and correct. This is the rebase ask from that review.

## What

Both text-entry callbacks in `openHierarchyParamEditor`'s `string` branch now call `closeOwnViewEditorToCaller()` instead of open-coding it, and `tests/host/test_editor_returns_to_caller.sh` grows a `string` case that drives them.

## Why

`closeOwnViewEditorToCaller()` exists because this branch was inlined once, under a comment saying the return "lives here rather than being repeated (and forgotten) at each one" — and it was then forgotten at the canvas, reported from the device as granny's position editor returning to the menu instead of the knobs. #281 added the fourth and fifth copies. It is a drop-in; neither callback uses the return value.

**The test is the real point.** `test_editor_returns_to_caller.sh` already lifted the whole of `openHierarchyParamEditor`, so #281's two lines were inside the lifted body — but the only case driving that function is `runEditModeClick`, with `hierEditorEditMode: true`, which takes the edit-mode toggle branch and `return`s before the string branch is ever reached. **Deleting or inverting either line passed CI.**

The keyboard has no close function to drive, because it is not a view: its `onConfirm` / `onCancel` *are* its two exits. So the new case reaches in through `openTextEntry`, keeps the options object it was handed, and fires the callbacks itself.

## Testing

`tests/host`: **174/174 green**, `make -C tests/host test` clean.

Mutation-checked, since a probe that cannot fail reports green:

| mutation | result |
|---|---|
| delete the confirm-side call | fails, 2 assertions |
| delete the cancel-side call | fails, 2 assertions |
| invert the helper's sense | fails, 15 assertions |
| confirm returns but skips the write | fails, 2 assertions |
| restored source | passes |

That last one matters: a return that skipped `setSlotParam` would satisfy every other assertion here and silently lose the text the user typed.

`setView` is spied even though the helper never calls it, so a future rewrite that sends the keyboard to the hierarchy list directly fails here rather than passing for want of an assertion.

## Not changed

Behaviour. #281's fix is correct as merged and was exercised on hardware by @athousanddetails; this only moves it onto the shared path and makes CI able to see it.