### PR TITLE
Overtake inject: flush the dedicated ring, bound it, and let releases go first

### DIFF
--- a/docs/ADDRESSING_MOVE_SYNTHS.md
+++ b/docs/ADDRESSING_MOVE_SYNTHS.md
@@ -148,6 +148,13 @@ time, so DSP output cannot loop back into its own `on_midi` input. A tool UI
 can check for `shadow_overtake_move_inject_active()` when it needs to support
 older hosts where this separation is not available.
 
+**Anything still queued when your module unloads is discarded**, so the next
+module to load does not replay your notes into Move. What is NOT undone is
+anything that already went out: packets reach Move immediately during the
+takeover, so a note-on you sent and did not match with a note-off leaves a note
+ringing after you exit. **Send your own all-notes-off before you exit** — the
+host does not synthesise one for you.
+
 ### 4. Timing from `render_block`
 
 `render_block` fires every 128-sample audio block (~2.9 ms at 44.1

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -594,6 +594,24 @@ void shadow_drain_midi_inject(void)
     const int MIDI_IN_MAX_EVTS   = 31;              /* SCHWUNG_MIDI_IN_MAX */
     const int MIDI_IN_MAX_BYTES  = MIDI_IN_EVT_STRIDE * MIDI_IN_MAX_EVTS;
 
+    /* WHAT THE OVERTAKE EARLY RETURN USED TO PROTECT, kept because deleting it
+     * is what invites it back. Measured on device 2026-07-29: injecting PADS
+     * here during overtake moved neither a parameter nor any of the 32 pad
+     * LEDs. That is true and it is about CABLE 0 -- Move's pad/button prefix
+     * protocol, which cannot reach a track instrument at all -- so it says
+     * nothing about the pitched cable-2 notes an overtake DSP sends, which do
+     * arrive. The dedicated ring below carries those; the shared ring stays
+     * off-limits during overtake because its consumer is the test-bus
+     * publisher in schwung_shim.c and this ring is documented single-consumer.
+     *
+     * OPEN, and worth knowing before trusting this path: the DEFER guard below
+     * requires three consecutive frames with an entirely empty MIDI_IN, reset
+     * by a non-zero slot on ANY cable. Move's own surface is filtered out of
+     * the mailbox during overtake, but cable 2 is not -- so an external USB
+     * keyboard played into an overtake module may hold the counter at zero and
+     * stall the dedicated ring for as long as you play. Not measured on
+     * hardware. Check it before relying on injection under live external MIDI. */
+
     /* Shim-originated packets first, and independent of the ring: they must
      * still reach Move while an overtake module is up, which is precisely when
      * the ring below belongs to someone else. */
@@ -619,6 +637,13 @@ void shadow_drain_midi_inject(void)
      * occupancy), so it also covers the case where MIDI_IN is idle at exit —
      * which the cable-0 occupancy defer below does not catch. */
     {
+        /* This block was DEAD until the overtake early return was removed:
+         * prev_overtake_for_hold is updated inside it, and the return made it
+         * unreachable during overtake, so the latch never armed. It is live
+         * again, which is what its own comment always intended. Safe direction
+         * -- it holds more, never less -- but it now also delays the dedicated
+         * ring for three frames at exit, which is why the shared ring drains
+         * first below. */
         static int prev_overtake_for_hold = 0;
         static int exit_hold_frames = 0;
         const int OVERTAKE_EXIT_HOLD_FRAMES = 3;  /* 2 also verified clean; 1 not */
@@ -662,13 +687,16 @@ void shadow_drain_midi_inject(void)
 
     uint8_t *midi_in = host_shadow_mailbox + MIDI_IN_OFFSET;
     int injected = shadow_overtake_midi_drain(inject_shm, overtake_active,
-                                               midi_in, MIDI_IN_MAX_EVTS);
+                                              midi_in, MIDI_IN_MAX_EVTS,
+                                              MIDI_IN_MAX_BYTES);
 
     if (host_log && injected > 0) {
+        /* No offset field. It used to distinguish the safe offset-0 injects
+         * from the SIGABRT-inducing non-zero ones, but the drain now always
+         * starts at slot 0 -- so the number is a constant, and a constant
+         * printed in the shape of a measurement is worse than no field. */
         char dbg[128];
-        snprintf(dbg, sizeof(dbg),
-                 "MIDI inject: drained %d pkts at offset %d",
-                 injected, 0);
+        snprintf(dbg, sizeof(dbg), "MIDI inject: drained %d pkts", injected);
         host_log(dbg);
     }
 }

--- a/src/host/shadow_overtake_midi.c
+++ b/src/host/shadow_overtake_midi.c
@@ -1,9 +1,8 @@
 #include <string.h>
 
+#include "shadow_midi_filter.h"   /* SHADOW_MIDI_IN_* geometry — the one copy */
 #include "shadow_midi_inject_writer.h"
 #include "shadow_overtake_midi.h"
-
-#define MIDI_IN_EVENT_STRIDE 8
 
 static shadow_midi_inject_t overtake_midi_ring;
 
@@ -18,20 +17,47 @@ int shadow_overtake_midi_send(const uint8_t *msg, int len)
     return shadow_midi_inject_push(&overtake_midi_ring, msg) == 0 ? 4 : 0;
 }
 
+void shadow_overtake_midi_discard(void)
+{
+    /* Same argument as the ROUTE_EXTERNAL discard in shadow_overtake_dsp_unload:
+     * the producer is a destroyed instance and can no longer fire, and the
+     * consumer is this same SPI thread, so re-initialising is safe here and
+     * nowhere else. Without it the ring is a shim-lifetime static, so the next
+     * module to load would drain the previous one's leftovers into Move as if
+     * it had played them. */
+    shadow_midi_inject_init(&overtake_midi_ring);
+}
+
+/* Copy packets into consecutive MIDI_IN slots starting at `first_event`.
+ *
+ * Bounded by BOTH the event count and the byte length. `max_events` alone was
+ * enough while the only caller passed 31, but the rule in CLAUDE.md is flat --
+ * bound every 8-stride walk with SHADOW_MIDI_IN_BYTES -- because the RX
+ * display-status word sits at +248 and this is precisely how it gets clobbered.
+ * A bound a caller can get wrong is not a bound. */
 static int drain_ring(shadow_midi_inject_t *ring,
                       uint8_t *midi_in,
                       int first_event,
-                      int max_events)
+                      int max_events,
+                      int midi_in_bytes)
 {
     int copied = first_event;
     uint8_t packet[4];
 
     if (!ring) return copied;
+
+    int slot_limit = midi_in_bytes / SHADOW_MIDI_IN_STRIDE;
+    if (max_events > slot_limit) max_events = slot_limit;
+
     while (copied < max_events && shadow_midi_inject_peek(ring, packet)) {
-        uint8_t *slot = &midi_in[copied * MIDI_IN_EVENT_STRIDE];
+        uint8_t *slot = &midi_in[copied * SHADOW_MIDI_IN_STRIDE];
+        /* Occupied means a hardware event arrived after the caller's
+         * all-slots-empty guard. Injecting alongside one races Move's firmware
+         * MIDI read path and aborts, so leave the packet queued and retry next
+         * frame rather than looking for a later hole. */
         if (slot[0] != 0) break;
         memcpy(slot, packet, 4);
-        memset(slot + 4, 0, 4);
+        memset(slot + SHADOW_MIDI_IN_STRIDE - 4, 0, 4);  /* zero the timestamp */
         shadow_midi_inject_pop(ring);
         copied++;
     }
@@ -41,13 +67,35 @@ static int drain_ring(shadow_midi_inject_t *ring,
 int shadow_overtake_midi_drain(shadow_midi_inject_t *shared,
                                int overtake_active,
                                uint8_t *midi_in,
-                               int max_events)
+                               int max_events,
+                               int midi_in_bytes)
 {
-    int copied;
+    int copied = 0;
 
-    if (!midi_in || max_events <= 0) return 0;
-    copied = drain_ring(&overtake_midi_ring, midi_in, 0, max_events);
+    if (!midi_in || max_events <= 0 || midi_in_bytes < SHADOW_MIDI_IN_STRIDE)
+        return 0;
+
+    /* SHARED FIRST, and the order is load-bearing rather than incidental.
+     *
+     * The shim's overtake-exit releases -- shift-off, volume-touch-off,
+     * back-off, jog-click-off -- go into the SHARED ring, and their own comment
+     * calls them "the highest-consequence injects: a dropped release leaves
+     * Move believing a control is still held". They are queued at exactly the
+     * overtake -> 0 edge, i.e. the first frame this branch is reachable. Behind
+     * a ringful of the departing DSP's notes they would wait extra frames, on
+     * top of the exit hold the caller already applies. Before this feature the
+     * shared ring was the only one, so draining it first is also what keeps the
+     * old behaviour exactly.
+     *
+     * Nothing is lost either way -- what does not fit stays queued -- so this
+     * is about latency on the packets that can leave Move wedged. */
     if (!overtake_active)
-        copied = drain_ring(shared, midi_in, copied, max_events);
+        copied = drain_ring(shared, midi_in, copied, max_events, midi_in_bytes);
+
+    /* The dedicated ring drains in both modes. That is the whole point of the
+     * split: while overtake owns the shared ring's consumer, an overtake DSP
+     * still needs a way to reach Move. */
+    copied = drain_ring(&overtake_midi_ring, midi_in, copied, max_events,
+                        midi_in_bytes);
     return copied;
 }

--- a/src/host/shadow_overtake_midi.h
+++ b/src/host/shadow_overtake_midi.h
@@ -12,11 +12,24 @@ void shadow_overtake_midi_init(void);
 /* Host API callback for an active overtake DSP. Returns 4 when queued. */
 int shadow_overtake_midi_send(const uint8_t *msg, int len);
 
-/* Drain dedicated DSP packets first. The shared inject queue is drained only
- * when no overtake owns its test-bus consumer. Returns packets copied. */
+/* Discard everything queued by an overtake DSP. Call on overtake unload: the
+ * ring is a shim-lifetime static, so without this the NEXT module drains the
+ * previous one's leftovers into Move as if it had played them. SPI-thread only
+ * (the producer is a destroyed instance by then, which is what makes the
+ * non-atomic reinit safe). */
+void shadow_overtake_midi_discard(void);
+
+/* Drain into MIDI_IN. The shared inject queue is drained only when no overtake
+ * owns its test-bus consumer, and it goes FIRST when it is drained at all --
+ * the shim's overtake-exit releases live in it. Returns packets copied.
+ *
+ * Bounded by BOTH max_events and midi_in_bytes; pass SHADOW_MIDI_IN_BYTES.
+ * The byte bound is not belt-and-braces: the RX display-status word sits
+ * immediately after MIDI_IN. */
 int shadow_overtake_midi_drain(shadow_midi_inject_t *shared,
                                int overtake_active,
                                uint8_t *midi_in,
-                               int max_events);
+                               int max_events,
+                               int midi_in_bytes);
 
 #endif /* SHADOW_OVERTAKE_MIDI_H */

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1810,6 +1810,16 @@ static void shadow_overtake_dsp_unload(void) {
      * inert here and a non-atomic reset is safe. */
     overtake_ext_ring.head = 0;
     overtake_ext_ring.tail = 0;
+
+    /* Same for the dedicated Move-injection ring. It is a shim-lifetime static,
+     * so without this the NEXT overtake module's first frames drain the
+     * departed module's queued notes into Move's MIDI_IN as if it had played
+     * them. Note what this does NOT fix: packets that already went out during
+     * the takeover are gone, so a DSP that queued a note-on and was exited
+     * before its note-off still leaves a note ringing in Move. That wants an
+     * all-notes-off on the overtake->0 edge, which is a change to the one
+     * transition documented as SIGABRT-prone and is not being made blind. */
+    shadow_overtake_midi_discard();
 }
 
 /* Per-slot render breakdown counters (added 2026-05-15 for render spike hunt).
@@ -8106,8 +8116,11 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
          * So in overtake mode the inject ring is drained HERE instead, onto
          * exactly the route a hardware press takes: publish to the shadow UI,
          * and hand note events to the overtake DSP. shadow_drain_midi_inject
-         * returns early while overtake_mode is set, so the ring keeps its
-         * single consumer.
+         * skips THIS ring while overtake_mode is set, so it keeps its single
+         * consumer. (It no longer returns early -- it drains the dedicated
+         * overtake ring in both modes, which is a different ring with a
+         * different consumer. The invariant is unchanged; the sentence that
+         * used to state it was not.)
          *
          * Realtime: peek/pop are lock-free atomic loads over a preallocated
          * ring, and the loop is bounded, so this adds no allocation and no

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -48,7 +48,7 @@ $(BUILD_DIR)/%: %.c | $(BUILD_DIR)
 $(BUILD_DIR)/test_overtake_native_led_repaint: test_overtake_native_led_repaint.c ../../src/host/shadow_led_queue.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
-$(BUILD_DIR)/test_overtake_midi_route: test_overtake_midi_route.c ../../src/host/shadow_overtake_midi.c | $(BUILD_DIR)
+$(BUILD_DIR)/test_overtake_midi_route: test_overtake_midi_route.c ../../src/host/shadow_overtake_midi.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_shadow_midi_filter: test_shadow_midi_filter.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)

--- a/tests/host/test_overtake_midi_route.c
+++ b/tests/host/test_overtake_midi_route.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "shadow_midi_filter.h"   /* SHADOW_MIDI_IN_BYTES */
 #include "shadow_midi_inject_writer.h"
 #include "shadow_overtake_midi.h"
 
@@ -30,7 +31,7 @@ static void test_active_overtake_uses_only_dedicated_queue(void)
     CHECK(shadow_overtake_midi_send(dsp_off, 4) == 4,
           "overtake note-off queued");
 
-    CHECK(shadow_overtake_midi_drain(&shared, 1, midi_in, 31) == 2,
+    CHECK(shadow_overtake_midi_drain(&shared, 1, midi_in, 31, sizeof(midi_in)) == 2,
           "active overtake drains both dedicated packets");
     CHECK(memcmp(&midi_in[0], dsp_on, 4) == 0,
           "dedicated note-on is first");
@@ -43,7 +44,7 @@ static void test_active_overtake_uses_only_dedicated_queue(void)
           "active overtake leaves shared queue for its publisher");
 
     memset(midi_in, 0, sizeof(midi_in));
-    CHECK(shadow_overtake_midi_drain(&shared, 0, midi_in, 31) == 1,
+    CHECK(shadow_overtake_midi_drain(&shared, 0, midi_in, 31, sizeof(midi_in)) == 1,
           "inactive mode resumes the shared queue");
     CHECK(memcmp(&midi_in[0], shared_pkt, 4) == 0,
           "shared packet reaches Move after overtake exits");
@@ -58,7 +59,10 @@ static void test_full_queue_preserves_fifo(void)
 
     shadow_overtake_midi_init();
     for (int i = 0; i < SHADOW_MIDI_INJECT_SLOTS; i++) {
-        packet[2] = (uint8_t)i;
+        /* Note 1 upward, never 0. The oldest packet is what this asserts on,
+         * and 0 is also what memset leaves in the buffer -- an assertion whose
+         * expected value equals the uninitialised value cannot fail. */
+        packet[2] = (uint8_t)(i + 1);
         CHECK(shadow_overtake_midi_send(packet, 4) == 4,
               "dedicated ring accepts every available slot");
     }
@@ -67,16 +71,91 @@ static void test_full_queue_preserves_fifo(void)
           "dedicated ring rejects a packet when full");
 
     memset(midi_in, 0, sizeof(midi_in));
-    CHECK(shadow_overtake_midi_drain(NULL, 1, midi_in, 1) == 1,
+    CHECK(shadow_overtake_midi_drain(NULL, 1, midi_in, 1, sizeof(midi_in)) == 1,
           "bounded drain copies only the requested packet count");
-    CHECK(midi_in[2] == 0,
+    CHECK(midi_in[2] == 1,
           "ring overflow does not disturb the oldest packet");
+}
+
+/* An unloaded module's leftovers must not be replayed into Move by whatever
+ * loads next. The ring is a shim-lifetime static, so "the instance went away"
+ * does not empty it. */
+static void test_unload_discards_the_departed_modules_packets(void)
+{
+    uint8_t midi_in[SHADOW_MIDI_IN_BYTES];
+    uint8_t note[4] = { 0x29, 0x90, 64, 100 };
+
+    shadow_overtake_midi_init();
+    CHECK(shadow_overtake_midi_send(note, 4) == 4, "a module queues a note");
+
+    shadow_overtake_midi_discard();
+
+    memset(midi_in, 0, sizeof(midi_in));
+    CHECK(shadow_overtake_midi_drain(NULL, 1, midi_in, 31, sizeof(midi_in)) == 0,
+          "after unload the ring has nothing to replay");
+    CHECK(midi_in[0] == 0,
+          "and the next module's first frame is clean");
+}
+
+/* The shim's overtake-exit releases (shift/vol/back/jog off) go into the
+ * SHARED ring at the overtake->0 edge. A dropped release leaves Move believing
+ * a control is still held, so they must not queue behind a departing DSP's
+ * leftovers. */
+static void test_shared_ring_outranks_the_dedicated_one_on_exit(void)
+{
+    shadow_midi_inject_t shared;
+    uint8_t midi_in[SHADOW_MIDI_IN_BYTES];
+    uint8_t release[4] = { 0x0B, 0xB0, 49, 0 };    /* shift off */
+    uint8_t leftover[4] = { 0x29, 0x90, 60, 100 };
+
+    shadow_midi_inject_init(&shared);
+    shadow_overtake_midi_init();
+    memset(midi_in, 0, sizeof(midi_in));
+
+    /* Dedicated queued FIRST, so passing this cannot be an accident of order. */
+    CHECK(shadow_overtake_midi_send(leftover, 4) == 4, "DSP leftover queued");
+    CHECK(shadow_midi_inject_push(&shared, release) == 0, "release queued");
+
+    CHECK(shadow_overtake_midi_drain(&shared, 0, midi_in, 31, sizeof(midi_in)) == 2,
+          "both drain once overtake is over");
+    CHECK(memcmp(&midi_in[0], release, 4) == 0,
+          "the RELEASE goes out first, ahead of the departed DSP's note");
+}
+
+/* CLAUDE.md: bound every 8-stride walk with SHADOW_MIDI_IN_BYTES. The RX
+ * display-status word sits at +248, so a caller passing a generous event count
+ * against a short buffer must not be believed. */
+static void test_drain_is_bounded_by_bytes_not_just_events(void)
+{
+    uint8_t guarded[SHADOW_MIDI_IN_STRIDE * 3 + 8];
+    uint8_t packet[4] = { 0x29, 0x90, 70, 100 };
+    const int usable = SHADOW_MIDI_IN_STRIDE * 3;
+
+    shadow_overtake_midi_init();
+    for (int i = 0; i < 10; i++) {
+        packet[2] = (uint8_t)(70 + i);
+        shadow_overtake_midi_send(packet, 4);
+    }
+
+    memset(guarded, 0, sizeof(guarded));
+    /* 31 events claimed, 3 slots of room. The byte bound is the only thing
+     * standing between this and the word past the end. */
+    int n = shadow_overtake_midi_drain(NULL, 1, guarded, 31, usable);
+    CHECK(n == 3, "the byte bound wins over the event count");
+
+    int past_end_clean = 1;
+    for (int i = usable; i < (int)sizeof(guarded); i++)
+        if (guarded[i] != 0) past_end_clean = 0;
+    CHECK(past_end_clean, "nothing was written past the buffer");
 }
 
 int main(void)
 {
     test_active_overtake_uses_only_dedicated_queue();
     test_full_queue_preserves_fifo();
+    test_unload_discards_the_departed_modules_packets();
+    test_shared_ring_outranks_the_dedicated_one_on_exit();
+    test_drain_is_bounded_by_bytes_not_just_events();
 
     if (fails) {
         fprintf(stderr, "%d check(s) failed\n", fails);


### PR DESCRIPTION
Review follow-ups to #293. The diagnosis and the split are right; these are the findings from reviewing it, fixed in-house rather than routed back to the author.

## The flush

`shadow_overtake_midi.c` had init/send/drain and no clear, and the ring is a shim-lifetime static — so the next overtake module to load drained the previous one's queued notes into Move as if it had played them. The sibling ring already solves this in `shadow_overtake_dsp_unload` with the same argument (the producer is a destroyed instance, the consumer is this thread, so the reinit is safe here and nowhere else). Both are now flushed side by side.

What the flush does **not** fix, said out loud in the code and in `ADDRESSING_MOVE_SYNTHS.md`: packets that already went out during the takeover are gone, so a DSP exited between note-on and note-off still leaves a note ringing. The complete answer is an all-notes-off on the `overtake -> 0` edge — a change to the one transition this tree documents as SIGABRT-prone, and not one to make without a device in front of it.

## The bound

`drain_ring` walked at an 8-byte stride bounded only by a caller-supplied event count. Safe today (the sole caller passes 31), but the rule is flat — bound every 8-stride walk with `SHADOW_MIDI_IN_BYTES` — because the RX display-status word sits at +248, and **a bound a caller can get wrong is not a bound**. It takes `midi_in_bytes` now, and the local third copy of `8` is gone.

## The order

The dedicated ring drained first in both modes. The shim's overtake-exit releases — shift/vol/back/jog off, whose own comment calls them *"the highest-consequence injects: a dropped release leaves Move believing a control is still held"* — live in the **shared** ring and are queued at exactly the `overtake -> 0` edge. Behind a ringful of the departing DSP's notes they waited extra frames, on top of the exit hold. Shared drains first when it drains at all, which is also exactly the pre-#293 behaviour.

## Comment fixes, each load-bearing for the next reader

- The deleted early return took a device measurement with it (*"injected pads moved neither a parameter nor any of the 32 pad LEDs"*, 2026-07-29). That measurement is **true**, and it is about **cable 0**, which cannot reach a track instrument at all — so it never contradicted the author's cable-2 result. Restored, narrowed to what it covers. Deleting it is what invites the early return back.
- The exit-hold block was **dead** until #293: `prev_overtake_for_hold` is updated inside it and the early return made it unreachable during overtake, so the latch never armed. It is live again, which is what its own comment always intended. Safe direction, but silent — so it now says so.
- `schwung_shim.c` still asserted "`shadow_drain_midi_inject` returns early while `overtake_mode` is set". It no longer returns early. The invariant holds; the sentence a future reader would check it against did not.
- The debug log printed a hard-coded `0` into `"at offset %d"`. The offset really is always 0 now, which makes it worse: a constant in the shape of a measurement. Field dropped.

## Tests

`test_overtake_midi_route` gains the flush, the release-priority order and the byte bound. **Each was mutation-checked** — reverting to dedicated-first, no-op'ing the discard, and removing the byte clamp each fail it, verified individually.

Also fixed an assertion that could not fail: the FIFO test seeded its oldest packet with note `0`, which is also what `memset` leaves in the buffer.

## Verified

Cross-compiles clean for ARM64 (0 errors); `make -C tests/host test` and all `tests/host/*.sh` green.

## Not fixed — needs the device

Removing the early return also exposes the dedicated ring to the `DEFER_FRAMES` guard, which wants three consecutive frames of an entirely empty MIDI_IN and resets on a non-zero slot on **any** cable. Move's own surface is filtered out of the mailbox during overtake — which is why a pad-driven test passes — but cable 2 is not, so an external USB keyboard played into an overtake module may hold that counter at zero and stall injection for as long as you play. That is the use case. Marked `OPEN` at the guard; check it with a keyboard held down before trusting this path under live external MIDI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbuNj8HH2zaYuuvVqhAwz3