### PR TITLE
test-bus: three ways wait_for_overtake_dsp returned before the module was up

### DIFF
--- a/tools/pytest-schwung/README.md
+++ b/tools/pytest-schwung/README.md
@@ -319,3 +319,38 @@ Modules with no `dsp` in their manifest never request a load, so
 `__ready` reads `"1"` throughout and the helper returns as soon as the
 mode flips. Hosts predating the param error on the GET, which is treated
 as ready — matching shadow_ui's own fallback.
+
+#### Opening a SECOND module: the mode never leaves 2
+
+`unloadModuleUi()` does not reset the overtake mode, and the
+`open_tool_cmd` handler's unload+load pair runs inside **one synchronous
+shadow_ui tick** — so a module → module switch presents no observable
+`2 → x → 2` transition. Gate 1 would pass on the outgoing module's mode
+and `__ready` would still read `"1"`, giving back the same lost first
+press by a different route.
+
+So when the mode is already `2` on the first poll, the helper first
+waits (bounded, `reload_settle`, 0.5 s) for `__ready` to go `"0"` — the
+only observable marker that a load actually started — before treating
+the mode as meaningful.
+
+**Known gap:** a module with *no* `dsp.so` never drives `__ready` to
+`"0"`, so on a reload it is indistinguishable from a stale mode. That
+case waits out the settle and proceeds, degrading to the old behaviour
+rather than hanging. Closing it properly needs the `open_tool_cmd` edge
+— shadow_ui auto-clears that byte when it picks the command up, which is
+exactly the signal, but the daemon exposes no way to read it back.
+
+If your test opens one module per test and uses `fresh_move`, none of
+this applies. It matters precisely when you skip `fresh_move` to save
+the 3 s, which the fixture explicitly invites.
+
+#### Timeouts
+
+Each gate has its own budget — `timeout` for the mode, `ready_timeout`
+(defaulting to `timeout`) for the DSP — so worst case is the sum. They
+are deliberately not one shared deadline: with one, a slow mode flip
+could consume the whole budget and leave the helper raising *"DSP still
+loading … may have failed to load"* without ever having issued a single
+`__ready` GET. A read that never happened is now reported as such
+rather than blamed on the module.

--- a/tools/pytest-schwung/src/schwung_bus/client.py
+++ b/tools/pytest-schwung/src/schwung_bus/client.py
@@ -741,10 +741,25 @@ class SchwungBus:
             f"counter={frozen_at_value} within {timeout}s"
         )
 
+    # The daemon's reply when the shim answers a param GET with error 14 —
+    # no handler claimed the key (schwung_shim.c). That is the genuine
+    # "host predates __ready" case, and it is deliberately NOT one of
+    # _PARAM_TRANSIENT_ERRORS, so it propagates on the first attempt with
+    # no retry delay. Contention ("param GET timeout", "param SHM busy")
+    # burns three retries and then re-raises the SAME exception type, so
+    # the two are separable only by message.
+    _PARAM_UNKNOWN_KEY_ERROR = "param GET error from peer"
+
+    # How long to look for the start of a load when overtake_mode is
+    # already OVERTAKE_MODULE on entry. See the gate 1b comment below.
+    RELOAD_SETTLE_S = 0.5
+
     def wait_for_overtake_dsp(
         self,
         timeout: float = 10.0,
         poll_interval: float = 0.1,
+        ready_timeout: Optional[float] = None,
+        reload_settle: Optional[float] = None,
     ) -> None:
         """Wait until a module opened by :meth:`set_open_tool` can accept input.
 
@@ -756,6 +771,15 @@ class SchwungBus:
            — the DSP instance actually exists.
 
         Both are required, and the order matters.
+
+        Each gate gets its own budget: ``timeout`` for the mode,
+        ``ready_timeout`` (defaulting to ``timeout``) for the DSP. They
+        are deliberately not one shared deadline — the two gates wait on
+        different things, and sharing one meant a slow mode flip could
+        consume the whole budget and leave gate 2 raising *"DSP still
+        loading"* without ever having issued a single ``__ready`` GET,
+        blaming the module's ``dsp.so`` for pure budget exhaustion.
+        Worst case is therefore ``timeout + ready_timeout``.
 
         The mode alone is not enough. The DSP load runs on the shim
         worker rather than the SPI thread (``dlopen()`` +
@@ -782,25 +806,35 @@ class SchwungBus:
 
         Hosts predating the ``__ready`` param raise on the GET; that is
         treated as ready, mirroring shadow_ui's own ``catch`` fallback,
-        so this helper stays safe against older device firmware.
+        so this helper stays safe against older device firmware. Only
+        that specific error is treated that way — see
+        ``_PARAM_UNKNOWN_KEY_ERROR``.
 
-        Raises :class:`SchwungBusError` if either gate misses
-        ``timeout``.
+        Raises :class:`SchwungBusError` if either gate misses its
+        budget.
         """
-        deadline = time.monotonic() + timeout
+        if ready_timeout is None:
+            ready_timeout = timeout
+        if reload_settle is None:
+            reload_settle = self.RELOAD_SETTLE_S
 
         # Gate 1: the host has accepted the load request.
+        gate1_deadline = time.monotonic() + timeout
         mode: Optional[int] = None
         reached_module = False
-        while time.monotonic() < deadline:
+        observed_non_module = False
+        while time.monotonic() < gate1_deadline:
             try:
                 st = self.state()
                 mode = st.overtake_mode
                 if mode == BusState.OVERTAKE_MODULE:
                     reached_module = True
                     break
+                observed_non_module = True
             except SchwungBusError:
-                # shadow_ui can be briefly unresponsive mid-load.
+                # shadow_ui can be briefly unresponsive mid-load. Note
+                # this does NOT count as evidence of a transition — an
+                # error tells us nothing about the mode.
                 pass
             time.sleep(poll_interval)
         if not reached_module:
@@ -811,20 +845,71 @@ class SchwungBus:
                 f"module id?"
             )
 
+        # Gate 1b: a reload whose start we never saw.
+        #
+        # If the mode was ALREADY OVERTAKE_MODULE on the first poll it
+        # carries no information. unloadModuleUi() does not reset the
+        # overtake mode, and the open_tool_cmd handler's unload+load pair
+        # runs inside ONE synchronous shadow_ui tick — so a module ->
+        # module switch never presents an observable 2 -> x -> 2
+        # transition. Both gates would otherwise pass immediately against
+        # the OUTGOING module's state, which is the same lost-first-press
+        # failure this helper exists to prevent.
+        #
+        # The only observable marker of a load actually starting is
+        # __ready going "0" (the shim sets overtake_dsp_loading when the
+        # load is queued). Wait a bounded window for that edge rather
+        # than trusting a mode that cannot answer the question.
+        if not observed_non_module:
+            settle_deadline = time.monotonic() + reload_settle
+            while time.monotonic() < settle_deadline:
+                try:
+                    if self.get_param("__ready") == "0":
+                        break
+                except SchwungBusError as e:
+                    if self._PARAM_UNKNOWN_KEY_ERROR in str(e):
+                        return
+                    # Contention. Keep looking for the edge.
+                time.sleep(poll_interval)
+            # Falling out without seeing "0" is NOT an error. A module
+            # with no dsp.so never requests a load, so it never drives
+            # __ready to "0" and is indistinguishable from a stale mode;
+            # that case degrades to the pre-existing behaviour. Telling
+            # the two apart needs a signal the bus does not expose today:
+            # shadow_ui auto-clears shadow_control.open_tool_cmd when it
+            # picks the command up, which is exactly the edge, but the
+            # daemon offers no way to read that byte back.
+
         # Gate 2: the DSP instance exists.
+        gate2_deadline = time.monotonic() + ready_timeout
         ready: Optional[str] = None
-        while time.monotonic() < deadline:
+        polled = False
+        while time.monotonic() < gate2_deadline:
             try:
                 ready = self.get_param("__ready")
-            except SchwungBusError:
-                # Unknown param => host predates __ready. Nothing to
-                # wait for; the load was synchronous on those builds.
-                return
+                polled = True
+            except SchwungBusError as e:
+                if self._PARAM_UNKNOWN_KEY_ERROR in str(e):
+                    # Unknown param => host predates __ready. Nothing to
+                    # wait for; the load was synchronous on those builds.
+                    return
+                # Transient param-SHM contention, which is MOST likely
+                # exactly here: the shim worker is in dlopen() while
+                # shadow_ui ticks. Catching the base class read this as
+                # an old host and returned "ready" mid-load.
+                time.sleep(poll_interval)
+                continue
             if ready != "0":
                 return
             time.sleep(poll_interval)
+        if not polled:
+            raise SchwungBusError(
+                f"wait_for_overtake_dsp: no successful overtake_dsp:__ready "
+                f"read within {ready_timeout}s — the param channel is not "
+                f"answering; check that shadow_ui is alive"
+            )
         raise SchwungBusError(
-            f"wait_for_overtake_dsp: DSP still loading after {timeout}s "
+            f"wait_for_overtake_dsp: DSP still loading after {ready_timeout}s "
             f"(overtake_dsp:__ready={ready!r}) — the module's dsp.so may "
             f"have failed to load; check the shim log"
         )

--- a/tools/pytest-schwung/tests/test_overtake_dsp_ready.py
+++ b/tools/pytest-schwung/tests/test_overtake_dsp_ready.py
@@ -12,6 +12,8 @@ is wrong in a different way, so the ordering is the thing worth pinning.
 
 from __future__ import annotations
 
+import time
+
 import pytest
 
 from schwung_bus import SchwungBus, SchwungBusError, BusState
@@ -85,14 +87,29 @@ def test_stale_ready_before_mode_flip_does_not_return_early():
 
 def test_module_without_dsp_returns_as_soon_as_mode_flips():
     """No dsp.so => no load requested => __ready reads "1" throughout."""
-    bus = make_bus(modes=[2], readys=["1"])
+    # Constructed as a COLD start (mode observed at 0 first). Written as
+    # modes=[2] it would instead be indistinguishable from a reload — see
+    # test_reload_falls_through_when_no_load_ever_starts.
+    bus = make_bus(modes=[0, 2], readys=["1"])
     bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
     assert bus._calls["ready"] == 1
 
 
 def test_host_without_ready_param_is_treated_as_ready():
-    """Older firmware errors on the unknown key; mirror shadow_ui's catch."""
-    bus = make_bus(modes=[2], readys=[SchwungBusError("param GET error 14")])
+    """Older firmware errors on the unknown key; mirror shadow_ui's catch.
+
+    The message must be the daemon's REAL one. On a host predating the
+    param the shim answers error 14 (no handler claimed the key) and
+    commands.c replies "param GET error from peer" — which is
+    deliberately not one of _PARAM_TRANSIENT_ERRORS, so it propagates
+    without retrying. An invented string here would pass against a
+    helper that catches SchwungBusError wholesale, which is precisely
+    the bug the discrimination fixes.
+    """
+    bus = make_bus(
+        modes=[0, 2],
+        readys=[SchwungBusError("param GET error from peer")],
+    )
     bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
 
 
@@ -102,7 +119,10 @@ def test_transient_state_errors_are_tolerated():
         modes=[SchwungBusError("param SHM busy"), 2],
         readys=["1"],
     )
-    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
+    # reload_settle=0 keeps this test about gate 1 only. A state() error is
+    # deliberately NOT counted as evidence of a transition, so without this
+    # the helper would also take the gate-1b settle path.
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0, reload_settle=0.0)
 
 
 def test_raises_when_mode_never_reaches_module():
@@ -122,3 +142,108 @@ def test_raises_when_dsp_never_finishes_loading():
 def test_busstate_module_constant_is_two():
     """The wire value the shim reports for module mode."""
     assert BusState.OVERTAKE_MODULE == 2
+
+
+# --- the three review findings ------------------------------------------
+#
+# Each of these passed vacuously before the fix, in the worst way available:
+# the helper RETURNED, so a test built on it went on to press a pad into a
+# shim that drops it. A silent pass, not a failure.
+
+
+def test_contention_on_ready_is_not_mistaken_for_an_old_host():
+    """Finding 1. A contention error must not end the wait.
+
+    _param_request_with_retry retries the transient errors three times and
+    then re-raises SchwungBusError — the same type an unknown key raises.
+    The DSP load window is exactly when /schwung-param is most contended
+    (shim worker in dlopen() while shadow_ui ticks), so catching the base
+    class returned "ready" at the one moment it is least true.
+    """
+    bus = make_bus(
+        modes=[0, 2],
+        readys=[SchwungBusError("param GET timeout"), "0", "1"],
+    )
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0)
+    # It kept polling through the error rather than returning on it.
+    assert bus._calls["ready"] == 3
+
+
+def test_gate2_gets_its_own_budget():
+    """Finding 2. A slow mode flip must not consume gate 2's deadline.
+
+    With one shared deadline, a state() round-trip that ate the budget left
+    gate 2's `while` false on entry: no __ready GET was ever issued, and the
+    helper still raised "DSP still loading ... may have failed to load",
+    blaming the module for pure budget exhaustion.
+    """
+    bus = make_bus(modes=[2], readys=["1"])
+    inner = bus.state
+
+    def slow_state():
+        # One round-trip that alone outlasts gate 1's whole budget. Stated
+        # as an inequality (0.3 > 0.2) rather than a race between two polls
+        # and a deadline, so scheduler overshoot can only strengthen it.
+        time.sleep(0.3)           # shadow_ui mid-load
+        return inner()
+
+    bus.state = slow_state
+    bus.wait_for_overtake_dsp(timeout=0.2, poll_interval=0.0,
+                              ready_timeout=1.0, reload_settle=0.0)
+    # The point of the fix: gate 2 actually ran. Sharing gate 1's deadline
+    # leaves this at 0 and raises instead.
+    assert bus._calls["ready"] >= 1
+
+
+def test_reload_does_not_pass_on_the_outgoing_modules_state():
+    """Finding 3. overtake_mode is already 2 across a module -> module swap.
+
+    unloadModuleUi() does not reset the overtake mode, and the
+    open_tool_cmd handler's unload+load pair runs in ONE synchronous
+    shadow_ui tick — so there is no observable 2 -> x -> 2 transition and
+    gate 1 passes on the stale mode. __ready then still reads "1" (the new
+    load has not been requested yet), so the helper returned before
+    anything had happened.
+
+    Reachable in practice because the `fresh_move` fixture is documented as
+    skippable, so a file that opens tool A then tool B without it hits this.
+    """
+    bus = make_bus(modes=[2], readys=["1", "0", "0", "1"])
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.0,
+                              reload_settle=1.0)
+    # It must have waited out the "0"s rather than returning on the leading
+    # stale "1". Returning early would leave this at 1.
+    assert bus._calls["ready"] == 4
+
+
+def test_reload_falls_through_when_no_load_ever_starts():
+    """Finding 3, the case that is NOT covered, pinned so it stays known.
+
+    A module with no dsp.so never requests a load, so it never drives
+    __ready to "0" — indistinguishable from a stale mode. The helper waits
+    the bounded settle and then proceeds, degrading to the pre-fix
+    behaviour rather than hanging. Telling the two apart needs the
+    open_tool_cmd edge, which the daemon does not expose.
+    """
+    bus = make_bus(modes=[2], readys=["1"])
+    started = time.monotonic()
+    bus.wait_for_overtake_dsp(timeout=5.0, poll_interval=0.01,
+                              reload_settle=0.15)
+    elapsed = time.monotonic() - started
+    assert elapsed >= 0.15, "should have waited the settle window"
+    assert elapsed < 2.0, "settle must be bounded, not the full timeout"
+
+
+def test_no_successful_ready_read_is_reported_as_such():
+    """A channel that never answers is not a module that failed to load.
+
+    Distinct from the "DSP still loading" message, which now means a real
+    observed "0" rather than a read that never happened.
+    """
+    bus = make_bus(
+        modes=[0, 2],
+        readys=[SchwungBusError("param SHM busy")],
+    )
+    with pytest.raises(SchwungBusError, match="no successful"):
+        bus.wait_for_overtake_dsp(timeout=0.2, poll_interval=0.02,
+                                  ready_timeout=0.1, reload_settle=0.0)


### PR DESCRIPTION
Review follow-ups to #210 (merged as `05e14028`). The helper's two-gate shape is right and is not changed here — all three of these are edges where it **returns instead of waiting**, which is the worst failure available: a test built on it then presses a pad into the shim's `overtake_dsp_gen && overtake_dsp_gen_inst` guards and loses it silently, at the exact site the helper was added to make trustworthy.

Each was reproduced by driving the real `wait_for_overtake_dsp` through the PR's own `make_bus` helper before being fixed.

### 1. Gate 2 read every bus error as "old host"

`_param_request_with_retry` retries `_PARAM_TRANSIENT_ERRORS` three times and then **re-raises `SchwungBusError`** — the same type an unknown key raises. The DSP load window is precisely when `/schwung-param` is most contended (shim worker in `dlopen()` while shadow_ui ticks), so catching the base class returned "ready" at the one moment it is least true.

The two cases are separable: the genuine old-host path is the shim answering error 14 (no handler claimed the key) → `commands.c` replies `"param GET error from peer"`, which is deliberately **not** in `_PARAM_TRANSIENT_ERRORS` and so propagates on the first attempt with no retry delay. Match on that.

Note the existing test used an invented message (`"param GET error 14"`), which passes against a wholesale catch. It now uses the daemon's real string.

### 2. Both gates shared one deadline

A slow mode flip consumed the whole budget, gate 2's `while` was false on entry, and the helper raised *"DSP still loading … the module's dsp.so may have failed to load; check the shim log"* — with `ready-polls = 0`. Budget exhaustion reported as a module defect, sending the reader to a log for a load that never started.

Each gate now has its own budget (`timeout`, `ready_timeout`), and a read that never happened is reported as such rather than as a stalled DSP.

### 3. Gate 1 cannot detect a transition

The one I could not settle from the diff, so I traced it:

- `set_open_tool` lands at the `open_tool_cmd` handler, which does `unloadModuleUi()` then `loadOvertakeModule(ot)`.
- `unloadModuleUi()` clears UI refs and param shims and **never touches the overtake mode** — none of the seven `shadow_set_overtake_mode(0)` sites is on this path.
- Both run in one synchronous tick, so even a reset would be externally unobservable.
- That block sits after the tick's only early returns (splash, analytics, upgrade overlay), so it is reached with a module already running — as its own fallback comment intends, since it exists to let pytest-schwung launch an overtake module.

So on a second `set_open_tool` the mode is already `2` and `__ready` still reads `"1"`, and the helper returned on the first poll of each gate. Reachable in practice: `fresh_move` is documented as skippable ("3 s reset × N tests adds up in CI"), so a file that opens tool A then tool B without it hits this.

Fix: when the mode is already `2` on the first poll it carries no information, so wait a bounded window for `__ready` to go `"0"` — the only observable marker that a load actually started — before trusting it.

**Known gap, pinned by a test rather than left implicit:** a module with no `dsp.so` never drives `__ready` to `"0"`, so on a reload it is indistinguishable from a stale mode. That case waits out the settle and proceeds, degrading to the previous behaviour rather than hanging. The airtight signal is shadow_ui auto-clearing `shadow_control.open_tool_cmd` when it picks the command up; the daemon exposes no way to read that byte back, and adding one is a C/device change rather than a harness one.

### Tests

32 → 37. **Each new test was verified to fail against a mutation reverting its own fix, and only that one.** Worth flagging: the first cut of the separate-budget test raced two polls against a deadline and failed under an unrelated mutation — it now rests on a single round-trip outlasting the whole budget, where scheduler overshoot can only strengthen the assertion. Baseline is stable across repeated runs.

Harness-side only; no shim or shadow_ui changes. Nothing in the tree calls `wait_for_overtake_dsp` yet, so this lands before the first caller exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLDsteZKDZdhRUPptk6CTV