### PR TITLE
shutdown prompt: park the overtake tool, do not tear it down

### DIFF
--- a/src/host/shadow_dbus.c
+++ b/src/host/shadow_dbus.c
@@ -206,8 +206,37 @@ static void shadow_dbus_handle_text(const char *text)
             *host.display_mode = 0;
             ctrl->display_mode = 0;
         }
-        /* Clear overtake mode so jog click reaches Move for shutdown confirm */
-        ctrl->overtake_mode = 0;
+        /* The jog click has to reach Move to confirm, so the tool must let go
+         * of the surface either way. The question is whether it is TORN DOWN
+         * or PARKED — and Back from this prompt is the common outcome, not the
+         * rare one, because the prompt is also what a mis-hold produces.
+         *
+         * A full overtake module (mode 2) is suspended, exactly as
+         * Shift+Vol+Back does it (schwung_shim.c, "suspend overtake"): raise
+         * suspend_overtake + JUMP_TO_OVERTAKE and let the JS side act. Its
+         * suspendOvertakeMode() parks the module in `suspendedOvertakes` with
+         * its callbacks alive and then calls shadow_set_overtake_mode(0)
+         * itself, so the wheel still reaches Move — and the tool resumes from
+         * the Tools menu instead of reloading from scratch.
+         *
+         * DO NOT clear overtake_mode here as well. The shim CONSUMES
+         * suspend_overtake on the mode -> 0 edge (see shim_post_transfer,
+         * "Skip if suspend_overtake is set"), so clearing it from this thread
+         * eats the flag before the JS tick reads it, and the JS falls through
+         * to exitOvertakeMode() — the teardown this exists to avoid, with no
+         * symptom other than the module being gone.
+         *
+         * Mode 1 is the overtake MENU, which has nothing to park; the JS
+         * branch for JUMP_TO_OVERTAKE outside VIEWS.OVERTAKE_MODULE opens the
+         * Tools menu, which is not what a shutdown prompt should do. It keeps
+         * the plain clear. */
+        if (ctrl->overtake_mode >= 2) {
+            host.log("Shutdown prompt: suspending overtake module (not exiting)");
+            ctrl->suspend_overtake = 1;
+            ctrl->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_OVERTAKE;
+        } else {
+            ctrl->overtake_mode = 0;
+        }
     }
 
     /* Track native Move sampler source from stock announcements. */

--- a/tests/host/test_shutdown_prompt_suspends_overtake.sh
+++ b/tests/host/test_shutdown_prompt_suspends_overtake.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Move's shutdown prompt must SUSPEND a full overtake module, not exit it.
+#
+# The prompt is what a mis-held power button produces, so Back is the common
+# outcome. Tearing the tool down on the way in means a stray press costs the
+# user their session; parking it means Back leaves it resumable from the Tools
+# menu with its callbacks alive.
+#
+# The trap this exists for: the shim CONSUMES suspend_overtake on the
+# overtake_mode -> 0 edge. Clearing the mode from shadow_dbus.c as well eats
+# the flag before the JS tick reads it, JS falls through to exitOvertakeMode(),
+# and the ONLY symptom is that the module is gone — which is also the old
+# behaviour, so it reads as "the fix didn't work" rather than as a bug.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+file="src/host/shadow_dbus.c"
+
+# Extract the shutdown-prompt block: from the strcasecmp guard to the line
+# where brace depth returns to its starting level.
+block=$(awk '
+  /strcasecmp\(text, "Press wheel to shut down"\)/ { inblk = 1 }
+  inblk {
+    print
+    n = gsub(/\{/, "{"); m = gsub(/\}/, "}")
+    depth += n - m
+    if (seen && depth <= 0) exit
+    if (n > 0) seen = 1
+  }
+' "$file")
+
+if [ -z "$block" ]; then
+  echo "FAIL: could not find the shutdown-prompt block in $file" >&2
+  exit 1
+fi
+
+# --- The suspend path exists at all -----------------------------------------
+if ! printf '%s' "$block" | rg -q 'suspend_overtake = 1'; then
+  echo "FAIL: shutdown prompt does not raise suspend_overtake" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$block" | rg -q 'SHADOW_UI_FLAG_JUMP_TO_OVERTAKE'; then
+  echo "FAIL: shutdown prompt does not raise JUMP_TO_OVERTAKE — the JS side" \
+       "never runs suspendOvertakeMode() without it" >&2
+  exit 1
+fi
+
+# --- It is scoped to a real module, not the overtake MENU --------------------
+# Mode 1 has nothing to park, and JUMP_TO_OVERTAKE outside VIEWS.OVERTAKE_MODULE
+# opens the Tools menu, which a shutdown prompt must not do.
+if ! printf '%s' "$block" | rg -q 'overtake_mode >= 2'; then
+  echo "FAIL: the suspend path is not gated on overtake_mode >= 2" >&2
+  exit 1
+fi
+
+# --- THE TRAP: the suspend branch must not clear the mode --------------------
+# Take everything from the `>= 2` test up to the `else`.
+suspend_branch=$(printf '%s' "$block" | awk '/overtake_mode >= 2/ { inb = 1 } inb { print } /^ *\} else \{/ { if (inb) exit }')
+
+if [ -z "$suspend_branch" ]; then
+  echo "FAIL: could not isolate the suspend branch" >&2
+  exit 1
+fi
+
+if printf '%s' "$suspend_branch" | rg -q 'overtake_mode = 0'; then
+  echo "FAIL: the suspend branch clears overtake_mode." >&2
+  echo "      The shim consumes suspend_overtake on the mode -> 0 edge, so this" >&2
+  echo "      eats the flag before the JS tick reads it and the module is torn" >&2
+  echo "      down instead of parked. Let suspendOvertakeMode() clear the mode." >&2
+  exit 1
+fi
+
+# --- The non-module path still clears ---------------------------------------
+# Without this the wheel never reaches Move from the overtake menu and the
+# device cannot be shut down at all.
+else_branch=$(printf '%s' "$block" | awk '/^ *\} else \{/ { inb = 1 } inb { print }')
+
+if ! printf '%s' "$else_branch" | rg -q 'overtake_mode = 0'; then
+  echo "FAIL: the non-module path no longer clears overtake_mode — the jog" \
+       "click cannot reach Move to confirm shutdown" >&2
+  exit 1
+fi
+
+# --- The save still happens, on every path ----------------------------------
+# This is what the whole block was originally for; the suspend must not have
+# displaced it.
+if ! printf '%s' "$block" | rg -q 'SHADOW_UI_FLAG_SAVE_STATE'; then
+  echo "FAIL: shutdown prompt no longer requests a state save" >&2
+  exit 1
+fi
+
+if ! printf '%s' "$block" | rg -q 'host\.save_state\(\)'; then
+  echo "FAIL: shutdown prompt no longer calls host.save_state()" >&2
+  exit 1
+fi
+
+echo "PASS: shutdown prompt suspends a full overtake module and still saves"


### PR DESCRIPTION
## What

Move's "Press wheel to shut down" prompt cleared `overtake_mode` outright, which runs the **full overtake exit** — LED restore, release injects, teardown. Back out of the prompt and the tool is gone; you reselect it from the Tools menu and it reloads from scratch.

The prompt is also what a *mis-held* power button produces, so **Back is the common outcome, not the rare one**, and a stray press costs a session.

## Why the clear can't just be deleted

The wheel has to reach Move to confirm the shutdown. But "let go of the surface" and "be destroyed" are different things — and the codebase already has the first one. Shift+Vol+Back suspends, and `suspendOvertakeMode()` parks the module in `suspendedOvertakes` with its callbacks alive, then calls `shadow_set_overtake_mode(0)` **itself**. So the wheel still reaches Move, and Back leaves something resumable.

Mode 2 now takes that path, verbatim as the shim's own Shift+Vol+Back does. Mode 1 (the overtake *menu*) keeps the plain clear: it has nothing to park, and `JUMP_TO_OVERTAKE` outside `VIEWS.OVERTAKE_MODULE` opens the Tools menu, which a shutdown prompt must not do.

## The trap

The shim **consumes** `suspend_overtake` on the `overtake_mode -> 0` edge. Clear the mode in `shadow_dbus.c` as well and the flag is eaten before the JS tick reads it, JS falls through to `exitOvertakeMode()`, and **the only symptom is the module being gone** — identical to the old behaviour, so it reads as "the fix didn't work" rather than as a bug. Nothing at either site says so.

`tests/host/test_shutdown_prompt_suspends_overtake.sh` pins it. Mutation-checked three ways, all caught:

| mutation | result |
|---|---|
| re-add the mode clear inside the suspend branch | FAIL |
| drop the `JUMP_TO_OVERTAKE` raise | FAIL |
| revert to the unconditional clear | FAIL |

It also pins the state save, which is what the block was originally for and must not be displaced.

## Scope — this does not touch persistence

Verified on hardware **before** writing anything that the save already fires from inside an overtake module:

```
[shim]   Shutdown prompt detected — saving state and dismissing shadow UI
[shadow] SAVE_STATE flag detected — shutdown imminent, saving all state
[shim]   Saved slots: ch=[0,1,2,3] fwd=[0,0,-1,-1] vol=[0.66,1.00,1.00,1.00] ...
```

0 ms apart. An earlier theory that #292 had opened a data-loss window by making shutdown reachable from inside a tool was **wrong** — the flag block runs on every tick with no overtake gate, deliberately. This PR changes only whether the tool survives, never whether state persists.

## Not fixed here

Nothing auto-resumes the tool when the prompt is dismissed. **Move emits no announcement on Back** — the D-Bus log is silent after the prompt — so there is nothing to detect. That is why two earlier auto-resume attempts (in movy's plan doc) were reverted; a trigger would have to come from the shim watching the surface, not from D-Bus. This at least makes the reselect cheap: the module is parked, not reloaded.

## Testing

- 182/182 `tests/host/*.sh`, C units pass
- ARM64 cross-compile clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pp8ijwjK2aRD3rkRa68B1n