### PR TITLE
manager: say so when a module's min_host_version is not checked

### DIFF
--- a/schwung-manager/host_compat_test.go
+++ b/schwung-manager/host_compat_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newTestApp builds the minimum App checkHostCompat touches: a base path and
+// a logger. The logger matters — the unknown-version branch logs, and a nil
+// one would panic on exactly the path that is hardest to reach in the field.
+func newTestApp(t *testing.T, hostVersion string) *App {
+	t.Helper()
+	base := t.TempDir()
+	if hostVersion != "" {
+		if err := os.MkdirAll(filepath.Join(base, "host"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(base, "host", "version.txt"),
+			[]byte(hostVersion+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &App{
+		basePath: base,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestCheckHostCompat(t *testing.T) {
+	cases := []struct {
+		name        string
+		hostVersion string // "" means host/version.txt is absent
+		minVersion  string
+		wantErr     bool
+	}{
+		{"no minimum declared", "0.9.0", "", false},
+		{"host newer than minimum", "0.12.1", "0.7.13", false},
+		{"host equals minimum", "0.12.1", "0.12.1", false},
+		{"host older than minimum", "0.12.0", "0.12.1", true},
+		// 0.9.16 must read as OLDER than 0.12.1: a lexical compare would call
+		// it newer and let an incompatible module through.
+		{"double-digit minor beats single", "0.9.16", "0.12.1", true},
+		// The deliberate fallback: unreadable version.txt installs anyway
+		// rather than bricking recovery. It must not panic while logging.
+		{"version file missing", "", "0.12.1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := newTestApp(t, tc.hostVersion).checkHostCompat(tc.minVersion)
+			if tc.wantErr && err == nil {
+				t.Fatalf("min %q vs host %q: wanted an error, got nil",
+					tc.minVersion, tc.hostVersion)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("min %q vs host %q: wanted nil, got %v",
+					tc.minVersion, tc.hostVersion, err)
+			}
+			if tc.wantErr && !strings.Contains(err.Error(), tc.minVersion) {
+				t.Fatalf("error should name the required version, got %q", err)
+			}
+		})
+	}
+}

--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -685,12 +685,22 @@ func (app *App) hostVersionString() string {
 // than the installed host version. A missing/unreadable host version
 // is treated as compatible — refusing installs when version.txt can't
 // be read would brick recovery on broken setups.
+//
+// That fallback stays, but it is no longer silent. A module declaring a
+// min_host_version installs unchecked on any device where host/version.txt
+// is missing, and then misbehaves in whatever way its unmet requirement
+// implies — which reads as a bug in the module, not as a skipped check.
+// One line in the log is the difference between diagnosing that in a minute
+// and not at all.
 func (app *App) checkHostCompat(minVersion string) error {
 	if minVersion == "" {
 		return nil
 	}
 	hostVersion := app.hostVersionString()
 	if hostVersion == "" || hostVersion == "unknown" {
+		app.logger.Warn("host version unknown; installing without checking the module's minimum",
+			"min_host_version", minVersion,
+			"version_file", filepath.Join(app.basePath, "host", "version.txt"))
 		return nil
 	}
 	if isNewerSemver(minVersion, hostVersion) {


### PR DESCRIPTION
A module with a `min_host_version` installs **unchecked** on any device where `host/version.txt` is missing or unreadable, and nothing anywhere says it happened.

`checkHostCompat` treats an unknown host version as compatible:

```go
hostVersion := app.hostVersionString()
if hostVersion == "" || hostVersion == "unknown" {
    return nil
}
```

That fallback is deliberate and I have not changed it — the comment is right that refusing installs when the version cannot be read would brick recovery on a broken setup. The problem is only that it is silent. The module installs, then misbehaves in whatever way its unmet requirement implies, and from the outside that reads as a broken module rather than a skipped check.

**How I ran into it.** Users reported a module of mine "not working" on Move. It declares `min_host_version` 0.12.1 because its device UI is the stock knob pages — those arrived in 0.12.0, and the `viz`-beside-the-param form it uses arrived in 0.12.1. On anything older it loads and passes audio with **no knobs at all**. The declared minimum was correct and should have caught it. On my own Move, which has `host/version.txt` = 0.12.1, everything worked, which is exactly why it took a while to see.

**The change** is one `Warn` naming the minimum that went unchecked and the file that could not be read. Behaviour is otherwise identical.

**Also adds a table test** for `checkHostCompat`, which had none. Two cases are worth keeping beyond the obvious ones:

- `0.9.16` against a `0.12.1` minimum. A lexical compare would call 0.9.16 the newer and admit an incompatible module; `isNewerSemver` compares numerically and correctly rejects it. Worth pinning so it stays that way.
- the missing-`version.txt` path, which now logs and therefore must not panic there — it is the branch hardest to reach in the field.

`go build`, `go vet`, `gofmt` and the full `schwung-manager` suite are clean.

**Possible follow-up, not done here:** surface the same fact in the UI. `module_detail.html` already shows `MinHostVer`, so an "unverified — host version unknown" note beside it would put it in front of the person installing rather than only in the log. Happy to add that if you want it in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)