### PR TITLE
Add 8W8 — TR-808 style drum machine

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1344,6 +1344,17 @@
       "default_branch": "master",
       "asset_name": "arranger-module.tar.gz",
       "min_host_version": "0.12.1"
+    },
+    {
+      "id": "8w8",
+      "name": "8W8",
+      "description": "TR-808 style drum machine. Sixteen voices, all synthesized, no samples — fifteen are circuit models built from the service notes and the published analyses, and the rim shot is a transcription of sc808, kept because two circuit builds lost to it by ear. Decay is loop gain on the kick and the toms rather than an envelope, one free-running metal bank feeds the hats, cymbal and cowbell as the hardware wires it, and velocity reaches most voices as a trigger voltage rather than a gain. Seven distortion characters per voice and on the master, bit-exactly bypassed at zero; reverb and delay sends on every voice but the kick; one-knob bus compressor; pad editor, remote web panel, Movy template.",
+      "author": "athousanddetails; circuit models from the TR-808 service notes and Werner/Abel/Smith; rim shot transcribed from sc808 (Yoshinosuke Horiuchi / Sam Aaron, Sonic Pi)",
+      "component_type": "sound_generator",
+      "github_repo": "athousanddetails/schwung-8W8",
+      "default_branch": "main",
+      "asset_name": "8w8-module.tar.gz",
+      "min_host_version": "0.12.1"
     }
   ]
 }


### PR DESCRIPTION
Adds **8W8** to the catalog. Sixteen-voice TR-808 style drum machine, all
synthesised, no samples — fifteen of the voices are circuit models built from
the service notes and the published analyses; the rim shot is a transcription
of Sonic Pi's sc808 (MIT), kept because two circuit rim shots were built from
the schematic and both lost to it by ear.

Repo: https://github.com/athousanddetails/schwung-8W8
Release: https://github.com/athousanddetails/schwung-8W8/releases/tag/v1.0.0

Also has seven distortion characters per voice and on the master (bit-exact
bypass at zero), velocity in place of an accent switch, reverb and delay send
buses on every voice but the kick, a one-knob bus compressor, the Main-page jog
lock, a remote web panel and a Movy template. Requires host 0.12.1.

Sits alongside 9W9 and 6W6, and shares their pad gestures and control layout so
the three feel the same under the hands.

**Checked before opening:**

- The diff is purely additive — 11 insertions, 0 deletions. The entry is
  appended after `arranger`, and no existing entry's bytes are touched
  (the file mixes raw UTF-8 and `\u` escapes between entries, so it was
  inserted textually rather than re-serialised).
- `module-catalog.json` still parses, 120 → 121 modules.
- The asset the store will fetch resolves anonymously:
  `https://github.com/athousanddetails/schwung-8W8/releases/latest/download/8w8-module.tar.gz`
  → HTTP 200, 59,484 bytes.
- The `dsp.so` in that tarball is byte-identical to the one that was tested on
  hardware.