### PR TITLE
param pages: two options is not a menu, so the click flips it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -627,16 +627,52 @@ two-option enum in the wire format (`["—","Rnd!"]`), so a predicate written on
 the option count alone turns every momentary in the fleet into a latch —
 euclidrum randomises a kit on the way past. Readouts are excluded the same way.
 
-**Both editors flip**, or the same parameter answers the same gesture two
-different ways depending on a Param View setting the user can flip — the drift
-`test_knob_surfaces_access.sh` exists to catch on the trigger latch. The
-hierarchy editor restates the predicate rather than importing it, because its
-meta is the RAW `chain_params` declaration (`type`, not `kind`, and no
-`divable` at all); the two exclusions `divable` carries are its own two early
-returns immediately above. `tests/host/test_two_option_enum_flip.sh` pins the
-lot — and its list-editor probe was anchored on the first `type === "enum"` in
+**THE FLIP IS THE GRID'S ANSWER. A LIST FOCUSES INSTEAD.** Both list surfaces
+— `knobsAsList` (Param View: List, and whatever the screen reader forces) and
+the hierarchy editor — put a two-option enum into EDIT MODE on click and let
+the jog step it, exactly like a float row. The flip needs a knob under your
+hand to be the saving it claims; a list has none, so a row that changed value
+the instant you clicked it would be the one row on the page with no focus
+state. Reported from the device: *"just show it focus and let jog change it.
+then it's the same gesture for each row. otherwise it's invisible."*
+
+`flipsOnClick` is still what both consult — it is the definition of "this enum
+is a two-way", not of "flip". The grid flips that set and the list focuses it,
+so the two can differ about what a two-way DOES without ever drifting about
+WHICH params are two-way. In `page_controller` it is the term that WIDENS the
+knobsAsList edit gate past `!divable`; the hierarchy editor restates the count
+instead, because its meta is the RAW `chain_params` declaration (`type`, not
+`kind`, and no `divable` at all) and the two exclusions `divable` carries are
+its own two early returns immediately above.
+
+`tests/host/test_two_option_enum_flip.sh` pins the grid half and the picker
+skip; `test_list_layout_footer.sh` drives the focus for real, clicking a
+two-option row and jogging it both ways — a footer assertion alone would pass
+with EDIT advertised over a row the jog does nothing to. The flip test's
+list-editor probe was anchored on the first `type === "enum"` in
 `shadow_ui.js` first, which landed on `isTriggerEnumMeta` 1500 lines earlier
-and stayed GREEN with the flip deleted.
+and stayed GREEN with the branch deleted.
+
+### A knob page drawn as a LIST has three states, and said none of them
+
+`footerHints()` had no branch for `knobsAsList` at all and fell through to the
+GRID's answer, `JOG PAGE / CLK MENU`, which is wrong outside the list, inside
+it and while editing a row. With Param View on List — or the screen reader on,
+which forces the layout — that is the only footer there is, and Global Settings
+is driven entirely by the jog. Now `JOG PAGE / CLK ENTER`, then
+`JOG SEL / CLK <row verb> / BACK OUT`, then `JOG ADJ / CLK DONE / BACK OUT`.
+
+The row verb is the ROW's, mirroring `onClick`'s ladder: `FIRE` a trigger,
+`EDIT` anything turnable that is not a longer enum (which now includes a
+two-option one), `OPEN` anything else divable. A readout gets **no** click pair
+— an absence is the truth and a verb would be a promise.
+
+**It must precede the held-knob branch**, and not for tidiness: in this layout
+`onClick` takes its param from the ROW CURSOR and overrides whatever knob is
+under your hand, so the held-knob footer describes a cell the click will not
+act on. Same promise-versus-behaviour bug that branch's own comments record
+twice, reached from the other side. Pinned as an ordering, and the seek loops
+in the test are BOUNDED because the row cursor clamps rather than wrapping.
 
 Past two options, the list is unchanged. Any enum that declares `options` is
 divable: hold its knob, click, pick from a scrolling list, Back cancels. The knob still steps it one detent at a time —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -595,10 +595,51 @@ byte-identical against `tests/fixtures/movy-geom-baseline.txt`
 Preview it without deploying: `node tools/param-pages/preview_knob_card.mjs
 <module-id> --knob N [--short] [--png DIR --scale 4]`.
 
-### Every enum opens a LIST
+### Every enum opens a LIST — except at TWO options, where the click FLIPS it
 
-Any enum that declares `options` is divable: hold its knob, click, pick from a
-scrolling list, Back cancels. The knob still steps it one detent at a time —
+A picker over two items is a menu whose entire content is the value already
+visible in the cell and the one other value there is, and it charges two
+gestures for a state one gesture can describe. So a two-option enum WRITES THE
+OTHER VALUE on click and never raises the list. Reported from the device
+against Global Settings' Mirror Display and Move->Schwung — *"if an option has
+two values, clicking it should change the option ... we dont need a whole menu
+for two items"*.
+
+**Deliberately NOT limited to booleans, and that is the interesting part.**
+`drawnAsSwitch` splits Off/On (212 fleet cells) from a two-way CHOICE —
+`Mix/Reverb`, `Saw/Square`, `Legato/Trig` (134 cells) — and that split is right
+for the PEEK, which exists to show a word the cell has no room for. It is wrong
+here: what the flip removes is the SECOND GESTURE, and a choice pays that
+exactly as a boolean does. Two rules over the same population, disagreeing on
+purpose.
+
+`flipsOnClick` (`param_meta.mjs`) is ONE definition serving two questions that
+must not disagree — what the click does (`page_controller.onClick`) and what
+the footer promises while the knob is held (`CLK FLIP`, not `CLK OPEN`). The
+divable/opaque pair beside it is written up as exactly that failure three times
+over: a cell became a door and the footer had to be told separately, so it
+advertised `CLK MENU` over a click that opened an editor. **The FLIP branch
+must precede the divable OPEN branch** — a two-option enum is still divable, so
+OPEN claims it otherwise.
+
+**It requires `divable`, which is what keeps TRIGGERS out.** A trigger is a
+two-option enum in the wire format (`["—","Rnd!"]`), so a predicate written on
+the option count alone turns every momentary in the fleet into a latch —
+euclidrum randomises a kit on the way past. Readouts are excluded the same way.
+
+**Both editors flip**, or the same parameter answers the same gesture two
+different ways depending on a Param View setting the user can flip — the drift
+`test_knob_surfaces_access.sh` exists to catch on the trigger latch. The
+hierarchy editor restates the predicate rather than importing it, because its
+meta is the RAW `chain_params` declaration (`type`, not `kind`, and no
+`divable` at all); the two exclusions `divable` carries are its own two early
+returns immediately above. `tests/host/test_two_option_enum_flip.sh` pins the
+lot — and its list-editor probe was anchored on the first `type === "enum"` in
+`shadow_ui.js` first, which landed on `isTriggerEnumMeta` 1500 lines earlier
+and stayed GREEN with the flip deleted.
+
+Past two options, the list is unchanged. Any enum that declares `options` is
+divable: hold its knob, click, pick from a scrolling list, Back cancels. The knob still steps it one detent at a time —
 the list is the other half, for a Recv Ch with seventeen options or a Braids
 model with forty-seven. `VIEWS.ENUM_PICKER`, `drawEnumPicker` in
 `src/shadow/shadow_ui.js`, hints `JOG SEL` / `CLK SET` / `BACK EXIT`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -653,6 +653,48 @@ list-editor probe was anchored on the first `type === "enum"` in
 `shadow_ui.js` first, which landed on `isTriggerEnumMeta` 1500 lines earlier
 and stayed GREEN with the branch deleted.
 
+### Two values means the DETENT TOGGLES, once per flick
+
+There were three spellings of one control and two of them had a dead
+direction: an Off/On (or int 0..1) boolean was direction-ABSOLUTE — right meant
+On, left meant Off, so at Off a left turn did nothing forever — while a two-way
+CHOICE like Mix/Reverb fell to the enum branch and CLAMPED behind the
+four-detent gate, so at Mix a left turn did nothing forever and a right turn
+took four detents to do anything.
+
+Reported from the device: *"if there are only two, why not let it wrap
+otherwise you have to know which way is off and which way is on, in which case
+you need some knowledge you dont have."* There is no way to acquire it — the
+cell shows a STATE, not a direction. Same argument that makes a trigger fire in
+either direction.
+
+**WRAPPING ALONE WOULD NOT DO, and that is the part worth keeping.** With two
+values, "wrap" and "toggle on every detent" are the same thing, and one flick
+of an encoder is a dozen detents — so a flick would land on whichever value the
+detent count happened to be even or odd about. `isTwoWayMeta` in
+`knob_engine.mjs` therefore pairs the toggle with a LATCH at
+`TWO_WAY_GESTURE_GAP_MS`, the same number and the same rule as
+`TRIGGER_KNOB_GESTURE_GAP_MS`: **one flick is one gesture.** And it is a latch
+rather than a rate limit — the stamp is the last **DETENT**, so the clock runs
+on STILLNESS. That distinction shipped wrong once already on the trigger and
+was reported from hardware; `test_two_way_knob_toggle.sh` pins it as a
+sequence, and pins the two constants EQUAL by number, because a user cannot
+learn two flick lengths for two controls that look alike.
+
+**It lives in the ENGINE, so every surface inherits it** — knob grid, knob
+card, list edit mode, the hierarchy editor and the patches screen all reach
+`knobStep`. A TRIGGER is excluded there by `access: "write"`, not by option
+count: it is a two-option enum on the wire, and toggling it writes "do nothing"
+on every other flick, which for euclidrum is the write that destroys a kit.
+Three or more options are untouched — they keep the gate and they CLAMP, because
+wrapping a 47-model list makes the end of it unreachable by feel.
+
+Consequence worth knowing: the jog in list edit mode routes through
+`knobEditStep` -> `onKnobTurn` -> `knobStep`, so it inherits the latch too. A
+deliberate jog detent is 1:1 everywhere else, so flipping a two-way twice in
+under ~270 ms from the jog is swallowed. Deliberate, and the cheapest place to
+revisit if it ever reads wrong.
+
 ### A knob page drawn as a LIST has three states, and said none of them
 
 `footerHints()` had no branch for `knobsAsList` at all and fell through to the

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1939,11 +1939,16 @@ Every enum with a non-empty `options` array is **divable**: on the knob grid,
 holding its knob and clicking opens a scrolling option list. You get this for
 free — there is nothing to declare, and nothing to declare it away.
 
-**Except at exactly two options, where the click FLIPS it instead.** A list of
-two is a menu whose whole content is the value already in the cell and the one
-other value there is, so the click writes the other one and the picker is never
-raised — the footer reads `CLK FLIP` rather than `CLK OPEN`. The knob still
-steps it, and the same rule applies in the list view.
+**Except at exactly two options, where there is no list to open.** On the knob
+grid the click FLIPS it — the picker would show the value already in the cell
+and the one other value there is — and the footer reads `CLK FLIP` rather than
+`CLK OPEN`. The knob still steps it.
+
+In the **list** view the same parameter is FOCUSED instead: click puts the row
+into edit mode and the jog steps it, exactly like a float row. The flip only
+saves a gesture when a knob is already under your hand, and in a list none is,
+so flipping there would leave one row with no focus state while every other row
+has one.
 
 This is a different line from the `switch` distinction two sections up, and
 they do not have to agree: a switch is a **boolean-flavoured** two-option enum

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1939,6 +1939,23 @@ Every enum with a non-empty `options` array is **divable**: on the knob grid,
 holding its knob and clicking opens a scrolling option list. You get this for
 free — there is nothing to declare, and nothing to declare it away.
 
+**Except at exactly two options, where the click FLIPS it instead.** A list of
+two is a menu whose whole content is the value already in the cell and the one
+other value there is, so the click writes the other one and the picker is never
+raised — the footer reads `CLK FLIP` rather than `CLK OPEN`. The knob still
+steps it, and the same rule applies in the list view.
+
+This is a different line from the `switch` distinction two sections up, and
+they do not have to agree: a switch is a **boolean-flavoured** two-option enum
+and only that group loses the peek, whereas *every* two-option enum flips —
+`Mix`/`Reverb` included. The peek exists to show a word the cell has no room
+for; the flip exists to save a gesture, and a choice pays that gesture exactly
+as a boolean does.
+
+Triggers (`access: "write"`) and readouts (`access: "read"`) are not divable at
+all, so neither flips: a trigger is a two-option enum on the wire, and firing
+it is not the same as setting it.
+
 **The cell marks do not mean "divable."** Measured over the fleet (2026-08):
 967 divable cells on knob pages, and **953 of them — 99% — wear no mark at
 all**, because almost every divable cell is an enum. Divability is announced by

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1939,6 +1939,12 @@ Every enum with a non-empty `options` array is **divable**: on the knob grid,
 holding its knob and clicking opens a scrolling option list. You get this for
 free — there is nothing to declare, and nothing to declare it away.
 
+**A two-option enum is turned differently, too.** With two values there is
+nowhere to go but the other one, so a detent TOGGLES it whichever way you
+turned — and one flick of the encoder is one flip, not a dozen. Three or more
+options keep the four-detent gate and clamp at the ends. A trigger
+(`access: "write"`) is never toggled; it fires.
+
 **Except at exactly two options, where there is no list to open.** On the knob
 grid the click FLIPS it — the picker would show the value already in the cell
 and the one other value there is — and the footer reads `CLK FLIP` rather than

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2882,15 +2882,39 @@ function openHierarchyParamEditor(selectedKey, meta, forceOpen) {
             index = (!isNaN(parsed) && parsed >= 0 && parsed < meta.options.length) ? parsed : 0;
         }
         const slot = hierEditorSlot;
+        const commit = (i) => {
+            setSlotParam(slot, fullKey, pluginUsesIndex ? String(i) : meta.options[i]);
+            if (shouldRefreshDynamicRateMeta(selectedKey)) refreshHierarchyChainParams();
+            refreshHierarchyVisibility();
+        };
+        /*
+         * TWO OPTIONS: the click FLIPS it rather than raising a list of the
+         * value you can see and the one other value there is. Same rule the
+         * knob grid applies (flipsOnClick in param_meta.mjs) and it has to be
+         * applied on BOTH editors or the same parameter answers the same
+         * gesture two different ways depending on a Param View setting the
+         * user can flip — which is the drift test_knob_surfaces_access.sh
+         * exists to catch on the trigger latch.
+         *
+         * The predicate is restated rather than imported because this meta is
+         * the RAW chain_params declaration, not a buildMetaIndex record: it
+         * has `type`, not `kind`, and no `divable` at all. The two guards that
+         * `divable` carries for the grid — trigger and readout — are the two
+         * early returns immediately above, so the exclusions are the same
+         * ones, reached a different way.
+         */
+        if (meta.options.length === 2) {
+            const next = index === 0 ? 1 : 0;
+            commit(next);
+            announce((meta.name || meta.label || selectedKey) + ", " + meta.options[next]);
+            needsRedraw = true;
+            return;
+        }
         openEnumPicker({
             title: meta.name || meta.label || selectedKey,
             options: meta.options,
             index,
-            commit: (i) => {
-                setSlotParam(slot, fullKey, pluginUsesIndex ? String(i) : meta.options[i]);
-                if (shouldRefreshDynamicRateMeta(selectedKey)) refreshHierarchyChainParams();
-                refreshHierarchyVisibility();
-            },
+            commit,
             returnToGrid: false,
         });
         return;
@@ -15477,6 +15501,13 @@ function drawHierarchyEditor() {
             hint = ["Click: keyboard", "Jog: scroll"];
         } else if (!hierEditorEditMode && selectedMeta && selectedMeta.type === "canvas") {
             hint = ["Click: open", "Jog: scroll"];
+        } else if (!hierEditorEditMode && selectedMeta && selectedMeta.type === "enum" &&
+                   Array.isArray(selectedMeta.options) && selectedMeta.options.length === 2 &&
+                   !isTriggerParam(selectedMeta) && !isReadoutParam(selectedMeta)) {
+            /* Two options: the click writes the other one rather than raising
+             * the picker, so say so. The grid's footer makes the same promise
+             * as CLK FLIP. */
+            hint = ["Click: flip", "Jog: scroll"];
         }
         drawFooter(hint);
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -2888,36 +2888,41 @@ function openHierarchyParamEditor(selectedKey, meta, forceOpen) {
             refreshHierarchyVisibility();
         };
         /*
-         * TWO OPTIONS: the click FLIPS it rather than raising a list of the
-         * value you can see and the one other value there is. Same rule the
-         * knob grid applies (flipsOnClick in param_meta.mjs) and it has to be
-         * applied on BOTH editors or the same parameter answers the same
-         * gesture two different ways depending on a Param View setting the
-         * user can flip — which is the drift test_knob_surfaces_access.sh
-         * exists to catch on the trigger latch.
+         * TWO OPTIONS: the click FOCUSES the row, and the jog changes it —
+         * the same gesture every other row in this list answers to. It does
+         * NOT open a picker (a list of the value you can see and the one other
+         * value there is) and it does NOT flip in place.
          *
-         * The predicate is restated rather than imported because this meta is
-         * the RAW chain_params declaration, not a buildMetaIndex record: it
-         * has `type`, not `kind`, and no `divable` at all. The two guards that
+         * The flip is the GRID's answer, where the knob under your hand is
+         * already the direct control and the click only saves a second
+         * gesture. Here there is no knob under your hand, so a row that
+         * changed value the instant you clicked it would be the one row with
+         * no focus state — reported from the device as "just show it focus and
+         * let jog change it. then it's the same gesture for each row.
+         * otherwise it's invisible."
+         *
+         * Falling through to beginHierarchyParamEdit is what does it, so this
+         * is a `break` out of the picker rather than a branch of its own: the
+         * edit-mode path already steps an enum through adjustHierSelectedParam
+         * and already draws the row as focused.
+         *
+         * The count is restated rather than imported because this meta is the
+         * RAW chain_params declaration, not a buildMetaIndex record: it has
+         * `type`, not `kind`, and no `divable` at all. The two guards that
          * `divable` carries for the grid — trigger and readout — are the two
          * early returns immediately above, so the exclusions are the same
          * ones, reached a different way.
          */
-        if (meta.options.length === 2) {
-            const next = index === 0 ? 1 : 0;
-            commit(next);
-            announce((meta.name || meta.label || selectedKey) + ", " + meta.options[next]);
-            needsRedraw = true;
+        if (meta.options.length !== 2) {
+            openEnumPicker({
+                title: meta.name || meta.label || selectedKey,
+                options: meta.options,
+                index,
+                commit,
+                returnToGrid: false,
+            });
             return;
         }
-        openEnumPicker({
-            title: meta.name || meta.label || selectedKey,
-            options: meta.options,
-            index,
-            commit,
-            returnToGrid: false,
-        });
-        return;
     }
     /* Everything else — including wav_position, whose editor IS edit mode on a
      * selected wav_position (see isInWavPositionEditor). */
@@ -15501,14 +15506,10 @@ function drawHierarchyEditor() {
             hint = ["Click: keyboard", "Jog: scroll"];
         } else if (!hierEditorEditMode && selectedMeta && selectedMeta.type === "canvas") {
             hint = ["Click: open", "Jog: scroll"];
-        } else if (!hierEditorEditMode && selectedMeta && selectedMeta.type === "enum" &&
-                   Array.isArray(selectedMeta.options) && selectedMeta.options.length === 2 &&
-                   !isTriggerParam(selectedMeta) && !isReadoutParam(selectedMeta)) {
-            /* Two options: the click writes the other one rather than raising
-             * the picker, so say so. The grid's footer makes the same promise
-             * as CLK FLIP. */
-            hint = ["Click: flip", "Jog: scroll"];
         }
+        /* A two-option enum needs NO special hint: it takes the ordinary
+         * "Click: edit" path with every other turnable row, which is the whole
+         * point of focusing it rather than flipping it here. */
         drawFooter(hint);
     }
 }

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -54,7 +54,7 @@ import { VIZ_SAMPLE } from '/data/UserData/schwung/shared/param_pages/viz.mjs';
 /* The enum option screen, shared with the picker view in shadow_ui.js — one
  * screen, two entries, opposite commit semantics. See enum_list.mjs. */
 import { drawEnumList } from '/data/UserData/schwung/shared/param_pages/enum_list.mjs';
-import { flipsOnClick } from '/data/UserData/schwung/shared/param_pages/param_meta.mjs';
+import { flipsOnClick, isTurnable } from '/data/UserData/schwung/shared/param_pages/param_meta.mjs';
 import { announce } from '/data/UserData/schwung/shared/screen_reader.mjs';
 import { log, isLoggingEnabled } from '/data/UserData/schwung/shared/logger.mjs';
 
@@ -688,6 +688,52 @@ function footerHints() {
         return controller.menuEntered && controller.menuEntered()
             ? orderedHints({ jog: "SEL", click: "OPEN", extra: [["BACK", "OUT"]] })
             : orderedHints({ jog: "PAGE", click: "ENTER", extra: fine });
+    }
+
+    /*
+     * A KNOB PAGE DRAWN AS A LIST is a door too, and this footer never said so.
+     *
+     * With Param View on List — or with the screen reader on, which forces the
+     * layout — a knob page becomes five rows driven entirely by the JOG: click
+     * enters, the jog is the row cursor, click opens the row, the jog is then
+     * the value, and Back steps out one layer at a time. Three states, and the
+     * footer reported the GRID's answer for all of them: `JOG PAGE / CLK MENU`,
+     * which is wrong in every one. Reported from the device as "when you're
+     * clicked in it actually still says jog page", against Global Settings —
+     * where the jog is the only thing you are using.
+     *
+     * It must come BEFORE the held-knob branch below, and that is not merely
+     * about ordering the common case first. In this layout `onClick` takes its
+     * param from the ROW CURSOR and overrides whatever knob is under your hand
+     * (see knobsAsList in page_controller). So the held-knob branch would
+     * describe a cell the click will not act on — the same promise-versus-
+     * behaviour bug that branch's own comments record twice, reached from the
+     * other side.
+     *
+     * The click verb is the ROW's, mirroring the controller's own ladder in
+     * onClick: fire a trigger, flip a two-option enum, open anything else
+     * divable, otherwise hand the jog to the value. A readout gets NO click
+     * pair, because nothing happens — an honest gap rather than a verb.
+     */
+    if (mp && mp.kind === PAGE_KNOBS && controller.isDoor && controller.isDoor(mp)) {
+        const entered = controller.menuEntered && controller.menuEntered();
+        if (!entered) return orderedHints({ jog: "PAGE", click: "ENTER", extra: fine });
+        /* Editing a row: the jog IS the value, and Back gives it back to the
+         * cursor rather than leaving the page. */
+        if (controller.knobEditing) {
+            return orderedHints({ jog: "ADJ", click: "DONE", extra: [["BACK", "OUT"]] });
+        }
+        const rows = controller.knobRows ? controller.knobRows() : [];
+        const row = rows[controller.knobRowIndex ? controller.knobRowIndex() : 0];
+        const rmeta = row && controller.metaAt ? controller.metaAt(row.slot) : null;
+        let verb = null;
+        if (rmeta) {
+            if (rmeta.writeOnly) verb = "FIRE";
+            else if (flipsOnClick(rmeta)) verb = "FLIP";
+            else if (rmeta.divable) verb = "OPEN";
+            else if (isTurnable(rmeta)) verb = "EDIT";
+        }
+        return orderedHints({ jog: "SEL", click: verb, extra: [["BACK", "OUT"]] });
     }
 
     /*

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -729,9 +729,12 @@ function footerHints() {
         let verb = null;
         if (rmeta) {
             if (rmeta.writeOnly) verb = "FIRE";
-            else if (flipsOnClick(rmeta)) verb = "FLIP";
+            /* A two-option enum FOCUSES here rather than flipping — see the
+             * knobsAsList branch of onClick. Same ladder, same order, and the
+             * `flipsOnClick` term is what keeps the widened gate identical on
+             * both sides. */
+            else if (isTurnable(rmeta) && (!rmeta.divable || flipsOnClick(rmeta))) verb = "EDIT";
             else if (rmeta.divable) verb = "OPEN";
-            else if (isTurnable(rmeta)) verb = "EDIT";
         }
         return orderedHints({ jog: "SEL", click: verb, extra: [["BACK", "OUT"]] });
     }

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -54,6 +54,7 @@ import { VIZ_SAMPLE } from '/data/UserData/schwung/shared/param_pages/viz.mjs';
 /* The enum option screen, shared with the picker view in shadow_ui.js — one
  * screen, two entries, opposite commit semantics. See enum_list.mjs. */
 import { drawEnumList } from '/data/UserData/schwung/shared/param_pages/enum_list.mjs';
+import { flipsOnClick } from '/data/UserData/schwung/shared/param_pages/param_meta.mjs';
 import { announce } from '/data/UserData/schwung/shared/screen_reader.mjs';
 import { log, isLoggingEnabled } from '/data/UserData/schwung/shared/logger.mjs';
 
@@ -775,6 +776,21 @@ function footerHints() {
          * become a door and the footer has had to be told separately, and the
          * first two are both written up as promise-versus-behaviour bugs.
          */
+        /*
+         * A TWO-OPTION enum is not a door: the click writes the other value
+         * (see flipsOnClick). FLIP, not OPEN — this branch is the third one
+         * in this function whose whole job is keeping the promise the footer
+         * makes in step with what the button does, and the other two are both
+         * written up above as bugs where it came apart.
+         *
+         * FLIP names the consequence rather than the gesture, which the
+         * trigger's own note argues for whenever no single gesture-word
+         * covers the control: you are not opening anything, and "SET" is the
+         * picker's word for committing a choice you have already scrolled to.
+         */
+        if (flipsOnClick(meta)) {
+            return orderedHints({ jog: "PAGE", click: "FLIP", extra: fine });
+        }
         if ((meta && meta.divable) ||
             (controller.diveTargetAt && controller.diveTargetAt(held))) {
             return orderedHints({ jog: "PAGE", click: "OPEN", extra: fine });

--- a/src/shared/knob_engine.mjs
+++ b/src/shared/knob_engine.mjs
@@ -109,6 +109,43 @@ function isSwitchMeta(meta) {
 }
 
 /**
+ * Minimum still time before a knob can flip a two-way control again.
+ *
+ * The same number and the same rule as `TRIGGER_KNOB_GESTURE_GAP_MS` in
+ * page_controller.mjs: ONE FLICK IS ONE GESTURE. A trigger fires once per
+ * flick; a two-way flips once per flick. Both would otherwise act a dozen
+ * times across a single twist of the encoder.
+ *
+ * It is a LATCH, not a rate limit, and that is the distinction the trigger
+ * shipped wrong first: the stamp is the last DETENT, so every detent extends
+ * the gesture and the clock only runs while the knob is STILL.
+ */
+export const TWO_WAY_GESTURE_GAP_MS = 270;
+
+/**
+ * A control with exactly TWO values and no travel between them.
+ *
+ * Both spellings count — an Off/On (or int 0..1) boolean, which is drawn as a
+ * switch, and a two-way CHOICE like Mix/Reverb or Saw/Square, which is drawn
+ * as an enum square. They behave identically under the hand even though they
+ * are drawn differently, because the question a detent asks is the same one:
+ * there is nowhere to go but the other value.
+ *
+ * A TRIGGER is excluded. It is a two-option enum on the wire (["—","Rnd!"])
+ * and toggling it would write "do nothing" on every other flick — which for
+ * euclidrum's rnd_preset is the write that destroys a kit. Callers that route
+ * triggers away before reaching here (page_controller does) are unaffected;
+ * this is for the ones that do not.
+ */
+function isTwoWayMeta(meta) {
+    if (!meta) return false;
+    if (meta.writeOnly || meta.access === "write") return false;
+    if (isSwitchMeta(meta)) return true;
+    return (meta.kind === "enum" || meta.type === "enum")
+        && Array.isArray(meta.options) && meta.options.length === 2;
+}
+
+/**
  * Reversing direction drops whatever partial turn was banked the other way.
  * Without it the residue is spent cancelling the new direction first, so a
  * reversal costs up to div + (div - 1) detents — 7 at ENUM_DELTA_DIV 4 — and
@@ -174,23 +211,54 @@ export function knobStep(state, meta, delta, nowMs, fine = false) {
         };
     }
 
-    /* A boolean flips on ONE detent in the direction turned, whether its author
-     * spelled it as an Off/On enum or as an int 0..1. Hoisted ABOVE the enum
-     * branch because an int never enters that branch -- it would fall through
-     * to the numeric path, which reaches the same two values but by
-     * accumulating rather than by direction, so a reversal could spend a
-     * detent doing nothing. The picture and the feel have to agree. */
-    if (isSwitchMeta(meta)) {
+    /*
+     * TWO VALUES: A DETENT TOGGLES, WHICHEVER WAY IT WENT.
+     *
+     * It used to be direction-ABSOLUTE — right meant option 1, left meant
+     * option 0 — and a two-way choice like Mix/Reverb instead fell through to
+     * the enum branch below and CLAMPED behind a four-detent gate. Three
+     * spellings of one control, two of them with a dead direction:
+     *
+     *   Off/On at Off, turned left     nothing, forever
+     *   Mix/Reverb at Mix, turned left nothing, forever
+     *
+     * Reported from the device: "if there are only two, why not let it wrap
+     * otherwise you have to know which way is off and which way is on, in
+     * which case you need some knowledge you dont have." There is no way to
+     * acquire that knowledge from the screen — the cell shows a state, not a
+     * direction — so half of every reach for the knob reads as a dead control.
+     * That is the same argument that makes a trigger fire in either direction.
+     *
+     * WRAPPING ALONE WOULD NOT DO, and this is the part worth keeping. With
+     * two values, "wrap" and "toggle on every detent" are the same thing, and
+     * one flick of an encoder is a dozen detents — so a flick would land on
+     * whichever value the detent count happened to be even or odd about. The
+     * LATCH is what makes the gesture legible: one flick, one flip, and the
+     * clock runs on STILLNESS because the stamp is the last detent rather than
+     * the last flip.
+     *
+     * Hoisted above the enum branch for the reason it always was: an int 0..1
+     * never enters that branch and would accumulate on the numeric path.
+     */
+    if (isTwoWayMeta(meta)) {
+        const t = typeof nowMs === "number" ? nowMs : 0;
+        const last = state.lastTwoWayMs;
+        const startsGesture = last === undefined
+            || (t - last) >= TWO_WAY_GESTURE_GAP_MS;
+        state.lastTwoWayMs = t;
         state.detentAccum = 0;
-        state.value = delta > 0 ? 1 : 0;
+        if (!startsGesture) return state.value;
+        state.value = Math.round(Number(state.value)) === 0 ? 1 : 0;
         return state.value;
     }
 
     if (meta.kind === "enum" || meta.type === "enum") {
-        /* A switch has two states and no travel, so it flips on ONE detent, in
-         * the direction turned. Running it through the click gate below cost 4
-         * detents to move at all (and up to 7 to come back), which reads as a
-         * dead control: the drawn knob simply does not move when you turn it. */
+        /* THREE OR MORE options only — anything with exactly two was taken by
+         * the branch above. That is what the four-detent gate is for: a long
+         * list wants a sweep, and a two-way has nothing to sweep through, so
+         * running one through this gate cost 4 detents to move at all (and up
+         * to 7 to come back), which reads as a dead control — the drawn knob
+         * simply does not move when you turn it. */
         const div = fine ? 1 : ENUM_DELTA_DIV;
         clearOnReversal(state, delta);
         state.detentAccum += delta;

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -2713,8 +2713,28 @@ export function createController(io = {}) {
                 announceKnobRow(mp, knobRowIndex(mp));
                 return null;
             }
+            /*
+             * A TWO-OPTION enum is FOCUSED here, not flipped and not opened.
+             *
+             * On the grid the click flips it, because the knob under your hand
+             * is already the direct control and the flip only saves the second
+             * gesture. A list has no knob under your hand: every other row is
+             * click-to-focus-then-jog, so a row that instead changed value the
+             * instant you clicked it would be the one row with no focus state
+             * at all. Reported from the device as exactly that — "just show it
+             * focus and let jog change it. then it's the same gesture for each
+             * row. otherwise it's invisible."
+             *
+             * `flipsOnClick` is what widens the gate, which keeps the two
+             * surfaces reading from ONE definition of "this enum is a
+             * two-way": the grid flips that set and the list focuses it, and
+             * neither can drift into disagreeing about WHICH params they are.
+             * Longer enums still open the picker — a focus-and-jog over 47
+             * Braids models is the thing the picker was built to replace.
+             */
             const rmeta = s.metaIndex ? s.metaIndex.getOrGuess(r.key) : null;
-            if (rmeta && !rmeta.writeOnly && !rmeta.divable && isTurnable(rmeta)) {
+            if (rmeta && !rmeta.writeOnly && isTurnable(rmeta)
+                && (!rmeta.divable || flipsOnClick(rmeta))) {
                 s.knobEditing = true;
                 announceKnobRow(mp, knobRowIndex(mp));
                 return null;

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -30,7 +30,7 @@
 import { planPages, pickMode, PAGE_KNOBS, PAGE_MENU, PAGE_PRESET, PAGE_ITEMS,
          buildTrailingPages, makeClaimer } from "./page_plan.mjs";
 import { resolveChildKey } from "./child_key.mjs";
-import { buildMetaIndex, inferFromValue, isTurnable, enumIndexOf, KIND_ENUM, KIND_OPAQUE } from "./param_meta.mjs";
+import { buildMetaIndex, inferFromValue, isTurnable, flipsOnClick, enumIndexOf, KIND_ENUM, KIND_OPAQUE } from "./param_meta.mjs";
 import { renderPage, renderPicker, renderHint, LAYOUT_DIAL } from "./render_page.mjs";
 import { renderPageMovy, drawFooter, drawHeader as drawHeaderMovy, drawBankBar,
          drawBrackets, drawPresetBody, displayValue, RULE_Y, LAYOUT_MOVY,
@@ -2750,7 +2750,6 @@ export function createController(io = {}) {
             key = via;
             meta = s.metaIndex.getOrGuess(via);
         }
-        s.pending = { action: "open", key, fullKey: fullKey(key), meta };
         /*
          * An enum opens a list of its OPTIONS, so the intent carries the list
          * and where in it we currently are — the host should not have to spend
@@ -2768,9 +2767,41 @@ export function createController(io = {}) {
                 learnEnumWireFormat(meta, raw);
             }
             const idx = enumIndexOf(meta, raw);
-            s.pending.options = meta.options.slice();
-            s.pending.index = idx >= 0 ? idx : 0;
+            const at = idx >= 0 ? idx : 0;
+            /*
+             * TWO OPTIONS: THE CLICK SETS IT. There is no list.
+             *
+             * A picker over two items is a menu whose entire content is the
+             * value you can already see and the one other value there is, and
+             * it costs two gestures to reach a state one gesture can describe.
+             * Reported from the device as exactly that — "if an option has two
+             * values, clicking it should change the option ... we don't need a
+             * whole menu for two items", against Mirror Display and
+             * Move->Schwung.
+             *
+             * Deliberately NOT limited to booleans. `drawnAsSwitch` splits
+             * Off/On from a two-way CHOICE (Mix/Reverb, Saw/Square) and that
+             * split is right for the PEEK, which exists to show a word the cell
+             * has no room for. It is wrong here: the cost being removed is the
+             * second gesture, and a choice pays it exactly as a switch does.
+             * The new value lands in the cell either way, which is the same
+             * feedback the list would have given after one more click.
+             *
+             * It also cannot fire anything by accident — a trigger is
+             * writeOnly and returned above, and a readout is not divable and
+             * never reaches here.
+             */
+            if (flipsOnClick(meta)) {
+                const next = at === 0 ? 1 : 0;
+                commitEnum(key, next);
+                announce(`${meta.label}, ${meta.options[next]}`);
+                return null;
+            }
+            s.pending = { action: "open", key, fullKey: fullKey(key), meta,
+                          options: meta.options.slice(), index: at };
+            return s.pending;
         }
+        s.pending = { action: "open", key, fullKey: fullKey(key), meta };
         return s.pending;
     }
 

--- a/src/shared/param_pages/param_meta.mjs
+++ b/src/shared/param_pages/param_meta.mjs
@@ -349,6 +349,30 @@ export function opensOnClick(meta) {
     return !!meta && !!meta.opaque_type && !!meta.divable;
 }
 
+/**
+ * True when clicking this cell FLIPS it instead of opening anything.
+ *
+ * An enum with exactly two options has nothing to browse: the list would show
+ * the value already in the cell and the only other value there is. So the
+ * click writes the other one, and the picker is never raised.
+ *
+ * ONE definition because it answers two questions that must not disagree —
+ * what the click DOES (page_controller.onClick) and what the footer PROMISES
+ * while the knob is held (paramPagesFooterHints). The divable/opaque pair one
+ * function up is written up as exactly that failure, three times over: a cell
+ * became a door and the footer had to be told separately, so it advertised
+ * CLK MENU over a click that opened an editor.
+ *
+ * `divable` is required, which is what keeps triggers and readouts out: both
+ * are excluded from `divable` by construction, and a trigger is a two-option
+ * enum in the wire format, so a test on the option count alone would turn
+ * every momentary in the fleet into a latch.
+ */
+export function flipsOnClick(meta) {
+    return !!meta && !!meta.divable && meta.kind === KIND_ENUM
+        && Array.isArray(meta.options) && meta.options.length === 2;
+}
+
 /** True when a knob can drive this param at all. */
 export function isTurnable(meta) {
     /* A readout has nothing to set; a trigger is fired, not scrubbed — turning

--- a/tests/host/test_int_boolean_switch.sh
+++ b/tests/host/test_int_boolean_switch.sh
@@ -64,12 +64,18 @@ Promise.all([
     if (isSwitch && !flipped)
       fail(name + " draws as a switch but did not flip on ONE detent (got " + st.value + ")");
   }
-  /* ...and a switch follows the DIRECTION turned, rather than accumulating --
-   * which is what an int would have done on the numeric path. */
+  /* ...and a switch reaches the other value on ONE detent rather than
+   * accumulating, which is what an int would have done on the numeric path.
+   *
+   * It no longer follows the DIRECTION turned: with two values there is
+   * nowhere to go but the other one, so either direction toggles and one
+   * flick is one flip. That rule and its latch live in
+   * tests/host/test_two_way_knob_toggle.sh; what matters HERE is only that
+   * what is drawn as a switch does not fall through to the numeric path. */
   {
     const st = K.knobInit(1);
     K.knobStep(st, { type: "int", min: 0, max: 1 }, -1, 1000);
-    if (st.value !== 0) fail("an int boolean did not follow the direction turned");
+    if (st.value !== 0) fail("an int boolean did not move on one detent");
   }
   console.log("  ok  what is drawn as a switch is turned as a switch");
 

--- a/tests/host/test_list_layout_footer.sh
+++ b/tests/host/test_list_layout_footer.sh
@@ -131,8 +131,14 @@ Promise.all([
   const verbAtRow = (key) => (seekRow(key) ? pairFor("CLK") : null);
   if (verbAtRow("cutoff") !== "EDIT")
     fail("a plain float hands the jog to the value; the footer said " + verbAtRow("cutoff"));
-  if (verbAtRow("flip2") !== "FLIP")
-    fail("a two-option enum flips; the footer said " + verbAtRow("flip2"));
+  /* A two-option enum FOCUSES like every other turnable row — it does not flip
+   * here and it does not open. That is the request verbatim: "the same gesture
+   * for each row". The grid flips the same param; the two surfaces read the
+   * widened gate from one predicate, so they cannot drift about WHICH params. */
+  if (verbAtRow("flip2") !== "EDIT")
+    fail("a two-option enum should focus like any other row; the footer said " +
+         verbAtRow("flip2") + " — FLIP is the answer the GRID gives, and there is no knob under " +
+         "your hand here");
   if (verbAtRow("pick3") !== "OPEN")
     fail("a three-option enum opens its list; the footer said " + verbAtRow("pick3"));
   if (verbAtRow("trig2") !== "FIRE")
@@ -148,6 +154,23 @@ Promise.all([
   if (!ctl.knobEditing) fail("clicking a float row should start editing it");
   if (pairFor("JOG") !== "ADJ") fail("while editing, the jog adjusts the value; got " + flat());
   if (pairFor("CLK") !== "DONE") fail("while editing, the click is done; got " + flat());
+
+  /* ...and a TWO-OPTION ENUM does the same, and the jog then STEPS it. This is
+   * the half a footer assertion cannot reach: EDIT could be advertised over a
+   * row the jog does nothing to. */
+  ctl.exitMenu();                 /* leave edit mode, stay on the row cursor */
+  seekRow("flip2");
+  ctl.onClick(0);
+  if (!ctl.knobEditing)
+    fail("clicking a two-option enum row should FOCUS it, not flip or open it");
+  const beforeFlip = ctl.state.values["flip2"];
+  ctl.onJog(1);
+  if (ctl.state.values["flip2"] === beforeFlip)
+    fail("the jog did not move a focused two-option enum — focus without a working jog is " +
+         "worse than the flip it replaced");
+  ctl.onJog(-1);
+  if (ctl.state.values["flip2"] !== beforeFlip)
+    fail("the focused enum did not step back; a two-way must be reachable in both directions");
 
   /* ---- 5. A HELD KNOB MUST NOT CLAIM THIS FOOTER ------------------------ */
   ctl.exitMenu();                 /* back to the row cursor */

--- a/tests/host/test_list_layout_footer.sh
+++ b/tests/host/test_list_layout_footer.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The footer on a KNOB PAGE DRAWN AS A LIST.
+#
+# With Param View on List — or with the screen reader on, which forces the
+# layout — a knob page becomes five rows driven entirely by the JOG. It is a
+# door: click enters, the jog is the row cursor, click opens the row, the jog is
+# then the value, Back steps out one layer at a time.
+#
+# footerHints() had NO branch for any of that and fell through to the grid's
+# answer, `JOG PAGE / CLK MENU`, which is wrong in all three states. Reported
+# from the device against Global Settings, where the jog is the only control
+# being used: "when you're clicked in it actually still says jog page".
+#
+# The ORDERING assertion at the end is the one that is easy to lose. In this
+# layout onClick takes its param from the ROW CURSOR and overrides whatever
+# knob is under your hand, so the held-knob branch must not get there first —
+# it would describe a cell the click will not act on. That branch's own
+# comments record the same promise-versus-behaviour bug twice, reached from the
+# other side, which is why it is pinned rather than left to reading order.
+#
+# footerHints is not exported and the file cannot be imported (its imports are
+# absolute /data/UserData paths), so the function is LIFTED with new Function
+# and a fixed dependency list, the same way test_chain_edit_read_budget.sh
+# lifts drawChainEdit.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2; exit 1
+fi
+
+node -e '
+const fs = require("fs");
+Promise.all([
+  import("./src/shared/param_pages/page_controller.mjs"),
+  import("./src/shared/param_pages/param_meta.mjs"),
+  import("./src/shared/param_pages/page_plan.mjs"),
+]).then(async ([C, M, P]) => {
+  let failures = 0;
+  const fail = (m) => { console.error("FAIL: " + m); failures++; };
+
+  /* ---- lift footerHints and orderedHints out of the shadow UI ---------- */
+  const SRC = "src/shadow/shadow_ui_param_pages.mjs";
+  const text = fs.readFileSync(SRC, "utf8");
+  const lift = (name) => {
+    const head = text.indexOf("function " + name + "(");
+    if (head < 0) throw new Error(SRC + " has no function " + name);
+    /* Top-level functions in this file close on a brace in column 0. */
+    const end = text.indexOf("\n}\n", head);
+    if (end < 0) throw new Error("could not find the end of " + name);
+    return text.slice(head, end + 3);
+  };
+
+  const make = (controller) => new Function(
+    "controller", "shiftIsHeld", "sectionsAreDistinct",
+    "PAGE_KNOBS", "PAGE_MENU", "PAGE_PRESET", "PAGE_ITEMS",
+    "flipsOnClick", "isTurnable",
+    lift("orderedHints") + "\n" + lift("footerHints") + "\nreturn footerHints;"
+  )(controller, () => false, () => false,
+    P.PAGE_KNOBS, P.PAGE_MENU, P.PAGE_PRESET, P.PAGE_ITEMS,
+    M.flipsOnClick, M.isTurnable);
+
+  /* ---- a real controller, in LIST layout ------------------------------- */
+  const store = { cutoff: "0.5", flip2: "Off", pick3: "A", trig2: "—", ro2: "No" };
+  const HIER = JSON.stringify({ modes: null, levels: { root: { label: "S",
+      knobs: ["cutoff", "flip2", "pick3", "trig2", "ro2"],
+      params: [{ key: "cutoff" }, { key: "flip2" }, { key: "pick3" },
+               { key: "trig2" }, { key: "ro2" }] } } });
+  const CP = JSON.stringify([
+    { key: "cutoff", name: "Cutoff",  type: "float", min: 0, max: 1, step: 0.01 },
+    { key: "flip2",  name: "Mirror",  type: "enum", options: ["Off", "On"] },
+    { key: "pick3",  name: "Overlay", type: "enum", options: ["A", "B", "C"] },
+    { key: "trig2",  name: "Rnd",     type: "enum", options: ["—", "Rnd!"], access: "write" },
+    { key: "ro2",    name: "Key",     type: "enum", options: ["No", "Yes"],      access: "read"  },
+  ]);
+  const ctl = C.createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return HIER;
+      if (b === "chain_params") return CP;
+      return b in store ? store[b] : "0";
+    },
+    setParam: () => {},
+    announce: () => {},
+  });
+  ctl.setLayout(C.LAYOUT_LIST);
+  ctl.load({ slot: 0, component: "synth" });
+  for (let i = 0; i < 8; i++) ctl.tick();
+  ctl.dismissHint();
+
+  const hints = make(ctl);
+  const flat = () => (hints() || []).map((h) => h.join(" ")).join(" / ");
+  const pairFor = (key) => {
+    const h = hints() || [];
+    const found = h.find((p) => p[0] === key);
+    return found ? found[1] : null;
+  };
+
+  if (ctl.page.kind !== P.PAGE_KNOBS) fail("expected a knob page, got " + ctl.page.kind);
+  if (!ctl.isDoor()) fail("a knob page in LIST layout should be a door");
+
+  /* ---- 1. not entered: the jog still pages, and the click goes IN ------- */
+  if (pairFor("JOG") !== "PAGE") fail("outside the list the jog should still page, got " + flat());
+  if (pairFor("CLK") !== "ENTER")
+    fail("outside the list the click enters it; the footer said " + flat() +
+         " — CLK MENU is the GRID answer and there is no grid here");
+
+  /* ---- 2. entered: the jog is the ROW CURSOR ---------------------------- */
+  ctl.enterMenu();
+  if (!ctl.menuEntered()) fail("enterMenu did not enter a knobs-as-list page");
+  if (pairFor("JOG") !== "SEL")
+    fail("inside the list the jog moves the cursor, but the footer still says " +
+         JSON.stringify(pairFor("JOG")) + " — this is the reported bug verbatim");
+  if (pairFor("BACK") !== "OUT") fail("inside the list Back steps out one layer, got " + flat());
+
+  /* ---- 3. the click verb is the ROW'"'"'S, not one word for all rows ------- */
+  /* The row cursor CLAMPS at both ends rather than wrapping, so a seek has to
+   * rewind first and every loop has to be bounded — an unbounded "jog until
+   * you get there" spins forever the moment the target is behind you. */
+  const seekRow = (key) => {
+    const rows = ctl.knobRows();
+    const at = rows.findIndex((r) => r && r.key === key);
+    if (at < 0) { fail("row " + key + " is not on the page"); return false; }
+    for (let i = 0; i < rows.length + 2 && ctl.knobRowIndex() > 0; i++) ctl.onJog(-1);
+    for (let i = 0; i < rows.length + 2 && ctl.knobRowIndex() < at; i++) ctl.onJog(1);
+    if (ctl.knobRowIndex() !== at) { fail("could not reach row " + key); return false; }
+    return true;
+  };
+  const verbAtRow = (key) => (seekRow(key) ? pairFor("CLK") : null);
+  if (verbAtRow("cutoff") !== "EDIT")
+    fail("a plain float hands the jog to the value; the footer said " + verbAtRow("cutoff"));
+  if (verbAtRow("flip2") !== "FLIP")
+    fail("a two-option enum flips; the footer said " + verbAtRow("flip2"));
+  if (verbAtRow("pick3") !== "OPEN")
+    fail("a three-option enum opens its list; the footer said " + verbAtRow("pick3"));
+  if (verbAtRow("trig2") !== "FIRE")
+    fail("a trigger fires; the footer said " + verbAtRow("trig2"));
+  /* A readout does nothing at all, so it gets no CLK pair. A verb here would
+   * be a promise; an absence is the truth. */
+  if (verbAtRow("ro2") !== null)
+    fail("a readout advertised " + JSON.stringify(verbAtRow("ro2")) + " over a click that does nothing");
+
+  /* ---- 4. editing a row: the jog IS the value --------------------------- */
+  seekRow("cutoff");
+  ctl.onClick(0);
+  if (!ctl.knobEditing) fail("clicking a float row should start editing it");
+  if (pairFor("JOG") !== "ADJ") fail("while editing, the jog adjusts the value; got " + flat());
+  if (pairFor("CLK") !== "DONE") fail("while editing, the click is done; got " + flat());
+
+  /* ---- 5. A HELD KNOB MUST NOT CLAIM THIS FOOTER ------------------------ */
+  ctl.exitMenu();                 /* back to the row cursor */
+  seekRow("cutoff");
+  const pick3Slot = (ctl.page.keys || []).indexOf("pick3");
+  if (pick3Slot < 0) fail("pick3 is not on the page");
+  ctl.onKnobTouch(pick3Slot, true, 1000);
+  if (pairFor("JOG") !== "SEL" || pairFor("CLK") !== "EDIT")
+    fail("holding a knob rewrote the list footer to " + flat() + " — in this layout the " +
+         "click acts on the ROW CURSOR, so the held-knob branch is describing a cell the " +
+         "click will not touch");
+  ctl.onKnobTouch(pick3Slot, false, 1010);
+
+  /* ---- 6. every word is in the canon, and the row fits ------------------ */
+  const R = await import("./src/shared/param_pages/render_page_movy.mjs");
+  const KEYS = new Set(R.FOOTER_CANON.keys);
+  for (const state of [() => ctl.exitMenu(), () => ctl.enterMenu()]) {
+    state();
+    const h = hints() || [];
+    for (const p of h) if (!KEYS.has(p[0])) fail("footer key " + p[0] + " is not in FOOTER_CANON");
+    const w = h.reduce((a, p) => a + R.hintPairWidth(p[0], p[1]), 0);
+    if (w > 128 && h.length <= 2)
+      fail("a two-pair footer overflowed at " + w + "px: " + flat());
+  }
+
+  if (failures) process.exit(1);
+  console.log("PASS: a knobs-as-list page reports its own three states, the click verb is the " +
+              "row’s, and a held knob does not claim the footer");
+}).catch((e) => { console.error("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'

--- a/tests/host/test_list_layout_footer.sh
+++ b/tests/host/test_list_layout_footer.sh
@@ -63,6 +63,7 @@ Promise.all([
     M.flipsOnClick, M.isTurnable);
 
   /* ---- a real controller, in LIST layout ------------------------------- */
+  let clock = 10000;   /* driven explicitly: the two-way latch is measured in ms */
   const store = { cutoff: "0.5", flip2: "Off", pick3: "A", trig2: "—", ro2: "No" };
   const HIER = JSON.stringify({ modes: null, levels: { root: { label: "S",
       knobs: ["cutoff", "flip2", "pick3", "trig2", "ro2"],
@@ -84,6 +85,7 @@ Promise.all([
     },
     setParam: () => {},
     announce: () => {},
+    now: () => clock,
   });
   ctl.setLayout(C.LAYOUT_LIST);
   ctl.load({ slot: 0, component: "synth" });
@@ -165,12 +167,38 @@ Promise.all([
     fail("clicking a two-option enum row should FOCUS it, not flip or open it");
   const beforeFlip = ctl.state.values["flip2"];
   ctl.onJog(1);
-  if (ctl.state.values["flip2"] === beforeFlip)
+  const afterUp = ctl.state.values["flip2"];
+  if (afterUp === beforeFlip)
     fail("the jog did not move a focused two-option enum — focus without a working jog is " +
          "worse than the flip it replaced");
-  ctl.onJog(-1);
+
+  /* EITHER DIRECTION toggles: from the same starting value, a DOWN detent must
+   * reach the same place an UP detent did. The cell shows a state, not a
+   * direction, so a control where left does nothing is dead half the time.
+   * Driven from a fresh gesture at the same start value rather than by
+   * reversing, which the latch is entitled to swallow. */
+  clock += 2000;
+  ctl.onJog(-1);                                   /* back to the start */
+  clock += 2000;
   if (ctl.state.values["flip2"] !== beforeFlip)
-    fail("the focused enum did not step back; a two-way must be reachable in both directions");
+    fail("a two-way did not come back on the opposite detent");
+  ctl.onJog(-1);                                   /* DOWN from the start */
+  if (ctl.state.values["flip2"] !== afterUp)
+    fail("a DOWN detent left a two-way at " + ctl.state.values["flip2"] + " but UP reached " +
+         afterUp + " — the direction still has to be known, which is the whole complaint");
+
+  /* ONE FLICK IS ONE FLIP. Wrapping alone would toggle on every detent, so a
+   * spin would land wherever the count happened to be even or odd about. */
+  const settled = ctl.state.values["flip2"];
+  for (let i = 0; i < 20; i++) { clock += 30; ctl.onJog(1); }
+  if (ctl.state.values["flip2"] !== settled)
+    fail("a 20-detent spin flipped a two-way again — this is a wrap, not a gesture latch");
+  /* ...and stillness ends the gesture, so the next reach works. */
+  clock += 2000;
+  ctl.onJog(1);
+  if (ctl.state.values["flip2"] === settled)
+    fail("the two-way stayed latched after the knob went still — the stamp must be the last " +
+         "DETENT, so the clock runs on stillness rather than on elapsed time");
 
   /* ---- 5. A HELD KNOB MUST NOT CLAIM THIS FOOTER ------------------------ */
   ctl.exitMenu();                 /* back to the row cursor */

--- a/tests/host/test_param_pages_input.sh
+++ b/tests/host/test_param_pages_input.sh
@@ -23,7 +23,8 @@ Promise.all([
   import("./src/shared/param_pages/page_input.mjs"),
   import("./src/shared/param_pages/page_controller.mjs"),
   import("./tools/param-pages/fake_device.mjs"),
-]).then(([I, C, D]) => {
+  import("./src/shared/param_pages/param_meta.mjs"),
+]).then(([I, C, D, M]) => {
   const fail = (msg) => { console.log("FAIL: " + msg); process.exit(1); };
   const cc = (n, v) => [0xb0, n, v];
   const noteOn = (n, v) => [0x90, n, v];
@@ -220,8 +221,15 @@ Promise.all([
     if (ctl.pickerOpen) fail("touching a knob should dismiss the picker");
     feed(noteOff(0));
 
+    /* A divable that actually OPENS something. A two-option enum is divable
+     * and does not: its click writes the other value in place (flipsOnClick),
+     * so picking the first divable cell on the page would test the flip and
+     * call it an open. */
     let opaque = -1;
-    for (let i = 0; i < 8; i++) { const m = ctl.metaAt(i); if (m && m.divable) { opaque = i; break; } }
+    for (let i = 0; i < 8; i++) {
+        const m = ctl.metaAt(i);
+        if (m && m.divable && !M.flipsOnClick(m)) { opaque = i; break; }
+    }
     if (opaque < 0) fail("expected a divable param on the mrdrums page");
     feed(noteOn(opaque, 100));
     const opened = feed(cc(3, 127));

--- a/tests/host/test_two_option_enum_flip.sh
+++ b/tests/host/test_two_option_enum_flip.sh
@@ -137,7 +137,7 @@ Promise.all([
   /* ---- 4. the FOOTER promises FLIP, and does so BEFORE it can say OPEN -- */
   const FOOT = "src/shadow/shadow_ui_param_pages.mjs";
   const foot = fs.readFileSync(FOOT, "utf8");
-  if (!/import \{ flipsOnClick \}/.test(foot))
+  if (!/import \{[^}]*\bflipsOnClick\b[^}]*\}/.test(foot))
     fail(FOOT + " must IMPORT flipsOnClick, not restate the rule — two copies is how the " +
          "footer and the click come apart");
   const iFlip = foot.indexOf("click: \"FLIP\"");

--- a/tests/host/test_two_option_enum_flip.sh
+++ b/tests/host/test_two_option_enum_flip.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A TWO-OPTION enum is FLIPPED by the click, not opened.
+#
+# The picker earns its place on a Recv Ch with seventeen options or a Braids
+# model with forty-seven. Over two options it is a menu whose entire content is
+# the value already visible in the cell and the one other value there is, and it
+# charges two gestures for a state one gesture can describe. Reported from the
+# device against Mirror Display and Move->Schwung: "if an option has two values,
+# clicking it should change the option ... we dont need a whole menu for two
+# items".
+#
+# What this pins, and why each half is here:
+#
+#   1. the flip itself, BOTH WAYS. One direction passes with a hard-coded write.
+#   2. three options still OPEN. Without this the fix is indistinguishable from
+#      deleting the picker.
+#   3. a TRIGGER still fires and a READOUT still does nothing. Both are
+#      two-option enums in the wire format — euclidrum's ["—","Rnd!"] is the
+#      dangerous one — so a predicate written on the option count ALONE turns
+#      every momentary in the fleet into a latch that destroys a kit on the way
+#      past. `divable` is what excludes them, which is why flipsOnClick requires
+#      it rather than testing options.length in isolation.
+#   4. the FOOTER says FLIP before it can say OPEN. A two-option enum is still
+#      divable, so the OPEN branch would claim it if it came first, and the
+#      footer would promise a screen the click never shows. That exact
+#      promise-versus-behaviour drift is written up twice already in
+#      paramPagesFooterHints.
+#   5. the LIST editor flips too. The same parameter must not answer the same
+#      gesture two different ways depending on the Param View setting.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2; exit 1
+fi
+
+node -e '
+const fs = require("fs");
+Promise.all([
+  import("./src/shared/param_pages/param_meta.mjs"),
+  import("./src/shared/param_pages/page_controller.mjs"),
+]).then(async ([M, C]) => {
+  let failures = 0;
+  const fail = (m) => { console.error("FAIL: " + m); failures++; };
+
+  /* ---- 1. the predicate ------------------------------------------------ */
+  const ix = M.buildMetaIndex({ chainParams: [
+    { key: "flip2",  type: "enum",  options: ["Off", "On"] },
+    { key: "pick3",  type: "enum",  options: ["A", "B", "C"] },
+    { key: "trig2",  type: "enum",  options: ["—", "Rnd!"], access: "write" },
+    { key: "ro2",    type: "enum",  options: ["No", "Yes"],      access: "read"  },
+    { key: "cutoff", type: "float", min: 0, max: 1 },
+  ]});
+  const meta = (k) => ix.getOrGuess(k);
+
+  if (!M.flipsOnClick(meta("flip2"))) fail("a two-option enum should flip on click");
+  if (M.flipsOnClick(meta("pick3")))  fail("a three-option enum must still open its list");
+  if (M.flipsOnClick(meta("trig2")))
+    fail("a TRIGGER is a two-option enum on the wire — flipping it would latch every " +
+         "momentary in the fleet");
+  if (M.flipsOnClick(meta("ro2")))    fail("a readout has nothing to set");
+  if (M.flipsOnClick(meta("cutoff"))) fail("a float is not an enum");
+  if (M.flipsOnClick(null))           fail("flipsOnClick(null) should be false");
+
+  /* ---- 2..3. drive the real controller --------------------------------- */
+  const store = { flip2: "Off", pick3: "A", trig2: "—", ro2: "No" };
+  const writes = [];
+  const spoken = [];
+  const HIER = JSON.stringify({ modes: null, levels: { root: { label: "S",
+      knobs: ["flip2", "pick3", "trig2", "ro2"],
+      params: [{ key: "flip2" }, { key: "pick3" }, { key: "trig2" }, { key: "ro2" }] } } });
+  const CP = JSON.stringify([
+    { key: "flip2", name: "Mirror",  type: "enum", options: ["Off", "On"] },
+    { key: "pick3", name: "Overlay", type: "enum", options: ["A", "B", "C"] },
+    { key: "trig2", name: "Rnd",     type: "enum", options: ["—", "Rnd!"], access: "write" },
+    { key: "ro2",   name: "Key",     type: "enum", options: ["No", "Yes"],      access: "read"  },
+  ]);
+  const ctl = C.createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return HIER;
+      if (b === "chain_params") return CP;
+      return b in store ? store[b] : "0";
+    },
+    setParam: (k, v) => { writes.push([String(k).replace(/^[^:]+:/, ""), v]); },
+    announce: (t) => spoken.push(String(t)),
+  });
+  ctl.load({ slot: 0, component: "synth" });
+  for (let i = 0; i < 8; i++) ctl.tick();
+
+  const slotOf = (key) => (ctl.page.keys || []).indexOf(key);
+  const s2 = slotOf("flip2"), s3 = slotOf("pick3");
+  const sT = slotOf("trig2"), sR = slotOf("ro2");
+  if (s2 < 0 || s3 < 0 || sT < 0 || sR < 0) fail("fixture did not put all four params on the grid");
+
+  /* Off -> On. */
+  writes.length = 0; spoken.length = 0;
+  if (ctl.onClick(s2) !== null)
+    fail("clicking a two-option enum handed back an open intent — the picker is still being raised");
+  if (writes.length !== 1) fail("clicking a two-option enum wrote " + writes.length + " times, expected 1");
+  if (writes[0][0] !== "flip2" || writes[0][1] !== "On")
+    fail("the flip wrote " + JSON.stringify(writes[0]) + ", expected [flip2, On]");
+  if (!spoken.some((t) => /On/.test(t)))
+    fail("the flip announced nothing containing the new value — with TTS on the screen " +
+         "reader is the only report the user gets");
+
+  /* ...and BACK. A hard-coded "write option 1" passes the half above. */
+  store.flip2 = "On";
+  writes.length = 0;
+  ctl.onClick(s2);
+  if (writes.length !== 1 || writes[0][1] !== "Off")
+    fail("the second click wrote " + JSON.stringify(writes) + ", expected Off — a flip must " +
+         "return, or the control is a one-way write");
+
+  /* Three options: unchanged, and the intent still carries the list. */
+  writes.length = 0;
+  const open = ctl.onClick(s3);
+  if (!open || open.action !== "open") fail("a three-option enum stopped opening its picker");
+  if (!Array.isArray(open.options) || open.options.length !== 3)
+    fail("the open intent lost its option list");
+  if (writes.length) fail("opening a picker wrote " + JSON.stringify(writes) + " — nothing may be " +
+                          "written on the way in, or Back stops being a cancel");
+
+  /* A trigger fires through the module wire; it does not flip. */
+  writes.length = 0;
+  if (ctl.onClick(sT) !== null) fail("clicking a trigger handed back an open intent");
+  if (writes.length !== 1 || writes[0][1] !== "Rnd!")
+    fail("clicking a trigger wrote " + JSON.stringify(writes) + ", expected [trig2, Rnd!]");
+
+  /* A readout: nothing at all. */
+  writes.length = 0;
+  ctl.onClick(sR);
+  if (writes.length) fail("clicking a readout wrote " + JSON.stringify(writes));
+
+  /* ---- 4. the FOOTER promises FLIP, and does so BEFORE it can say OPEN -- */
+  const FOOT = "src/shadow/shadow_ui_param_pages.mjs";
+  const foot = fs.readFileSync(FOOT, "utf8");
+  if (!/import \{ flipsOnClick \}/.test(foot))
+    fail(FOOT + " must IMPORT flipsOnClick, not restate the rule — two copies is how the " +
+         "footer and the click come apart");
+  const iFlip = foot.indexOf("click: \"FLIP\"");
+  const iOpen = foot.indexOf("click: \"OPEN\"", foot.indexOf("meta.divable"));
+  if (iFlip < 0) fail(FOOT + " no longer offers a FLIP hint");
+  if (iOpen < 0) fail(FOOT + " lost the divable OPEN hint");
+  if (iFlip > iOpen)
+    fail("the FLIP branch must come BEFORE the divable OPEN branch — a two-option enum is " +
+         "still divable, so OPEN would claim it and the footer would advertise a screen the " +
+         "click never shows");
+
+  /* ---- 5. the LIST editor flips the same parameter ---------------------- */
+  const UI = "src/shadow/shadow_ui.js";
+  const ui = fs.readFileSync(UI, "utf8");
+  /* Anchored on the hierarchy editor'"'"'s OWN enum branch, not on the first
+   * `type === "enum"` in the file. The loose anchor landed on
+   * isTriggerEnumMeta 1500 lines earlier, whose own `options.length === 2`
+   * satisfied the search — so deleting the flip left the probe GREEN. */
+  const enumBranch = ui.indexOf("!hierEditorEditMode && meta && meta.type === \"enum\" &&");
+  if (enumBranch < 0) fail(UI + " no longer has the hierarchy-editor enum branch");
+  const picker = ui.indexOf("openEnumPicker({", enumBranch);
+  const flip = ui.indexOf("meta.options.length === 2", enumBranch);
+  if (flip < 0 || flip > picker)
+    fail("the hierarchy editor still raises the picker for a two-option enum — the same " +
+         "parameter would answer the same gesture differently depending on Param View");
+
+  if (failures) process.exit(1);
+  console.log("PASS: a two-option enum flips on click on both editors; three options still open; " +
+              "triggers and readouts are untouched");
+}).catch((e) => { console.error("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'

--- a/tests/host/test_two_option_enum_flip.sh
+++ b/tests/host/test_two_option_enum_flip.sh
@@ -29,8 +29,13 @@ cd "$(dirname "$0")/../.."
 #      footer would promise a screen the click never shows. That exact
 #      promise-versus-behaviour drift is written up twice already in
 #      paramPagesFooterHints.
-#   5. the LIST editor flips too. The same parameter must not answer the same
-#      gesture two different ways depending on the Param View setting.
+#   5. the LIST editor does NOT flip -- it FOCUSES the row and lets the jog
+#      change it, like every other row. The flip needs a knob under your hand
+#      to be the saving it claims; a list has none, so a row that changed on
+#      the click would be the one row with no focus state. Same predicate
+#      decides both, so the two surfaces cannot drift about WHICH params are
+#      two-way -- only about what a two-way DOES on each. That half is driven
+#      for real in test_list_layout_footer.sh.
 
 if ! command -v node >/dev/null 2>&1; then
   echo "FAIL: node is required" >&2; exit 1
@@ -149,23 +154,35 @@ Promise.all([
          "still divable, so OPEN would claim it and the footer would advertise a screen the " +
          "click never shows");
 
-  /* ---- 5. the LIST editor flips the same parameter ---------------------- */
+  /* ---- 5. the LIST editor does NOT flip: it FOCUSES --------------------
+   *
+   * The flip is the GRID answer, where the knob under your hand is already the
+   * direct control. A list has no knob under your hand, so every row is
+   * click-to-focus-then-jog and a row that changed value on the click would be
+   * the one row with no focus state at all. Reported from the device: "just
+   * show it focus and let jog change it. then it is the same gesture for each
+   * row. otherwise it is invisible."
+   *
+   * So what must hold here is only that the PICKER is skipped — the focus
+   * itself is driven for real in test_list_layout_footer.sh, which clicks a
+   * two-option row and then jogs it in both directions.
+   */
   const UI = "src/shadow/shadow_ui.js";
   const ui = fs.readFileSync(UI, "utf8");
-  /* Anchored on the hierarchy editor'"'"'s OWN enum branch, not on the first
+  /* Anchored on the hierarchy editor OWN enum branch, not on the first
    * `type === "enum"` in the file. The loose anchor landed on
    * isTriggerEnumMeta 1500 lines earlier, whose own `options.length === 2`
-   * satisfied the search — so deleting the flip left the probe GREEN. */
+   * satisfied the search — so deleting the guard left the probe GREEN. */
   const enumBranch = ui.indexOf("!hierEditorEditMode && meta && meta.type === \"enum\" &&");
   if (enumBranch < 0) fail(UI + " no longer has the hierarchy-editor enum branch");
   const picker = ui.indexOf("openEnumPicker({", enumBranch);
-  const flip = ui.indexOf("meta.options.length === 2", enumBranch);
-  if (flip < 0 || flip > picker)
-    fail("the hierarchy editor still raises the picker for a two-option enum — the same " +
-         "parameter would answer the same gesture differently depending on Param View");
+  const guard = ui.indexOf("meta.options.length !== 2", enumBranch);
+  if (guard < 0 || guard > picker)
+    fail("the hierarchy editor still raises the picker for a two-option enum — it should " +
+         "fall through to beginHierarchyParamEdit and focus the row instead");
 
   if (failures) process.exit(1);
-  console.log("PASS: a two-option enum flips on click on both editors; three options still open; " +
-              "triggers and readouts are untouched");
+  console.log("PASS: a two-option enum flips on the GRID and focuses in the LIST; three options " +
+              "still open; triggers and readouts are untouched");
 }).catch((e) => { console.error("FAIL: " + (e && e.stack || e)); process.exit(1); });
 '

--- a/tests/host/test_two_way_knob_toggle.sh
+++ b/tests/host/test_two_way_knob_toggle.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A control with exactly TWO values TOGGLES on a detent, whichever way it went,
+# once per flick.
+#
+# There were three spellings of one control and two of them had a dead
+# direction:
+#
+#   Off/On (or int 0..1)  direction-ABSOLUTE: right meant On, left meant Off,
+#                         so at Off a left turn did nothing, forever
+#   Mix/Reverb            fell to the enum branch and CLAMPED behind a
+#                         four-detent gate, so at Mix a left turn did nothing,
+#                         forever, and a right turn took four detents
+#
+# Reported from the device: "if there are only two, why not let it wrap
+# otherwise you have to know which way is off and which way is on, in which
+# case you need some knowledge you dont have." There is no way to acquire it —
+# the cell shows a STATE, not a direction.
+#
+# WRAPPING ALONE IS NOT THE ANSWER, which is what most of this file is about.
+# With two values, "wrap" and "toggle on every detent" are identical, and one
+# flick of an encoder is a dozen detents — so a flick would land on whichever
+# value the detent count happened to be even or odd about. The LATCH is what
+# makes the gesture legible, and it is a latch rather than a rate limit: the
+# stamp is the last DETENT, so the clock runs on STILLNESS. That distinction
+# shipped wrong once already on the trigger and was reported from hardware.
+#
+# The gap VALUE is deliberately not pinned. The tests assert "clearly inside"
+# and "clearly outside" so the constant can be retuned without breaking them,
+# while a broken latch still fails.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2; exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/knob_engine.mjs"),
+]).then(([K]) => {
+  let failures = 0;
+  const fail = (m) => { console.error("FAIL: " + m); failures++; };
+
+  const OFF_ON  = { type: "enum", options: ["Off", "On"] };
+  const CHOICE  = { type: "enum", options: ["Mix", "Reverb"] };
+  const INTBOOL = { type: "int", min: 0, max: 1 };
+  const THREE   = { type: "enum", options: ["A", "B", "C"] };
+  const TRIGGER = { type: "enum", options: ["—", "Rnd!"], access: "write" };
+
+  /* One detent, from a cold state, at t. */
+  const tap = (meta, from, dir, t) => {
+    const st = K.knobInit(from);
+    K.knobStep(st, meta, dir, t);
+    return st.value;
+  };
+
+  /* ---- 1. either direction reaches the other value --------------------- */
+  for (const [name, meta] of [["Off/On", OFF_ON], ["Mix/Reverb", CHOICE], ["int 0..1", INTBOOL]]) {
+    for (const from of [0, 1]) {
+      const want = from === 0 ? 1 : 0;
+      for (const dir of [1, -1]) {
+        const got = tap(meta, from, dir, 1000);
+        if (got !== want)
+          fail(name + " at " + from + " turned " + (dir > 0 ? "up" : "down") + " gave " + got +
+               ", expected " + want + " — a two-way with a dead direction is dead half the " +
+               "time, and the cell shows a state, not a direction");
+      }
+    }
+  }
+
+  /* ---- 2. ONE FLICK IS ONE FLIP ---------------------------------------- */
+  for (const [name, meta] of [["Off/On", OFF_ON], ["Mix/Reverb", CHOICE], ["int 0..1", INTBOOL]]) {
+    const st = K.knobInit(0);
+    let t = 1000;
+    K.knobStep(st, meta, 1, t);
+    if (st.value !== 1) fail(name + ": the first detent of a flick did not flip it");
+    /* Two seconds of detents 30ms apart. Under a plain wrap this lands on
+     * whichever parity the count has; under a RATE LIMIT of any plausible
+     * size it flips several times. */
+    for (t = 1030; t <= 3000; t += 30) K.knobStep(st, meta, 1, t);
+    if (st.value !== 1)
+      fail(name + ": a 2-second spin left it at " + st.value + " — one flick must be one flip, " +
+           "so this is a wrap or a rate limit rather than a gesture latch");
+  }
+
+  /* ---- 3. the clock runs on STILLNESS, not on elapsed time -------------- */
+  {
+    const st = K.knobInit(0);
+    let t = 1000;
+    K.knobStep(st, OFF_ON, 1, t);                       /* flip */
+    for (t = 1030; t <= 3000; t += 30) K.knobStep(st, OFF_ON, 1, t);
+    /* Still latched at t=3000 even though 2s have passed since the FLIP —
+     * because the knob never stopped. Now let it stop. */
+    K.knobStep(st, OFF_ON, 1, 5000);
+    if (st.value !== 0)
+      fail("the knob went still for 2s and the next detent did not flip it — the stamp must be " +
+           "the last DETENT, written before the early return");
+    /* And a detent clearly INSIDE the window is still swallowed. */
+    K.knobStep(st, OFF_ON, 1, 5100);
+    if (st.value !== 0) fail("a detent 100ms after a flip was not swallowed");
+  }
+
+  /* ---- 4. what is NOT a two-way ----------------------------------------- */
+  {
+    /* Three options keep the sweep: a long list wants a gate, not a toggle. */
+    const st = K.knobInit(0);
+    K.knobStep(st, THREE, 1, 1000);
+    if (st.value === 1)
+      fail("a three-option enum flipped on ONE detent — it should still be gated, and it " +
+           "should never toggle");
+    for (let t = 1030; t <= 1200; t += 30) K.knobStep(st, THREE, 1, t);
+    if (st.value !== 1) fail("a three-option enum did not advance across a gated sweep");
+    /* ...and it CLAMPS at the top rather than wrapping round to A. Wrapping a
+     * 47-model list would make the end of it unreachable by feel. */
+    for (let t = 1230; t <= 3000; t += 30) K.knobStep(st, THREE, 1, t);
+    if (st.value !== 2) fail("a three-option enum did not clamp at its last option");
+
+    /* A TRIGGER is a two-option enum on the wire. Toggling it would write
+     * "do nothing" on every other flick — for euclidrum that is the write that
+     * destroys a kit. */
+    const tv = tap(TRIGGER, 1, 1, 1000);
+    if (tv === 0)
+      fail("a trigger was toggled back to its IDLE spelling — a two-way rule must never " +
+           "reach access:write");
+  }
+
+  /* ---- 5. the gap matches the trigger latch, by NUMBER ------------------ */
+  {
+    const fs = require("fs");
+    const pc = fs.readFileSync("src/shared/param_pages/page_controller.mjs", "utf8");
+    const m = pc.match(/TRIGGER_KNOB_GESTURE_GAP_MS\s*=\s*(\d+)/);
+    if (!m) fail("could not find TRIGGER_KNOB_GESTURE_GAP_MS in page_controller.mjs");
+    else if (Number(m[1]) !== K.TWO_WAY_GESTURE_GAP_MS)
+      fail("the two-way latch is " + K.TWO_WAY_GESTURE_GAP_MS + "ms and the trigger latch is " +
+           m[1] + "ms — they are the same rule (one flick is one gesture) and a user cannot " +
+           "learn two different flick lengths for two controls that look alike");
+  }
+
+  if (failures) process.exit(1);
+  console.log("PASS: a two-value control toggles either way, once per flick, and neither a " +
+              "longer enum nor a trigger is touched");
+}).catch((e) => { console.error("FAIL: " + (e && e.stack || e)); process.exit(1); });
+'


### PR DESCRIPTION
A picker over two items is a menu whose entire content is the value already
visible in the cell and the one other value there is, and it charges two
gestures for a state one gesture can describe. Reported from the device against
Global Settings' **Mirror Display** and **Move->Schwung**: *"if an option has
two values, clicking it should change the option ... we dont need a whole menu
for two items"*.

So a two-option enum now **writes the other value on click** and never raises
the list. Past two options nothing changes.

## What holds it together

`flipsOnClick` (`param_meta.mjs`) is **one definition serving two questions
that must not disagree** — what the click does (`page_controller.onClick`) and
what the footer promises while the knob is held (`CLK FLIP`, not `CLK OPEN`).
The divable/opaque pair beside it is written up as exactly that failure three
times over: a cell became a door and the footer had to be told separately, so
it advertised `CLK MENU` over a click that opened an editor.

**The FLIP branch must precede the divable OPEN branch** — a two-option enum is
still divable, so OPEN claims it otherwise. Pinned as an ordering.

**It requires `divable`, which is what keeps TRIGGERS out.** A trigger is a
two-option enum in the wire format (`["—","Rnd!"]`), so a predicate written on
the option count alone turns every momentary in the fleet into a latch —
euclidrum randomises a kit on the way past. Readouts are excluded the same way.

## Two scope calls

**Not limited to booleans.** `drawnAsSwitch` splits Off/On (212 fleet cells)
from a two-way CHOICE — `Mix/Reverb`, `Saw/Square`, `Legato/Trig` (134 cells) —
and that split is right for the **peek**, which exists to show a word the cell
has no room for. It is wrong here: what the flip removes is the SECOND GESTURE,
and a choice pays that exactly as a boolean does. Two rules over the same
population, disagreeing on purpose.

**Both editors flip.** The hierarchy list editor too, or the same parameter
answers the same gesture two different ways depending on a Param View setting
the user can flip — the drift `test_knob_surfaces_access.sh` exists to catch on
the trigger latch. It restates the predicate rather than importing it, because
its meta is the RAW `chain_params` declaration (`type`, not `kind`, and no
`divable` at all); the two exclusions `divable` carries are its own two early
returns immediately above.

## Tests

`tests/host/test_two_option_enum_flip.sh` drives the real controller — the flip
**both ways** (one direction passes with a hard-coded write), three options
still opening with their list intact, a trigger still firing through the module
wire, a readout still inert — plus source pins for the footer ordering and the
list editor.

Mutated four ways to prove it can fail, and **the list-editor probe passed with
the flip deleted** on the first attempt: it anchored on the first
`type === "enum"` in `shadow_ui.js`, which is `isTriggerEnumMeta` 1500 lines
earlier, whose own `options.length === 2` satisfied the search. Re-anchored on
the hierarchy editor's own branch; all four mutations now fail correctly.

Footer measured rather than counted: `JOG PAGE / CLK FLIP` is 83px against
OPEN's 86px, and with `SHFT FINE` it is 127px — so the third pair survives
where it did not before.

Full `tests/host` suite green (shell + C units). Docs updated in `CLAUDE.md`
and `docs/MODULES.md`; the manual sentence lives in the catalog-site repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Teq4Bz8wTG1cfff8XUnWoP