### PR TITLE
param pages: a page arrives with its values, not without them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1451,12 +1451,54 @@ when the renderer observes one, so it never showed the widgets the placeholder
 and passed with the bug fully present), and its positive control turned a
 two-option enum already at its top, so nothing moved.
 
-Still open, and a separate change: this stops the MOTION, not the fill-in. Cells
-still populate one per tick, so a page arrives showing `--` in cells whose reads
-have not landed. The `page-slide-transition` branch's `neighbourPrefetch`
-(`2ba94c0b`) warms pages ±1 on spare rotation stops and is the fix for that —
-but it only covers a jog to an adjacent page, never first entry into a
-component, and it depends on that branch`s `fullKey(key, page)` change.
+### The neighbour lane warms page ±1, and it is NOT the same fix
+
+`observeLanded` stops what arrives from moving; it does not make it arrive any
+sooner. The rotation still serves one key per tick, so jogging to a cold page
+means watching it populate a cell at a time. `neighbourPrefetch` spends a
+CONDITIONAL extra rotation stop on one uncached key belonging to page ±1, so a
+warm neighbourhood costs nothing at all and a cold one is bounded by the sixteen
+keys either side of you. Ported from the `page-slide-transition` branch
+(`2ba94c0b`), where it existed because a page whose cells fill in *while it
+slides* is what the slide was added to avoid.
+
+Held off for one full pass after a page change (`PREFETCH_HOLD_TICKS`, 12 — the
+page you ARRIVED on owns the screen) and entirely while any key is settling (a
+knob is under a finger). Both are HOLDS: the lane resumes on its own, and "no
+reads happened" cannot distinguish a hold from a lane that is switched off,
+which is why each is tested against a positive control.
+
+**`fullKey` gained an optional PAGE argument for this** — it resolves a
+child-level template against whichever page is passed, defaulting to the current
+one, so a bare key would ask the wire about `synth:tune` for a neighbour serving
+`synth:part2_tune`: a number read off the wrong parameter, cached under the bare
+key, with nothing on screen to say so.
+
+**The two fixes are independent, and the ablation matrix is the evidence** (a
+jog onto a page carrying all three animated widgets):
+
+| lane | observeLanded | warmed | ticks to fill | animates in |
+|---|---|---|---|---|
+| on | on | 3/3 | 0 | no |
+| off | on | 0/3 | 3 | no |
+| on | off | 3/3 | 0 | no |
+| off | off | 0/3 | 3 | **yes** |
+
+Either one alone suppresses the animation *on a jog* — but only the lane removes
+the fill-in, and only `observeLanded` covers a component's FIRST page, which the
+lane can never reach because nothing is adjacent to a page set that does not
+exist yet. Keep both.
+
+**The probe that produced that table was wrong first, in the now-familiar way:**
+it jogged and snapshotted without TICKING, so no value ever *arrived* and the
+animation axis could not move — every row read "settled", including the
+all-disabled control. A matrix whose control cannot fail is not a matrix.
+
+`tests/host/test_neighbour_prefetch.sh` asserts a read COUNT, because "the
+values are there" passes just as well with a lane that reads every tick forever.
+Four mutants killed on this branch: lane disabled, hold removed, child key
+resolved against the wrong page, and the tri-state ignored so a failed read is
+cached.
 
 ### Recording / capture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1500,6 +1500,61 @@ Four mutants killed on this branch: lane disabled, hold removed, child key
 resolved against the wrong page, and the tri-state ignored so a failed read is
 cached.
 
+### The FIRST page is warmed synchronously, because nothing is adjacent to it
+
+The lane cannot reach a component's first page — nothing is adjacent to a page
+set that does not exist yet — so entry still filled one key per tick, ~9 ticks
+(~150ms), with every cell drawing a confidently WRONG picture until its value
+landed. Reported from the device: *"all of the controls up for a frame or so
+with the wrong value before snapping to the right one"*.
+
+**It snaps together rather than filling in cell by cell because of the viz
+groups.** obxd's Main page draws a filter curve from four keys and an ADSR from
+four more, so a graphic stays wrong until its LAST member arrives and then the
+whole thing jumps. Rendered, frame 0 had the filter curve collapsed into the
+bottom-left corner, the envelope a spike at the left edge, and Octave reading
+`--`. Suppressing the ANIMATION did not stop the placeholder being DRAWN — same
+rule, one layer up.
+
+`warmCurrentPage()` reads the entered page's keys before the first frame. It is
+called from the LOAD path, never from `tick()`: the controller is built during
+input handling and the draw happens on a later frame, so a warm here lands
+before anything is shown while a warm on the tick is always one frame late —
+and one frame late is the whole bug. Measured over the fleet: **all 95 modules
+now draw frame 0 identical to settled**, worst entry cost 8 reads ≈ 22 ms,
+capped by the 8-knob page.
+
+**It stops at the FIRST failed read, and that bound matters more than the warm.**
+A module not serving yet — minijv and osirus are the slowest in the fleet —
+costs one timeout instead of eight, and the rotation retries for free. Entry
+stalling on eight dead reads is a worse failure than the flash this removes.
+
+Deliberately NOT on every page change: the lane keeps neighbours warm, so a jog
+finds them cached and blocking there would put a hitch on the exact gesture the
+lane exists to smooth. A far JUMP from the section picker can still land cold —
+known, and left rather than widened without a report.
+
+**`acceptValue` is the extraction that made this safe.** The tri-state here is
+three rules deep and every one was a shipped bug — a failed read is not a value;
+`""` is a MISS for a number or enum (`Number("") === 0` put a silent zero on the
+slot-settings Volume knob); `""` is a VALUE for an opaque key (an empty filepath
+is NONE). The rotation and the warm share it rather than each carrying a copy.
+The condition re-plan lives in it too: a warm that stored a condition key without
+replanning would leave the rotation reading the same value later, seeing no
+change, and never revealing the pages that key gates.
+
+`warmCurrentPage` therefore runs **two passes** — `acceptValue` can re-plan
+underneath it, swapping the page being warmed for a different key set. The
+second pass is free when nothing changed (every key is already cached, so it
+makes no reads). The bound of 2 is DEFENCE, not behaviour: no fleet contract
+reaches it, and raising it to 99 kills no test — recorded so the survival is not
+read as a coverage hole, exactly like the prefetch's two guards.
+
+`tests/host/test_page_entry_warm.sh` asserts **exactly** one read per key, not
+"at least": the cached-key skip is invisible on the happy path, and without it a
+plain page costs 16 reads — twice the entry budget, and a mutant that survived
+the first version of this test.
+
 ### Recording / capture
 
 Audio capture is shim-side: the Quantized Sampler (Shift+Sample) and Skipback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1415,21 +1415,25 @@ passes vacuously: forgetting `setLayout(LAYOUT_MOVY)` (the default is
 `LAYOUT_DIAL`, which has no animated widget at all), and asserting a particular
 picture instead of a difference between two frames.
 
-**A value ARRIVING is not a value changing, and 51 of 95 fleet modules
+**A value ARRIVING is not a value changing, and 46 of 95 fleet modules
 animated their first page in.** The read cursor serves one key per tick, so a
 full page of 8 knobs spends ~9 ticks (~200ms) with `values[key]` undefined —
 and every animated widget rendered that absence as a CONCRETE PLACEHOLDER:
-`drawSwitch` read NaN and drew OFF, `drawWaveform` resolved shape 0,
-`drawEnumSquare` sized itself around `"--"`. `observe` recorded the placeholder
-as the settled first sighting, so the real value arrived as a TRANSITION —
-switches sweeping on, waveforms morphing, enum boxes growing, out of values
-nobody had set. This is the tri-state read rule one layer below where it is
+`drawWaveform` resolved shape 0 and `drawEnumSquare` sized itself around
+`"--"`. `observe` recorded the placeholder as the settled first sighting, so
+the real value arrived as a TRANSITION — waveforms morphing and enum boxes
+growing, out of values nobody had set. (`drawSwitch` was the third and the
+loudest, reading NaN and drawing OFF; #323 cut its fill for unrelated reasons
+while this was in flight, which is why the count is 46 and not the 51 measured
+before it landed. The switch stays in the absence test`s fixture but is no
+longer one of its subjects — a widget that cannot animate cannot demonstrate
+an arrival.) This is the tri-state read rule one layer below where it is
 usually enforced: a read that did not complete must not produce a plan, a
 default or a cached verdict, and **a widget frame is all three**.
 
 `observeLanded(state, key, raw, value, now, ms)` takes the RAW value alongside
 the token being animated. **The two are separate arguments on purpose**: every
-derivation here is TOTAL, so `on ? 1 : 0`, `"s" + shape` and a pixel width all
+derivation here is TOTAL, so `"s" + shape` and a pixel width both
 produce a perfectly ordinary token for an absent input — which is exactly how
 the placeholder got in. Only the raw value still carries the absence, so only
 it can be asked about it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1529,10 +1529,36 @@ A module not serving yet — minijv and osirus are the slowest in the fleet —
 costs one timeout instead of eight, and the rotation retries for free. Entry
 stalling on eight dead reads is a worse failure than the flash this removes.
 
-Deliberately NOT on every page change: the lane keeps neighbours warm, so a jog
-finds them cached and blocking there would put a hitch on the exact gesture the
-lane exists to smooth. A far JUMP from the section picker can still land cold —
-known, and left rather than widened without a report.
+**IT RUNS ON EVERY PAGE CHANGE TOO, and the first cut did not.** That version
+argued the lane already keeps neighbours warm so a jog finds them cached, and
+blocking would "put a hitch on the exact gesture the lane exists to smooth."
+Measured, that is false at any speed a hand actually jogs. The lane fires on ONE
+stop of a ~10-stop rotation — one neighbour key per ~10 ticks, so eight keys is
+~80 ticks plus the 12-tick hold. Against a 3 × 8-knob module, by dwell before
+jogging on:
+
+| dwell | known on arrival | fill-in |
+|---|---|---|
+| 200 ms | 1/8 | 153 ms |
+| 500 ms | 3/8 | 153 ms |
+| 1000 ms | 6/8 | 153 ms |
+| 1500 ms | 8/8 | none |
+
+So the lane only wins if you sit on a page for a second and a half. Reported
+from the device as *"i still see it … just going from one page to another
+slowly"* — precisely the 200–1000 ms band. The old objection is answered by the
+measurement: the alternative is not a smooth gesture, it is 153 ms of WRONG
+PICTURE, and ~22 ms of nothing is better. With the warm on the hop, every dwell
+arrives 8/8 and settles in one frame, and the cost degrades gracefully — 22 ms
+at a fast jog, 0 once the lane has kept up.
+
+**That is what the lane is actually for**, and it is worth stating because the
+first cut had it backwards: the lane does not make the page correct, the warm
+does. The lane makes the warm FREE, turning a per-hop cost into an occasional
+one. Neither is redundant.
+
+`goToPage` gets it too — that is the path a far JUMP from the section picker
+takes, where the lane has warmed nothing at all.
 
 **`acceptValue` is the extraction that made this safe.** The tri-state here is
 three rules deep and every one was a shipped bug — a failed read is not a value;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1415,6 +1415,49 @@ passes vacuously: forgetting `setLayout(LAYOUT_MOVY)` (the default is
 `LAYOUT_DIAL`, which has no animated widget at all), and asserting a particular
 picture instead of a difference between two frames.
 
+**A value ARRIVING is not a value changing, and 51 of 95 fleet modules
+animated their first page in.** The read cursor serves one key per tick, so a
+full page of 8 knobs spends ~9 ticks (~200ms) with `values[key]` undefined —
+and every animated widget rendered that absence as a CONCRETE PLACEHOLDER:
+`drawSwitch` read NaN and drew OFF, `drawWaveform` resolved shape 0,
+`drawEnumSquare` sized itself around `"--"`. `observe` recorded the placeholder
+as the settled first sighting, so the real value arrived as a TRANSITION —
+switches sweeping on, waveforms morphing, enum boxes growing, out of values
+nobody had set. This is the tri-state read rule one layer below where it is
+usually enforced: a read that did not complete must not produce a plan, a
+default or a cached verdict, and **a widget frame is all three**.
+
+`observeLanded(state, key, raw, value, now, ms)` takes the RAW value alongside
+the token being animated. **The two are separate arguments on purpose**: every
+derivation here is TOTAL, so `on ? 1 : 0`, `"s" + shape` and a pixel width all
+produce a perfectly ordinary token for an absent input — which is exactly how
+the placeholder got in. Only the raw value still carries the absence, so only
+it can be asked about it.
+
+**Nothing is recorded while the value is absent**, rather than recorded and
+suppressed: leaving the key out of the store makes the first real value a first
+sighting, which `observe` already stamps as already-past. Recording it would
+leave `from` pointing at a value that was never on screen, and the next genuine
+change would animate out of it. `undefined` ONLY — the controller refuses to
+cache `null` or `""` as a value, so an unanswered key is `undefined` and nothing
+else, and widening to falsy would swallow `0`, a legitimate reading of every
+switch, shape and enum in the fleet.
+
+`tests/host/test_anim_absent_values.sh` asserts BOTH halves — an arrival draws
+the settled frame immediately, AND a change after it still animates — because
+the first alone passes with every animation deleted. **Its two probe defects are
+the reusable part**: it ticked without DRAWING (the store only learns a value
+when the renderer observes one, so it never showed the widgets the placeholder
+and passed with the bug fully present), and its positive control turned a
+two-option enum already at its top, so nothing moved.
+
+Still open, and a separate change: this stops the MOTION, not the fill-in. Cells
+still populate one per tick, so a page arrives showing `--` in cells whose reads
+have not landed. The `page-slide-transition` branch's `neighbourPrefetch`
+(`2ba94c0b`) warms pages ±1 on spare rotation stops and is the fix for that —
+but it only covers a jog to an adjacent page, never first entry into a
+component, and it depends on that branch`s `fullKey(key, page)` change.
+
 ### Recording / capture
 
 Audio capture is shim-side: the Quantized Sampler (Shift+Sample) and Skipback

--- a/fp.mjs
+++ b/fp.mjs
@@ -1,0 +1,36 @@
+import { createController, LAYOUT_MOVY } from "./src/shared/param_pages/page_controller.mjs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
+import fs from "fs";
+const fx = JSON.parse(fs.readFileSync("tests/fixtures/module-contracts.json", "utf8"));
+let affected = [], total = 0;
+for (const m of fx.modules) {
+  const cp = m.chain_params; if (!cp) continue;
+  const params = typeof cp === "string" ? JSON.parse(cp) : cp;
+  const vals = Object.create(null);
+  for (const p of params) {
+    if (p.type === "enum" && Array.isArray(p.options)) vals[p.key] = String(Math.min(1, p.options.length - 1));
+    else if (p.type === "int") vals[p.key] = String(p.min ?? 0);
+    else vals[p.key] = "0.5";
+  }
+  let clock = 1000, served = false; total++;
+  try {
+    const ctl = createController({
+      getParam: (k) => {
+        const b = String(k).replace(/^[^:]+:/, "");
+        if (b === "ui_hierarchy") return m.ui_hierarchy ? JSON.stringify(m.ui_hierarchy) : "";
+        if (b === "chain_params") return typeof cp === "string" ? cp : JSON.stringify(cp);
+        if (!served && b in vals) return "";
+        return b in vals ? vals[b] : "";
+      }, setParam: () => {}, announce: () => {}, now: () => clock });
+    ctl.setLayout(LAYOUT_MOVY); ctl.load({ prefix: "synth" });
+    const shot = () => { const fb = createFramebuffer(); ctl.render(drawContext(fb)); return Buffer.from(fb.pixels).toString("base64"); };
+    for (let i = 0; i < 25; i++) { ctl.tick(); shot(); }
+    served = true;
+    const keys = ((ctl.page && ctl.page.keys) || []).filter(Boolean);
+    let g = 0;
+    while (g++ < 300 && !keys.every((k) => ctl.state.values[k] !== undefined)) { ctl.tick(); shot(); }
+    const a = shot(); clock += 900;
+    if (a !== shot()) affected.push(m.id);
+  } catch (e) {}
+}
+console.log("driven:", total, " animate themselves in:", affected.length);

--- a/src/shared/param_pages/anim_state.mjs
+++ b/src/shared/param_pages/anim_state.mjs
@@ -88,9 +88,10 @@ export function observe(state, key, value, now, durationMs = 120) {
  * own because by the time a widget calls in, an absent value has already been
  * turned into a concrete picture. The read cursor serves one key per tick, so a
  * page of 8 knobs spends ~9 ticks (~200ms) with `values[key]` undefined — and
- * every animated widget rendered that as a real reading: drawSwitch read NaN
- * and drew OFF, drawWaveform resolved shape 0, drawEnumSquare sized itself
- * around "--". `observe` then recorded that placeholder as the settled first
+ * every animated widget rendered that as a real reading: drawWaveform resolved
+ * shape 0 and drawEnumSquare sized itself around "--" (and drawSwitch read NaN
+ * and drew OFF, until #323 cut its fill and left it with nothing to animate).
+ * `observe` then recorded that placeholder as the settled first
  * sighting and the real value arrived as a TRANSITION, so every page animated
  * itself in from values nobody had set.
  *
@@ -100,7 +101,7 @@ export function observe(state, key, value, now, durationMs = 120) {
  *
  * `raw` is the value as it came off the wire, NOT the token being animated.
  * The two are separate arguments on purpose: every caller here animates
- * something derived (`on ? 1 : 0`, `"s" + shape`, a pixel width), and every one
+ * something derived (`"s" + shape`, a pixel width), and every one
  * of those derivations is total — it produces a perfectly ordinary token for an
  * absent input, which is exactly how the placeholder got in. Only the raw value
  * still carries the absence, so only the raw value can be asked about it.

--- a/src/shared/param_pages/anim_state.mjs
+++ b/src/shared/param_pages/anim_state.mjs
@@ -81,6 +81,48 @@ export function observe(state, key, value, now, durationMs = 120) {
     return { from: state.from.get(key), to: value, t, moving: t < 1 };
 }
 
+/**
+ * `observe`, but only once the value has actually been READ.
+ *
+ * AN ARRIVAL IS NOT A CHANGE, and the store cannot tell the difference on its
+ * own because by the time a widget calls in, an absent value has already been
+ * turned into a concrete picture. The read cursor serves one key per tick, so a
+ * page of 8 knobs spends ~9 ticks (~200ms) with `values[key]` undefined — and
+ * every animated widget rendered that as a real reading: drawSwitch read NaN
+ * and drew OFF, drawWaveform resolved shape 0, drawEnumSquare sized itself
+ * around "--". `observe` then recorded that placeholder as the settled first
+ * sighting and the real value arrived as a TRANSITION, so every page animated
+ * itself in from values nobody had set.
+ *
+ * This is the tri-state read rule (see `shadow_get_param`) one layer below
+ * where it is usually enforced: a read that did not complete must not produce a
+ * plan, a default or a cached verdict — and a widget frame is all three.
+ *
+ * `raw` is the value as it came off the wire, NOT the token being animated.
+ * The two are separate arguments on purpose: every caller here animates
+ * something derived (`on ? 1 : 0`, `"s" + shape`, a pixel width), and every one
+ * of those derivations is total — it produces a perfectly ordinary token for an
+ * absent input, which is exactly how the placeholder got in. Only the raw value
+ * still carries the absence, so only the raw value can be asked about it.
+ *
+ * NOTHING IS RECORDED while the value is absent. That is the point: leaving the
+ * key out of the store entirely means the first real value is a FIRST SIGHTING,
+ * which `observe` already stamps as already-past. Recording the placeholder and
+ * suppressing the animation instead would leave `from` set to it, so the next
+ * genuine change would animate out of a value that was never on screen.
+ *
+ * `undefined` ONLY. `null` and `""` are not absences here: the controller
+ * refuses to cache either as a value (`""` is a served channel with nothing to
+ * say — except for an opaque key, where it is the real reading NONE), so a key
+ * that has never been answered is `undefined` and nothing else. Widening this
+ * to falsy would swallow `0`, which is a legitimate reading of every switch,
+ * shape and enum in the fleet.
+ */
+export function observeLanded(state, key, raw, value, now, durationMs = 120) {
+    if (raw === undefined) return { from: null, to: value, t: 1, moving: false };
+    return observe(state, key, value, now, durationMs);
+}
+
 function progress(state, key, now, durationMs) {
     const since = state.since.get(key);
     if (since === undefined || !(durationMs > 0)) return 1;

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -1358,11 +1358,29 @@ export function createController(io = {}) {
      * would stall on eight dead reads, which is a far worse failure than the
      * flash this removes.
      *
-     * Deliberately NOT applied on every page change: the lane already keeps
-     * neighbours warm, so a jog finds them cached, and blocking there would put
-     * a hitch on the exact gesture the lane exists to smooth. A far JUMP from
-     * the section picker can still land cold — known, and left alone rather
-     * than widened without a report.
+     * IT RUNS ON EVERY PAGE CHANGE TOO, and the first version of this did not
+     * — "deliberately NOT applied on every page change: the lane already keeps
+     * neighbours warm, so a jog finds them cached". **Measured, that is false
+     * at any speed a hand actually jogs.** The lane fires on ONE stop of a
+     * ~10-stop rotation, so it warms one neighbour key per ~10 ticks: eight
+     * keys is ~80 ticks, plus the 12-tick hold. Dwell on a page before jogging
+     * on, against a 3 x 8-knob module:
+     *
+     *     dwell  200ms -> 1/8 known on arrival, 153ms of fill-in
+     *     dwell  500ms -> 3/8
+     *     dwell 1000ms -> 6/8
+     *     dwell 1500ms -> 8/8, correct on frame 1
+     *
+     * So the lane only wins if you sit on a page for a second and a half.
+     * Reported from the device as *"i still see it ... just going from one page
+     * to another slowly"* — which is exactly the 200-1000ms band.
+     *
+     * The old objection was that blocking here puts "a hitch on the exact
+     * gesture the lane exists to smooth". The measurement answers it: the
+     * alternative is not a smooth gesture, it is 153ms of WRONG PICTURE, and
+     * ~22ms of nothing is better than that. The lane still earns its keep — it
+     * makes this call free whenever it has kept up, which is what turns a
+     * per-hop cost into an occasional one.
      */
     function warmCurrentPage() {
         if (!s.metaIndex) return 0;
@@ -2362,6 +2380,10 @@ export function createController(io = {}) {
             s.cursor = 0;
             s.touched = -1;
             s.turnClaimMs = 0;
+            /* Whatever the lane has not got to yet, read now — see
+             * warmCurrentPage. Usually free: the lane keeps the page you are
+             * jogging onto warm, so this makes no reads at all. */
+            warmCurrentPage();
             /* One full pass for the page you arrived on before warming
              * anything else. A page of 8 knobs is 9 stops, ~0.16s. */
             s.prefetchHoldUntil = s.tickCount + PREFETCH_HOLD_TICKS;
@@ -2414,6 +2436,9 @@ export function createController(io = {}) {
         s.cursor = 0;
         s.touched = -1;
         s.turnClaimMs = 0;
+        /* Same as onJog — and this is the path a far JUMP from the section
+         * picker takes, where the lane has warmed nothing at all. */
+        warmCurrentPage();
         /* Same hold as onJog: the arrived page owns the first full pass. */
         s.prefetchHoldUntil = s.tickCount + PREFETCH_HOLD_TICKS;
         /* enterMenu refuses an empty list, and then nobody has spoken yet. */

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -260,6 +260,15 @@ import { announcePage, announceTouch, announceTurn, announcePageContents } from 
 export const SETTLE_TICKS = 9;
 
 /**
+ * Ticks the neighbour-prefetch lane stays shut after a page change.
+ *
+ * A full page of 8 knobs is 9 rotation stops, so 12 covers one whole pass with
+ * room for the viz extra key and the lane's own stop: the page you ARRIVED on
+ * refreshes completely before anything reads for a page nobody is looking at.
+ */
+export const PREFETCH_HOLD_TICKS = 12;
+
+/**
  * Minimum gap between announcements for the SAME key while it is being
  * turned continuously. A fast physical spin decodes to one MIDI CC message
  * per detent — measured on device at up to ~286/s during a fast Braids turn
@@ -558,6 +567,10 @@ export function createController(io = {}) {
         /* key -> tick at which reads may resume */
         settleUntil: Object.create(null),
         tickCount: 0,
+        /* Tick at which the neighbour-prefetch lane may resume; armed on every
+         * page change so the arrived page gets one whole pass to itself. See
+         * neighbourPrefetch(). */
+        prefetchHoldUntil: 0,
         knobStates: Object.create(null),
         /* key -> ms of the last announce() for that key — see ANNOUNCE_THROTTLE_MS */
         lastAnnounceMs: Object.create(null),
@@ -693,13 +706,26 @@ export function createController(io = {}) {
         const at = s.childIndex[level];
         return (typeof at === "number" && at >= 0) ? at : 0;
     };
-    const childResolve = (key) => {
-        const p = page();
+    /*
+     * Resolve a child-level key against a page — the CURRENT one unless another
+     * is named.
+     *
+     * The optional argument exists for the neighbour-prefetch lane, which reads
+     * keys belonging to page ±1. Defaulting to the current page would ask the
+     * wire about `synth:tune` for a page serving `synth:part2_tune`: a number
+     * read off the wrong parameter, cached under the bare key, with nothing on
+     * screen to say so.
+     *
+     * Same shape as pageLabel(p): the argument defaults to the current page, so
+     * the two dozen call sites that genuinely mean "now" are unchanged.
+     */
+    const childResolve = (key, pg) => {
+        const p = pg === undefined ? page() : pg;
         if (!p || !p.childLevel || !Array.isArray(p.keys)) return key;
         if (p.keys.indexOf(key) < 0) return key;
         return resolveChildKey(p.childLevel, childIndexFor(p.level), key) || key;
     };
-    const fullKey = (key) => `${s.prefix}:${childResolve(key)}`;
+    const fullKey = (key, pg) => `${s.prefix}:${childResolve(key, pg)}`;
     const page = () => s.pages[s.pageIndex] || null;
 
     /*
@@ -1225,6 +1251,51 @@ export function createController(io = {}) {
         s.touched = -1;
     }
 
+    /**
+     * One uncached key belonging to an adjacent page, as `{key, page}` — or
+     * null when both neighbours are warm, which is the steady state.
+     *
+     * Returns the PAGE as well as the key because fullKey resolves a
+     * child-level template against whichever page is passed, defaulting to the
+     * current one; a bare key would be resolved against the wrong level.
+     *
+     * Held off for one full pass after a page change: the page you have just
+     * ARRIVED on is the one whose values are on screen, and it must not have
+     * to share the rotation with a page nobody is looking at yet.
+     *
+     * Held off entirely while anything is settling — a settle window means a
+     * knob is under a finger, and that key's own refresh is what the rotation
+     * is for. Both are HOLDS, not cancellations: the lane resumes on its own,
+     * which is a thing "no reads happened" cannot distinguish from a lane that
+     * is switched off, so the test pairs each with a positive control.
+     *
+     * TWO OF THE GUARDS BELOW ARE DEFENCE, NOT BEHAVIOUR, and the test cannot
+     * kill a mutant of either — recorded so the next reader does not take the
+     * survival for a coverage hole. Dropping `q.kind !== PAGE_KNOBS` changes
+     * nothing today because every non-knob page carries `keys: []`; dropping
+     * the `cur.keys` skip changes nothing because a key on the current page is
+     * either already in s.values or about to be read by the ordinary rotation.
+     * Both are kept so that a page kind which one day grows a `keys` array, or
+     * a level that repeats a key across a page break, cannot quietly make the
+     * lane read the screen back to itself.
+     */
+    function neighbourPrefetch(cur) {
+        if (s.tickCount < (s.prefetchHoldUntil || 0)) return null;
+        for (const k in s.settleUntil) {
+            if ((s.settleUntil[k] || 0) > s.tickCount) return null;
+        }
+        for (const d of [1, -1]) {
+            const q = s.pages[s.pageIndex + d];
+            if (!q || q.kind !== PAGE_KNOBS || !Array.isArray(q.keys)) continue;
+            for (const k of q.keys) {
+                if (!k) continue;
+                if (cur.keys.indexOf(k) >= 0) continue;
+                if (!(k in s.values)) return { key: k, page: q };
+            }
+        }
+        return null;
+    }
+
     function tick() {
         s.tickCount++;
         flushDueWrites();
@@ -1298,9 +1369,58 @@ export function createController(io = {}) {
          * takes.
          */
         const extraKeys = vizEnabled ? vizExtraKeys() : [];
-        const stops = p.keys.length + 1 + extraKeys.length;
+        /*
+         * THE NEIGHBOUR LANE — why the incoming page arrives populated.
+         *
+         * The rotation serves one key per tick, so a page of 8 knobs takes ~9
+         * ticks (~200ms) to fill. Jog to it and you watch it populate a cell at
+         * a time. This spends a stop on a key belonging to page ±1 that is not
+         * yet cached, so by the time you arrive it is already there.
+         *
+         * It PAIRS with observeLanded rather than replacing it. This stops the
+         * cells arriving one by one; that stops what arrives from animating.
+         * Neither covers the other: a warm page still has to not animate in
+         * (the lane cannot reach a component`s FIRST page — nothing is adjacent
+         * to a page set that does not exist yet), and a page that does not
+         * animate still fills in slowly without this.
+         *
+         * Bounded by construction: only UNCACHED keys, only the two adjacent
+         * pages, so it goes quiet on its own and stays quiet. A lane that kept
+         * reading would cost ~2.8ms per tick — more than the 1.68ms whole-page
+         * render it decorates — which is why the test counts reads rather than
+         * checking that the values are present. "The values are there" passes
+         * just as well with a lane that never stops.
+         *
+         * The stop is CONDITIONAL, so a warm neighbourhood costs nothing at
+         * all. That makes `stops` change by one as the lane opens and closes,
+         * which shifts `at` by one for a tick. Harmless: the rotation is a
+         * refresh loop, not a sequence with meaning — a key merely gets its
+         * turn one tick early or late.
+         *
+         * Blocking at jog time was rejected: up to eight uncached keys is
+         * ~22ms of dead time on a page's first visit, a visible hitch on the
+         * exact gesture this exists to smooth.
+         */
+        const warm = neighbourPrefetch(p);
+        const stops = p.keys.length + 1 + extraKeys.length + (warm ? 1 : 0);
         const at = s.cursor % stops;
         s.cursor = (s.cursor + 1) % stops;
+
+        if (warm && at === stops - 1) {
+            /* fullKey resolves a CHILD-level template against the page the key
+             * belongs to, so the neighbour page is passed explicitly — the
+             * default is the CURRENT page, which would ask the wire about
+             * `synth:p3` when the neighbour serves `synth:part2_p3`. */
+            const v = getParam(fullKey(warm.key, warm.page));
+            /* The tri-state, same as everywhere: a read that did not complete
+             * must not be cached as a value, and neither must the "" a served
+             * channel returns for a key nobody answers. Leaving it absent
+             * simply means the lane tries it again — and nothing revisits a
+             * key that IS in s.values, so caching either would blank that cell
+             * for good. */
+            if (v !== null && v !== undefined && v !== "") s.values[warm.key] = v;
+            return null;
+        }
 
         /* Give late metadata a chance to arrive, on a wall-clock cadence. */
         if (!triedReresolve && s.tickCount % META_RETRY_INTERVAL_TICKS === 0) {
@@ -2145,6 +2265,9 @@ export function createController(io = {}) {
             s.cursor = 0;
             s.touched = -1;
             s.turnClaimMs = 0;
+            /* One full pass for the page you arrived on before warming
+             * anything else. A page of 8 knobs is 9 stops, ~0.16s. */
+            s.prefetchHoldUntil = s.tickCount + PREFETCH_HOLD_TICKS;
             /* Leaving a page leaves the door it was. Without this, entering a
              * browser, Shift+jogging away and jogging BACK put you inside it
              * again without a click — the page had never been marked as left,
@@ -2194,6 +2317,8 @@ export function createController(io = {}) {
         s.cursor = 0;
         s.touched = -1;
         s.turnClaimMs = 0;
+        /* Same hold as onJog: the arrived page owns the first full pass. */
+        s.prefetchHoldUntil = s.tickCount + PREFETCH_HOLD_TICKS;
         /* enterMenu refuses an empty list, and then nobody has spoken yet. */
         if (!(enterIfDoor && isDoor(page()) && enterMenu())) announcePageChange();
         return s.pageIndex;

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -938,6 +938,9 @@ export function createController(io = {}) {
          * See restorePage(): the pages may not have existed when the caller
          * asked. */
         applyPendingRestore();
+        /* Before anything is drawn, never from tick() — see warmCurrentPage.
+         * s.values was cleared above, so this is the page's whole set. */
+        warmCurrentPage();
         announcePageChange();
         return true;
     }
@@ -1279,6 +1282,120 @@ export function createController(io = {}) {
      * a level that repeats a key across a page break, cannot quietly make the
      * lane read the screen back to itself.
      */
+    /**
+     * Take a value off the wire into `s.values`. Returns true if it was kept.
+     *
+     * ONE definition, because the tri-state here is three rules deep and every
+     * one of them was a shipped bug: a failed read is not a value, `""` is a
+     * MISS for a number or an enum (a key nobody serves answers `""`, and
+     * `Number("") === 0` put a silent zero on the slot-settings Volume knob),
+     * and `""` is a VALUE for an opaque key (an empty filepath is the module
+     * saying NONE). The read cursor and the entry warm below both go through
+     * this rather than each carrying a copy — a second copy is how one of them
+     * ends up disagreeing about `""` the first time either is touched.
+     *
+     * The condition re-plan lives here too, keyed on the value actually
+     * CHANGING. It has to: a warm that stored a condition key without replanning
+     * would leave the rotation reading the same value later, seeing no change,
+     * and never revealing the pages that key gates.
+     */
+    function acceptValue(key, raw, meta) {
+        if (raw === null || raw === undefined) return false;
+        if (raw === "" && meta.kind !== KIND_OPAQUE) return false;
+
+        /* First successful read repairs a guessed range, once — and teaches an
+         * enum which wire format its plugin speaks. This is THE read detection
+         * is allowed to use: it comes from the device, it is already being
+         * made, and it keeps arriving, so a verdict is never derived from a
+         * value the grid itself wrote. See learnEnumWireFormat. */
+        learnEnumWireFormat(meta, raw);
+        if (meta.guessed) {
+            const patch = inferFromValue(meta, raw);
+            if (patch) Object.assign(meta, patch);
+            delete meta.guessed;
+        }
+        /* A change to a key that gates visibility re-plans the page set: the
+         * params it hides or reveals are not otherwise reachable. */
+        const changed = s.values[key] !== raw;
+        s.values[key] = raw;
+        if (changed) replanIfCondition(key);
+        return true;
+    }
+
+    /**
+     * Read the page we are about to SHOW, before the first frame is drawn.
+     *
+     * THE FIRST PAGE OF A COMPONENT CANNOT BE PREFETCHED. The neighbour lane
+     * warms pages ±1, and nothing is adjacent to a page set that does not exist
+     * yet — so on entry the rotation filled the page one key per tick, ~9 ticks
+     * (~150ms), and every cell drew a confidently WRONG picture until its value
+     * landed. Reported from the device: *"all of the controls up for a frame or
+     * so with the wrong value before snapping to the right one"*.
+     *
+     * **It snaps together rather than filling in cell by cell because of the
+     * viz groups.** obxd's Main page draws a filter curve from four keys and an
+     * ADSR from four more, so a graphic stays visibly wrong until its LAST
+     * member arrives and then the whole thing jumps. Rendered, frame 0 has the
+     * filter curve collapsed into the bottom-left corner and the envelope as a
+     * spike at the left edge. That is the same rule `observeLanded` enforces one
+     * layer down — a read that did not answer must not become a picture — and
+     * suppressing the ANIMATION did not stop the placeholder being DRAWN.
+     *
+     * So this is called from the load path, not from `tick()`: the controller is
+     * built during input handling and the draw happens on a later frame, so a
+     * warm here lands before anything is shown, while a warm on the tick would
+     * always be one frame late — and one frame late is the whole bug.
+     *
+     * COST: ~8 reads at ~2.8ms, so ~23ms once, on a gesture that is already a
+     * module transition. That is under two frames against 150ms of wrong
+     * picture. The rotation would have made these same reads anyway; this only
+     * moves them ahead of the first draw.
+     *
+     * **It stops at the FIRST failed read, and that bound is the point.** A
+     * module that is not answering yet — minijv and osirus are the two slowest
+     * in the fleet — costs one timeout here instead of eight, and the ordinary
+     * rotation retries for free. Without the bound, entry to a slow module
+     * would stall on eight dead reads, which is a far worse failure than the
+     * flash this removes.
+     *
+     * Deliberately NOT applied on every page change: the lane already keeps
+     * neighbours warm, so a jog finds them cached, and blocking there would put
+     * a hitch on the exact gesture the lane exists to smooth. A far JUMP from
+     * the section picker can still land cold — known, and left alone rather
+     * than widened without a report.
+     */
+    function warmCurrentPage() {
+        if (!s.metaIndex) return 0;
+        let reads = 0;
+        /*
+         * TWO passes, because acceptValue can re-plan underneath us: a
+         * condition key gates which params are visible, so storing one can
+         * swap the page we are standing on for a different set of keys, and a
+         * single pass would then have warmed the page we left. The second pass
+         * costs nothing in the normal case — every key is already in s.values,
+         * so it makes no reads at all — and bounding it at two means a pair of
+         * condition keys that keep re-planning cannot spin here.
+         */
+        for (let pass = 0; pass < 2; pass++) {
+            const p = page();
+            if (!p || p.kind !== PAGE_KNOBS || !Array.isArray(p.keys)) return reads;
+            let readsThisPass = 0;
+            for (const key of p.keys) {
+                if (!key) continue;
+                if (key in s.values) continue;
+                const raw = getParam(fullKey(key, p));
+                reads++; readsThisPass++;
+                /* A failed read means the module is not serving yet. Stop —
+                 * see above. `""` is NOT a failure: acceptValue decides what
+                 * it means per kind, and the walk carries on either way. */
+                if (raw === null || raw === undefined) return reads;
+                acceptValue(key, raw, s.metaIndex.getOrGuess(key));
+            }
+            if (!readsThisPass) break;
+        }
+        return reads;
+    }
+
     function neighbourPrefetch(cur) {
         if (s.tickCount < (s.prefetchHoldUntil || 0)) return null;
         for (const k in s.settleUntil) {
@@ -1543,27 +1660,7 @@ export function createController(io = {}) {
          * still a miss, which is what keeps the slot-settings Volume bug
          * fixed: "" sailing through as a reading showed Number("") = 0.
          */
-        if (raw === null || raw === undefined) return null;
-        if (raw === "" && meta.kind !== KIND_OPAQUE) return null;
-
-        /* First successful read repairs a guessed range, once. */
-        /*
-         * ...and teaches an enum which wire format its plugin speaks. This is
-         * THE read detection is allowed to use: it comes from the device, it is
-         * already being made, and it keeps arriving, so a verdict is never
-         * derived from a value the grid itself wrote. See learnEnumWireFormat.
-         */
-        learnEnumWireFormat(meta, raw);
-        if (meta.guessed) {
-            const patch = inferFromValue(meta, raw);
-            if (patch) Object.assign(meta, patch);
-            delete meta.guessed;
-        }
-        /* A change to a key that gates visibility re-plans the page set: the
-         * params it hides or reveals are not otherwise reachable. */
-        const changed = s.values[key] !== raw;
-        s.values[key] = raw;
-        if (changed) replanIfCondition(key);
+        if (!acceptValue(key, raw, meta)) return null;
         return key;
     }
 

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -41,7 +41,7 @@ import {
 } from "./font_big_num.mjs";
 import { fontWidth4x5, fontPrint4x5, FONT4_HEIGHT, FONT4_MEASURE } from "./font4x5.mjs";
 import { fontWidth5x3, fontPrint5x3 } from "./font5x3.mjs";
-import { observe as animObserve, easeOut, lerp } from "./anim_state.mjs";
+import { observe as animObserve, observeLanded as animObserveLanded, easeOut, lerp } from "./anim_state.mjs";
 /* The one definition of the chrome geometry (see the band comment below). */
 import { SCREEN_WIDTH as W, HEADER_H, RULE_Y, FOOTER_Y, FOOTER_H,
          MENU_LIST_X, MENU_LIST_Y, MENU_LIST_W } from "../list_geometry.mjs";
@@ -1412,7 +1412,7 @@ export function enumSquareWidth(text) {
  * behaviour it did not ask for. A missing `anim` is the normal case, not an
  * error.
  */
-export function drawEnumSquare(ctx, kx, ky, text, anim, nowMs, animKey) {
+export function drawEnumSquare(ctx, kx, ky, text, anim, nowMs, animKey, raw) {
     const h = BOX_H;
     const target = enumSquareWidth(text);
 
@@ -1424,7 +1424,11 @@ export function drawEnumSquare(ctx, kx, ky, text, anim, nowMs, animKey) {
      */
     let w = target;
     if (anim && typeof nowMs === "number" && animKey) {
-        const a = animObserve(anim, "enumw:" + animKey, target, nowMs, ENUM_ANIM_MS);
+        /* `raw` is the value BEHIND the text, and the text alone cannot stand
+         * in for it: an unread key renders as "--", which is a perfectly
+         * ordinary string with a perfectly ordinary width, so the box would
+         * grow out of it on arrival. See observeLanded. */
+        const a = animObserveLanded(anim, "enumw:" + animKey, raw, target, nowMs, ENUM_ANIM_MS);
         if (a.moving && typeof a.from === "number") {
             w = Math.round(lerp(a.from, target, easeOut(a.t)));
             if (w < ENUM_MIN_W) w = ENUM_MIN_W;
@@ -1832,7 +1836,7 @@ export function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, ce
         /* Its own centring — it reserves an ENUM_W slot, not KW, and sizes
          * itself inside it. */
         drawEnumSquare(ctx, cellLeft(g, col) + Math.floor((g.cellW - ENUM_W) / 2), ky, text,
-                       anim, nowMs, animKey);
+                       anim, nowMs, animKey, shown);
         return;
     }
     /*

--- a/src/shared/param_pages/viz_draw.mjs
+++ b/src/shared/param_pages/viz_draw.mjs
@@ -34,7 +34,7 @@ import {
 } from "./viz.mjs";
 import { enumIndexOf } from "./param_meta.mjs";
 import { wavPeaks, resamplePeaks } from "./wav_peaks.mjs";
-import { observe, easeOut, lerp } from "./anim_state.mjs";
+import { observeLanded, easeOut, lerp } from "./anim_state.mjs";
 
 /* ------------------------------------------------------------- animation --
  *
@@ -1077,7 +1077,12 @@ export function drawWaveform(ctx, rect, key, values, metaIndex, anim, nowMs) {
          * retarget morphs from the shape it was heading to — the last thing
          * actually drawn — which at 100ms is at most one frame stale.
          */
-        const tr = observe(anim, "wave:" + key, "s" + shape, nowMs, WAVE_MORPH_MS);
+        /* The RAW value, not the shape id: `lfoShapeIdOf` falls through to a
+         * default for anything it does not recognise, so an unread key resolves
+         * to a perfectly ordinary shape and the morph out of it looks exactly
+         * like a real one. See observeLanded. */
+        const tr = observeLanded(anim, "wave:" + key, values ? values[key] : undefined,
+                                 "s" + shape, nowMs, WAVE_MORPH_MS);
         if (tr.moving && typeof tr.from === "string") {
             const f = Number(tr.from.slice(1));
             if (Number.isFinite(f) && f !== shape) { morphFrom = f; morphT = easeOut(tr.t); }

--- a/tests/host/test_anim_absent_values.sh
+++ b/tests/host/test_anim_absent_values.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A VALUE ARRIVING IS NOT A VALUE CHANGING.
+#
+# The read cursor serves ONE key per tick, so a full page of 8 knobs takes ~9
+# ticks (~200ms) to populate. Until a key`s read lands, `s.values[key]` is
+# undefined -- and every animated widget rendered that absence as a CONCRETE
+# PLACEHOLDER: drawSwitch read NaN and drew OFF, drawWaveform resolved shape 0,
+# drawEnumSquare sized itself around "--". The store recorded that placeholder
+# as the settled first sighting, and the real value then arrived as a CHANGE.
+#
+# So every page animated itself in on entry -- switches sweeping on, waveforms
+# morphing, enum boxes growing -- from values nobody had set. This is the
+# tri-state read rule one layer below where it is usually enforced: an
+# unanswered read must not become a picture, and here it became a picture that
+# then moved.
+#
+# THE FIX IS NOT "DO NOT ANIMATE". This asserts BOTH halves:
+#   - an arrival draws the settled frame immediately, and
+#   - a change after that still animates.
+# A test with only the first half passes with every animation deleted.
+#
+# NO APOSTROPHES inside the node script: single-quoted bash string.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the anim absence test" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { createController, LAYOUT_MOVY }
+  from "./src/shared/param_pages/page_controller.mjs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
+
+let fail = 0;
+const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
+
+/* One of each animated widget: the waveform morph and the enum square resize.
+   A test carrying only one of them passes while the other still animates
+   itself in.
+
+   THE SWITCH IS DELIBERATELY NOT A SUBJECT. It used to be -- it was the
+   loudest of the three -- but #323 cut its 160ms fill entirely ("the switch
+   toggles, it does not animate"), so it can no longer prove anything about an
+   arrival. `onoff` stays in the fixture only to keep a switch on the page, so
+   that a future change re-animating it is caught by the frame comparison
+   rather than sailing past a test that stopped looking. */
+const CHAIN_PARAMS = [
+  { key: "onoff", name: "Gate", type: "enum", options: ["Off", "On"] },
+  { key: "shape", name: "Shape", type: "enum",
+    options: ["Sine", "Tri", "Saw", "Square", "Noise"] },
+  { key: "mode", name: "Mode", type: "enum",
+    options: ["A", "Beta", "Gamma"] },
+];
+const HIER = { modes: null, levels: { root: { label: "T",
+  knobs: ["onoff", "shape", "mode"], params: CHAIN_PARAMS.map((p) => ({ key: p.key })) } } };
+
+let clock = 1000;
+/* The values the module WILL report once it answers. Deliberately not the
+   zeroth option of anything: the placeholder every widget falls back to is
+   option 0, so a fixture sitting on 0 cannot tell an arrival from a no-op. */
+const store = { onoff: "1", shape: "3", mode: "2" };
+/* While false, the value keys read "" -- a served channel with nothing to
+   say, which the controller correctly refuses to cache. That is exactly the
+   state a page is in before its reads land, and it is reachable without
+   faking the rotation. */
+let served = false;
+const ctl = createController({
+  getParam: (k) => {
+    const b = String(k).replace(/^[^:]+:/, "");
+    if (b === "ui_hierarchy") return JSON.stringify(HIER);
+    if (b === "chain_params") return JSON.stringify(CHAIN_PARAMS);
+    if (!served && b in store) return "";
+    return b in store ? store[b] : "";
+  },
+  setParam: (k, v) => { store[String(k).replace(/^[^:]+:/, "")] = String(v); },
+  announce: () => {},
+  now: () => clock,
+});
+ctl.setLayout(LAYOUT_MOVY);
+ctl.load({ prefix: "synth" });
+
+const shot = () => {
+  const fb = createFramebuffer();
+  ctl.render(drawContext(fb));
+  return Buffer.from(fb.pixels).toString("base64");
+};
+/* THE DEVICE DRAWS EVERY TICK, AND THAT IS THE WHOLE MECHANISM.
+   The store only learns a value when the RENDERER observes one, so a probe
+   that ticks without drawing never shows the widgets the placeholder and
+   passes with the bug fully present. Ticking and drawing together is what the
+   grid actually does while its reads trickle in. */
+const step = () => { ctl.tick(); shot(); };
+const landed = () => ["onoff", "shape", "mode"]
+  .every((k) => ctl.state.values[k] !== undefined);
+
+/* Settle the page with the values still unserved. */
+for (let i = 0; i < 20; i++) step();
+ok(!landed(), "the fixture really does start with no values -- otherwise the " +
+   "arrival below is not an arrival and this whole test is vacuous");
+
+/* Now the module answers. Ticks do NOT advance the clock, so the frame taken
+   the moment the last value lands sits at t=0 of any animation the arrival
+   started: maximally mid-flight, which is the easiest possible case to catch. */
+served = true;
+let guard = 0;
+while (!landed() && guard++ < 200) step();
+ok(landed(), "the values landed");
+
+const onArrival = shot();
+clock += 900;
+const afterArrival = shot();
+
+ok(onArrival === afterArrival,
+   "the frame at the instant the values arrive is ALREADY the settled one -- " +
+   "an arrival is not a change, and a page must not animate itself in");
+
+/* THE OTHER HALF. Deleting the animations passes everything above.
+
+   Driven on the WAVEFORM, not the switch: #323 cut the switch fill, so a flip
+   is settled on every frame and would report "no animation" whether or not the
+   arrival fix is present -- which is a positive control that cannot fail. */
+const slotOf = (k) => (ctl.page.keys || []).indexOf(k);
+const sw = slotOf("shape");
+ok(sw >= 0, "the waveform reached the page");
+
+const before = shot();
+/* Turn it DOWN: the fixture rests at Square (index 3 of 5), so down is a real
+   step either way. An enum is gated at 4 raw detents per option. */
+for (let i = 0; i < 6; i++) { clock += 20; ctl.onKnobTurn(sw, -1, clock); }
+clock += 40;
+const mid = shot();
+clock += 900;
+const settled = shot();
+
+ok(mid !== before, "the turn changed the picture at all");
+ok(mid !== settled,
+   "a real CHANGE still animates -- without this, suppressing the arrival by " +
+   "deleting the animation passes every assertion above");
+
+process.exit(fail ? 1 : 0);
+'

--- a/tests/host/test_neighbour_prefetch.sh
+++ b/tests/host/test_neighbour_prefetch.sh
@@ -1,0 +1,483 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# THE PREFETCH IS ASSERTED AS A READ COUNT, NOT AS "THE VALUES ARE THERE".
+#
+# "The incoming page has its values" passes just as well with a lane that reads
+# every tick forever -- and a parameter read is ~2.8ms against a ~18ms tick, so
+# a lane that never goes quiet costs more than the 1.68ms whole-page render it
+# is decorating. What must be true is that it warms the neighbours and then
+# STOPS. So every probe below counts reads that name a key belonging to a page
+# the user is not on, and the quiet assertion requires that count to be ZERO
+# over hundreds of idle ticks.
+#
+# Two of these probes have a POSITIVE CONTROL beside them on purpose. "No
+# neighbour reads happened" is satisfied by a lane that is switched off, by a
+# fixture whose neighbours are already warm, and by a fixture with no
+# neighbours at all -- three ways to pass while measuring nothing. Each hold
+# probe therefore first proves the lane WOULD have read here, then holds it off
+# and proves it did not.
+#
+# NO APOSTROPHES inside the node script: single-quoted bash string.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the neighbour prefetch test" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { createController, LAYOUT_MOVY, SETTLE_TICKS, PREFETCH_HOLD_TICKS }
+  from "./src/shared/param_pages/page_controller.mjs";
+
+let fail = 0;
+const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
+
+/* 24 knobs paginate to three pages of eight, so the middle page has a
+   neighbour on BOTH sides -- the -1 direction is half the feature and a
+   fixture standing on page 0 never exercises it. */
+const KEYS = [];
+for (let i = 0; i < 24; i++) KEYS.push("p" + i);
+const CHAIN_PARAMS = KEYS.map((k, i) => ({
+  key: k, name: "P" + i, type: "float", min: 0, max: 1, step: 0.01,
+}));
+const HIER = { modes: null, levels: { root: { label: "T", knobs: KEYS,
+  params: CHAIN_PARAMS.map((p) => ({ key: p.key })) } } };
+
+/* Every getParam lands here. A wire key is `<prefix>:<key>` and may carry a
+   suffix (`:base`), so the BARE name is the first segment after the prefix. */
+const baseOf = (k) => String(k).replace(/^[^:]+:/, "").split(":")[0];
+
+let reads = [];
+let clock = 1000;
+const ctl = createController({
+  getParam: (k) => {
+    const b = baseOf(k);
+    reads.push(b);
+    if (b === "ui_hierarchy") return JSON.stringify(HIER);
+    if (b === "chain_params") return JSON.stringify(CHAIN_PARAMS);
+    if (b === "preset_name") return "Init";
+    return KEYS.indexOf(b) >= 0 ? "0.5" : "";
+  },
+  setParam: () => {},
+  announce: () => {},
+  now: () => clock,
+});
+ctl.setLayout(LAYOUT_MOVY);
+ctl.load({ prefix: "synth" });
+
+const s = ctl.state;
+const keysOf = (i) => ((s.pages[i] && s.pages[i].keys) || []).filter(Boolean);
+const run = (n) => { for (let i = 0; i < n; i++) { clock += 18; ctl.tick(); } };
+/* Reads naming a param key that is NOT on the page being looked at. Only the
+   lane can produce one, so this is the lane`s read count. */
+const offPageReads = () => {
+  const own = keysOf(s.pageIndex);
+  return reads.filter((k) => KEYS.indexOf(k) >= 0 && own.indexOf(k) < 0);
+};
+
+run(40);
+ok(s.pages.length >= 3, "the fixture plans at least three knob pages");
+
+ctl.goToPage(1, { remember: false });
+ok(s.pageIndex === 1, "standing on the middle page, with a neighbour each side");
+
+const prevKeys = keysOf(0), nextKeys = keysOf(2), ownKeys = keysOf(1);
+ok(prevKeys.length === 8 && nextKeys.length === 8 && ownKeys.length === 8,
+   "each of the three pages carries eight keys");
+
+/* ---------------------------------------------------------------- warm up */
+
+/* Page 0 was the landing page, so its keys are already in s.values from the
+   ordinary rotation -- leave them there and the -1 half of the assertion below
+   is true whether or not a lane exists. Evict them. */
+for (const k of prevKeys) delete s.values[k];
+ok(prevKeys.every((k) => !(k in s.values)),
+   "the page BEHIND has been evicted, so warming it can only be the lane");
+
+run(300);
+const warmedNext = nextKeys.filter((k) => k in s.values).length;
+const warmedPrev = prevKeys.filter((k) => k in s.values).length;
+ok(warmedNext === nextKeys.length,
+   "every key of the page AHEAD is cached without ever having visited it ("
+   + warmedNext + "/" + nextKeys.length + ")");
+ok(warmedPrev === prevKeys.length,
+   "every key of the page BEHIND is cached too ("
+   + warmedPrev + "/" + prevKeys.length + ")");
+
+/* ------------------------------------------------------ and then it stops */
+
+reads = [];
+run(300);
+const stray = offPageReads();
+ok(stray.length === 0,
+   "once warm the lane issues NO further reads over 300 idle ticks ("
+   + stray.length + " seen)");
+
+/* The page you ARE on must still be refreshing -- a lane that went quiet by
+   killing the whole rotation would pass the assertion above. */
+const ownRefresh = reads.filter((k) => ownKeys.indexOf(k) >= 0).length;
+ok(ownRefresh > 100,
+   "the ordinary rotation is still refreshing the current page ("
+   + ownRefresh + " reads)");
+
+/*
+ * THE STOP IS CONDITIONAL, and this is the only assertion that says so.
+ *
+ * Making the extra stop UNCONDITIONAL costs no IPC -- the read is still
+ * guarded by "is there a warm key" -- so every read-count assertion above
+ * survives it. What it costs is a DEAD stop in the rotation: with 8 keys and
+ * the preset name that is 9 stops per pass, and a tenth that reads nothing
+ * slows the current page`s own refresh by 10% forever. Measured as "every idle
+ * tick issues exactly one read", which is what a rotation with no dead stop
+ * means, and which drops to 9/10 of the ticks the moment one appears.
+ */
+ok(reads.length === 300,
+   "with a warm neighbourhood every tick still spends its stop on a real read ("
+   + reads.length + " reads over 300 ticks)");
+ok(ownRefresh + reads.filter((k) => k === "preset_name").length === 300,
+   "and those reads are the page`s own keys plus the preset name, nothing else");
+
+/* -------------------------------------------------- arriving costs nothing */
+
+reads = [];
+clock += 18;
+ctl.onJog(1);
+ok(reads.length === 0, "the jog itself issues no reads at all");
+ok(s.pageIndex === 2, "the jog landed on the page that was warmed");
+ok(keysOf(2).every((k) => k in s.values),
+   "the arrived page is already populated at the instant of arrival");
+
+/* ------------------------- the hold is armed by the JOG, not only goToPage */
+
+/*
+ * onJog and goToPage each arm the hold at their own call site, so a probe that
+ * only ever changes page one way leaves the other arming unmeasured. Set up a
+ * cold neighbour BEFORE jogging, so the hold is the only thing that could keep
+ * the lane quiet on arrival.
+ */
+{
+  ctl.goToPage(0, { remember: false });
+  run(300);                       /* pages 0 and 1 warm; page 2 is not a neighbour */
+  for (const k of keysOf(2)) delete s.values[k];
+  clock += 18;
+  reads = [];
+  ctl.onJog(1);                   /* -> page 1, whose +1 neighbour is cold */
+  /*
+   * RUN THE WHOLE HOLD, NOT ONE PASS.
+   *
+   * This first said `run(keys + 1)` -- exactly one pass -- and dropping the
+   * hold entirely SURVIVED it. s.cursor is reset to 0 by the page change and
+   * the lane stop is the LAST one in the rotation, so a run of one pass never
+   * reaches the lane whether the hold exists or not: the probe excluded the
+   * case it was written to catch. Run to one tick short of the hold, which is
+   * past the lane stop and still inside it.
+   */
+  run(PREFETCH_HOLD_TICKS - 1);
+  ok(s.pageIndex === 1, "the jog landed on the middle page");
+  ok(offPageReads().length === 0,
+     "the jog arms the hold too: nothing off-page is read for the whole hold "
+     + "after a JOG (" + offPageReads().length + " strays)");
+  reads = [];
+  run(60);
+  ok(offPageReads().length > 0,
+     "control: that neighbour really was cold, and is read once the hold "
+     + "expires (" + offPageReads().length + ")");
+  /* Put the fixture back where the next section expects it: on page 2, warm. */
+  ctl.goToPage(2, { remember: false });
+  run(300);
+}
+
+/* --------------------------------- the first pass belongs to the arrival */
+
+/*
+ * POSITIVE CONTROL FIRST. Page 2 has an unwarmed neighbour ahead of it only if
+ * the pages exist; with three pages, arriving on 2 leaves page 1 (warm) behind
+ * and nothing ahead, so the lane has nothing to do and "no lane reads" would be
+ * vacuously true. Force a cold neighbour by evicting page 1`s keys, then show
+ * the lane WOULD read them, before proving the hold suppresses it.
+ */
+for (const k of keysOf(1)) delete s.values[k];
+reads = [];
+run(30);
+ok(offPageReads().length > 0,
+   "control: with a cold neighbour and no hold, the lane does read ("
+   + offPageReads().length + ")");
+
+/* Now re-cool them and change page, which arms the hold. */
+ctl.goToPage(1, { remember: false });
+for (const k of keysOf(0)) delete s.values[k];
+for (const k of keysOf(2)) delete s.values[k];
+reads = [];
+const pass = keysOf(1).length + 1;   /* eight keys plus the preset-name stop */
+/* Same reason as the jog probe above: one pass is shorter than the reach of
+   the lane stop, so it cannot tell a hold from no hold. */
+run(PREFETCH_HOLD_TICKS - 1);
+const duringFirstPass = offPageReads();
+ok(duringFirstPass.length === 0,
+   "nothing off-page is read for the whole hold after a goToPage ("
+   + duringFirstPass.length + " strays)");
+ok(reads.filter((k) => keysOf(1).indexOf(k) >= 0).length >= pass - 2,
+   "and it spends that time on the arrived page rather than idling");
+
+/* The hold is a hold, not a cancellation: it must let go. */
+reads = [];
+run(60);
+ok(offPageReads().length > 0,
+   "once the hold expires the lane resumes ("
+   + offPageReads().length + " reads)");
+
+/* ------------------------------------- a knob under a finger owns the tick */
+
+/* Re-cool both neighbours so the lane genuinely has work waiting. */
+run(300);
+for (const k of keysOf(0)) delete s.values[k];
+for (const k of keysOf(2)) delete s.values[k];
+
+/* Control: no settle armed, the lane reads. */
+reads = [];
+run(20);
+ok(offPageReads().length > 0,
+   "control: with neighbours cold and nothing settling, the lane reads ("
+   + offPageReads().length + ")");
+
+/* Now arm a settle window the way a real turn does, and re-cool. */
+for (const k of keysOf(0)) delete s.values[k];
+for (const k of keysOf(2)) delete s.values[k];
+clock += 18;
+ctl.onKnobTurn(0, 1, clock);
+const settledKey = keysOf(1)[0];
+ok((s.settleUntil[settledKey] || 0) > s.tickCount,
+   "the turn armed a settle window on the touched key");
+reads = [];
+run(SETTLE_TICKS - 1);
+const duringSettle = offPageReads();
+ok(duringSettle.length === 0,
+   "no neighbour is read while a key is inside its settle window ("
+   + duringSettle.length + " strays)");
+
+/* And the settle is not a permanent off switch either. */
+reads = [];
+run(60);
+ok(offPageReads().length > 0,
+   "the lane resumes once the settle window expires ("
+   + offPageReads().length + " reads)");
+
+/* --------------------------------------------- a failed read is not a value */
+
+/*
+ * THE TRI-STATE. null means the read did not complete; "" means the channel
+ * served us and the key produced nothing. Caching either as a value would make
+ * the lane go quiet on a page it never actually read -- and the cell would
+ * then draw whatever "" or null formats to, forever, because nothing revisits
+ * a key that is present in s.values.
+ *
+ * Asserted as an ABSENCE from s.values plus a RETRY, because "the value is
+ * wrong" is not observable here: an uncached key and a key cached as "" both
+ * draw blank.
+ */
+let denyNeighbours = "null";
+const ctl2 = createController({
+  getParam: (k) => {
+    const b = baseOf(k);
+    reads.push(b);
+    if (b === "ui_hierarchy") return JSON.stringify(HIER);
+    if (b === "chain_params") return JSON.stringify(CHAIN_PARAMS);
+    if (b === "preset_name") return "Init";
+    if (KEYS.indexOf(b) < 0) return "";
+    const own = ((ctl2.state.pages[ctl2.state.pageIndex] || {}).keys || []);
+    if (own.indexOf(b) >= 0) return "0.5";
+    if (denyNeighbours === "null") return null;
+    if (denyNeighbours === "empty") return "";
+    if (denyNeighbours === "undefined") return undefined;
+    return "0.5";
+  },
+  setParam: () => {}, announce: () => {}, now: () => clock,
+});
+ctl2.setLayout(LAYOUT_MOVY);
+ctl2.load({ prefix: "synth" });
+const s2 = ctl2.state;
+const run2 = (n) => { for (let i = 0; i < n; i++) { clock += 18; ctl2.tick(); } };
+run2(40);
+ctl2.goToPage(1, { remember: false });
+
+/* `undefined` is here because the io contract says string-or-null and a host
+   binding that answers neither is exactly the case a `!== null` guard alone
+   lets through. */
+for (const mode of ["null", "empty", "undefined"]) {
+  denyNeighbours = mode;
+  run2(200);
+  const off = ((s2.pages[2] || {}).keys || []).filter(Boolean);
+  const cached = off.filter((k) => k in s2.values).length;
+  ok(cached === 0,
+     "a neighbour read answering " + mode + " caches nothing (" + cached + ")");
+  reads = [];
+  run2(60);
+  const retried = reads.filter((k) => off.indexOf(k) >= 0).length;
+  ok(retried > 0,
+     "and the lane keeps retrying it rather than treating it as done ("
+     + retried + ")");
+  /*
+   * AND THE CURRENT PAGE MUST STILL BE GETTING ITS WHOLE ROTATION.
+   *
+   * Moving the lane to stop 0 instead of the last stop passes every other
+   * assertion in this file, and starves p.keys[0] of the CURRENT page for as
+   * long as any neighbour is cold -- which, with a neighbour that never
+   * answers, is forever. Assert that every key of the page on screen is still
+   * being read while the lane retries.
+   */
+  const ownHere = ((s2.pages[s2.pageIndex] || {}).keys || []).filter(Boolean);
+  const starved = ownHere.filter((k) => reads.indexOf(k) < 0);
+  ok(starved.length === 0,
+     "the page on screen keeps its whole rotation while the lane retries ("
+     + starved.join(",") + ")");
+}
+
+/* Serving it for real settles the lane, which proves the retry above is
+   driven by the absence and not by an unconditional read every tick. */
+denyNeighbours = "serve";
+run2(300);
+reads = [];
+run2(200);
+const ownNow = ((s2.pages[s2.pageIndex] || {}).keys || []);
+const strays2 = reads.filter((k) => KEYS.indexOf(k) >= 0 && ownNow.indexOf(k) < 0);
+ok(strays2.length === 0,
+   "once served, the retrying lane goes quiet (" + strays2.length + ")");
+
+/* ------------------------- a CHILD-level neighbour is resolved as its own */
+
+/*
+ * fullKey resolves a child-level template against a PAGE, and that page
+ * argument defaults to the CURRENT one. The lane reads for a page that is by
+ * definition not current, so omitting the argument asks the wire about
+ * `synth:tune` when the neighbour serves `synth:part0_tune` -- a value read off
+ * the wrong parameter and then cached under the bare key, invisibly. Nothing on
+ * screen says so: both keys exist and both answer a plausible number.
+ *
+ * Needs its own fixture. The shared one has a child level, but its child knob
+ * page is fenced in by two ITEMS pages, and tick() returns early on those --
+ * the lane can never look at it from either side. Here `tail` follows the child
+ * level, so a plain knob page stands directly after a child one.
+ */
+{
+  const CKEYS = ["a", "b", "c", "d"];
+  const CPARAMS = [
+    ...CKEYS.map((k) => ({ key: k, name: k, type: "float", min: 0, max: 1, step: 0.01 })),
+    ...["tune", "level"].map((k) => ({ key: k, name: k, type: "float", min: 0, max: 1, step: 0.01 })),
+    ...["x", "y"].map((k) => ({ key: k, name: k, type: "float", min: 0, max: 1, step: 0.01 })),
+  ];
+  const CHIER = { modes: null, levels: {
+    root: { label: "T", knobs: CKEYS,
+            params: [...CKEYS.map((k) => ({ key: k })),
+                     { level: "parts", label: "Parts" },
+                     { level: "tail", label: "Tail" }] },
+    parts: { label: "Parts", child_count: 4, child_prefix: "part", child_label: "Part",
+             knobs: ["tune", "level"], params: [{ key: "tune" }, { key: "level" }] },
+    tail: { label: "Tail", knobs: ["x", "y"], params: [{ key: "x" }, { key: "y" }] },
+  } };
+  const cstore = {};
+  for (const k of [...CKEYS, "x", "y"]) cstore[k] = "0.5";
+  /* Both forms exist and both answer. That is the point: reading the wrong one
+     returns a number rather than failing, so only the ASKED key reveals it. */
+  for (const k of ["tune", "level"]) {
+    cstore[k] = "0.9";
+    for (let i = 0; i < 4; i++) cstore["part" + i + "_" + k] = "0.2";
+  }
+
+  const asked = [];
+  let ck = 1000;
+  const c = createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      asked.push(b);
+      if (b === "ui_hierarchy") return JSON.stringify(CHIER);
+      if (b === "chain_params") return JSON.stringify(CPARAMS);
+      return b in cstore ? cstore[b] : "";
+    },
+    setParam: () => {}, announce: () => {}, now: () => ck,
+  });
+  c.setLayout(LAYOUT_MOVY);
+  c.load({ prefix: "synth" });
+  for (let i = 0; i < 60; i++) { ck += 18; c.tick(); }
+
+  const P = c.state.pages;
+  let stand = -1, childAt = -1;
+  for (let i = 0; i < P.length; i++) {
+    if (!P[i] || P[i].kind !== "knobs" || !P[i].childLevel) continue;
+    for (const d of [-1, 1]) {
+      const q = P[i + d];
+      if (q && q.kind === "knobs" && !q.childLevel) { stand = i + d; childAt = i; break; }
+    }
+    if (stand >= 0) break;
+  }
+  ok(stand >= 0, "the fixture puts a plain knob page next to a child-level one");
+
+  if (stand >= 0) {
+    c.goToPage(stand, { remember: false });
+    for (let i = 0; i < 200; i++) { ck += 18; c.tick(); }
+    const childKeys = (P[childAt].keys || []).filter(Boolean);
+    for (const k of childKeys) delete c.state.values[k];
+    asked.length = 0;
+    for (let i = 0; i < 120; i++) { ck += 18; c.tick(); }
+
+    const bareAsks = asked.filter((k) => childKeys.indexOf(k) >= 0).length;
+    const resolvedAsks = asked.filter(
+      (k) => childKeys.some((t) => k !== t && k.endsWith("_" + t))).length;
+    ok(resolvedAsks > 0,
+       "the lane asks the wire for the CHILD-resolved key (" + resolvedAsks + " asks)");
+    ok(bareAsks === 0,
+       "and never for the bare template, which belongs to no level ("
+       + bareAsks + " asks)");
+    /* And the value it cached is the child`s, not the bare key`s. */
+    ok(c.state.values[childKeys[0]] === "0.2",
+       "the cached value came from the child parameter, not the template ("
+       + c.state.values[childKeys[0]] + ")");
+  }
+}
+
+/* ------------------------ exactly ONE page in each direction, and no more */
+
+/*
+ * The bound is what keeps the lane cheap and what makes it go quiet. Widening
+ * it to +/-2 breaks nothing above -- the first fixture has three pages, so two
+ * away is off the end -- and it doubles the work for pages the slide will not
+ * reach on the next jog. Five pages, stood in the middle, is the shape that
+ * can tell the difference.
+ */
+{
+  const WK = [];
+  for (let i = 0; i < 40; i++) WK.push("w" + i);
+  const WP = WK.map((k, i) => ({ key: k, name: "W" + i, type: "float", min: 0, max: 1, step: 0.01 }));
+  const WH = { modes: null, levels: { root: { label: "T", knobs: WK,
+    params: WP.map((q) => ({ key: q.key })) } } };
+  let wk = 1000;
+  const w = createController({
+    getParam: (k) => {
+      const b = baseOf(k);
+      if (b === "ui_hierarchy") return JSON.stringify(WH);
+      if (b === "chain_params") return JSON.stringify(WP);
+      if (b === "preset_name") return "Init";
+      return WK.indexOf(b) >= 0 ? "0.5" : "";
+    },
+    setParam: () => {}, announce: () => {}, now: () => wk,
+  });
+  w.setLayout(LAYOUT_MOVY);
+  w.load({ prefix: "synth" });
+  for (let i = 0; i < 40; i++) { wk += 18; w.tick(); }
+  const wp = w.state.pages;
+  ok(wp.length === 5, "the wide fixture plans five knob pages (" + wp.length + ")");
+
+  w.goToPage(2, { remember: false });
+  for (const k of Object.keys(w.state.values)) delete w.state.values[k];
+  for (let i = 0; i < 600; i++) { wk += 18; w.tick(); }
+
+  const cachedOn = (i) => (wp[i].keys || []).filter((k) => k && (k in w.state.values)).length;
+  ok(cachedOn(1) === 8 && cachedOn(3) === 8,
+     "both immediate neighbours are warmed (" + cachedOn(1) + "/" + cachedOn(3) + ")");
+  ok(cachedOn(0) === 0 && cachedOn(4) === 0,
+     "and NOTHING two pages away is (" + cachedOn(0) + "/" + cachedOn(4) + ")");
+}
+
+process.exit(fail ? 1 : 0);
+'

--- a/tests/host/test_page_entry_warm.sh
+++ b/tests/host/test_page_entry_warm.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# THE FIRST PAGE OF A COMPONENT CANNOT BE PREFETCHED.
+#
+# The neighbour lane warms pages +/-1, and nothing is adjacent to a page set
+# that does not exist yet -- so on entry the rotation filled the page one key
+# per tick (~9 ticks, ~150ms) and every cell drew a confidently WRONG picture
+# until its value landed. Reported from the device: "all of the controls up for
+# a frame or so with the wrong value before snapping to the right one".
+#
+# It snaps TOGETHER rather than filling in cell by cell because a viz group is
+# drawn from several keys -- obxd`s Main page draws a filter curve from four and
+# an ADSR from four more -- so a graphic stays wrong until its LAST member
+# arrives and then the whole thing jumps.
+#
+# THE BOUND IS AS IMPORTANT AS THE WARM. A module that is not serving yet must
+# cost ONE timeout, not eight: entry stalling on eight dead reads is a worse
+# failure than the flash this removes. So this asserts the read COUNT and the
+# stop-on-first-failure, not just "the picture is right".
+#
+# NO APOSTROPHES inside the node script: single-quoted bash string.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the page entry warm test" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { createController, LAYOUT_MOVY }
+  from "./src/shared/param_pages/page_controller.mjs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
+
+let fail = 0;
+const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
+
+const CP = [];
+for (let i = 0; i < 8; i++) {
+  CP.push({ key: "k" + i, name: "K" + i, type: "float", min: 0, max: 1, step: 0.01 });
+}
+const HIER = { modes: null, levels: { root: { label: "T",
+  knobs: CP.map((p) => p.key), params: CP.map((p) => ({ key: p.key })) } } };
+
+/* Values deliberately NOT the placeholder: an absent float renders at zero, so
+   a fixture resting on zero cannot tell a warmed page from a cold one. */
+function makeCtl({ answer }) {
+  const asked = [];
+  let clock = 1000;
+  const ctl = createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return JSON.stringify(HIER);
+      if (b === "chain_params") return JSON.stringify(CP);
+      asked.push(b);
+      return answer(b);
+    },
+    setParam: () => {}, announce: () => {}, now: () => clock,
+  });
+  ctl.setLayout(LAYOUT_MOVY);
+  return { ctl, asked, bump: (ms) => { clock += ms; } };
+}
+
+const shot = (ctl) => {
+  const fb = createFramebuffer();
+  ctl.render(drawContext(fb));
+  return Buffer.from(fb.pixels).toString("base64");
+};
+
+/* ---- 1. the first DRAWN frame is already correct ---------------------- */
+{
+  const { ctl, asked } = makeCtl({ answer: () => "0.78" });
+  ctl.load({ prefix: "synth" });
+  const first = shot(ctl);
+  const known = (ctl.page.keys || []).filter((k) => k && ctl.state.values[k] !== undefined).length;
+  ok(known === 8, "every value on the entered page is known before the first draw (" + known + "/8)");
+  /* EXACTLY eight, not "at least". The second pass exists for a condition key
+     that re-plans the page underneath the first, and it must skip everything
+     already cached -- without that guard a plain page costs 16 reads, which is
+     twice the entry hitch this whole change is budgeted against, and "the
+     values are there" cannot see it. */
+  const warmAsks = asked.filter((b) => /^k[0-7]$/.test(b));
+  ok(warmAsks.length === 8,
+     "and it cost EXACTLY one read per key (" + warmAsks.length + "), never re-reading a cached one");
+
+  /* Let the rotation run out a full pass and settle. */
+  for (let i = 0; i < 30; i++) ctl.tick();
+  ok(first === shot(ctl),
+     "the FIRST frame drawn equals the settled one -- no fill-in, no flash");
+}
+
+/* ---- 2. it is BOUNDED, and it stops at the first failed read ---------- */
+{
+  /* Third key answers null: the module is not serving yet. */
+  const { ctl, asked } = makeCtl({ answer: (b) => (b === "k2" ? null : "0.78") });
+  ctl.load({ prefix: "synth" });
+  const valueAsks = asked.filter((b) => /^k[0-7]$/.test(b));
+  ok(valueAsks.length === 3,
+     "a failed read STOPS the warm: 3 reads, not 8 (" + valueAsks.length + ")");
+  ok(ctl.state.values.k2 === undefined,
+     "and the failed read cached nothing -- a read that did not complete is not a value");
+  ok(ctl.state.values.k0 === "0.78",
+     "the reads before it were kept");
+}
+
+/* ---- 3. a warm page costs NOTHING on a re-entry ----------------------- */
+{
+  const { ctl, asked } = makeCtl({ answer: () => "0.78" });
+  ctl.load({ prefix: "synth" });
+  const afterFirst = asked.length;
+  /* Same contract, same fingerprint: reloadIfChanged returns early, so no
+     second warm. Reading anything here would mean entry cost doubles every
+     time the grid re-resolves its contract. */
+  ctl.load({ prefix: "synth" });
+  ok(asked.length === afterFirst,
+     "re-entering the same page set makes no further warm reads (" +
+     (asked.length - afterFirst) + ")");
+}
+
+/* ---- 4. the warm is not a per-tick lane ------------------------------- */
+{
+  const { ctl, asked } = makeCtl({ answer: () => "0.78" });
+  ctl.load({ prefix: "synth" });
+  const afterLoad = asked.length;
+  for (let i = 0; i < 40; i++) ctl.tick();
+  const perTick = (asked.length - afterLoad) / 40;
+  ok(perTick <= 1.05,
+     "the rotation still reads at most ~1 key per tick (" + perTick.toFixed(2) +
+     ") -- the warm is an entry cost, not a standing one");
+}
+
+process.exit(fail ? 1 : 0);
+'

--- a/tests/host/test_page_entry_warm.sh
+++ b/tests/host/test_page_entry_warm.sh
@@ -130,5 +130,48 @@ const shot = (ctl) => {
      ") -- the warm is an entry cost, not a standing one");
 }
 
+/* ---- 5. A JOG lands on a correct page too ----------------------------- */
+{
+  /* THE CASE THE FIRST VERSION MISSED. The warm ran only on load, on the
+     reasoning that "the lane already keeps neighbours warm". Measured, the lane
+     fires on ONE stop of a ~10-stop rotation -- one neighbour key per ~10 ticks
+     -- so eight keys needs ~1.5s of dwell. Reported from the device as "i still
+     see it ... just going from one page to another slowly", which is exactly
+     the band where the lane has done some of the work and not all of it. */
+  const WIDE = [];
+  for (let i = 0; i < 24; i++) {
+    WIDE.push({ key: "w" + i, name: "W" + i, type: "float", min: 0, max: 1, step: 0.01 });
+  }
+  const WH = { modes: null, levels: { root: { label: "T",
+    knobs: WIDE.map((p) => p.key), params: WIDE.map((p) => ({ key: p.key })) } } };
+  let clock = 1000;
+  const ctl = createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return JSON.stringify(WH);
+      if (b === "chain_params") return JSON.stringify(WIDE);
+      return /^w\d+$/.test(b) ? "0.78" : "";
+    },
+    setParam: () => {}, announce: () => {}, now: () => clock,
+  });
+  ctl.setLayout(LAYOUT_MOVY);
+  ctl.load({ prefix: "synth" });
+  ok(ctl.state.pages.length >= 3, "the wide fixture plans at least three pages");
+
+  /* A dwell far too short for the lane -- ~200ms, a brisk but ordinary jog. */
+  for (let i = 0; i < 12; i++) { ctl.tick(); clock += 17; }
+  ctl.onJog(1);
+  const keys = (ctl.page.keys || []).filter(Boolean);
+  const known = keys.filter((k) => ctl.state.values[k] !== undefined).length;
+  ok(known === keys.length,
+     "jogging onto a page the lane has NOT warmed still arrives complete (" +
+     known + "/" + keys.length + ")");
+
+  const arrival = shot(ctl);
+  for (let i = 0; i < 30; i++) { ctl.tick(); clock += 17; }
+  ok(arrival === shot(ctl),
+     "and its first frame is the settled one -- no fill-in on a jog either");
+}
+
 process.exit(fail ? 1 : 0);
 '


### PR DESCRIPTION
Reported from hardware: *"when a page is loaded the values animate in"*, then — after the first fix — *"i still see it … just going from one page to another slowly"*.

Three defects, one cause: **the grid drew values it had not read yet.** The read cursor serves one key per tick, so a page of 8 knobs spends ~9 ticks (~150 ms) with `values[key]` undefined, and every widget turned that absence into a confident picture.

## 1. An arrival is not a change (`observeLanded`)

`drawWaveform` resolved shape 0, `drawEnumSquare` sized itself around `"--"`. `observe()` recorded the placeholder as the settled first sighting, so the real value arrived as a **transition** — waveforms morphing, enum boxes growing, out of values nobody had set. **46 of 95 fleet modules animated their first page in; now 0.**

`observeLanded` takes the raw value alongside the animated token. They are separate arguments on purpose: every derivation here is *total*, so `"s" + shape` and a pixel width both produce a perfectly ordinary token for an absent input — which is how the placeholder got in. Nothing is recorded while absent, so the first real value is a first sighting, which `observe` already stamps as already-past.

This is the tri-state read rule one layer below where it is usually enforced: a read that did not complete must not produce a plan, a default or a cached verdict — and a widget frame is all three.

## 2. The entered page is read before it is drawn (`warmCurrentPage`)

Suppressing the animation did not stop the placeholder being **drawn**. Rendered, obxd's frame 0 had the filter curve collapsed into the bottom-left corner and the envelope a spike at the left edge. It snaps together rather than filling in cell by cell because a viz group is built from several keys — the curve from four, the ADSR from four more — so a graphic stays wrong until its *last* member lands.

Called from the load path, never `tick()`: the controller is built during input handling and the draw happens on a later frame, so a warm here lands before anything is shown while a warm on the tick is always one frame late. **All 95 modules now draw frame 0 identical to settled.** Worst cost 8 reads ≈ 22 ms.

It stops at the **first failed read** — a module not serving yet costs one timeout instead of eight.

## 3. The warm runs on the hop, because the lane is far too slow (measured)

The neighbour prefetch (ported from `page-slide-transition`) fires on one stop of a ~10-stop rotation — one key per ~10 ticks. Measured against a 3 × 8-knob module, by dwell before jogging on:

| dwell | known on arrival | fill-in |
|---|---|---|
| 200 ms | 1/8 | 153 ms |
| 500 ms | 3/8 | 153 ms |
| 1000 ms | 6/8 | 153 ms |
| 1500 ms | 8/8 | none |

The lane only wins if you sit on a page for a second and a half — and the report lands squarely in the 200–1000 ms band. The original objection (blocking would "put a hitch on the exact gesture the lane exists to smooth") is answered by the measurement: the alternative is not a smooth gesture, it is 153 ms of wrong picture.

**The lane does not make the page correct — the warm does. The lane makes the warm free**, degrading the cost from 22 ms at a fast jog to 0 once it has kept up. Neither is redundant.

## Notes

- `acceptValue` is extracted so the rotation and the warm share one definition of the value tri-state — three rules deep, every one a shipped bug (`Number("") === 0` on the Volume knob; `""`-is-NONE for opaque keys).
- `fullKey` gains an optional page argument for the lane's child-level resolution.
- Rebased onto #323, which cut the switch fill while this was in flight. The switch is no longer an animated widget, so it is no longer a test subject — but it stays in the fixture so a change re-animating it is still caught.

## Verification

189/189 shell tests and all compiled units green. Every fix mutated back individually and confirmed to fail its test. Four probe defects found and fixed along the way — ticking without drawing, a positive control already at its clamp, an unasserted read count that let a 16-read double-read pass, and a jog matrix whose control could not fail.

Deployed and confirmed on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GxZYebV8L4RRaDADBggxLk