### PR TITLE
Knob CC Out: an overtake unload must not eat the chain's packets

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -245,6 +245,7 @@ if needs_rebuild build/schwung-shim.so \
     src/host/usbc_out_gate.c src/host/usbc_out_gate.h \
     src/host/shadow_midi.c src/host/shadow_midi_filter.c src/host/shadow_midi_filter.h \
     src/host/shadow_overtake_midi.c src/host/shadow_overtake_midi.h \
+    src/host/ext_midi_ring.h \
     src/host/unified_log.c src/host/shim_worker.c \
     src/host/rt_thread_audit.c src/host/rt_thread_audit.h \
     src/host/spi_tally.c src/host/spi_tally.h \

--- a/src/host/ext_midi_ring.h
+++ b/src/host/ext_midi_ring.h
@@ -1,0 +1,133 @@
+/* ext_midi_ring.h — the ROUTE_EXTERNAL packet ring, as pure state.
+ *
+ * Packets queued here are drained into Move's 80-byte MIDI_OUT region once per
+ * audio block and go out of USB-A. It has TWO producers:
+ *
+ *   EXT_SRC_OVERTAKE   an overtake DSP's midi_send_external
+ *   EXT_SRC_CHAIN      chain knob CC out (a chain slot answering a controller)
+ *
+ * Both run on the SPI callback, so the plain head/tail bumps are safe — but
+ * that is a property of the callers, not of this file, and a producer added on
+ * a worker thread would break it.
+ *
+ * WHY THE SOURCE TAG EXISTS. When an overtake module unloads, its queued
+ * packets must be discarded: otherwise the next load ships up to a ringful of
+ * a dead module's events to USB-A across the first few blocks. That discard
+ * used to reset head/tail, which was correct while the overtake DSP was the
+ * only producer and stopped being correct the moment the chain became one —
+ * the chain outlives the overtake module, and a swallowed chain packet is
+ * worse than a dropped one, because knob_emit_cc_out only records a value as
+ * delivered on a non-zero push and will not retry a value it thinks it sent.
+ * So a discard blanks packets BY SOURCE and leaves the cursors alone.
+ *
+ * Pure: no allocation, no I/O, no locks, no clock. SPI-callback-safe, and
+ * host-testable without a device (tests/host/test_ext_midi_ring.c).
+ */
+
+#ifndef EXT_MIDI_RING_H
+#define EXT_MIDI_RING_H
+
+#include <stdint.h>
+#include <string.h>
+
+#define EXT_MIDI_RING_PACKETS 64          /* 64 slots x 4 bytes USB-MIDI = 256 B */
+
+/* Source tags. 0 is reserved for "discarded — skip on drain", so a real
+ * producer must never be 0. */
+#define EXT_SRC_NONE     0
+#define EXT_SRC_OVERTAKE 1
+#define EXT_SRC_CHAIN    2
+
+typedef struct {
+    uint8_t pkt[EXT_MIDI_RING_PACKETS][4];
+    uint8_t src[EXT_MIDI_RING_PACKETS];   /* EXT_SRC_*; EXT_SRC_NONE = skip */
+    volatile uint32_t head;               /* producers write */
+    volatile uint32_t tail;               /* consumer writes */
+    volatile int drops;                   /* ring-full count, reported off-RT */
+} ext_midi_ring_t;
+
+static inline void ext_midi_ring_init(ext_midi_ring_t *r) {
+    if (r) memset((void *)r, 0, sizeof(*r));
+}
+
+/* Enqueue. Drop-newest on full. Returns len when queued, 0 when dropped —
+ * and 0 MUST be treated as "not sent", never as "sent". */
+static inline int ext_midi_ring_push(ext_midi_ring_t *r, const uint8_t *msg,
+                                     int len, uint8_t src) {
+    if (!r || !msg || len < 4) return 0;
+
+    uint32_t head = r->head;
+    uint32_t tail = r->tail;
+    __sync_synchronize();  /* acquire */
+    if ((uint32_t)(head - tail) >= EXT_MIDI_RING_PACKETS) {
+        r->drops++;
+        return 0;
+    }
+    uint32_t idx = head % EXT_MIDI_RING_PACKETS;
+    memcpy(r->pkt[idx], msg, 4);
+    r->src[idx] = src;
+    __sync_synchronize();  /* release — packet visible before the head bump */
+    r->head = head + 1;
+    return len;
+}
+
+/* Blank every queued packet from one producer, in place.
+ *
+ * Deliberately does NOT touch head/tail: the other producer's packets are
+ * interleaved with this one's, and there is no cursor position that separates
+ * them. The drain steps over EXT_SRC_NONE without spending a mailbox slot. */
+static inline void ext_midi_ring_discard_source(ext_midi_ring_t *r, uint8_t src) {
+    if (!r || src == EXT_SRC_NONE) return;
+    uint32_t tail = r->tail;
+    uint32_t head = r->head;
+    __sync_synchronize();
+    for (uint32_t i = tail; i != head; i++) {
+        uint32_t idx = i % EXT_MIDI_RING_PACKETS;
+        if (r->src[idx] != src) continue;
+        r->src[idx] = EXT_SRC_NONE;
+        memset(r->pkt[idx], 0, 4);
+    }
+    __sync_synchronize();
+}
+
+/* Drain into a MIDI_OUT region of `region_bytes` bytes, filling only 4-byte
+ * slots that are entirely zero. Returns packets copied.
+ *
+ * Packets that do not fit this block STAY IN THE RING and are retried next
+ * block — this is a delay, not a loss. (The loss downstream is
+ * shadow_inject_ui_midi_out's, which memsets its source before copying.) */
+static inline int ext_midi_ring_drain(ext_midi_ring_t *r, uint8_t *midi_out,
+                                      int region_bytes) {
+    if (!r || !midi_out || region_bytes < 4) return 0;
+
+    uint32_t tail = r->tail;
+    uint32_t head = r->head;
+    __sync_synchronize();  /* acquire — see packet data the producer published */
+    if (tail == head) return 0;
+
+    int copied = 0;
+    int slot = 0;
+    while (tail != head) {
+        uint32_t idx = tail % EXT_MIDI_RING_PACKETS;
+        /* Discarded in place by ext_midi_ring_discard_source. Consume the ring
+         * position, spend no mailbox slot. */
+        if (r->src[idx] == EXT_SRC_NONE) { tail++; continue; }
+
+        while (slot + 4 <= region_bytes &&
+               (midi_out[slot] || midi_out[slot+1] ||
+                midi_out[slot+2] || midi_out[slot+3])) {
+            slot += 4;
+        }
+        if (slot + 4 > region_bytes) break;  /* full this block — retry next */
+
+        memcpy(&midi_out[slot], r->pkt[idx], 4);
+        slot += 4;
+        tail++;
+        copied++;
+    }
+    __sync_synchronize();
+    r->tail = tail;
+    return copied;
+}
+
+#endif /* EXT_MIDI_RING_H */

--- a/src/host/plugin_api_v1.h
+++ b/src/host/plugin_api_v1.h
@@ -138,6 +138,25 @@ typedef struct host_api_v1 {
      * Returns: bytes queued, or 0 on failure
      */
     int (*midi_send_internal)(const uint8_t *msg, int len);
+
+    /* midi_send_external queues onto the shim's lock-free ROUTE_EXTERNAL ring,
+     * drained into Move's 80-byte MIDI_OUT region once per audio block. Safe
+     * from every entry point (they are all the SPI callback — see the contract
+     * at the top of this file): no allocation, no syscall, no logging.
+     *
+     * IT IS NOT A DELIVERY GUARANTEE, and the 0 return is the whole contract.
+     * The ring drops-newest when full, and those 80 bytes are shared with
+     * Move's own output, the LED queue and the shadow UI. Retry on 0; never
+     * record a packet as delivered on a 0. A caller that mistakes "queued" for
+     * "sent" leaves whatever it was reporting permanently stale.
+     *
+     * CHAIN SUB-PLUGINS GET THIS TOO, as of chain knob CC out — the chain host
+     * copies its own host_api down to every synth, audio FX and MIDI FX it
+     * loads. It was NULL there for years, so a module that guards on NULL has
+     * silently been a no-op inside a chain slot and will now start emitting to
+     * USB-A. If that is not what your module wants in a chain, check
+     * slot_recv_channel() first: it answers -2 when the instance is not
+     * slot-registered. */
     int (*midi_send_external)(const uint8_t *msg, int len);
 
     /* Clock status query for sync-aware plugins.

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -524,6 +524,26 @@ static void drain_events(void) {
 
 /* ---- thread ------------------------------------------------------------ */
 
+/* Report ROUTE_EXTERNAL ring-full drops at ~1 Hz, and only when there are any.
+ * Silent on an idle device by construction: no drops, no line. Reports the
+ * DELTA and the running total, because "is it still dropping?" is the question
+ * a stale motor raises and a cumulative counter alone cannot answer. */
+static void ext_midi_drop_tick(void)
+{
+    static int last_total = 0;
+    int total = shim_ext_midi_drops;
+    int delta = total - last_total;
+    if (delta <= 0) { last_total = total; return; }
+    last_total = total;
+
+    char msg[128];
+    snprintf(msg, sizeof(msg),
+             "ext-midi: %d MIDI_OUT ring drop(s) this window (%d total) - "
+             "mailbox saturated, external CC out is lagging",
+             delta, total);
+    LOG_DEBUG("shim", msg);
+}
+
 static void *worker_main(void *arg) {
     (void)arg;
 
@@ -660,6 +680,7 @@ static void *worker_main(void *arg) {
         if (tick % 5 == 0) rt_audit_tick();       /* ~1 Hz, no-op unless armed */
         if (tick % 5 == 0) spi_tally_tick();      /* ~1 Hz, no-op unless armed */
         align_capture_tick();                    /* 5 Hz: arm on trigger, drain when full */
+        if (tick % 5 == 0) ext_midi_drop_tick();  /* ~1 Hz, silent unless dropping */
         if (tick % 7 == 0) shadow_poll_current_set(); /* ~1.4 s FS scan */
         tick++;
     }

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -57,6 +57,13 @@ extern volatile int shim_inject_boot_jack;
  * boot via shim_inject_boot_jack. */
 extern volatile int shim_jack_persist;
 
+/* ROUTE_EXTERNAL ring-full drops, incremented by the SPI callback. The RT path
+ * cannot log, so the worker reports the delta at ~1 Hz. A drop here is the one
+ * silent failure mode of chain knob CC out: the emitter records a value as
+ * delivered only on a non-zero return, so a DROP self-heals on the next turn —
+ * but a burst of them means the mailbox is saturated and motors are lagging. */
+extern volatile int shim_ext_midi_drops;
+
 /* Last USB-C audio-out source seen by the RT path (0 = Mic, 1 = Main Out),
  * -1 until observed. Worker persists it on change and re-asserts it at boot —
  * Move's firmware reverts this to Mic on every reboot. */

--- a/src/modules/chain/dsp/chain_patch.c
+++ b/src/modules/chain/dsp/chain_patch.c
@@ -1508,6 +1508,14 @@ int v2_load_from_patch_info(chain_instance_t *inst, patch_info_t *patch) {
         const char *target = inst->knob_mappings[i].target;
         const char *param = inst->knob_mappings[i].param;
 
+        /* "Nothing sent to the controller yet" is -1, but the rows we just
+         * copied came from a patch_info_t whose parser clears each row with
+         * memset — so they arrive claiming they have already sent CC 0, and a
+         * knob genuinely sitting at 0 would then never be emitted. Today the
+         * bulk dump forces -1 before it emits and hides this; a future
+         * per-knob emit that does not go through the dump would not. */
+        inst->knob_mappings[i].last_cc_out = -1;
+
         char val_buf[64];
         int got = -1;
         /* Indexed rather than enumerated: the old fx1/fx2 + midi_fx1/midi_fx2

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -69,6 +69,7 @@ extern align_capture_t g_align_capture;
 #include "host/shadow_xmos_audio.h"
 #include "host/shadow_midi.h"
 #include "host/shadow_overtake_midi.h"
+#include "host/ext_midi_ring.h"
 #include "host/shadow_midi_filter.h"
 #include "host/fx_midi_filter.h"
 #include "host/shadow_shm_util.h"
@@ -1405,69 +1406,43 @@ static int overtake_midi_send_internal(const uint8_t *msg, int len) {
  * Capability sentinel shadow_overtake_send_external_async_active() lets
  * opt-in tools call this with the audio-thread guarantee. */
 
-#define OVERTAKE_EXT_RING_PACKETS 64           /* 64 slots × 4 bytes USB-MIDI = 256 B */
+/* The ring itself is src/host/ext_midi_ring.h — pure state, so the source-tag
+ * discard below is unit-tested without a device. These are the shim-side
+ * bindings: the instance, the two tagged producer entry points, and the drain
+ * that knows where MIDI_OUT lives. */
 
-typedef struct {
-    uint8_t pkt[OVERTAKE_EXT_RING_PACKETS][4];
-    volatile uint32_t head;  /* producer writes (any audio thread) */
-    volatile uint32_t tail;  /* consumer writes (shim_pre_transfer) */
-} overtake_ext_ring_t;
+static ext_midi_ring_t overtake_ext_ring;
 
-static overtake_ext_ring_t overtake_ext_ring;
-static volatile int overtake_ext_drops = 0;     /* incremented on ring-full; no log from audio thread */
+/* Ring-full count, mirrored into the worker-visible symbol it reports at ~1 Hz.
+ * The RT path must never log; before this the counter was a static nobody could
+ * read, so the one failure mode this path has — a packet dropped, and whatever
+ * it was reporting left stale — was invisible from the device. */
+volatile int shim_ext_midi_drops = 0;
 
-/* Audio-thread producer. Lock-free SPSC enqueue. Drop-newest on full.
- * No logging — runs at FIFO 70 with ~900µs total SPI-callback budget. */
+/* Audio-thread producer for an overtake DSP (host_api midi_send_external). */
 static int overtake_midi_send_external(const uint8_t *msg, int len) {
-    if (!msg || len < 4) return 0;
-
-    uint32_t head = overtake_ext_ring.head;
-    uint32_t tail = overtake_ext_ring.tail;
-    __sync_synchronize();  /* acquire */
-    if ((uint32_t)(head - tail) >= OVERTAKE_EXT_RING_PACKETS) {
-        overtake_ext_drops++;  /* silently — counter only; no get_param binding yet */
-        return 0;
-    }
-    uint32_t idx = head % OVERTAKE_EXT_RING_PACKETS;
-    memcpy(overtake_ext_ring.pkt[idx], msg, 4);
-    __sync_synchronize();   /* release — packet data visible before head bump */
-    overtake_ext_ring.head = head + 1;
-    return len;
+    int rc = ext_midi_ring_push(&overtake_ext_ring, msg, len, EXT_SRC_OVERTAKE);
+    shim_ext_midi_drops = overtake_ext_ring.drops;
+    return rc;
 }
 
-/* Audio-thread consumer. Drains up to 20 packets from the ring into empty
- * 4-byte slots of the MIDI_OUT region (shadow + MIDI_OUT_OFFSET, 80 bytes).
- * Called from shim_pre_transfer once per block, BEFORE the JACK MIDI writer
- * so sequencer notes get slot priority over JACK chain output.
- * Capacity: 20 slots/block * ~344 blocks/sec ≈ 6880 pkt/sec sustained;
- * realistic chord-rate sequencer traffic is well under this. */
+/* Audio-thread producer for the chain host (chain knob CC out). Tagged
+ * separately so an overtake unload cannot silently swallow it — see the
+ * header. */
+static int chain_midi_send_external(const uint8_t *msg, int len) {
+    int rc = ext_midi_ring_push(&overtake_ext_ring, msg, len, EXT_SRC_CHAIN);
+    shim_ext_midi_drops = overtake_ext_ring.drops;
+    return rc;
+}
+
+/* Audio-thread consumer. Called from shim_pre_transfer once per block, BEFORE
+ * the JACK MIDI writer so sequencer notes get slot priority over JACK chain
+ * output. Capacity: 20 slots/block * ~344 blocks/sec ~= 6880 pkt/sec
+ * sustained. */
 static void overtake_ext_drain_into_shadow(uint8_t *shadow) {
     if (!shadow) return;
-    uint32_t tail = overtake_ext_ring.tail;
-    uint32_t head = overtake_ext_ring.head;
-    __sync_synchronize();  /* acquire — see packet data the producer published */
-    if (tail == head) return;
-
-    uint8_t *midi_out = shadow + MIDI_OUT_OFFSET;
-    int slot = 0;
-    while (tail != head) {
-        /* Find next empty 4-byte slot. */
-        while (slot < 80 &&
-               (midi_out[slot] || midi_out[slot+1] ||
-                midi_out[slot+2] || midi_out[slot+3])) {
-            slot += 4;
-        }
-        if (slot >= 80) break;  /* no slots left this block — leave rest in ring */
-        uint32_t idx = tail % OVERTAKE_EXT_RING_PACKETS;
-        midi_out[slot]   = overtake_ext_ring.pkt[idx][0];
-        midi_out[slot+1] = overtake_ext_ring.pkt[idx][1];
-        midi_out[slot+2] = overtake_ext_ring.pkt[idx][2];
-        midi_out[slot+3] = overtake_ext_ring.pkt[idx][3];
-        slot += 4;
-        tail++;
-    }
-    __sync_synchronize();
-    overtake_ext_ring.tail = tail;
+    ext_midi_ring_drain(&overtake_ext_ring, shadow + MIDI_OUT_OFFSET,
+                        HW_MIDI_OUT_SIZE);
 }
 
 /* ---- Off-RT cached remote snapshot (generic opt-in facility) -------------
@@ -1805,20 +1780,28 @@ static void shadow_overtake_dsp_unload(void) {
     /* Discard any ROUTE_EXTERNAL packets the unloaded DSP left in the ring.
      * Without this, the next overtake load would drain the previous module's
      * leftover packets into Move's MIDI_OUT region — up to 64 stray events
-     * shipped to USB-A across the first ~4 audio blocks after load. The
-     * producer (destroyed instance) can no longer fire, so the ring is
-     * inert here and a non-atomic reset is safe. */
-    overtake_ext_ring.head = 0;
-    overtake_ext_ring.tail = 0;
+     * shipped to USB-A across the first ~4 audio blocks after load.
+     *
+     * This used to reset head/tail, justified by "the producer (destroyed
+     * instance) can no longer fire, so the ring is inert here". That stopped
+     * being true when chain knob CC out made the CHAIN a second producer on
+     * the same ring — one that is very much still running. Resetting took its
+     * queued knob CCs with it, and those are the packets that must not be lost
+     * silently: the emitter already recorded them as delivered
+     * (knob_emit_cc_out sets last_cc_out only on a non-zero return), so a
+     * swallowed one leaves that knob's motor wrong until the user happens to
+     * move it again. Discard by source instead. */
+    ext_midi_ring_discard_source(&overtake_ext_ring, EXT_SRC_OVERTAKE);
 
-    /* Same for the dedicated Move-injection ring. It is a shim-lifetime static,
-     * so without this the NEXT overtake module's first frames drain the
-     * departed module's queued notes into Move's MIDI_IN as if it had played
-     * them. Note what this does NOT fix: packets that already went out during
-     * the takeover are gone, so a DSP that queued a note-on and was exited
-     * before its note-off still leaves a note ringing in Move. That wants an
-     * all-notes-off on the overtake->0 edge, which is a change to the one
-     * transition documented as SIGABRT-prone and is not being made blind. */
+    /* Same for the dedicated Move-INJECTION ring, which is a different ring
+     * with a different destination (Move's MIDI_IN, not MIDI_OUT) and only one
+     * producer — so it is emptied wholesale rather than by source. Without
+     * this the NEXT overtake module's first frames drain the departed module's
+     * queued notes into Move as if it had played them. What it does NOT fix:
+     * packets that already went out during the takeover are gone, so a DSP
+     * exited between note-on and note-off still leaves a note ringing. That
+     * wants an all-notes-off on the overtake->0 edge, which is a change to the
+     * one transition documented as SIGABRT-prone and is not made blind. */
     shadow_overtake_midi_discard();
 }
 
@@ -4576,7 +4559,10 @@ static void shim_init_subsystems(void)
             .get_bpm = shim_get_bpm,
             .get_beat_position = shadow_transport_beat_position,
             .on_param_changed = web_param_notify_push,
-            .midi_send_external = overtake_midi_send_external,
+            /* Tagged as EXT_SRC_CHAIN, not the overtake entry point: the chain
+             * outlives an overtake module, so its packets must survive the
+             * discard that overtake unload performs on the shared ring. */
+            .midi_send_external = chain_midi_send_external,
         };
         chain_mgmt_init(&cm_host);
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1692,6 +1692,10 @@ let knobEditorCcOut = 0;         // Cached knob_cc_out for the slot being edited
                                  // Cached rather than read per repaint: a
                                  // get_param is served once per draw, and this
                                  // row would otherwise pay that on every frame.
+                                 // null = the read did not complete. NOT the
+                                 // same as Off: this row is a TOGGLE, so a
+                                 // failed read shown as "Off" makes the next
+                                 // click write the value it already had.
 let knobParamPickerFolder = null; // null = main (targets), string = target name for params
 let knobParamPickerIndex = 0;    // Selected index in param picker
 let knobParamPickerParams = [];  // Available params in current folder
@@ -11188,9 +11192,12 @@ function loadKnobAssignments(slot) {
         const param = getSlotParam(slot, `knob_${i + 1}_param`) || "";
         knobEditorAssignments.push({ target, param });
     }
-    /* Absent on a chain DSP older than this feature — treat as Off. */
+    /* Three answers, not two (CLAUDE.md). "" is a chain DSP older than this
+     * feature — genuinely Off. null is a read that did not complete, and it
+     * must not become a value: this row is a toggle, so believing a false
+     * "Off" makes the click write 1 to a slot that was already on. */
     const ccOut = getSlotParam(slot, "knob_cc_out");
-    knobEditorCcOut = (ccOut !== null && parseInt(ccOut)) ? 1 : 0;
+    knobEditorCcOut = (ccOut === null) ? null : (parseInt(ccOut) ? 1 : 0);
 }
 
 /* Get available targets for knob assignment (components with modules loaded) */
@@ -15601,7 +15608,7 @@ function handleJog(delta, shift = isShiftHeld()) {
             /* Navigate the 8 knobs plus the trailing Knob CC Out toggle. */
             knobEditorIndex = Math.max(0, Math.min(NUM_KNOBS, knobEditorIndex + delta));
             if (knobEditorIndex === NUM_KNOBS) {
-                announceMenuItem("Knob CC Out", knobEditorCcOut ? "On" : "Off");
+                announceMenuItem("Knob CC Out", knobCcOutLabel());
             } else {
                 /* Announce knob and current assignment */
                 const knobNum = knobEditorIndex + 1;
@@ -16339,10 +16346,25 @@ function handleSelect() {
         case VIEWS.KNOB_EDITOR:
             if (knobEditorIndex === NUM_KNOBS) {
                 /* Flip Knob CC Out. Turning it on makes the DSP dump every
-                 * mapped knob, so the controller starts in sync. */
+                 * mapped knob, so the controller starts in sync.
+                 *
+                 * A toggle cannot flip a state it does not know. If the cached
+                 * read failed, ask once more and act only on a real answer —
+                 * writing a guess here would silently turn the feature OFF for
+                 * someone who had it on, which is the failure this feature
+                 * exists to avoid. */
+                if (knobEditorCcOut === null) {
+                    const retry = getSlotParam(knobEditorSlot, "knob_cc_out");
+                    if (retry === null) {
+                        announceMenuItem("Knob CC Out", "Unavailable");
+                        needsRedraw = true;
+                        break;
+                    }
+                    knobEditorCcOut = parseInt(retry) ? 1 : 0;
+                }
                 knobEditorCcOut = knobEditorCcOut ? 0 : 1;
                 setSlotParam(knobEditorSlot, "knob_cc_out", String(knobEditorCcOut));
-                announceMenuItem("Knob CC Out", knobEditorCcOut ? "On" : "Off");
+                announceMenuItem("Knob CC Out", knobCcOutLabel());
                 needsRedraw = true;
             } else {
                 /* Edit this knob's assignment */
@@ -17435,6 +17457,13 @@ function drawComponentEdit() {
 /* drawChainSettings() -> shadow_ui_settings.mjs */
 
 /* Draw knob assignment editor - list of 8 knobs with their assignments */
+/* The toggle's value column. "--" is the third state: the read did not
+ * complete, so we do not know and must not claim Off. */
+function knobCcOutLabel() {
+    if (knobEditorCcOut === null) return "--";
+    return knobEditorCcOut ? "On" : "Off";
+}
+
 function drawKnobEditor() {
     clear_screen();
     drawHeader(`S${knobEditorSlot + 1} Knobs`);
@@ -17462,7 +17491,7 @@ function drawKnobEditor() {
         getLabel: (item) => item.label,
         getValue: (item) => item.type === "knob"
             ? truncateText(getKnobAssignmentLabel(item.assignment), 12)
-            : (item.type === "toggle" ? (knobEditorCcOut ? "On" : "Off") : ""),
+            : (item.type === "toggle" ? knobCcOutLabel() : ""),
         listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
         valueAlignRight: true,
         prioritizeSelectedValue: true

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -12,10 +12,20 @@ CFLAGS ?= -O2 -g -Wall -Wextra -Wno-unused-parameter -std=c11
 INCLUDES = -I../../src/host
 LDFLAGS = -lpthread
 
+# Track HEADER dependencies. Several of the units under test are header-only
+# (ext_midi_ring.h, fx_midi_filter.h, master_fx_key.h, chain_permute.h), and
+# without this the rules below depend on the .c alone — so editing the header
+# leaves a stale binary and `make test` reports PASS against the code you just
+# changed. CI does a clean build and never saw it; a local mutation check does,
+# and silently concluded the mutation was harmless. -MMD emits a .d per target,
+# -MP adds phony targets so a DELETED header does not wedge the build.
+DEPFLAGS = -MMD -MP
+
 BUILD_DIR = ../../build/tests/host
 
 TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_overtake_midi_route \
+	$(BUILD_DIR)/test_ext_midi_ring \
 	$(BUILD_DIR)/test_overtake_native_led_repaint \
 	$(BUILD_DIR)/test_shadow_midi_filter \
 	$(BUILD_DIR)/test_midi_in_compact \
@@ -35,6 +45,7 @@ ifeq ($(strip $(MASTER_FX_SLOTS)),)
 $(error could not read MASTER_FX_SLOTS from ../../src/host/shadow_chain_mgmt.h)
 endif
 
+.DEFAULT_GOAL := all
 .PHONY: all test clean
 
 all: $(TARGETS)
@@ -43,25 +54,25 @@ $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
 $(BUILD_DIR)/%: %.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_overtake_native_led_repaint: test_overtake_native_led_repaint.c ../../src/host/shadow_led_queue.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L $(INCLUDES) $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(DEPFLAGS) -D_POSIX_C_SOURCE=200809L $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_overtake_midi_route: test_overtake_midi_route.c ../../src/host/shadow_overtake_midi.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_shadow_midi_filter: test_shadow_midi_filter.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_midi_in_compact: test_midi_in_compact.c ../../src/host/shadow_midi_filter.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_rt_thread_audit: test_rt_thread_audit.c ../../src/host/rt_thread_audit.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_spi_tally: test_spi_tally.c ../../src/host/spi_tally.c | $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_align_capture: test_align_capture.c ../../src/host/align_capture.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS)
@@ -70,7 +81,7 @@ $(BUILD_DIR)/test_master_fx_snapshot: test_master_fx_snapshot.c ../../src/host/m
 	$(CC) $(CFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_master_fx_slot_routing: test_master_fx_slot_routing.c ../../src/host/master_fx_key.h ../../src/host/shadow_chain_mgmt.h | $(BUILD_DIR)
-	$(CC) $(CFLAGS) $(INCLUDES) -DTEST_MASTER_FX_SLOTS=$(MASTER_FX_SLOTS) $< -o $@ $(LDFLAGS)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) -DTEST_MASTER_FX_SLOTS=$(MASTER_FX_SLOTS) $< -o $@ $(LDFLAGS)
 
 test: $(TARGETS)
 	@for t in $(TARGETS); do \
@@ -80,3 +91,8 @@ test: $(TARGETS)
 
 clean:
 	rm -rf $(BUILD_DIR)
+
+# Header dependencies, included LAST. An included makefile's first target can
+# become the default goal, which is why .DEFAULT_GOAL is set above — without it
+# `make -C tests/host` built one target and said "up to date" for the rest.
+-include $(TARGETS:=.d)

--- a/tests/host/test_ext_midi_ring.c
+++ b/tests/host/test_ext_midi_ring.c
@@ -1,0 +1,155 @@
+/*
+ * Does an overtake unload take the chain's knob CCs with it?
+ *
+ * The ROUTE_EXTERNAL ring grew a second producer when chain knob CC out landed
+ * (PR #307). Overtake unload discards the departing DSP's queued packets, and
+ * that discard used to reset head/tail — correct while the overtake DSP was
+ * the only producer, wrong the moment the chain became one, because the chain
+ * is still running and its packets are interleaved with the DSP's.
+ *
+ * Losing a chain packet HERE is worse than the ring being full. A full ring
+ * returns 0 and knob_emit_cc_out declines to record the value, so it retries.
+ * A packet accepted and then blanked was recorded as delivered, and that knob's
+ * motor stays wrong until the user happens to move it again.
+ *
+ * The properties worth proving are the ones that are silent when wrong:
+ *   1. a discard removes ONLY the named source;
+ *   2. it does NOT reset the cursors (which is how it would take the other
+ *      producer's packets);
+ *   3. the drain steps OVER a discarded slot without spending a mailbox slot,
+ *      so a discard costs no throughput;
+ *   4. FIFO order across the two producers survives all of it;
+ *   5. a packet that does not fit the block STAYS in the ring — a delay, not a
+ *      loss — because that is the promise knob_emit_cc_out's retry relies on.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "ext_midi_ring.h"
+#include "shadow_constants.h"   /* HW_MIDI_OUT_SIZE — the real 80 */
+
+/* The mailbox MIDI_OUT region, as the shim passes it. Taken from the real
+ * constant rather than written as 80 here: a test that hard-codes the size
+ * still passes after the region moves, which is the case this ring would
+ * quietly overrun. */
+#define HW_MIDI_OUT_REGION HW_MIDI_OUT_SIZE
+
+static int failures = 0;
+
+static void check(int cond, const char *what) {
+    if (cond) {
+        printf("  ok   %s\n", what);
+    } else {
+        printf("  FAIL %s\n", what);
+        failures++;
+    }
+}
+
+static uint8_t pkt_of(uint8_t d1) { return d1; }
+
+static void push(ext_midi_ring_t *r, uint8_t d1, uint8_t src, int expect) {
+    const uint8_t msg[4] = { 0x2B, 0xB0, pkt_of(d1), 64 };
+    int rc = ext_midi_ring_push(r, msg, 4, src);
+    if (rc != expect) {
+        printf("  FAIL push d1=%u src=%u returned %d, expected %d\n",
+               d1, src, rc, expect);
+        failures++;
+    }
+}
+
+int main(void) {
+    ext_midi_ring_t r;
+    uint8_t out[HW_MIDI_OUT_REGION];
+
+    /* 1. A DISCARD REMOVES ONLY THE NAMED SOURCE. */
+    printf("an overtake unload leaves the chain's packets alone\n");
+    ext_midi_ring_init(&r);
+    memset(out, 0, sizeof(out));
+    push(&r, 10, EXT_SRC_OVERTAKE, 4);
+    push(&r, 11, EXT_SRC_CHAIN,    4);
+    push(&r, 12, EXT_SRC_OVERTAKE, 4);
+    push(&r, 13, EXT_SRC_CHAIN,    4);
+
+    uint32_t head_before = r.head, tail_before = r.tail;
+    ext_midi_ring_discard_source(&r, EXT_SRC_OVERTAKE);
+    check(r.head == head_before && r.tail == tail_before,
+          "the discard does not touch the cursors");
+
+    int n = ext_midi_ring_drain(&r, out, (int)sizeof(out));
+    check(n == 2, "only the two chain packets are drained");
+    check(out[2] == 11 && out[6] == 13,
+          "and they are the chain's, in order");
+    check(out[8] == 0 && out[9] == 0 && out[10] == 0 && out[11] == 0,
+          "a discarded packet spends no mailbox slot");
+
+    /* 2. THE MIRROR CASE — discarding the chain must not eat the DSP's. This
+     * is not a thing the shim does, and that is exactly why it is here: it
+     * proves the filter is on the TAG and not on some incidental ordering. */
+    printf("the tag is what selects, not the order\n");
+    ext_midi_ring_init(&r);
+    memset(out, 0, sizeof(out));
+    push(&r, 20, EXT_SRC_OVERTAKE, 4);
+    push(&r, 21, EXT_SRC_CHAIN,    4);
+    ext_midi_ring_discard_source(&r, EXT_SRC_CHAIN);
+    n = ext_midi_ring_drain(&r, out, (int)sizeof(out));
+    check(n == 1 && out[2] == 20, "discarding the chain leaves the DSP's packet");
+
+    /* 3. FIFO ACROSS PRODUCERS. */
+    printf("one queue, one order\n");
+    ext_midi_ring_init(&r);
+    memset(out, 0, sizeof(out));
+    for (int i = 0; i < 8; i++)
+        push(&r, (uint8_t)(30 + i), (i % 2) ? EXT_SRC_CHAIN : EXT_SRC_OVERTAKE, 4);
+    n = ext_midi_ring_drain(&r, out, (int)sizeof(out));
+    check(n == 8, "all eight drain in one block");
+    int ordered = 1;
+    for (int i = 0; i < 8; i++)
+        if (out[i * 4 + 2] != (uint8_t)(30 + i)) ordered = 0;
+    check(ordered, "interleaved producers keep insertion order");
+
+    /* 4. A PACKET THAT DOES NOT FIT IS DELAYED, NOT LOST. */
+    printf("an over-full block delays, it does not drop\n");
+    ext_midi_ring_init(&r);
+    memset(out, 0, sizeof(out));
+    for (int i = 0; i < 30; i++)
+        push(&r, (uint8_t)(40 + i), EXT_SRC_CHAIN, 4);
+    n = ext_midi_ring_drain(&r, out, (int)sizeof(out));
+    check(n == HW_MIDI_OUT_REGION / 4, "the block fills exactly");
+    check(n < 30, "and it could not take them all");
+    memset(out, 0, sizeof(out));
+    int n2 = ext_midi_ring_drain(&r, out, (int)sizeof(out));
+    check(n + n2 == 30, "the remainder arrives on the next block");
+    check(out[2] == (uint8_t)(40 + n),
+          "and it resumes exactly where the last block stopped");
+
+    /* 5. PRE-OCCUPIED SLOTS ARE STEPPED OVER, NOT OVERWRITTEN. Move's own
+     * output is already in this region in normal shadow mode — this ring was
+     * designed and measured under overtake, where the region is cleared first. */
+    printf("Move's own MIDI_OUT is not overwritten\n");
+    ext_midi_ring_init(&r);
+    memset(out, 0, sizeof(out));
+    out[0] = 0x09; out[1] = 0x90; out[2] = 60; out[3] = 100;   /* Move's packet */
+    push(&r, 50, EXT_SRC_CHAIN, 4);
+    n = ext_midi_ring_drain(&r, out, (int)sizeof(out));
+    check(n == 1, "one packet placed");
+    check(out[2] == 60, "Move's packet is untouched");
+    check(out[6] == 50, "ours went into the next free slot");
+
+    /* 6. FULL RING RETURNS 0, AND 0 MUST MEAN NOT SENT. */
+    printf("a full ring refuses rather than overwriting\n");
+    ext_midi_ring_init(&r);
+    for (int i = 0; i < EXT_MIDI_RING_PACKETS; i++)
+        push(&r, (uint8_t)i, EXT_SRC_CHAIN, 4);
+    push(&r, 99, EXT_SRC_CHAIN, 0);
+    check(r.drops == 1, "the drop is counted");
+    memset(out, 0, sizeof(out));
+    (void)ext_midi_ring_drain(&r, out, (int)sizeof(out));
+    check(out[2] == 0, "drop-NEWEST: the oldest packet is still first");
+
+    if (failures) {
+        printf("FAILURES: %d\n", failures);
+        return 1;
+    }
+    printf("PASS: ext midi ring — a discard is scoped to one producer\n");
+    return 0;
+}


### PR DESCRIPTION
Review follow-ups to #307. The feature is right; these are the findings from reviewing it, fixed in-house rather than routed back to the author.

## The one that loses data

Chain knob CC out made the chain a **second** producer on the ROUTE_EXTERNAL ring, and overtake unload discards that ring by resetting `head`/`tail`. That reset was justified in so many words — *"the producer (destroyed instance) can no longer fire, so the ring is inert here"* — and the chain is very much still running, so the reset took its queued knob CCs with it.

That loss is worse than a full ring. A full ring returns 0 and `knob_emit_cc_out` declines to record the value, so it retries. A packet **accepted and then blanked** was recorded as delivered, and that knob's motor stays wrong until the user happens to move it again — which is the exact staleness the feature exists to remove.

The ring is now `src/host/ext_midi_ring.h` — pure state, no I/O — and packets carry a source tag. A discard blanks **by source** and leaves the cursors alone; the drain steps over a blanked slot without spending a mailbox slot. Extracting it is what makes `test_ext_midi_ring.c` possible; the alternative was a grep-for-a-string pin.

## Also here

- `overtake_ext_drops` was a static nobody could read, with a comment noting it had *"no get_param binding yet"*. It is now `shim_ext_midi_drops`, reported by the worker at ~1 Hz and silent when there are none. The RT path still never logs. **A feature whose failure mode is a silently stale motor should not also be silent about its drops.**
- `knob_mapping_t.last_cc_out` uses `-1` for "nothing sent yet", but the patch parser clears each row with `memset`, so rows arrived claiming they had already sent CC 0. Masked today because the bulk dump forces `-1` first; a future per-knob emit that skipped the dump would swallow a genuine 0.
- The Knob CC Out row is a **toggle**, and `loadKnobAssignments` collapsed a failed read to "Off". Not just a wrong label: clicking it then writes `1` to a slot that was already on. Third state is `--`, and the click re-reads once rather than flipping a value it does not know.
- `plugin_api_v1.h` now says what `midi_send_external` means. Two things were undocumented: the `0` return is "not sent" and must never be recorded as sent, and chain **sub-plugins** now inherit this hook, which was NULL there for years. Nothing in the fleet calls it from a chainable module today (checked every repo: one caller, `schwung-fourtrack`, a `utility`) — so that is a contract note, not a live change.

## And the test infrastructure that hid itself

`tests/host/Makefile` depended on the `.c` alone, so editing a **header** left a stale binary and `make test` reported PASS against code that was never compiled. Found by mutating this fix away and watching the test pass.

Several units under test are header-only (`fx_midi_filter.h`, `master_fx_key.h`, `chain_permute.h`), so this was not hypothetical — CI does a clean build and never saw it. Now `-MMD -MP`, with `.DEFAULT_GOAL` set because an included `.d`'s first target otherwise steals the default goal, which it promptly did.

## Verified

Cross-compiles clean for ARM64 (0 errors); `make -C tests/host test` and all `tests/host/*.sh` green. The new test fails on the pre-fix behaviour and on a tag-filter mutation, checked both ways.

## Left for the author

A dropped **final** CC of a sweep does not self-heal, because nothing moves again to trigger a retry. Whether that wants a periodic reconcile or a guaranteed-final emit is a question you answer with a motorised controller in front of you, and @jeffclementson-cloud has one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbuNj8HH2zaYuuvVqhAwz3