### PR TITLE
LED drops: write_idx is a byte offset into 512 bytes and was a uint8_t

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1951,7 +1951,7 @@ muting every FX with no visible cause.
 
 Take full UI control in shadow mode. Listed in Tools menu below "Overtake" divider. Set `component_type: "overtake"` to keep the overtake lifecycle (LED clear, ~500 ms init delay, Shift+Vol+Jog-Click exit).
 
-Requirements: handle all MIDI via `onMidiMessageInternal/External`; use progressive LED init (output buffer holds ~64 packets, >60/frame overflows):
+Requirements: handle all MIDI via `onMidiMessageInternal/External`; use progressive LED init (the shadow-UI MIDI-out buffer holds **128 packets per flush**, and a write past that is refused rather than silently wrapped):
 
 ```javascript
 let ledInitPending = true;
@@ -1963,6 +1963,28 @@ globalThis.tick = function() {
 ```
 
 Lifecycle: host clears LEDs ("Loading...") → ~500 ms → `init()` → run → Shift+Vol+Jog Click → host clears LEDs ("Exiting...") → return to Move.
+
+**The old figure here was "~64 packets, >60/frame overflows", and it was a
+symptom, not a limit.** `shadow_midi_out_t.write_idx` is a byte offset into a
+512-byte buffer and was declared `uint8_t`, so it saturated at 255: only the
+first 63 packets were addressable, `write_idx = write_offset + 4` wrapped
+252 -> 0 and silently rewound the buffer mid-flush, and the
+`write_offset + 4 <= SHADOW_MIDI_OUT_BUFFER_SIZE` bounds check could never fire
+because a `uint8_t` cannot reach 512 — it read as a working overflow guard and
+was dead code.
+
+Widening it to `uint16_t` costs nothing (it takes a reserved byte, `sizeof` is
+unchanged, and both mappers use `sizeof`). A `_Static_assert` beside the field
+now requires it to be able to address its own buffer.
+
+Two consequences worth holding on to. **A dropped LED was permanent, not a
+flicker**: `input_filter`'s `setLED` recorded the colour it believed it had
+sent and suppressed the next identical repaint, so a lost packet was never
+retried. It now caches only on a successful send. And **`move_midi_internal_send`
+returned true either way** — the write discarded and reported success, which is
+the same defect class as the tri-state read rule above. It now returns false and
+the drop is counted and logged (rate-limited, from `shadow_ui`, which is
+SCHED_OTHER and may log). Pinned by `tests/host/test_shadow_midi_out_capacity.c`.
 
 Reference: `src/modules/controller/ui.js`.
 

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -528,11 +528,31 @@ typedef struct shadow_param_t {
  * to external USB devices (cable 2) or control Move LEDs (cable 0).
  */
 typedef struct shadow_midi_out_t {
-    volatile uint8_t write_idx;      /* Shadow UI increments after writing */
+    /* uint16_t, and it MUST be: the buffer is 512 bytes and this is a BYTE
+     * offset into it. As a uint8_t it saturated at 255, so
+     *   - only the first 63 packets of a 128-packet buffer were addressable,
+     *     and the back half was never read at all;
+     *   - `write_idx = write_offset + 4` wrapped 252 -> 0, silently rewinding
+     *     the buffer so later packets overwrote earlier ones mid-flush;
+     *   - the `write_offset + 4 <= SHADOW_MIDI_OUT_BUFFER_SIZE` bounds check
+     *     in js_shadow_midi_send could never fire, because a uint8_t cannot
+     *     reach 512. The guard read as a working overflow check and was dead.
+     * This is the "~64 packets, >60/frame overflows" limit CLAUDE.md recorded
+     * as a property of the buffer; it was a property of THIS FIELD. Widening it
+     * costs nothing — it takes one of the reserved bytes, so sizeof is
+     * unchanged and both mappers (shadow_ui.c:83, schwung_shim.c:3417) use
+     * sizeof. */
+    volatile uint16_t write_idx;     /* Shadow UI increments after writing */
     volatile uint8_t ready;          /* Toggle to signal new data */
-    volatile uint8_t reserved[2];
+    volatile uint8_t reserved[1];
     uint8_t buffer[SHADOW_MIDI_OUT_BUFFER_SIZE];  /* USB-MIDI packets (4 bytes each) */
 } shadow_midi_out_t;
+
+/* The field above is load-bearing and its width is not obvious from its uses.
+ * A byte offset into the buffer must be able to reach the end of it. */
+_Static_assert((1ull << (8 * sizeof(((shadow_midi_out_t *)0)->write_idx))) >
+                   SHADOW_MIDI_OUT_BUFFER_SIZE,
+               "shadow_midi_out_t.write_idx cannot address its own buffer");
 
 /*
  * MIDI-to-DSP structure for shadow UI to send MIDI to chain DSP slots.

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -1349,6 +1349,12 @@ static JSValue js_shadow_get_param(JSContext *ctx, JSValueConst this_val, int ar
 
 /* === MIDI output functions for overtake modules === */
 
+/* Packets discarded because the shadow-UI MIDI-out SHM buffer was full when
+ * the caller wrote. Was silently zero-information before: the write returned
+ * success either way. See js_shadow_midi_send. */
+static long shadow_midi_out_drops = 0;
+
+
 /* Common implementation for sending MIDI via shared memory */
 static JSValue js_shadow_midi_send(int cable, JSContext *ctx, JSValueConst this_val,
                                    int argc, JSValueConst *argv) {
@@ -1365,6 +1371,7 @@ static JSValue js_shadow_midi_send(int cable, JSContext *ctx, JSValueConst this_
     JS_FreeValue(ctx, len_val);
 
     /* Process 4 bytes at a time (USB-MIDI packet format) */
+    int dropped = 0;
     for (int i = 0; i < len; i += 4) {
         uint8_t packet[4] = {0, 0, 0, 0};
 
@@ -1383,12 +1390,37 @@ static JSValue js_shadow_midi_send(int cable, JSContext *ctx, JSValueConst this_
         int write_offset = shadow_midi_out->write_idx;
         if (write_offset + 4 <= SHADOW_MIDI_OUT_BUFFER_SIZE) {
             memcpy(&shadow_midi_out->buffer[write_offset], packet, 4);
-            shadow_midi_out->write_idx = write_offset + 4;
+            shadow_midi_out->write_idx = (uint16_t)(write_offset + 4);
+        } else {
+            dropped++;
         }
     }
 
     /* Signal shim that data is ready */
     shadow_midi_out->ready++;
+
+    /* A write that discards and reports success is how an LED goes permanently
+     * wrong: input_filter's setLED records the colour it believes the hardware
+     * now shows and suppresses the next identical repaint, so a packet lost
+     * here is never retried. Report the failure so the caller can decline to
+     * cache it, and count it so "sometimes drops LEDs" is a number rather than
+     * a feeling. Logging here is safe — shadow_ui is a separate SCHED_OTHER
+     * process, not the SPI callback — but it is rate-limited so a flood cannot
+     * turn a dropped LED into a dropped audio block. */
+    if (dropped) {
+        shadow_midi_out_drops += dropped;
+        static time_t last_report = 0;
+        time_t now = time(NULL);
+        if (now != last_report) {
+            last_report = now;
+            unified_log("shadow_ui", LOG_LEVEL_DEBUG,
+                        "shadow MIDI out: buffer full, dropped %d packet(s) "
+                        "(%ld total) - more than %d bytes queued in one flush",
+                        dropped, shadow_midi_out_drops,
+                        SHADOW_MIDI_OUT_BUFFER_SIZE);
+        }
+        return JS_FALSE;
+    }
 
     return JS_TRUE;
 }

--- a/src/shared/input_filter.mjs
+++ b/src/shared/input_filter.mjs
@@ -62,18 +62,32 @@ export function getPadIndex(noteNumber) {
 const ledCache = new Array(128).fill(-1);
 const buttonCache = new Array(128).fill(-1);
 
+/*
+ * Cache what the hardware shows ONLY if the packet was actually queued.
+ *
+ * These two suppress a repaint matching the cache, which is what keeps a full
+ * redraw from costing 128 packets a frame. The cost of that is that a write
+ * recorded but never delivered is never retried — the LED stays wrong until
+ * its value happens to change, which for a pad that is simply "off" can be
+ * forever. move_midi_internal_send returns false when the shadow-UI MIDI-out
+ * buffer was full, so record -1 and let the next draw re-emit it.
+ *
+ * -1 rather than leaving the previous value: the previous value is a claim
+ * about the hardware that we have just failed to make true.
+ */
+
 /* Set LED color for a note (pad, step, etc.) */
 export function setLED(note, color, force = false) {
     if (!force && ledCache[note] === color) return;
-    ledCache[note] = color;
-    move_midi_internal_send([0x09, MidiNoteOn, note, color]);
+    const sent = move_midi_internal_send([0x09, MidiNoteOn, note, color]);
+    ledCache[note] = sent ? color : -1;
 }
 
 /* Set LED color via CC (for buttons) */
 export function setButtonLED(cc, color, force = false) {
     if (!force && buttonCache[cc] === color) return;
-    buttonCache[cc] = color;
-    move_midi_internal_send([0x0b, MidiCC, cc, color]);
+    const sent = move_midi_internal_send([0x0b, MidiCC, cc, color]);
+    buttonCache[cc] = sent ? color : -1;
 }
 
 /*

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -19,11 +19,18 @@ LDFLAGS = -lpthread
 # changed. CI does a clean build and never saw it; a local mutation check does,
 # and silently concluded the mutation was harmless. -MMD emits a .d per target,
 # -MP adds phony targets so a DELETED header does not wedge the build.
-DEPFLAGS = -MMD -MP
+# -MF names ONE dep file explicitly. Without it, -MMD on a rule with several
+# sources asks the compiler to emit several .d files while -o names one output;
+# gcc tolerates that, clang refuses ("cannot specify -o when generating multiple
+# output files"). CI is gcc, so it went green; the local failure only appears
+# once the multi-source targets actually rebuild, which is why it survived the
+# commit that introduced it.
+DEPFLAGS = -MMD -MP -MF $@.d
 
 BUILD_DIR = ../../build/tests/host
 
 TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
+	$(BUILD_DIR)/test_shadow_midi_out_capacity \
 	$(BUILD_DIR)/test_overtake_midi_route \
 	$(BUILD_DIR)/test_ext_midi_ring \
 	$(BUILD_DIR)/test_overtake_native_led_repaint \

--- a/tests/host/test_shadow_midi_out_capacity.c
+++ b/tests/host/test_shadow_midi_out_capacity.c
@@ -1,0 +1,106 @@
+/*
+ * Can shadow_midi_out_t.write_idx address its own buffer?
+ *
+ * It could not. The buffer is 512 bytes and write_idx was a uint8_t, so:
+ *
+ *   - only the first 63 packets were reachable; the back half of the buffer
+ *     was never written and never read;
+ *   - `write_idx = write_offset + 4` wrapped 252 -> 0, silently rewinding the
+ *     buffer mid-flush so later packets overwrote earlier ones;
+ *   - the `write_offset + 4 <= SHADOW_MIDI_OUT_BUFFER_SIZE` bounds check in
+ *     js_shadow_midi_send could never fire, because a uint8_t cannot reach
+ *     512. It read as a working overflow check and was dead code.
+ *
+ * Symptom on hardware: an overtake module playing heavily loses LED updates,
+ * permanently, because input_filter's setLED caches the colour it believes it
+ * sent and suppresses the next identical repaint.
+ *
+ * This is the "~64 packets, >60/frame overflows" limit CLAUDE.md recorded as a
+ * property of the buffer. It was a property of the FIELD.
+ *
+ * The test drives the real write loop against the real struct, so it fails if
+ * the field is ever narrowed back — which is the only way this returns.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "shadow_constants.h"
+
+static int failures = 0;
+
+static void check(int cond, const char *what) {
+    if (cond) {
+        printf("  ok   %s\n", what);
+    } else {
+        printf("  FAIL %s\n", what);
+        failures++;
+    }
+}
+
+/* Byte-for-byte the write step of js_shadow_midi_send. Returns 1 if queued. */
+static int push_packet(shadow_midi_out_t *m, const uint8_t pkt[4]) {
+    int write_offset = m->write_idx;
+    if (write_offset + 4 <= SHADOW_MIDI_OUT_BUFFER_SIZE) {
+        memcpy(&m->buffer[write_offset], pkt, 4);
+        m->write_idx = (uint16_t)(write_offset + 4);
+        return 1;
+    }
+    return 0;
+}
+
+int main(void) {
+    static shadow_midi_out_t m;
+    const int CAPACITY = SHADOW_MIDI_OUT_BUFFER_SIZE / 4;
+
+    /* 1. THE WHOLE BUFFER IS REACHABLE. */
+    printf("every packet the buffer has room for is accepted\n");
+    memset(&m, 0, sizeof(m));
+    int queued = 0;
+    for (int i = 0; i < CAPACITY; i++) {
+        uint8_t pkt[4] = { 0x09, 0x90, (uint8_t)i, 100 };
+        queued += push_packet(&m, pkt);
+    }
+    check(queued == CAPACITY, "all 128 packets queued, not 63");
+    check(m.write_idx == SHADOW_MIDI_OUT_BUFFER_SIZE,
+          "write_idx reaches the end of the buffer");
+
+    /* 2. NOTHING REWOUND. The wrap overwrote packet 0 with packet 64; the
+     * note number in each slot is what proves it did not happen here. */
+    printf("no packet was overwritten by a later one\n");
+    int intact = 1;
+    for (int i = 0; i < CAPACITY; i++)
+        if (m.buffer[i * 4 + 2] != (uint8_t)i) { intact = 0; break; }
+    check(intact, "every slot still holds the packet written to it");
+
+    /* 3. THE GUARD ACTUALLY FIRES. It could not before: a uint8_t
+     * write_offset cannot reach 512, so the bounds check was unreachable and
+     * a full buffer was indistinguishable from a successful write. */
+    printf("a full buffer refuses, and says so\n");
+    uint8_t extra[4] = { 0x09, 0x90, 127, 100 };
+    check(push_packet(&m, extra) == 0, "the packet past the end is refused");
+    check(m.write_idx == SHADOW_MIDI_OUT_BUFFER_SIZE,
+          "and a refused write does not advance the cursor");
+
+    /* 4. THE SHIM READS WHAT WAS WRITTEN. shadow_inject_ui_midi_out does
+     * `int snapshot_len = midi_out_shm->write_idx`, so a field that cannot
+     * express the length silently truncates the drain as well as the fill. */
+    printf("the length the shim reads covers everything written\n");
+    int snapshot_len = m.write_idx;
+    check(snapshot_len == SHADOW_MIDI_OUT_BUFFER_SIZE,
+          "the drain sees all 512 bytes, not the low 8 bits of the count");
+
+    /* 5. THE STRUCT DID NOT GROW. Both processes map by sizeof and are built
+     * together, but a size change is still an ABI change and this one was
+     * meant to be free — it takes a reserved byte. */
+    printf("widening the field cost no memory\n");
+    check(sizeof(shadow_midi_out_t) == 4 + SHADOW_MIDI_OUT_BUFFER_SIZE,
+          "sizeof is unchanged at header + buffer");
+
+    if (failures) {
+        printf("FAILURES: %d\n", failures);
+        return 1;
+    }
+    printf("PASS: shadow MIDI out buffer is fully addressable\n");
+    return 0;
+}


### PR DESCRIPTION
Reported from hardware: Chord Finder loses LED updates when you play a lot of notes. Asked whether it was the module, too many messages, or the host.

**It's the host, and the mechanism is one word wide.**

## The bug

`shadow_midi_out_t.write_idx` is a **byte offset into a 512-byte buffer**, declared `uint8_t`. So it saturated at 255:

- only the first **63** packets of a 128-packet buffer were addressable — the back half was never written and never read
- `write_idx = write_offset + 4` wrapped **252 → 0**, silently rewinding the buffer mid-flush so later packets overwrote earlier ones
- the `write_offset + 4 <= SHADOW_MIDI_OUT_BUFFER_SIZE` bounds check in `js_shadow_midi_send` **could never fire**, because a `uint8_t` cannot reach 512. It read as a working overflow guard and was dead code.

CLAUDE.md has recorded this for as long as overtake modules have existed — *"output buffer holds ~64 packets, >60/frame overflows"* — as a property of the **buffer**. 255/4 = 63.75. It was a property of the **field**, and module authors have been writing progressive-LED-init workarounds around a one-character bug.

Widening to `uint16_t` costs nothing: it takes one of the two reserved bytes, `sizeof` is unchanged, and both mappers (`shadow_ui.c:83`, `schwung_shim.c:3417`) use `sizeof`. A `_Static_assert` beside the field now requires it to address its own buffer.

## Two things made it invisible, both fixed here

- **`move_midi_internal_send` returned true whether or not the packet landed.** A write that discards and reports success is the same defect class as the tri-state read rule in CLAUDE.md. It now returns false and counts the drop, logged once a second from `shadow_ui` (SCHED_OTHER, not the SPI callback, so logging there is allowed).
- **`input_filter`'s `setLED`/`setButtonLED` recorded the colour they believed they had sent**, then suppressed the next identical repaint. So a lost packet was never retried and the LED stayed wrong until its value happened to change — which for a pad that is simply "off" is forever. That is why this reads as *"drops some LEDs"* rather than *"flickers"*. They now cache only on success.

## Test

`tests/host/test_shadow_midi_out_capacity.c` drives the real write loop against the real struct. Mutation-checked both ways: narrowing the field alone fails the `_Static_assert` at compile time; narrowing it **with the assert removed** fails 5 of the 7 runtime checks.

Worth noting the first check ("all 128 queued") *passes* under the mutation — a `uint8_t` makes every push report success while overwriting. It's the other four that catch it, which is why the test asserts on slot contents and cursor position rather than just the accept count.

## Also fixes a build regression I shipped in #313

`DEPFLAGS` was `-MMD -MP`. On a rule with several sources that asks for several `.d` files while `-o` names one output: **gcc tolerates it, clang refuses.** CI is gcc so it went green, and locally the multi-source targets did not need rebuilding, so it stayed hidden until they did. `-MF $@.d` names one dep file and both compilers are happy.

## Verified

ARM64 cross-compile clean (0 errors); `make -C tests/host test` and all `tests/host/*.sh` green from a clean build. **Not deployed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbuNj8HH2zaYuuvVqhAwz3