### PR TITLE
The defer guard does not stall external MIDI — measured, not reasoned

### DIFF
--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -604,13 +604,22 @@ void shadow_drain_midi_inject(void)
      * off-limits during overtake because its consumer is the test-bus
      * publisher in schwung_shim.c and this ring is documented single-consumer.
      *
-     * OPEN, and worth knowing before trusting this path: the DEFER guard below
-     * requires three consecutive frames with an entirely empty MIDI_IN, reset
-     * by a non-zero slot on ANY cable. Move's own surface is filtered out of
-     * the mailbox during overtake, but cable 2 is not -- so an external USB
-     * keyboard played into an overtake module may hold the counter at zero and
-     * stall the dedicated ring for as long as you play. Not measured on
-     * hardware. Check it before relying on injection under live external MIDI. */
+     * MEASURED 2026-08-28, because reading the DEFER guard below suggests a
+     * hazard that is not real and the next reader will re-derive it. The guard
+     * wants two consecutive frames with an entirely empty MIDI_IN and resets on
+     * a non-zero slot on ANY cable; cable 2 is NOT filtered from the mailbox
+     * during overtake, so live external MIDI does land in the buffer it scans.
+     * That much is true -- Move plays those notes on its own instrument, which
+     * is how you can see them arrive.
+     *
+     * It does not stall the drain, and the reason is the packet RATE. Move
+     * consumes MIDI_IN every frame, so holding the counter at zero needs a
+     * packet in essentially every 2.9 ms frame -- about 340/second sustained.
+     * A held note is ONE packet, and a mod-wheel or pitch-bend sweep is 100-200
+     * per second, so both still leave the two clear frames the counter needs.
+     * Verified on hardware with Chord Finder: pads, sustained mod wheel and
+     * pitch bend, 205 drains, no dropouts. Something that genuinely saturates
+     * every frame could still stall this; nothing a controller produces does. */
 
     /* Shim-originated packets first, and independent of the ring: they must
      * still reach Move while an overtake module is up, which is precisely when


### PR DESCRIPTION
Replaces the `OPEN` marker I left at the MIDI_IN defer guard when #312 landed. **Comment only, no behaviour change.**

## The finding was wrong

Reading the guard, the hazard looks real, and every fact in it is true:

- it wants two consecutive frames with an entirely empty MIDI_IN
- it resets on a non-zero slot on **any** cable
- cable 2 genuinely is **not** filtered from the mailbox during overtake

You can even watch the external notes arrive, because Move plays them on its own instrument. That is what made it convincing.

## What I never did was compute the rate

Move consumes MIDI_IN every frame, so holding the counter at zero needs a packet in essentially **every 2.9 ms frame — about 340/second, sustained**. A held note is *one* packet. A mod-wheel or pitch-bend sweep is 100–200 per second. Both leave the clear frames the counter needs, with room to spare.

My first repro could not even exercise it: I asked for a held key, which is a single note-on.

## Verified on hardware

Chord Finder, v0.12.1 + #312/#313, on `7291a6d7`: pads, sustained mod wheel, sustained pitch bend. **205 drains, 3 packets each (the triad), no dropouts, no aborts.**

Something that genuinely saturates every frame could still stall this. Nothing a controller produces does — and the comment now says so, with the number, so the next reader does not re-derive the same warning from the same true facts.

> A guard is not a bug because it *can* deny; it is a bug when something real makes it deny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbuNj8HH2zaYuuvVqhAwz3