### PR TITLE
catalog: minijv needs a host that gates pages by mode

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -65,7 +65,7 @@
       "github_repo": "charlesvestal/schwung-jv880",
       "default_branch": "main",
       "asset_name": "minijv-module.tar.gz",
-      "min_host_version": "0.3.0",
+      "min_host_version": "0.13.0",
       "requires": "ROM files (place in module's roms/ folder)"
     },
     {


### PR DESCRIPTION
Sets minijv's `min_host_version` to `0.13.0` (was `0.3.0`), ahead of charlesvestal/schwung-jv880#10.

### Would it break on an old device, or just show things together?

Just show them together — measured by planning minijv 0.6.0's real emitted contract with **0.12.1's own planner**:

```
0.12.1 (pre-#320)   patch 79 pages, performance 79 — identical
main  (with #320)   patch 70 pages, performance 10
```

No crash, every declared key still reachable, no duplicate page names, and the new DSP params work fine — they're plain get/set and don't care about the host. It's the pre-existing "both trees, always" muddle with three more pages in it.

### The one thing that IS worse than before

Patch mode on an old host now offers two save pages:

```
Save to Slot       -> save_slot/do_save_to_slot            writes the patch
Save to Slot - 2   -> save_perf_slot/do_save_to_perf_slot  writes the performance
```

`Save to Slot - 2` writes the temp performance into one of the 16 Internal performance slots and persists NVRAM immediately. Destructive, unrecoverable without a backup, and distinguished from its sibling only by a numeral the deduper appended. That page did not exist before 0.6.0, which is what makes this a gate rather than a preference.

### Why 0.13.0

#320 is merged but unreleased — `src/host/version.txt` still reads `0.12.1` — so there is no shipped host to point at, and 1.0.0 lands shortly. `0.13.0` blocks every current device and is satisfied by 1.0.0.

Verified against **both** comparators, since there are two: `isNewerSemver` in schwung-manager (the enforced path — `main.go:1125`, which reads *this* field, not the module's own `module.json`) and `compareVersions` in `store_utils.mjs`. They agree on all five cases:

```
min=0.13.0  host=0.12.1  -> BLOCKED
min=0.13.0  host=0.9.9   -> BLOCKED
min=0.13.0  host=0.13.0  -> ALLOWED
min=0.13.0  host=0.13.1  -> ALLOWED
min=0.13.0  host=1.0.0   -> ALLOWED
```

### Scope of the protection

`checkHostCompat` fails **open** when `host/version.txt` cannot be read — deliberately, so a broken setup can still recover. So this gates the manager's install path, not a hand-copied install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013d8mi3cKNYtK7P4Sq4ciFa