### PR TITLE
ui: the knob scrolls the file browser instead of editing the slot behind it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -569,6 +569,34 @@ Slot Settings and Master FX Settings, which are synthesised contracts with no
 `ui_hierarchy` to enter, and it keeps the slot io's own mappings (Fwd's offset,
 MPE's compound write) applied rather than bypassed.
 
+### A filepath param opens a browser, and the knob scrolls THAT too
+
+Diving a `filepath` param from the grid — mrsample's Sample cell is the case —
+lands in `VIEWS.FILEPATH_BROWSER`, and the gesture that got you there leaves
+your hand on the knob. It now scrolls the file list through the same
+`listKnobStep` accumulator the enum picker uses, and a knob TOUCH raises
+nothing over it, for the same reason: the card covers the rows being scrolled.
+
+**This was not a missing affordance, it was a write.** With no route, the turn
+fell through `adjustKnobAndShow` (which returns false — `buildKnobContextForKnob`
+matches no view here) to `handleKnobTurn`, which writes `knob_N_adjust` into the
+**selected slot's global knob mapping**. Behind a full-screen browser, so the
+only visible symptom was the legacy "Knob 1" overlay drawn over the file list —
+which reads as a cosmetic glitch and is not one. Identical in kind to the bug
+the picker's branch fixed, and the filepath browser was the last list dived into
+from the grid that still leaked.
+
+`filepathBrowserJog(delta)` is shared by the jog case and the knob branch on
+purpose: the live-preview arm and the `announceMenuItem` live in it, and two
+copies is how a knob ends up scrolling without auditioning or speaking.
+`tests/host/test_filepath_browser_knob.sh` pins the routing order from source
+*and* lifts the helper to drive it — scroll, audition, announce, clamp, and
+clearing the pending audition when the highlight lands on a directory.
+
+Still unrouted, and each is its own decision: `TOOL_FILE_BROWSER`,
+`KNOB_PARAM_PICKER`, `LFO_TARGET_*` and `DYNAMIC_PARAM_PICKER` are all lists
+whose knob turns still reach `handleKnobTurn`.
+
 ### The knob grid is the DEFAULT param view, and it reflows to stay drawable
 
 `paramViewGlobal` defaults to 1 (the grid). The hierarchy list is still there

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -12382,6 +12382,31 @@ function refreshHierarchyChainParams() {
 }
 
 /* Open generic file browser for a filepath parameter */
+/* Knob-scroll accumulator for the filepath browser, exactly as the enum
+ * picker has one: the JOG stays 1:1 because a jog detent is a deliberate
+ * click, while a knob detent is a fraction of a twist. */
+let filepathBrowserKnob = listKnobInit();
+
+/* Move the browser's highlight by `delta` entries.
+ *
+ * Shared by the jog and the knob so the live-preview arm and the
+ * announcement cannot drift apart between the two inputs — a browser that
+ * scrolled on the knob but did not audition or speak would be a different
+ * bug in the same place. */
+function filepathBrowserJog(delta) {
+    if (!filepathBrowserState) return;
+    moveFilepathBrowserSelection(filepathBrowserState, delta);
+    const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
+    if (filepathBrowserState.livePreviewEnabled && selected && selected.kind === "file" && selected.path) {
+        filepathBrowserState.previewPendingPath = selected.path;
+        filepathBrowserState.previewPendingTime = Date.now();
+    } else if (filepathBrowserState.livePreviewEnabled) {
+        filepathBrowserState.previewPendingPath = "";
+        filepathBrowserState.previewPendingTime = 0;
+    }
+    if (selected) announceMenuItem(selected.label || "File", "");
+}
+
 function openHierarchyFilepathBrowser(key, meta) {
     refreshHierarchyChainParams();
     const effectiveMeta = getParamMetadata(key) || meta;
@@ -12407,6 +12432,7 @@ function openHierarchyFilepathBrowser(key, meta) {
     filepathBrowserState.hooksOnCancel = hooks.onCancel;
     filepathBrowserState.hooksOnCommit = hooks.onCommit;
     filepathBrowserState.hookRestoreValues = {};
+    filepathBrowserKnob = listKnobInit();
     applyFilepathHookActions(filepathBrowserState, filepathBrowserState.hooksOnOpen, { path: currentVal });
 
     refreshFilepathBrowser(filepathBrowserState, FILEPATH_BROWSER_FS);
@@ -15365,18 +15391,7 @@ function handleJog(delta, shift = isShiftHeld()) {
             /* Canvas animation is autonomous; jog is forwarded via onMidi hook. */
             break;
         case VIEWS.FILEPATH_BROWSER:
-            if (filepathBrowserState) {
-                moveFilepathBrowserSelection(filepathBrowserState, delta);
-                const selected = filepathBrowserState.items[filepathBrowserState.selectedIndex];
-                if (filepathBrowserState.livePreviewEnabled && selected && selected.kind === "file" && selected.path) {
-                    filepathBrowserState.previewPendingPath = selected.path;
-                    filepathBrowserState.previewPendingTime = Date.now();
-                } else if (filepathBrowserState.livePreviewEnabled) {
-                    filepathBrowserState.previewPendingPath = "";
-                    filepathBrowserState.previewPendingTime = 0;
-                }
-                if (selected) announceMenuItem(selected.label || "File", "");
-            }
+            filepathBrowserJog(delta);
             break;
         case VIEWS.KNOB_EDITOR:
             /* Navigate knob list (8 knobs) */
@@ -20508,6 +20523,21 @@ globalThis.onMidiMessageInternal = function(data) {
                 return;
             }
 
+            /* The filepath browser is a list too, and it was the last one
+             * dived into from the grid that still leaked its knob turns.
+             * Same fix and for the same reason as the picker above: falling
+             * through wrote knob_N_adjust into the SELECTED SLOT's global
+             * knob mapping — behind a full-screen browser, so the only
+             * visible sign was the legacy "Knob 1" card sitting on top of the
+             * file list. mrsample's Sample cell is the way in. */
+            if (view === VIEWS.FILEPATH_BROWSER) {
+                const step = listKnobStep(filepathBrowserKnob, delta, Date.now(),
+                                          filepathBrowserState
+                                              ? filepathBrowserState.items.length : 0);
+                if (step) filepathBrowserJog(step);
+                return;
+            }
+
             /* Use shared knob handler for hierarchy/chain editor contexts */
             if (adjustKnobAndShow(knobIndex, delta)) {
                 return;
@@ -20556,7 +20586,7 @@ globalThis.onMidiMessageInternal = function(data) {
              * stays consistent for whatever is underneath when the picker
              * closes; only the drawing is suppressed.
              */
-            if (view === VIEWS.ENUM_PICKER) return;
+            if (view === VIEWS.ENUM_PICKER || view === VIEWS.FILEPATH_BROWSER) return;
 
             /* Multi-marker view overrides the level's knob row:
              *   marker knobs (1..N) → switch active marker + show its value

--- a/tests/host/test_filepath_browser_knob.sh
+++ b/tests/host/test_filepath_browser_knob.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# While the filepath browser is up, a knob must SCROLL IT.
+#
+# You reach it by holding a knob on the grid and clicking — mrsample's Sample
+# cell is the way in — so the hand is already on the knob and the reflex is to
+# keep turning. This is the same fix the enum picker got, on the last list
+# dived into from the grid that still leaked its knob turns.
+#
+# The half worth pinning is the CORRECTNESS half, not the affordance: without
+# the route, a turn fell through to handleKnobTurn and wrote knob_N_adjust
+# into the SELECTED SLOT's global knob mapping. Behind a full-screen browser,
+# so the only visible sign was the legacy "Knob 1" card drawn over the file
+# list, which reads as a cosmetic glitch and is not one.
+
+file="src/shadow/shadow_ui.js"
+
+# ---------------------------------------------------------------- source pins
+
+block=$(awk '/Handle knob CCs \(71-78\) for parameter control/,/adjustKnobAndShow\(knobIndex, delta\)/' "$file")
+if [ -z "$block" ]; then
+  echo "FAIL: could not find the knob CC handler in $file" >&2
+  exit 1
+fi
+
+if ! grep -q "VIEWS.FILEPATH_BROWSER" <<<"$block"; then
+  echo "FAIL: a knob turn is not routed to the filepath browser." >&2
+  echo "      It falls through to handleKnobTurn, which writes knob_N_adjust" >&2
+  echo "      to the selected slot behind the browser." >&2
+  exit 1
+fi
+if ! grep -q "filepathBrowserJog" <<<"$block"; then
+  echo "FAIL: the FILEPATH_BROWSER branch does not call filepathBrowserJog" >&2
+  exit 1
+fi
+
+# ORDER: before adjustKnobAndShow/handleKnobTurn, or the write happens first
+# and the scroll is dead code.
+fp_line=$(grep -n "VIEWS.FILEPATH_BROWSER" <<<"$block" | head -n 1 | cut -d: -f1)
+adj_line=$(grep -n "adjustKnobAndShow(knobIndex, delta)" <<<"$block" | head -n 1 | cut -d: -f1)
+if [ -z "$fp_line" ] || [ -z "$adj_line" ] || [ "$fp_line" -ge "$adj_line" ]; then
+  echo "FAIL: the FILEPATH_BROWSER route must come BEFORE adjustKnobAndShow" >&2
+  echo "      (browser at line $fp_line, adjustKnobAndShow at $adj_line)" >&2
+  exit 1
+fi
+
+# And it must RETURN, or the turn scrolls AND writes.
+if ! sed -n "${fp_line},\$p" <<<"$block" | sed -n '1,14p' | grep -q "return;"; then
+  echo "FAIL: the FILEPATH_BROWSER branch does not return — the turn would" >&2
+  echo "      scroll the list AND edit the slot mapping underneath it." >&2
+  exit 1
+fi
+
+# It must go through listKnobStep, not 1:1. A jog detent is a click; a knob
+# detent is a fraction of a twist, and a Samples folder is long.
+if ! sed -n "${fp_line},\$p" <<<"$block" | sed -n '1,14p' | grep -q "listKnobStep"; then
+  echo "FAIL: the FILEPATH_BROWSER branch does not use listKnobStep — a 1:1" >&2
+  echo "      knob is the 'way too fast' the accumulator exists to fix." >&2
+  exit 1
+fi
+
+# The accumulator must be RESET when the browser opens, or the banked partial
+# turn from the last list carries into this one.
+if ! awk '/^function openHierarchyFilepathBrowser\(/,/^}/' "$file" \
+     | grep -q "filepathBrowserKnob = listKnobInit()"; then
+  echo "FAIL: openHierarchyFilepathBrowser does not reset filepathBrowserKnob" >&2
+  exit 1
+fi
+
+# A knob TOUCH must raise nothing while the browser is up — same argument as
+# the picker: the legacy card covers the very rows being scrolled.
+touch_start=$(grep -n "knobTouched\[knobIndex\] = true" "$file" | head -n 1 | cut -d: -f1)
+if [ -z "$touch_start" ]; then
+  echo "FAIL: could not find the knob-touch record in $file" >&2
+  exit 1
+fi
+touch_block=$(sed -n "$((touch_start - 6)),$((touch_start + 30))p" "$file")
+if ! grep -q "VIEWS.FILEPATH_BROWSER" <<<"$touch_block"; then
+  echo "FAIL: a knob TOUCH still raises the legacy overlay over the browser." >&2
+  exit 1
+fi
+rec_line=$(grep -n "knobTouched\[knobIndex\] = true" <<<"$touch_block" | head -n 1 | cut -d: -f1)
+ret_line=$(grep -n "VIEWS.FILEPATH_BROWSER" <<<"$touch_block" | head -n 1 | cut -d: -f1)
+if [ "$rec_line" -ge "$ret_line" ]; then
+  echo "FAIL: the browser early-return must come AFTER knobTouched is recorded" >&2
+  exit 1
+fi
+
+# The jog case must DELEGATE to the same helper. Two copies is how the knob
+# path ends up scrolling without auditioning or speaking.
+jog_case=$(awk '/case VIEWS.FILEPATH_BROWSER:/{f=1} f{print} f&&/break;/{exit}' "$file")
+if ! grep -q "filepathBrowserJog(delta)" <<<"$jog_case"; then
+  echo "FAIL: the jog case does not delegate to filepathBrowserJog — the knob" >&2
+  echo "      and the jog can now drift apart on preview and announcement." >&2
+  exit 1
+fi
+
+echo "  ok  source: knob routed to the browser, before the fallthrough, via listKnobStep"
+
+# ------------------------------------------------------- behaviour: lift & run
+
+node --input-type=module -e '
+import fs from "node:fs";
+import { listKnobInit, listKnobStep } from "./src/shared/param_pages/list_knob.mjs";
+import { moveFilepathBrowserSelection } from "./src/shared/filepath_browser.mjs";
+
+const src = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+const m = src.match(/function filepathBrowserJog\(delta\) \{[\s\S]*?\n\}/);
+if (!m) { console.error("FAIL: filepathBrowserJog not found"); process.exit(1); }
+
+let announced = [];
+const state = {
+    items: [
+        { kind: "up",   label: "..",   path: "/x" },
+        { kind: "file", label: "a.wav", path: "/x/a.wav" },
+        { kind: "file", label: "b.wav", path: "/x/b.wav" },
+        { kind: "file", label: "c.wav", path: "/x/c.wav" },
+        { kind: "file", label: "d.wav", path: "/x/d.wav" },
+    ],
+    selectedIndex: 0,
+    livePreviewEnabled: true,
+    previewPendingPath: "",
+    previewPendingTime: 0,
+};
+
+const jog = new Function(
+    "filepathBrowserState", "moveFilepathBrowserSelection", "announceMenuItem",
+    m[0] + "; return filepathBrowserJog;"
+)(state, moveFilepathBrowserSelection, (l, v) => announced.push(l));
+
+// A knob turn moves the highlight, arms the audition, and speaks the row.
+const knob = listKnobInit();
+let t = 0, moved = 0;
+for (let i = 0; i < 40; i++) {
+    const step = listKnobStep(knob, 1, (t += 40), state.items.length);
+    if (step) { jog(step); moved++; }
+}
+if (moved === 0) { console.error("FAIL: 40 detents produced no step at all"); process.exit(1); }
+if (state.selectedIndex === 0) { console.error("FAIL: the knob did not move the selection"); process.exit(1); }
+const sel = state.items[state.selectedIndex];
+if (sel.kind === "file" && state.previewPendingPath !== sel.path) {
+    console.error("FAIL: the knob scrolled but did not arm the live preview");
+    process.exit(1);
+}
+if (announced.length !== moved) {
+    console.error("FAIL: the knob scrolled without announcing every row (" +
+                  announced.length + " of " + moved + ")");
+    process.exit(1);
+}
+
+// It clamps at both ends: a fast turn can deliver a step bigger than the list.
+jog(999);
+if (state.selectedIndex !== state.items.length - 1) {
+    console.error("FAIL: an oversized step ran off the end"); process.exit(1);
+}
+jog(-999);
+if (state.selectedIndex !== 0) {
+    console.error("FAIL: an oversized negative step ran off the start"); process.exit(1);
+}
+
+// A non-file row (".." / a directory) must CLEAR the pending audition rather
+// than leaving the previous file armed to play after you have walked away.
+state.selectedIndex = 1; jog(0);
+if (state.previewPendingPath !== "/x/a.wav") { console.error("FAIL: file row did not arm"); process.exit(1); }
+jog(-1);
+if (state.previewPendingPath !== "" || state.previewPendingTime !== 0) {
+    console.error("FAIL: a directory row left a stale audition armed"); process.exit(1);
+}
+console.log("  ok  behaviour: scrolls, auditions, announces, clamps, clears on a non-file row");
+'
+
+echo "PASS: a knob scrolls the filepath browser instead of editing the slot behind it"


### PR DESCRIPTION
Reported from the device: in mrsample, jog-clicking the sample selection and then turning a knob raises the old "Knob 1" overlay.

**The overlay was the symptom, not the bug.** `VIEWS.FILEPATH_BROWSER` had no branch in the knob CC block, so the turn fell through `adjustKnobAndShow` (which returns false — `buildKnobContextForKnob` matches no view here) to `handleKnobTurn`, which writes `knob_N_adjust` into the **selected slot's global knob mapping**. Behind a full-screen browser, so a write nobody asked for surfaced as a cosmetic glitch. Identical in kind to the bug the enum picker's branch fixed; the filepath browser was the last list dived into from the grid that still leaked.

## The fix

- Route the turn through `listKnobStep` — 1:1 is the "way too fast" the accumulator exists for, and a Samples folder is long.
- Return **before** the fallthrough, so it scrolls instead of also writing.
- Reset the accumulator in `openHierarchyFilepathBrowser`, so a banked partial turn from the last list doesn't carry in.
- Swallow the knob **touch** (`VIEWS.ENUM_PICKER || VIEWS.FILEPATH_BROWSER`), so re-gripping can't cover the rows being scrolled.
- The jog case now delegates to a shared `filepathBrowserJog(delta)`: the live-preview arm and the `announceMenuItem` live in it, and two copies is how the knob path ends up scrolling without auditioning or speaking.

## Test

`tests/host/test_filepath_browser_knob.sh` — source pins for the routing order plus a `new Function` lift of the helper that drives it: scroll, audition, announce, clamp at both ends, and clear the pending audition when the highlight lands on a directory.

Eight mutations each fail it: route deleted, no return, 1:1 step, no reset on open, touch card restored, preview unarmed, stale audition on a dir row, announcement dropped.

Full local suite: 174/174 shell + all compiled C green. Not deployed to hardware.

## Left alone, deliberately

`TOOL_FILE_BROWSER`, `KNOB_PARAM_PICKER`, `LFO_TARGET_*` and `DYNAMIC_PARAM_PICKER` are also lists whose knob turns still reach `handleKnobTurn`. Each is its own decision — noted in CLAUDE.md rather than swept in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ea5totXCwhJz6UYULxbTk