### PR TITLE
Modulation indicators on covered cells, and finishing the child-key contract

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1385,6 +1385,7 @@ These optional fields declare the real shape instead:
 | `child_index_base` | First instance number — pads are usually 1..16 | `0` |
 | `child_index_digits` | Zero-pad the index to this width (`p01_` not `p1_`) | none |
 | `child_key_overrides` | Per-key template overrides, for the odd key that breaks the pattern | none |
+| `child_index_param` | A param through which **your module** owns which instance is focused | none (UI-local) |
 
 ```json
 "pad_settings": {
@@ -1405,6 +1406,45 @@ the UI — with no per-module configuration file anywhere.
 
 `child_prefix` continues to mean exactly what it always did, so existing
 declarations are unaffected.
+
+#### `child_index_param` — when the MODULE owns the focus
+
+By default the focused instance is UI state, changed only by picking from the
+instance list. That is right for a synth, where "Part 2" is a deliberate
+navigation choice, and wrong for a drum module, where **hitting a pad** is how
+you choose what you are editing.
+
+Declare `child_index_param` and the param becomes the single source of truth in
+both directions: the UI reads it and follows, and picking from the list writes
+it. So a module that moves the focus itself and a user who picks from the list
+can never disagree — they are the same write.
+
+```json
+"pad_settings": {
+  "child_count": 16, "child_label": "Pad",
+  "child_key_template": "p{index}_{key}",
+  "child_index_base": 1, "child_index_digits": 2,
+  "child_index_param": "focused_pad",
+  "knobs": ["vol", "pan", "tune", "start"]
+}
+```
+
+The value is the instance number **in your own numbering** — with
+`child_index_base: 1`, pad 1 is `"1"`. Serve it from `get_param` and accept it
+in `set_param`.
+
+Two things the host guarantees, which you can rely on:
+
+- **A read that does not answer never moves the focus.** An empty, non-numeric
+  or out-of-range value is ignored rather than treated as instance 0 — moving
+  the user off the pad they were editing because a read timed out would re-key
+  every page on screen.
+- **It costs no extra IPC.** The read shares a rotation stop with the preset
+  name, and a level that does not declare it reads nothing at all.
+
+Without this, adding a child level to a module that already follows the played
+pad would *cost* that behaviour — the grid would sit on the instance the picker
+last chose. With it, the declaration is purely additive.
 
 ### Example: Chord MIDI FX Hierarchy
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -14836,10 +14836,15 @@ function drawWavPositionEditor(selectedKey, selectedMeta) {
         if (modRatio >= 0 && modRatio >= zoomStart && modRatio <= zoomEnd) {
             const mx = plotX + 1 +
                 Math.round(((modRatio - zoomStart) / zoomRange) * (innerW - 1));
-            set_pixel(mx, plotY + 1, 1);
-            set_pixel(mx, plotY + 2, 1);
-            set_pixel(mx, plotY + plotH - 2, 1);
-            set_pixel(mx, plotY + plotH - 3, 1);
+            /* A COARSE DASH, 2 on 2 off -- the same rhythm the grid cell uses
+             * for this mark, and deliberately unlike the two lines already in
+             * this plot: the cursor is SOLID and the spray fences are a fine
+             * every-other-row dither. Three vertical marks in one plot are only
+             * legible if each has its own rhythm. */
+            for (let yy = plotY + 1; yy < plotY + plotH - 1; yy++) {
+                if (((yy - (plotY + 1)) & 3) >= 2) continue;
+                set_pixel(mx, yy, 1);
+            }
         }
 
         /* Single-marker legacy: just the active cursor. */

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -3034,8 +3034,8 @@ function openParamEditorFromGrid(slotIndex, fullKey, meta) {
      * an opaque param there landed on the module menu instead of the editor. */
     const paramPrefix = `${getComponentParamPrefix(componentKey)}:`;
     const raw = String(fullKey || "");
-    const bare = raw.startsWith(paramPrefix) ? raw.slice(paramPrefix.length)
-                                             : raw.replace(/^[^:]+:/, "");
+    let bare = raw.startsWith(paramPrefix) ? raw.slice(paramPrefix.length)
+                                           : raw.replace(/^[^:]+:/, "");
 
     exitParamPages();
     /* Without this the list entry below sees Param View = Knobs and bounces
@@ -3075,6 +3075,11 @@ function openParamEditorFromGrid(slotIndex, fullKey, meta) {
      * in the `main` level. Searching only the page level found nothing and fell
      * through to the module menu, which is exactly the bug. So if the page
      * level does not list it, find the level that does and go there. */
+    /* Back to the level's own dialect before looking it up -- see
+     * hierGenericKeyFor. Done AFTER landing, because the level (and therefore
+     * the key list to search) is only settled here. */
+    bare = hierGenericKeyFor(getHierarchyLevelDef(), hierEditorChildIndex, bare);
+
     let idx = indexOfHierParam(bare);
     if (idx < 0) {
         const owner = findLevelListingParam(bare);
@@ -13026,6 +13031,35 @@ function hierChildKeyFor(levelDef, index, rawKey) {
         return rawKey;
     }
     return resolveChildKey(levelDef, index, rawKey) || rawKey;
+}
+
+/*
+ * The GENERIC key a concrete one came from, or the key unchanged.
+ *
+ * The inverse of hierChildKeyFor, and it is needed because the two halves of a
+ * dive speak different dialects: the GRID addresses `synth:p01_sample_path`
+ * (the controller resolved it), while the editor's param list holds what the
+ * level LISTS -- `sample_path`. So the lookup missed, the owner search missed,
+ * and the click opened nothing at all. Found by reproducing the dive on the
+ * host rather than on the device, which is how it should have been found four
+ * reports earlier.
+ *
+ * Searched over the level's own declared keys rather than parsed out of the
+ * template: a template is not invertible in general (`p{index}_{key}` happens
+ * to be, `{key}_v{index}` is not), and the level's list is small and exact.
+ */
+function hierGenericKeyFor(levelDef, index, concreteKey) {
+    if (!concreteKey || index < 0 || !childLevelHasChildren(levelDef)) return concreteKey;
+    const cand = [];
+    for (const k of (levelDef.knobs || [])) cand.push(typeof k === "string" ? k : (k && k.key));
+    for (const p of (levelDef.params || [])) {
+        if (p && typeof p === "object") { if (!p.level) cand.push(p.key); }
+        else cand.push(p);
+    }
+    for (const g of cand) {
+        if (g && resolveChildKey(levelDef, index, g) === concreteKey) return g;
+    }
+    return concreteKey;
 }
 
 function buildHierarchyParamKey(key) {

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -18523,7 +18523,35 @@ function lfoTargetParamsFor(target, compKey, logLabel) {
             const params = JSON.parse(json);
             for (let i = 0; i < params.length; i++) {
                 const p = params[i];
-                if (p.type === "float" || p.type === "int" || p.type === "enum") {
+                /*
+                 * `wav_position` IS a modulation target, and leaving it out
+                 * cost the whole indicator chain.
+                 *
+                 * This is a TYPE ALLOWLIST written before wav_position
+                 * existed, and it silently excluded every sample-position
+                 * param in the fleet -- mrdrums Sample Start, granny, mrsample.
+                 * A wav_position is a ranged number a knob turns (min/max
+                 * declared, 0..1), which is the only property the modulation
+                 * engine needs: chain_mod_emit_value looks the key up with
+                 * find_param_by_key and scales by the declared range, and
+                 * neither cares what the UI calls the type.
+                 *
+                 * The consequence was not "one missing menu row". Because the
+                 * param could not be picked, an LFO aimed at a sample start
+                 * had to be routed to the CONCRETE per-pad key instead, while
+                 * the grid draws the ALIAS -- so `<alias>:modulated` answered
+                 * 0, the read cursor never asked for `:base`, and the key
+                 * never entered refreshModulatedValues. Reported from the
+                 * device as a lost LFO dot and a choppy cell: the cell was
+                 * being fed the effective value by the ordinary rotation at
+                 * ~6Hz instead of the base plus a 44Hz dot.
+                 *
+                 * Confirmed on hardware with param_tally: `synth:pad_start`
+                 * and `synth:pad_start:modulated` both read 6x/window, and
+                 * `synth:pad_start:base` NEVER read.
+                 */
+                if (p.type === "float" || p.type === "int" || p.type === "enum"
+                    || p.type === "wav_position") {
                     result.push({ key: p.key, label: p.name || p.label || p.key });
                 }
             }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -56,6 +56,27 @@ import { RULE_Y as MOVY_RULE_Y,
  * the module header. */
 import { drawEnumList }
     from '/data/UserData/schwung/shared/param_pages/enum_list.mjs';
+/*
+ * The child-key contract, shared with the page planner.
+ *
+ * This file used to implement it ITSELF, and only the legacy shape --
+ * `<child_prefix><index>_<key>`, zero-based, unpadded -- open-coded at five
+ * sites. child_key.mjs was written because none of the six modules that need
+ * repeated elements use that shape (mrdrums 209 unreachable keys,
+ * weird-dreams 187, forge 106), but only the PLANNER was migrated to it. So a
+ * level declaring `child_key_template` planned and drew correctly and then
+ * broke the moment you dived into a cell: the editor built `synth:sample_path`
+ * where the module serves `synth:p01_sample_path`, and the file browser opened
+ * on a param nobody answers. Reported from the device as being unable to dive
+ * into sample selection.
+ *
+ * One definition now serves both halves, which is the point -- a second
+ * spelling of "which key does this cell address" is how the two disagreed for
+ * as long as they did.
+ */
+import { hasChildren as childLevelHasChildren, childCount as childLevelCount,
+         childLabel as childLevelLabel, resolveChildKey }
+    from '/data/UserData/schwung/shared/param_pages/child_key.mjs';
 /* The bands around a chain editor's row of boxes — header, label, info,
  * footer — and the module picker it opens on a position. Both shared with
  * Master FX so the two editors wear the same furniture. */
@@ -4223,13 +4244,9 @@ function normalizeVisibilityConditionKey(componentPrefix, levelDef, childIndex, 
     if (!rawKey) return "";
     if (rawKey.includes(":")) return rawKey;
     if (!componentPrefix) return rawKey;
-    if (levelDef && levelDef.child_prefix && childIndex >= 0) {
-        if (rawKey.startsWith(levelDef.child_prefix)) {
-            return `${componentPrefix}:${rawKey}`;
-        }
-        return `${componentPrefix}:${levelDef.child_prefix}${childIndex}_${rawKey}`;
-    }
-    return `${componentPrefix}:${rawKey}`;
+    /* Same resolution the editor uses for a value key -- a condition naming a
+     * per-instance param must read the INSTANCE it is gating, not the template. */
+    return `${componentPrefix}:${hierChildKeyFor(levelDef, childIndex, rawKey)}`;
 }
 
 function compareConditionValue(actualRaw, expectedRaw) {
@@ -11455,29 +11472,43 @@ function getNumericParamsForTarget(slot, target, numericOnly = true) {
                         const level = levels[levelName];
                         if (!level || !Array.isArray(level.params)) continue;
 
-                        const childPrefix = (typeof level.child_prefix === "string") ? level.child_prefix : "";
-                        const rawChildCount = parseInt(level.child_count, 10);
-                        const childCount = Number.isFinite(rawChildCount) ? Math.max(0, rawChildCount) : 0;
-                        const childLabel = (typeof level.child_label === "string" && level.child_label)
-                            ? level.child_label : "Item";
+                        const childCount = childLevelCount(level);
 
                         for (const entry of level.params) {
                             const key = (typeof entry === "string") ? entry : (entry && entry.key ? entry.key : "");
                             if (!key) continue;
 
-                            const meta = chainMetaByKey.get(key);
+                            /*
+                             * A GENERIC child key is declared nowhere: a level
+                             * lists `start` and the module declares p01_start
+                             * … p16_start. Looking the generic key up directly
+                             * finds nothing and skipped the whole level, so a
+                             * template-shaped module offered NONE of its
+                             * per-instance params here. Fall back to instance
+                             * 0, which carries the same structure as every
+                             * other instance.
+                             */
+                            const meta = chainMetaByKey.get(key)
+                                || (childCount > 0
+                                    ? chainMetaByKey.get(resolveChildKey(level, 0, key) || "")
+                                    : null);
                             if (!meta) continue;
                             const type = (meta.type || "").toLowerCase();
                             const isNumeric = type === "float" || type === "int" ||
                                 (!type && (meta.min !== undefined || meta.max !== undefined));
                             if (numericOnly && !isNumeric) continue;
 
-                            if (childPrefix && childCount > 0) {
+                            if (childCount > 0) {
                                 for (let i = 0; i < childCount; i++) {
-                                    const fullKey = `${childPrefix}${i}_${key}`;
-                                    if (seen.has(fullKey)) continue;
+                                    /* One definition of the key shape, and one
+                                     * of the instance NUMBER -- childLabel
+                                     * honours child_index_base, so pads read
+                                     * "Pad 1".."Pad 16" and not 0..15. */
+                                    const fullKey = resolveChildKey(level, i, key);
+                                    if (!fullKey || seen.has(fullKey)) continue;
                                     const baseLabel = meta.name || meta.label || key;
-                                    params.push({ key: fullKey, label: `${childLabel} ${i + 1} ${baseLabel}` });
+                                    params.push({ key: fullKey,
+                                                  label: `${childLevelLabel(level, i)} ${baseLabel}` });
                                     seen.add(fullKey);
                                 }
                             } else {
@@ -12283,7 +12314,7 @@ function enterHierarchyEditorFromParamPages() {
          * anything". The other two navigation sites set these; only the
          * hand-off from the grid did not.
          */
-        hierEditorChildCount = levelDef.child_count || 0;
+        hierEditorChildCount = childLevelCount(levelDef);
         hierEditorChildLabel = levelDef.child_label || "Child";
         loadHierarchyLevel();
     }
@@ -12528,8 +12559,9 @@ function loadHierarchyLevel() {
         (rootDef && rootDef.children === hierEditorLevel)
     );
 
-    /* Child selector for levels that require child_prefix */
-    if (levelDef.child_prefix && hierEditorChildCount > 0 && hierEditorChildIndex < 0) {
+    /* Child selector for any level declaring repeated instances -- template
+     * or legacy child_prefix, which hasChildren() answers for both. */
+    if (childLevelHasChildren(levelDef) && hierEditorChildCount > 0 && hierEditorChildIndex < 0) {
         hierEditorIsPresetLevel = false;
         hierEditorIsDynamicItems = false;
         hierEditorPresetEditMode = false;
@@ -12945,13 +12977,29 @@ function getHierarchyLevelDef() {
     return hierEditorHierarchy.levels ? hierEditorHierarchy.levels[hierEditorLevel] : null;
 }
 
+/*
+ * The concrete key `rawKey` addresses for instance `index` of `levelDef`, or
+ * rawKey unchanged when the level declares no children.
+ *
+ * A key ALREADY CONCRETE passes through. The legacy code expressed that as
+ * `rawKey.startsWith(child_prefix)`, which a template has no equivalent of, so
+ * the test is now membership of the level's own declared keys -- the same
+ * question childResolve asks in page_controller, and the honest one: only a
+ * key the level LISTS is a generic key to be multiplied.
+ */
+function hierChildKeyFor(levelDef, index, rawKey) {
+    if (!rawKey || index < 0 || !childLevelHasChildren(levelDef)) return rawKey;
+    const listed = (k) => (typeof k === "string" ? k : (k && k.key)) === rawKey;
+    if (!(levelDef.knobs || []).some(listed) && !(levelDef.params || []).some(listed)) {
+        return rawKey;
+    }
+    return resolveChildKey(levelDef, index, rawKey) || rawKey;
+}
+
 function buildHierarchyParamKey(key) {
     const prefix = getComponentParamPrefix(hierEditorComponent);
     const levelDef = getHierarchyLevelDef();
-    if (levelDef && levelDef.child_prefix && hierEditorChildIndex >= 0) {
-        return `${prefix}:${levelDef.child_prefix}${hierEditorChildIndex}_${key}`;
-    }
-    return `${prefix}:${key}`;
+    return `${prefix}:${hierChildKeyFor(levelDef, hierEditorChildIndex, key)}`;
 }
 
 function getHierarchyDisplayRawValue(slot, fullKey) {
@@ -12987,10 +13035,7 @@ function isHierarchyParamModulated(slot, fullKey) {
 
 function buildHierarchyParamKeyForLevel(levelDef, key, childIndex) {
     const prefix = getComponentParamPrefix(hierEditorComponent);
-    if (levelDef && levelDef.child_prefix && childIndex >= 0) {
-        return `${prefix}:${levelDef.child_prefix}${childIndex}_${key}`;
-    }
-    return `${prefix}:${key}`;
+    return `${prefix}:${hierChildKeyFor(levelDef, childIndex, key)}`;
 }
 
 function resetHierarchyEditState() {
@@ -14572,7 +14617,7 @@ function applyLinkedWavEndDefaultsForFilepath(filepathKey) {
 
     for (const levelDef of levels) {
         if (!levelDef || !Array.isArray(levelDef.params)) continue;
-        const hasChildren = !!(levelDef.child_prefix && typeof levelDef.child_prefix === "string");
+        const hasChildren = childLevelHasChildren(levelDef);
         const childIndices = hasChildren && selectedChildIndex >= 0 ? [selectedChildIndex] : [-1];
 
         for (const entry of levelDef.params) {
@@ -16569,11 +16614,12 @@ function handleSelect() {
                     hierEditorLevel = selectedParam.level;
                     hierEditorSelectedIdx = 0;
                     hierEditorPresetEditMode = false;
-                    /* Set up child count/label if target level has child_prefix */
+                    /* Set up child count/label for any level declaring
+                     * repeated instances -- template or legacy prefix. */
                     const targetLevel = hierEditorHierarchy.levels[selectedParam.level];
-                    if (targetLevel && targetLevel.child_prefix && targetLevel.child_count) {
+                    if (childLevelHasChildren(targetLevel)) {
                         hierEditorChildIndex = -1;
-                        hierEditorChildCount = targetLevel.child_count;
+                        hierEditorChildCount = childLevelCount(targetLevel);
                         hierEditorChildLabel = targetLevel.child_label || "Child";
                     }
                     loadHierarchyLevel();
@@ -17188,7 +17234,7 @@ function handleBack() {
                 announceHierLevel();
             } else if (hierEditorChildIndex >= 0) {
                 const levelDef = getHierarchyLevelDef();
-                if (levelDef && levelDef.child_prefix) {
+                if (childLevelHasChildren(levelDef)) {
                     /* Return to child selector list */
                     hierEditorChildIndex = -1;
                     if (hierEditorPath.length > 0) {
@@ -17213,7 +17259,7 @@ function handleBack() {
                     announce("Mode Selection");
                 } else {
                     const levelDef = getHierarchyLevelDef();
-                    if (levelDef && levelDef.child_prefix) {
+                    if (childLevelHasChildren(levelDef)) {
                         hierEditorChildIndex = -1;
                         hierEditorChildCount = 0;
                         hierEditorChildLabel = "";

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -12996,6 +12996,11 @@ function buildHierarchyParamKeyForLevel(levelDef, key, childIndex) {
 function resetHierarchyEditState() {
     hierEditorEditKey = "";
     hierEditorEditValue = null;
+    /* Both are seeded per EDIT SESSION by beginHierarchyParamEdit, so they must
+     * die with it: a marker left behind would be drawn over the next
+     * wav_position opened, at a position belonging to a different parameter. */
+    wavEditorSpray = null;
+    wavEditorMod = null;
 }
 
 function beginHierarchyParamEdit(key) {
@@ -13012,7 +13017,52 @@ function beginHierarchyParamEdit(key) {
     hierEditorEditKey = fullKey;
     hierEditorEditValue = String((baseVal !== null) ? baseVal : liveVal);
     seedWavEditorSpray(key, meta);
+    seedWavEditorMod(key, meta, fullKey);
     return true;
+}
+
+/*
+ * Is the position being edited driven by a source, and where is it right now?
+ *
+ * The editor is the screen you are on SPECIFICALLY to set this value, so the
+ * base-versus-live distinction matters more here than anywhere: in edit mode
+ * the cursor is `hierEditorEditValue`, which beginHierarchyParamEdit seeds
+ * from `:base` -- correctly, that is what the jog moves -- and with an LFO
+ * running that leaves the cursor sitting still while the sound sweeps, with
+ * nothing on screen to say why.
+ *
+ * Read ONCE, like the spray beside it and for the same reason: this frame
+ * resamples the WAV and is already the most expensive screen here, so a
+ * per-frame IPC read (~2.8ms against a 1.68ms whole-page render) is not
+ * affordable. Unlike the spray, the value this tracks MOVES on its own, so a
+ * seeded reading goes stale -- deliberately. What it is for is stating THAT a
+ * source is driving the position and roughly where, not animating it; the
+ * grid cell is where the live motion is shown, at the tick rate, because it
+ * costs nothing extra there.
+ *
+ * Null unless `:modulated` says 1, so an unmodulated position -- every
+ * wav_position in the fleet until an LFO is pointed at one -- draws nothing
+ * and pays for nothing.
+ */
+/*
+ * The RAW value is stored, not a ratio, and it is normalised at the draw with
+ * the SAME durationSec the cursor uses. A wav_position may be declared in
+ * seconds (`display_unit: "sec"`), and normalizeWavPositionRatio then needs
+ * the file duration to place it -- which is not known here and returns 0 for
+ * a missing one, i.e. a marker silently pinned to the head of the file.
+ */
+let wavEditorMod = null;   /* { fullKey, raw } */
+function seedWavEditorMod(key, meta, fullKey) {
+    wavEditorMod = null;
+    if (!meta || meta.ui_type !== "wav_position") return;
+    if (!isHierarchyParamModulated(hierEditorSlot, fullKey)) return;
+    const raw = getSlotParam(hierEditorSlot, fullKey);
+    /* A FAILED read is not a position. Drawing nothing is honest; inventing 0
+     * would plant a marker at the head of the file and claim the source is
+     * there. */
+    if (raw === null || raw === "") return;
+    if (!Number.isFinite(Number(raw))) return;
+    wavEditorMod = { fullKey, raw: String(raw) };
 }
 
 /*
@@ -14764,6 +14814,34 @@ function drawWavPositionEditor(selectedKey, selectedMeta) {
                 }
             }
         }
+        /*
+         * WHERE THE SOURCE HAS IT, when one is driving this position.
+         *
+         * Drawn as 2px stubs at the top and bottom of the plot rather than as
+         * a rule, which is the SAME language the grid uses for a modulated
+         * sample cell and a modulated fader -- one mark meaning "this is the
+         * other end of the base/live pair", so the three surfaces do not each
+         * invent a spelling. It also has to be distinct from the spray fences
+         * immediately above, which already own the dotted full-height line: a
+         * second dotted column would read as a third fence.
+         *
+         * Before the cursor, so a source passing through the base leaves the
+         * solid cursor owning the column -- the two coinciding IS the reading
+         * "it is at your value right now".
+         */
+        const modRatio = wavEditorMod
+            ? Math.max(0, Math.min(1, normalizeWavPositionRatio(
+                wavEditorMod.raw, selectedMeta, preview.durationSec || 0)))
+            : -1;
+        if (modRatio >= 0 && modRatio >= zoomStart && modRatio <= zoomEnd) {
+            const mx = plotX + 1 +
+                Math.round(((modRatio - zoomStart) / zoomRange) * (innerW - 1));
+            set_pixel(mx, plotY + 1, 1);
+            set_pixel(mx, plotY + 2, 1);
+            set_pixel(mx, plotY + plotH - 2, 1);
+            set_pixel(mx, plotY + plotH - 3, 1);
+        }
+
         /* Single-marker legacy: just the active cursor. */
         for (let y = plotY + 1; y < plotY + plotH - 1; y++) {
             set_pixel(cursorX, y, 1);

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -248,7 +248,7 @@ import {
 import {
     paramPagesEnabled, enterParamPages, exitParamPages, paramPagesActive,
     tickParamPages, drawParamPages, handleParamPagesMidi, currentParamPage,
-    paramPagesComponent, paramPagesSlot, clearParamPagesTouch,
+    paramPagesComponent, paramPagesSlot, paramPagesChildIndex, clearParamPagesTouch,
     enumPickerFooterHints, CONTRACT_SETTLE_MS, LAYOUT_LIST,
     paramPagesRefreshTrailing, paramPagesExitMenu
 } from './shadow_ui_param_pages.mjs';
@@ -3018,6 +3018,9 @@ function openParamEditorFromGrid(slotIndex, fullKey, meta) {
      * param lives, and exitParamPages tears the controller down. */
     const page = currentParamPage();
     const level = page && page.level;
+    /* Which instance the grid was showing. Captured HERE, beside `level`, for
+     * the same reason: exitParamPages below tears the controller down. */
+    const childAt = level ? paramPagesChildIndex(level) : -1;
     paramEditorReturnPage = (page && page.name) || "";
     /* Carry the page's knob ORDER in with us — see hierEditorKnobsFromPage.
      * Captured here for the same reason `level` is: exitParamPages tears the
@@ -3044,9 +3047,21 @@ function openParamEditorFromGrid(slotIndex, fullKey, meta) {
     /* Land on the level the grid was on, not the hierarchy root. */
     if (level && hierEditorHierarchy && hierEditorHierarchy.levels &&
         hierEditorHierarchy.levels[level] && level !== hierEditorLevel) {
+        const levelDef = hierEditorHierarchy.levels[level];
         hierEditorLevel = level;
         hierEditorPath = [];
-        hierEditorChildIndex = -1;
+        /*
+         * ...and on the INSTANCE it was showing. This is the dive path, so
+         * handing off -1 makes loadHierarchyLevel raise the child selector and
+         * a click on Sample Path lands on "which pad?" instead of the file
+         * browser. Reported from the device.
+         *
+         * `childAt` is captured beside `level`, above, and for the same reason:
+         * exitParamPages has already torn the controller down by here.
+         */
+        hierEditorChildIndex = childLevelHasChildren(levelDef) ? childAt : -1;
+        hierEditorChildCount = childLevelCount(levelDef);
+        hierEditorChildLabel = levelDef.child_label || "";
         loadHierarchyLevel();
     }
 
@@ -12257,6 +12272,20 @@ function enterHierarchyEditorFromParamPages() {
     const page = currentParamPage();
     const slotIndex = paramPagesSlot();
     const componentKey = paramPagesComponent();
+    /*
+     * WHICH INSTANCE, captured BEFORE exitParamPages tears the controller down.
+     *
+     * The grid already knows which pad you are editing -- the module owns it
+     * through child_index_param and the controller follows. Handing off with
+     * -1 made the editor open its CHILD SELECTOR instead of the parameter,
+     * so diving into Sample Path landed on a "which pad?" menu. Reported from
+     * the device, and it is the same defect as the duplicate picker pages: a
+     * second control for a fact that already has one.
+     *
+     * Backing out of the parameter still reaches the selector, so nothing is
+     * lost -- only the question nobody asked is.
+     */
+    const childAt = (page && page.level) ? paramPagesChildIndex(page.level) : -1;
 
     /*
      * A SYNTHESISED CONTRACT HAS NOWHERE TO EJECT TO.
@@ -12296,7 +12325,10 @@ function enterHierarchyEditorFromParamPages() {
         const levelDef = hierEditorHierarchy.levels[page.level];
         hierEditorLevel = page.level;
         hierEditorPath = [];
-        hierEditorChildIndex = -1;
+        /* The instance the grid was showing, not "ask again". Falls back to
+         * -1 -- the selector -- for a level with no children, which is what
+         * every non-child level gets and always got. */
+        hierEditorChildIndex = childLevelHasChildren(levelDef) ? childAt : -1;
         /*
          * The CHILD COUNT travels with the level, and this path used to drop
          * it.

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -382,6 +382,20 @@ export function currentParamPage() {
 }
 
 /**
+ * Which instance of `level` the grid is showing, zero-based; -1 if unknown.
+ *
+ * The editor hand-off needs it. Without it the editor opened its CHILD
+ * SELECTOR -- "which pad?" -- on a dive, when the grid already knew, and the
+ * module owns the answer through child_index_param anyway. Same defect as the
+ * duplicate picker pages: a second control for a fact that already has one.
+ */
+export function paramPagesChildIndex(level) {
+    if (!controller || !level) return -1;
+    return (typeof controller.childIndexOf === "function")
+        ? controller.childIndexOf(level) : -1;
+}
+
+/**
  * Once per frame. Polls for a contract that changed underneath us (a module
  * finishing an async ROM or sample load republishes a larger tree) and advances
  * the staggered read cursor by exactly one param.

--- a/src/shared/param_pages/child_key.mjs
+++ b/src/shared/param_pages/child_key.mjs
@@ -94,6 +94,66 @@ export function childKeysFor(level, i) {
 }
 
 /**
+ * The param through which the MODULE owns which instance is focused, or null.
+ *
+ *   "pads": { …, "child_index_param": "focused_pad" }
+ *
+ * Without this the index is UI-only state, written in exactly one place: a
+ * pick from the instance list. That is fine for a synth whose "Part 2" is a
+ * deliberate navigation choice, and wrong for a drum module, where hitting a
+ * pad is how you choose the thing you are editing. mrdrums is the case --
+ * `ui_auto_select_pad` follows the pad you play, so with the index owned by
+ * the UI the grid would sit on Pad 1 while the module moved on, and declaring
+ * a child level at all would COST that behaviour. This is what makes the
+ * declaration additive for such a module instead of a trade.
+ *
+ * The param is the single source of truth in BOTH directions: a pick writes
+ * it, and reading it back is what moves the UI. So there is no third copy of
+ * the index to disagree, and a module that moves the focus itself and a user
+ * who picks from the list cannot fight -- they are the same write.
+ *
+ * OPTIONAL, and its absence is the existing behaviour exactly: a level with no
+ * `child_index_param` keeps a purely local index, so nothing that works today
+ * changes.
+ */
+export function childIndexParam(level) {
+    if (!hasChildren(level)) return null;
+    const k = level && level.child_index_param;
+    return (typeof k === "string" && k.length) ? k : null;
+}
+
+/**
+ * The wire value naming instance `i` — in the MODULE's numbering.
+ *
+ * `i` is zero-based everywhere inside the page engine; the module counts from
+ * `child_index_base` (pads are 1..16). Converting in one place, next to
+ * formatIndex which already does it for key templates, is what stops the two
+ * spellings drifting.
+ */
+export function childIndexToWire(level, i) {
+    return String((i | 0) + indexBase(level));
+}
+
+/**
+ * The zero-based instance a wire value names, or NULL if it does not name one.
+ *
+ * Null for a failed read, an empty answer, a non-number, or an index outside
+ * the declared count — never a fallback to 0. The caller uses this to decide
+ * whether to MOVE the user's focus, and moving it to the first instance
+ * because a read timed out would re-key every page on screen and drop the
+ * cached values with it. Same tri-state rule the read cursor follows.
+ */
+export function childIndexFromWire(level, raw) {
+    if (!hasChildren(level)) return null;
+    if (raw === null || raw === undefined || raw === "") return null;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return null;
+    const i = Math.round(n) - indexBase(level);
+    if (i < 0 || i >= childCount(level)) return null;
+    return i;
+}
+
+/**
  * Every concrete key a child level can address across all its instances.
  * Used by the contract validator to stop reporting per-instance keys as
  * unreachable once a template covers them.

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -29,7 +29,8 @@
 
 import { planPages, pickMode, PAGE_KNOBS, PAGE_MENU, PAGE_PRESET, PAGE_ITEMS,
          buildTrailingPages, makeClaimer } from "./page_plan.mjs";
-import { resolveChildKey } from "./child_key.mjs";
+import { resolveChildKey, childIndexParam, childIndexToWire, childIndexFromWire }
+    from "./child_key.mjs";
 import { buildMetaIndex, inferFromValue, isTurnable, flipsOnClick, enumIndexOf, KIND_ENUM, KIND_OPAQUE } from "./param_meta.mjs";
 import { renderPage, renderPicker, renderHint, LAYOUT_DIAL } from "./render_page.mjs";
 import { renderPageMovy, drawFooter, drawHeader as drawHeaderMovy, drawBankBar,
@@ -705,6 +706,21 @@ export function createController(io = {}) {
     const childIndexFor = (level) => {
         const at = s.childIndex[level];
         return (typeof at === "number" && at >= 0) ? at : 0;
+    };
+    /*
+     * The level DEFINITION behind a level name.
+     *
+     * Pages carry `childLevel` (the object, for resolveChildKey) and `childOf`
+     * (the name, for the index cache), and the picker only has the name. Found
+     * from the pages rather than from the hierarchy so it cannot disagree with
+     * what was actually planned.
+     */
+    const childLevelDef = (name) => {
+        if (!name) return null;
+        for (const pg of s.pages) {
+            if (pg.level === name && pg.childLevel) return pg.childLevel;
+        }
+        return null;
     };
     /*
      * Resolve a child-level key against a page — the CURRENT one unless another
@@ -1414,6 +1430,55 @@ export function createController(io = {}) {
         return reads;
     }
 
+    /**
+     * Drop everything cached for a child level, because it belonged to the
+     * instance we just left.
+     *
+     * The same cell now addresses a different pad, so its cached value, its
+     * pending write and its knob state are all about the previous one. Leaving
+     * them puts the old instance's numbers under the new instance's labels,
+     * which is the bug this exists to prevent -- and the pending write is the
+     * dangerous one: it would land on the NEW instance.
+     */
+    function dropChildLevelCache(levelName) {
+        for (const pg of s.pages) {
+            if (pg.level !== levelName || !Array.isArray(pg.keys)) continue;
+            for (const k of pg.keys) {
+                delete s.values[k];
+                delete s.pendingWrite[k];
+                delete s.knobStates[k];
+            }
+        }
+        s.cursor = 0;
+    }
+
+    /**
+     * Adopt the instance the MODULE says is focused.
+     *
+     * Only for a level that declares `child_index_param` -- otherwise the
+     * index is local UI state and there is nothing to read. Costs no stop of
+     * its own; it rides on the preset-name stop.
+     *
+     * Deliberately NOT gated on a settle window. A settle means a KNOB is being
+     * turned, and turning a knob does not change which pad you are editing;
+     * playing one does. Gating this would mean the grid refused to follow the
+     * pad you just hit for as long as your hand was on a knob, which is
+     * precisely the moment it matters.
+     */
+    function syncChildIndexFromModule(p) {
+        const name = p && p.level;
+        const def = p && p.childLevel;
+        if (!name || !def) return;
+        const idxParam = childIndexParam(def);
+        if (!idxParam) return;
+        const raw = getParam(`${s.prefix}:${idxParam}`);
+        const i = childIndexFromWire(def, raw);
+        if (i === null) return;                 /* tri-state: not an answer */
+        if (i === childIndexFor(name)) return;  /* already there */
+        s.childIndex[name] = i;
+        dropChildLevelCache(name);
+    }
+
     function neighbourPrefetch(cur) {
         if (s.tickCount < (s.prefetchHoldUntil || 0)) return null;
         for (const k in s.settleUntil) {
@@ -1565,6 +1630,19 @@ export function createController(io = {}) {
         if (at === p.keys.length) {
             const pn = getParam(`${s.prefix}:preset_name`);
             s.presetName = (pn && pn.length) ? pn : null;
+            /*
+             * ...and, on the same stop, which instance the MODULE says is
+             * focused. Folded in here rather than given a stop of its own so a
+             * child level costs the rotation nothing extra -- the same bargain
+             * the preset name takes, and the reason both live on one stop.
+             *
+             * A NULL answer changes nothing. childIndexFromWire refuses a
+             * failed read, an empty one, a non-number and an out-of-range
+             * index, and adopting 0 from any of those would silently move the
+             * user off the instance they were editing -- re-keying every page
+             * and dropping its cached values -- because a read timed out.
+             */
+            syncChildIndexFromModule(p);
             return null;
         }
         if (at > p.keys.length) {
@@ -1829,15 +1907,23 @@ export function createController(io = {}) {
              * the old part's numbers sitting under the new part's labels.
              */
             s.childIndex[p.childOf] = it.index;
-            for (const pg of s.pages) {
-                if (pg.level !== p.childOf || !Array.isArray(pg.keys)) continue;
-                for (const k of pg.keys) {
-                    delete s.values[k];
-                    delete s.pendingWrite[k];
-                    delete s.knobStates[k];
-                }
+            /*
+             * ...and tell the MODULE, when it owns the focus. The param is the
+             * single source of truth in both directions, so a pick is the same
+             * write the module itself would make -- which is what stops a user
+             * choosing from this list and a module auto-following the pad you
+             * played from ever disagreeing.
+             *
+             * Written through the level, NOT through childResolve: this key
+             * names the level, not an instance of it, so resolving it would ask
+             * for `p01_focused_pad`.
+             */
+            const idxParam = childIndexParam(childLevelDef(p.childOf));
+            if (idxParam) {
+                setParam(`${s.prefix}:${idxParam}`,
+                         childIndexToWire(childLevelDef(p.childOf), it.index));
             }
-            s.cursor = 0;
+            dropChildLevelCache(p.childOf);
         } else if (p.selectParam) {
             setParam(fullKey(p.selectParam), String(it.index));
         }

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -3698,6 +3698,10 @@ export function createController(io = {}) {
          *  it. Read-only view of the cache the renderer uses — the injected
          *  isModulated is deliberately NOT called during a draw. */
         isModulatedCached: (key) => !!s.modCache[key],
+        /** Which instance of `level` is focused, zero-based. The editor
+         *  hand-off needs it: without it the editor re-asks which child,
+         *  when the grid already knows. */
+        childIndexOf: (level) => childIndexFor(level),
         get metaIndex() { return s.metaIndex; },
         /** True while `<prefix>:ui_hierarchy` could not be READ. The page set,
          *  if any, is the previous one — nothing here was planned from the

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -3553,7 +3553,20 @@ export function createController(io = {}) {
     function vizGroups() {
         const p = page();
         if (!p || p.kind !== PAGE_KNOBS || !s.metaIndex) return [];
-        const cacheKey = `${s.fingerprint}#${s.pageIndex}`;
+        /*
+         * THE FOCUSED CHILD IS PART OF THE KEY.
+         *
+         * A group's `extraKeys` are resolved from metadata, and on a child
+         * level that metadata is an ALIAS that moves with the focused instance
+         * -- `filepath_param` goes from p01_sample_path to p05_sample_path.
+         * Keyed on fingerprint and page alone, neither of which changes when
+         * the pad does, the cache kept handing back a group naming the
+         * PREVIOUS pad's file: the rotation went on reading pad 1 while pad 5
+         * was on screen, and only a page change busted it. Reported from the
+         * device as the waveform updating only after jogging away and back.
+         */
+        const childAt = p.childLevel ? childIndexFor(p.level) : -1;
+        const cacheKey = `${s.fingerprint}#${s.pageIndex}#${childAt}`;
         if (vizCache && vizCache.key === cacheKey) return vizCache.groups;
         const { groups } = resolveViz({ keys: p.keys, metaIndex: s.metaIndex, overrides: vizOverrides });
         vizCache = { key: cacheKey, groups };

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -954,6 +954,11 @@ export function createController(io = {}) {
          * See restorePage(): the pages may not have existed when the caller
          * asked. */
         applyPendingRestore();
+        /* Before the warm, so the first reads already know each key's real
+         * declaration -- acceptValue repairs a GUESSED range from the first
+         * value it sees, and a guess repaired that way would then look
+         * settled and never be revisited. */
+        installChildAliases();
         /* Before anything is drawn, never from tick() — see warmCurrentPage.
          * s.values was cleared above, so this is the page's whole set. */
         warmCurrentPage();
@@ -1440,7 +1445,43 @@ export function createController(io = {}) {
      * which is the bug this exists to prevent -- and the pending write is the
      * dangerous one: it would land on the NEW instance.
      */
+    /**
+     * Point each child page's GENERIC keys at the focused instance's
+     * declaration.
+     *
+     * A child level lists `start`; the module declares `p01_start` … and
+     * nothing called `start`. Without this the metadata falls to getOrGuess and
+     * becomes a plain 0..1 float, which is a STRUCTURE guess: mrdrums Sample
+     * Start lost `wav_position` and its `filepath_param` and drew as a bare
+     * knob instead of the waveform. Reported from the device as exactly that.
+     *
+     * Re-run on every index change, because the borrowed declaration carries
+     * instance-specific cross-references -- `filepath_param` has to follow from
+     * `p01_sample_path` to `p05_sample_path` or the waveform keeps drawing the
+     * previous pad's file.
+     *
+     * Cheap and pure: no reads, just Map writes over the keys of child pages.
+     */
+    function installChildAliases() {
+        if (!s.metaIndex || typeof s.metaIndex.setAlias !== "function") return;
+        for (const pg of s.pages) {
+            if (!pg.childLevel || !Array.isArray(pg.keys)) continue;
+            const i = childIndexFor(pg.level);
+            for (const k of pg.keys) {
+                if (!k) continue;
+                const concrete = resolveChildKey(pg.childLevel, i, k);
+                /* A passthrough override resolves to itself -- that is how a
+                 * level's GLOBAL keys stay global -- and aliasing a key to
+                 * itself is a no-op setAlias already refuses. */
+                if (concrete) s.metaIndex.setAlias(k, concrete);
+            }
+        }
+    }
+
     function dropChildLevelCache(levelName) {
+        /* The borrowed metadata belonged to the instance we just left -- above
+         * all filepath_param, which still names the previous pad's file. */
+        installChildAliases();
         for (const pg of s.pages) {
             if (pg.level !== levelName || !Array.isArray(pg.keys)) continue;
             for (const k of pg.keys) {

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -33,9 +33,28 @@ function allListedKeys(hierarchy) {
     const add = (k) => { if (typeof k === "string" && k) out.add(k); };
     for (const lvl of Object.values((hierarchy && hierarchy.levels) || {})) {
         if (!lvl || typeof lvl !== "object") continue;
+        /*
+         * LISTED IS NOT REACHABLE, and the difference is a trap.
+         *
+         * An overflow key pulled from `params[]` is dropped when it is
+         * `ui_`-prefixed -- see the filter that builds `extra` below, whose
+         * comment names ui_current_pad and ui_preset_path outright. So a
+         * module can list its index param in params[] and that param still
+         * never gets a cell.
+         *
+         * This has to agree with that filter exactly. It did not, and the cost
+         * was the picker being suppressed as "redundant" while the control it
+         * deferred to did not exist: with auto-select off there was then NO
+         * way to change instance at all. Reported from the device as "if I
+         * turn off autoselect how do I get to another pad's settings?".
+         *
+         * A key on `knobs[]` is the author's intent and is honoured whatever
+         * it is called, which is why the two lists are treated differently
+         * here rather than merged.
+         */
         for (const p of (lvl.params || [])) {
-            if (p && typeof p === "object") { if (!p.level) add(p.key); }
-            else add(p);
+            const k = (p && typeof p === "object") ? (p.level ? null : p.key) : p;
+            if (typeof k === "string" && k && !/^ui_/.test(k)) add(k);
         }
         for (const k of (lvl.knobs || [])) {
             if (k && typeof k === "object") add(k.key); else add(k);

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -19,7 +19,57 @@
  * (c) 2026 megadake, MIT — https://github.com/DimaDake/schwung-movy
  */
 
-import { hasChildren, childCount } from "./child_key.mjs";
+import { hasChildren, childCount, childIndexParam } from "./child_key.mjs";
+
+/**
+ * Every param key the hierarchy lists ANYWHERE — so the planner can ask
+ * whether a key is reachable by the user at all.
+ *
+ * Nav entries (`{level: …}`) are not params and are skipped, exactly as
+ * buildMetaIndex skips them.
+ */
+function allListedKeys(hierarchy) {
+    const out = new Set();
+    const add = (k) => { if (typeof k === "string" && k) out.add(k); };
+    for (const lvl of Object.values((hierarchy && hierarchy.levels) || {})) {
+        if (!lvl || typeof lvl !== "object") continue;
+        for (const p of (lvl.params || [])) {
+            if (p && typeof p === "object") { if (!p.level) add(p.key); }
+            else add(p);
+        }
+        for (const k of (lvl.knobs || [])) {
+            if (k && typeof k === "object") add(k.key); else add(k);
+        }
+    }
+    return out;
+}
+
+/**
+ * Does this child level still need a picker PAGE?
+ *
+ * The picker exists because nothing else owns the focus. Once a level declares
+ * `child_index_param` the MODULE owns it — and if that param is also listed
+ * somewhere the user can reach, the picker becomes a second control for a fact
+ * that already has one. This tree treats that as a defect rather than a
+ * convenience: the list arrows went when the scrollbar arrived, and the file
+ * browser's `13/30` counter went for the same reason.
+ *
+ * It showed up the moment a module declared TWO child levels sharing one
+ * index: mrdrums got a pad picker on root AND on Pad Settings, both selecting
+ * the same pad, in sync with each other and with the pad you played. Reported
+ * from the device as exactly that question.
+ *
+ * REACHABILITY IS THE CONDITION, not merely the declaration. A module that
+ * names an index param it never lists would otherwise lose its picker and
+ * leave no way at all to change instance by hand — so in that case the picker
+ * stays, and a module gets the deduplication only by offering the control
+ * itself.
+ */
+function childPickerNeeded(lvl, listedKeys) {
+    const idxParam = childIndexParam(lvl);
+    if (!idxParam) return true;
+    return !listedKeys.has(idxParam);
+}
 
 import { alignGroupsToRows, gatherGroupMembers } from "./viz.mjs";
 import { buildMetaIndex } from "./param_meta.mjs";
@@ -272,6 +322,10 @@ function balancedChunk(arr, size) {
 export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
                             trailingMenus } = {}) {
     const warnings = [];
+    /* Whether a child level still needs a picker PAGE depends on the WHOLE
+     * hierarchy, not on the level: the index param may be listed on a sibling
+     * level, which is exactly where mrdrums puts it. */
+    const listedKeys = allListedKeys(hierarchy);
     /*
      * Built once per plan so knob pages can be nudged into a drawable layout —
      * see alignGroupsToRows. Planning happens on component load, not per frame,
@@ -600,7 +654,7 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
         /* Repeated elements declared once and multiplied by the host. The
          * level object travels with the page so the caller can resolve concrete
          * keys without re-reading the hierarchy (see child_key.mjs). */
-        if (hasChildren(lvl)) {
+        if (hasChildren(lvl) && childPickerNeeded(lvl, listedKeys)) {
             /*
              * A child selector IS an items page.
              *

--- a/src/shared/param_pages/param_meta.mjs
+++ b/src/shared/param_pages/param_meta.mjs
@@ -88,13 +88,66 @@ export function buildMetaIndex({ hierarchy, chainParams } = {}) {
     }
 
     const cache = new Map();
+    /*
+     * bare key -> concrete key whose DECLARATION it borrows.
+     *
+     * A child level lists generic keys (`start`) and the module declares only
+     * the concrete ones (`p01_start`, … `p16_start`). Nothing declares `start`,
+     * so it fell to getOrGuess and became a plain 0..1 float -- which is a
+     * STRUCTURE guess, exactly what the comment below says this library must
+     * never make. mrdrums is the case: `p01_start` is a `wav_position` with a
+     * `filepath_param`, and losing both drew the sample cell as a bare knob.
+     *
+     * Borrowing rather than copying is what keeps it correct across pads: the
+     * alias is re-pointed when the focused instance changes, so
+     * `filepath_param` follows from `p01_sample_path` to `p05_sample_path`. It
+     * stays CONCRETE on purpose -- the file is read as a viz extra key, which
+     * is not resolved through the child template, so a bare `sample_path`
+     * there would ask for a param no module serves.
+     */
+    const aliases = new Map();
     const get = (key) => {
         if (cache.has(key)) return cache.get(key);
+        /*
+         * The two sources are resolved SEPARATELY, and that split is the point.
+         *
+         * A level listing `{key:"start", label:"Start"}` creates an inline
+         * entry carrying a LABEL and no structure. Treating that as "declared"
+         * vetoed the alias and left the key a plain float again -- the very
+         * bug this exists to fix, reintroduced by the level being polite enough
+         * to name its own params. So the level keeps its own label (inline, by
+         * the bare key) and borrows the STRUCTURE (chain, by the alias).
+         *
+         * chain.get(key) is tried first, so a module that really does declare
+         * the bare key is never shadowed.
+         */
         const i = inline.get(key) || null;
-        const c = chain.get(key) || null;
+        const c = chain.get(key) || chain.get(aliases.get(key) || key) || null;
+        /* Normalised under the BARE key, because that is what the page, the
+         * value cache and the renderer all address it by. Only the declaration
+         * is borrowed. */
         const meta = (i || c) ? normalize(key, { ...(i || {}), ...(c || {}) }) : null;
         cache.set(key, meta);
         return meta;
+    };
+    /**
+     * Point `bare` at `concrete`'s declaration. Returns true if anything moved.
+     *
+     * Refuses to shadow a key the module actually declares -- mrdrums declares
+     * `pad_start` as well as `p01_start`, and a level listing `pad_start`
+     * must keep its own metadata rather than silently borrow another key's.
+     */
+    const setAlias = (bare, concrete) => {
+        if (!bare || !concrete || bare === concrete) return false;
+        /* Only a REAL declaration blocks borrowing -- an inline entry is
+         * usually just a label, and vetoing on it is what re-broke the case
+         * this exists for. See the two-source split in get(). */
+        if (chain.has(bare)) return false;
+        if (!chain.has(concrete)) return false;
+        if (aliases.get(bare) === concrete) return false;
+        aliases.set(bare, concrete);
+        cache.delete(bare);
+        return true;
     };
 
     /* A key a module puts on a knob but declares nowhere. Rare and real: sfz
@@ -109,7 +162,7 @@ export function buildMetaIndex({ hierarchy, chainParams } = {}) {
     };
 
     const keys = [...new Set([...inline.keys(), ...chain.keys()])];
-    return { get, getOrGuess, keys, conflicts: [...new Set(conflicts)] };
+    return { get, getOrGuess, keys, setAlias, conflicts: [...new Set(conflicts)] };
 }
 
 /**

--- a/src/shared/param_pages/param_meta.mjs
+++ b/src/shared/param_pages/param_meta.mjs
@@ -27,6 +27,13 @@
 import { enumWiresNames } from "../param_format.mjs";
 
 /** A knob turns it continuously — float/int. */
+/*
+ * child_key.mjs imports nothing, so this cannot cycle. The child aliases are
+ * seeded here rather than by the caller because planPages builds its OWN index
+ * from the same inputs, and a key TYPE decides its fate at plan time.
+ */
+import { hasChildren, resolveChildKey } from "./child_key.mjs";
+
 export const KIND_NUMBER = "number";
 /** A knob steps through discrete options — enum/toggle. */
 export const KIND_ENUM = "enum";
@@ -183,6 +190,40 @@ export function buildMetaIndex({ hierarchy, chainParams } = {}) {
         type: "float", min: 0, max: 1, step: 0.01,
         kind: KIND_NUMBER, guessed: true,
     };
+
+    /*
+     * SEED THE CHILD ALIASES HERE, not in the controller.
+     *
+     * A child level lists `sample_path`; the module declares p01_sample_path …
+     * and nothing generic. The controller can re-point these as the focused
+     * instance changes, but it does so AFTER planPages has run -- and the plan
+     * is where a key's TYPE decides its fate. Unaliased, `sample_path` was a
+     * guessed 0..1 float, so it was planned as an ordinary turnable knob
+     * instead of an opaque filepath cell: no file cell, nothing to dive into,
+     * and the sample selection simply gone. Reported from the device.
+     *
+     * Instance 0 is the right seed because every instance carries the same
+     * structure; only the cross-references (filepath_param) name an instance,
+     * and those are re-pointed on a focus change.
+     *
+     * planPages builds its own index from the same inputs, so seeding here is
+     * what keeps the planner and the renderer deciding from ONE description --
+     * the split between them is exactly how this bug survived a layer down.
+     */
+    for (const lvl of Object.values((hierarchy && hierarchy.levels) || {})) {
+        if (!hasChildren(lvl)) continue;
+        const generic = new Set();
+        for (const k of (lvl.knobs || [])) generic.add(typeof k === "string" ? k : (k && k.key));
+        for (const p of (lvl.params || [])) {
+            if (p && typeof p === "object") { if (!p.level) generic.add(p.key); }
+            else generic.add(p);
+        }
+        for (const g of generic) {
+            if (!g) continue;
+            const concrete = resolveChildKey(lvl, 0, g);
+            if (concrete) setAlias(g, concrete);
+        }
+    }
 
     const keys = [...new Set([...inline.keys(), ...chain.keys()])];
     return { get, getOrGuess, keys, setAlias, conflicts: [...new Set(conflicts)] };

--- a/src/shared/param_pages/param_meta.mjs
+++ b/src/shared/param_pages/param_meta.mjs
@@ -122,7 +122,30 @@ export function buildMetaIndex({ hierarchy, chainParams } = {}) {
          * the bare key is never shadowed.
          */
         const i = inline.get(key) || null;
-        const c = chain.get(key) || chain.get(aliases.get(key) || key) || null;
+        let c = chain.get(key) || null;
+        if (!c) {
+            const src = aliases.get(key);
+            const borrowed = src ? chain.get(src) : null;
+            if (borrowed) {
+                /*
+                 * STRUCTURE ONLY -- the NAME is never borrowed.
+                 *
+                 * A per-instance declaration names its instance: mrdrums calls
+                 * `p01_pan` "P01 Pan", so borrowing the name put "P01PAN" in a
+                 * cell whose whole point is that it shows the FOCUSED pad.
+                 * Reported from the device. The label belongs to the generic
+                 * key -- it is the same control whichever pad is focused, and
+                 * the pad is stated once in the header, not sixteen times in
+                 * the labels.
+                 *
+                 * Dropped rather than overwritten so the ordinary fallbacks
+                 * still run: the level's own inline label wins if it has one,
+                 * otherwise normalize derives it from the bare key.
+                 */
+                const { name, label, ...structure } = borrowed;
+                c = structure;
+            }
+        }
         /* Normalised under the BARE key, because that is what the page, the
          * value cache and the renderer all address it by. Only the declaration
          * is borrowed. */

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -2131,7 +2131,12 @@ export function drawKnobRow(ctx, o, row, rowY, lblY, geom) {
         drawVizGroup(ctx, {
             x: cellLeft(g, localStart), y: rowY,
             w: group.slotSpan * g.cellW, h: lblY - rowY,
-        }, group, liveValues, metaIndex, o.anim, o.nowMs);
+        }, group, liveValues, metaIndex, o.anim, o.nowMs,
+           /* The BASE, and only when something is actually modulated -- so a
+            * page with no source passes null and the graphic draws exactly as
+            * it always has. `liveValues === values` in that case anyway, and a
+            * mark whose base equals its cursor would never be drawn. */
+           hasMod ? values : null);
         /*
          * ONE MARK FOR THE WHOLE GRAPHIC.
          *

--- a/src/shared/param_pages/viz_draw.mjs
+++ b/src/shared/param_pages/viz_draw.mjs
@@ -1382,7 +1382,7 @@ export function drawSwitch(ctx, rect, key, values, metaIndex, _anim, _nowMs) {
  * The envelope is the file's real peaks, decoded by wav_peaks.mjs and advanced
  * from the tick. When there are none, there is no envelope — see below.
  */
-export function drawSample(ctx, rect, roles, values, metaIndex) {
+export function drawSample(ctx, rect, roles, values, metaIndex, baseValues) {
     const x0 = rect.x, w = rect.w;
     const { topY, botY, midY, amp } = band(rect);
 
@@ -1469,11 +1469,12 @@ export function drawSample(ctx, rect, roles, values, metaIndex) {
      * floor(p*w). The obvious round(p*(w-1)) disagrees for a quarter of all
      * positions and lands a pixel off the column that will actually play. */
     const colOf = (p) => Math.min(w - 1, Math.floor(clamp01(p) * w));
-    const posOf = (role) => {
+    const posIn = (src, role) => {
         const k = roles[role];
-        if (!k || !values || values[k] === undefined || values[k] === null) return undefined;
-        return clamp01(fractionOf(metaIndex.getOrGuess(k), values[k]));
+        if (!k || !src || src[k] === undefined || src[k] === null) return undefined;
+        return clamp01(fractionOf(metaIndex.getOrGuess(k), src[k]));
     };
+    const posOf = (role) => posIn(values, role);
 
     /*
      * LOOP BOUNDS FIRST, so the playback cursor draws on top of them — the
@@ -1545,6 +1546,49 @@ export function drawSample(ctx, rect, roles, values, metaIndex) {
      * bright line; through a loud one it becomes a dark notch cut into the
      * body. Either way it is the highest-contrast thing in the column.
      */
+    /*
+     * THE BASE MARK: where the knob is SET, when a source is moving it.
+     *
+     * A graphic COVERS its cells, so `drawKnobWidget` never runs for them and
+     * the modulation dot -- the only thing that says "this is yours, that is
+     * the LFO" -- has no way onto the screen. That was invisible until a lone
+     * `wav_position` started forming a one-cell sample group (5f5fb11c): the
+     * cell had been an ordinary knob, with a pointer at the base and a dot at
+     * the effective value, and it silently became a waveform whose cursor
+     * tracks the effective value with the base nowhere on screen. Reported as
+     * "we lost the knob LFO indicator", against mrdrums' Sample Start.
+     *
+     * So the graphic carries what the widget it replaced carried. The cursor
+     * is already the live value; this is its base, and the two together say
+     * the same thing the pointer and the dot said.
+     *
+     * Drawn as STUBS at the band edges rather than a full-height line, and
+     * that is the whole design: the cursor is full height and solid, the spray
+     * fences are full height and dotted, so a third full-height mark would be
+     * a third thing competing at the same weight. Two 2px ticks read as an
+     * annotation on the track instead.
+     *
+     * Same COMPLEMENT technique as the cursor -- a lit pixel over a lit body
+     * is invisible, and at a loud peak the body reaches the band edge -- so
+     * the stub is cut out of the waveform where it lands inside it.
+     *
+     * Before the cursor, so that where the LFO passes through its own base the
+     * solid cursor wins the column. Nothing is lost by that: the two marks
+     * coinciding IS the reading "the source is at the base right now", which
+     * is exactly what the cursor alone shows.
+     */
+    const basePos = baseValues ? posIn(baseValues, "position") : undefined;
+    if (basePos !== undefined && pos !== undefined && colOf(basePos) !== colOf(pos)) {
+        const bi = colOf(basePos), bh = halfAt(bi), bx = x0 + bi;
+        const stub = (yy) => {
+            if (yy < topY || yy > botY) return;
+            const inWave = yy >= midY - bh && yy <= midY + bh;
+            ctx.fillRect(bx, yy, 1, 1, inWave ? 0 : 1);
+        };
+        stub(topY); stub(topY + 1);
+        stub(botY); stub(botY - 1);
+    }
+
     if (pos !== undefined) {
         const mi = colOf(pos);
         const h = halfAt(mi), mx = x0 + mi;
@@ -1566,7 +1610,8 @@ const DRAW = {
     [VIZ_FADER]: (ctx, rect, group, values, metaIndex) => drawFader(ctx, rect, group.roles.value, values, metaIndex),
     [VIZ_SWITCH]: (ctx, rect, group, values, metaIndex, anim, nowMs) =>
         drawSwitch(ctx, rect, group.roles.value, values, metaIndex, anim, nowMs),
-    [VIZ_SAMPLE]: (ctx, rect, group, values, metaIndex) => drawSample(ctx, rect, group.roles, values, metaIndex),
+    [VIZ_SAMPLE]: (ctx, rect, group, values, metaIndex, anim, nowMs, baseValues) =>
+        drawSample(ctx, rect, group.roles, values, metaIndex, baseValues),
 };
 
 /**
@@ -1580,7 +1625,14 @@ const DRAW = {
  * pixels it always did — the animations are opt-in per caller, which is what
  * keeps the harness, the pinned baselines and the device unaffected.
  */
-export function drawVizGroup(ctx, rect, group, values, metaIndex, anim, nowMs) {
+/*
+ * `baseValues` is OPTIONAL and is only ever the BASE of a modulated key --
+ * null when nothing on the page is modulated, which is the common case and
+ * costs the callers nothing. Only drawSample reads it today (see its base
+ * mark); the rest of the table ignores the argument, exactly as they already
+ * ignore `anim`/`nowMs` when they do not animate.
+ */
+export function drawVizGroup(ctx, rect, group, values, metaIndex, anim, nowMs, baseValues) {
     const fn = DRAW[group.kind];
-    if (fn) fn(ctx, rect, group, values, metaIndex, anim, nowMs);
+    if (fn) fn(ctx, rect, group, values, metaIndex, anim, nowMs, baseValues);
 }

--- a/src/shared/param_pages/viz_draw.mjs
+++ b/src/shared/param_pages/viz_draw.mjs
@@ -1613,13 +1613,31 @@ export function drawSample(ctx, rect, roles, values, metaIndex, baseValues) {
     const basePos = baseValues ? posIn(baseValues, "position") : undefined;
     if (basePos !== undefined && pos !== undefined && colOf(basePos) !== colOf(pos)) {
         const bi = colOf(basePos), bh = halfAt(bi), bx = x0 + bi;
-        const stub = (yy) => {
-            if (yy < topY || yy > botY) return;
+        /*
+         * A COARSE DASH -- 2 on, 2 off -- and the rhythm is the whole point.
+         *
+         * This column has to be told apart from the two other vertical marks
+         * that can share the cell: the playback cursor is SOLID, and the spray
+         * fences are a fine every-other-row dither. Two-on-two-off is legible
+         * as a third rhythm in a 13px band, where a single stub pair at the
+         * edges (the first cut) was four pixels and read as noise on the frame.
+         * Reported from the device as wanting "a different line ... dotted with
+         * large dots".
+         *
+         * Phased from topY, an ABSOLUTE coordinate, so the dash does not crawl
+         * as the base moves between columns -- the same rule the fills follow,
+         * and the opposite of the fader lattice, where re-phasing IS the
+         * signal.
+         *
+         * Complemented against the waveform body like the cursor: a lit pixel
+         * over a lit body is invisible, so inside the envelope the dash is cut
+         * OUT of it instead.
+         */
+        for (let yy = topY; yy <= botY; yy++) {
+            if (((yy - topY) & 3) >= 2) continue;
             const inWave = yy >= midY - bh && yy <= midY + bh;
             ctx.fillRect(bx, yy, 1, 1, inWave ? 0 : 1);
-        };
-        stub(topY); stub(topY + 1);
-        stub(botY); stub(botY - 1);
+        }
     }
 
     if (pos !== undefined) {

--- a/src/shared/param_pages/viz_draw.mjs
+++ b/src/shared/param_pages/viz_draw.mjs
@@ -1176,7 +1176,7 @@ export function drawEq(ctx, rect, roles, values, metaIndex) {
  * said — five detents in six move nothing on screen, which is fine for a level
  * grabbed roughly and bad for anything nudged.
  */
-export function drawFader(ctx, rect, key, values, metaIndex) {
+export function drawFader(ctx, rect, key, values, metaIndex, baseValues) {
     const meta = metaIndex.getOrGuess(key);
     const normVal = fractionOf(meta, values ? values[key] : undefined);
     const { topY: top, botY: bot } = band(rect); const h = bot - top;
@@ -1232,6 +1232,39 @@ export function drawFader(ctx, rect, key, values, metaIndex) {
     if (bh >= 3) {
         fillDithered(ctx, bx + 1, y + 1, bw - 2, bh - 2, pattern);
         notchCorners(ctx, bx, y, bw, bh);
+    }
+
+    /*
+     * THE BASE MARK, for a fader a source is driving.
+     *
+     * Same rule as the sample cell: a viz group COVERS its cells, so
+     * drawKnobWidget never runs for them and the modulation dot -- the only
+     * thing that says where you SET the value as opposed to where it is right
+     * now -- has no way onto the screen. The bar tracks the effective value,
+     * so without this a modulated fader is a bar moving on its own with the
+     * base nowhere to be seen.
+     *
+     * OUTSIDE THE RAILS, which is what makes it collision-proof rather than
+     * merely tidy. The bar spans cx-3..cx+3 and the dashed rails sit at cx+-4,
+     * so cx+-5..6 is the only part of the cell nothing else ever draws in. A
+     * mark inside the bar would have to fight the dithered lattice -- whose
+     * whole point is that it re-phases as the value moves -- and would be
+     * unreadable exactly when the value is moving, which is the only time this
+     * mark exists.
+     *
+     * Two stubs rather than a rule across the cell, matching drawSample: the
+     * fill boundary is already a full-width horizontal edge, so a second one
+     * would read as a second bar top.
+     */
+    if (baseValues) {
+        const baseNorm = fractionOf(meta, baseValues[key]);
+        if (baseNorm !== undefined && baseNorm !== null && !Number.isNaN(baseNorm)) {
+            const byy = Math.round(bot - clamp01(baseNorm) * h);
+            if (byy >= top && byy <= bot) {
+                ctx.fillRect(cx - 6, byy, 2, 1, 1);
+                ctx.fillRect(cx + 5, byy, 2, 1, 1);
+            }
+        }
     }
 }
 
@@ -1607,7 +1640,8 @@ const DRAW = {
     [VIZ_EQ]: (ctx, rect, group, values, metaIndex) => drawEq(ctx, rect, group.roles, values, metaIndex),
     [VIZ_WAVEFORM]: (ctx, rect, group, values, metaIndex, anim, nowMs) =>
         drawWaveform(ctx, rect, group.roles.value, values, metaIndex, anim, nowMs),
-    [VIZ_FADER]: (ctx, rect, group, values, metaIndex) => drawFader(ctx, rect, group.roles.value, values, metaIndex),
+    [VIZ_FADER]: (ctx, rect, group, values, metaIndex, anim, nowMs, baseValues) =>
+        drawFader(ctx, rect, group.roles.value, values, metaIndex, baseValues),
     [VIZ_SWITCH]: (ctx, rect, group, values, metaIndex, anim, nowMs) =>
         drawSwitch(ctx, rect, group.roles.value, values, metaIndex, anim, nowMs),
     [VIZ_SAMPLE]: (ctx, rect, group, values, metaIndex, anim, nowMs, baseValues) =>

--- a/tests/host/test_child_index_param.sh
+++ b/tests/host/test_child_index_param.sh
@@ -31,7 +31,8 @@ node -e '
 Promise.all([
   import("./src/shared/param_pages/page_controller.mjs"),
   import("./src/shared/param_pages/child_key.mjs"),
-]).then(([PC, CK]) => {
+  import("./src/shared/param_pages/page_plan.mjs"),
+]).then(([PC, CK, PLAN]) => {
   let bad = 0;
   const fail = (m) => { console.log("FAIL: " + m); bad++; };
 
@@ -304,6 +305,57 @@ Promise.all([
          + "so the waveform shows the previous pad until you jog away and back");
   }
 
+
+  /* ---- the picker only goes when the index is REALLY reachable ---------
+   *
+   * The picker is suppressed when the module owns the focus AND offers the
+   * control itself. "Offers" has to mean a CELL, not a mention: an overflow
+   * key pulled from params[] is dropped when it is `ui_`-prefixed (page_plan
+   * filters exactly that, naming ui_current_pad in its comment), so a module
+   * can list its index param and still give it no cell.
+   *
+   * Getting this wrong removed the picker while the control it deferred to did
+   * not exist -- with auto-select off there was then no way to reach another
+   * instance at all. Reported from the device as "if I turn off autoselect how
+   * do I get to another pads settings?".
+   */
+  {
+    const mkLvl = (params, knobs) => ({
+      label: "Pads", child_count: 4, child_label: "Pad",
+      child_key_template: "p{index}_{key}",
+      child_index_base: 1, child_index_digits: 2,
+      child_index_param: "ui_cur",
+      child_key_overrides: { ui_cur: "ui_cur" },
+      params, knobs,
+    });
+    const CP4 = [{ key: "ui_cur", name: "Cur", type: "int", min: 1, max: 4 }];
+    for (let i = 1; i <= 4; i++) {
+      const n = String(i).padStart(2, "0");
+      CP4.push({ key: `p${n}_vol`, name: "Vol", type: "float", min: 0, max: 1, step: 0.01 });
+    }
+    const plan = (lvl) => PLAN.planPages({
+      hierarchy: { modes: null, levels: { root: lvl } }, chainParams: CP4 });
+    const hasPicker = (r) => (r.pages || r).some((p) => p.childOf);
+    const hasCell = (r) => (r.pages || r).some((p) => (p.keys || []).indexOf("ui_cur") >= 0);
+
+    /* Listed in params[] ONLY, and ui_-prefixed: no cell, so the picker stays. */
+    const onlyParams = plan(mkLvl(["ui_cur", "vol"], ["vol"]));
+    if (hasCell(onlyParams))
+      fail("a ui_-prefixed key from params[] got a cell — this test no longer "
+         + "covers the case it was written for");
+    if (!hasPicker(onlyParams))
+      fail("the child picker was suppressed while the index param has NO cell — "
+         + "with the module`s own focus control off there is no way to change instance");
+
+    /* On knobs[]: the author placed it, so it gets a cell and the picker goes. */
+    const onKnobs = plan(mkLvl(["ui_cur", "vol"], ["ui_cur", "vol"]));
+    if (!hasCell(onKnobs))
+      fail("an authored knob was dropped for being ui_-prefixed — knobs[] is intent");
+    if (hasPicker(onKnobs))
+      fail("the picker survived even though the index param has its own cell — "
+         + "two controls for one fact");
+  }
+
   /* ---- a level with NO child_index_param is untouched ------------------ */
   {
     const L2 = Object.assign({}, LEVEL);
@@ -326,6 +378,7 @@ Promise.all([
     console.log("  ok  choosing a child writes it back, so the two cannot disagree");
     console.log("  ok  a generic child key borrows the concrete declaration, and follows");
     console.log("  ok  the graphic follows the focused child with no page change");
+    console.log("  ok  the picker goes only when the index param really has a cell");
     console.log("  ok  a level that declares none reads none");
     console.log("PASS: a module can own which child instance is focused");
   }

--- a/tests/host/test_child_index_param.sh
+++ b/tests/host/test_child_index_param.sh
@@ -186,6 +186,72 @@ Promise.all([
     }
   }
 
+
+  /* ---- a generic child key BORROWS the concrete declaration ------------
+   *
+   * A child level lists `start`; the module declares p01_start … p16_start and
+   * nothing called `start`. Without an alias that falls to getOrGuess and
+   * becomes a plain 0..1 float -- a STRUCTURE guess, which is the one thing
+   * the meta index is not allowed to make. On mrdrums it cost Sample Start its
+   * wav_position type and its filepath_param, so the cell drew as a bare knob
+   * instead of the waveform. Reported from the device.
+   */
+  {
+    const CP2 = [{ key: "ui_current_pad", name: "Current Pad", type: "int", min: 1, max: 16 }];
+    for (let i = 1; i <= 16; i++) {
+      const n = String(i).padStart(2, "0");
+      CP2.push({ key: `p${n}_start`, name: "Start", type: "wav_position",
+                 filepath_param: `p${n}_sample_path`, min: 0, max: 1, step: 0.01 });
+      CP2.push({ key: `p${n}_sample_path`, name: "Sample", type: "filepath" });
+      CP2.push({ key: `p${n}_vol`, name: "Vol", type: "float", min: 0, max: 1, step: 0.01 });
+    }
+    const L3 = {
+      label: "Pads", child_count: 16, child_label: "Pad",
+      child_key_template: "p{index}_{key}",
+      child_index_base: 1, child_index_digits: 2,
+      child_index_param: "ui_current_pad",
+      knobs: ["vol", "start"], params: [{ key: "vol" }, { key: "start" }],
+    };
+    let pad = "1";
+    const c = PC.createController({
+      getParam: (k) => {
+        if (k.endsWith(":ui_hierarchy")) return JSON.stringify({ modes: null, levels: { root: L3 } });
+        if (k.endsWith(":chain_params")) return JSON.stringify(CP2);
+        if (k.endsWith(":ui_current_pad")) return pad;
+        if (k.endsWith(":preset_name")) return "";
+        if (k.endsWith(":is_loading")) return "0";
+        if (k.endsWith(":module")) return "mrdrums";
+        return "0.5";
+      },
+      setParam: () => {}, announce: () => {}, now: () => 0,
+    });
+    c.load({ slot: 0, component: "synth", prefix: "synth" });
+    c.setLayout("movy");
+    for (let i = 0; i < 30; i++) c.tick();
+
+    const meta = c.metaIndex.getOrGuess("start");
+    if (meta.guessed)
+      fail("the generic child key `start` was GUESSED -- it must borrow the "
+         + "concrete declaration, or the widget is chosen from an invented type");
+    if (meta.type !== "wav_position")
+      fail("`start` resolved to type " + meta.type + ", expected wav_position");
+    if (meta.filepath_param !== "p01_sample_path")
+      fail("`start` borrowed filepath_param " + meta.filepath_param
+         + ", expected p01_sample_path");
+
+    /* It must FOLLOW the focused instance: the cross-reference names a pad, so
+     * a stale alias keeps drawing the previous pad file. */
+    pad = "5";
+    for (let i = 0; i < 30; i++) c.tick();
+    if (c.metaIndex.getOrGuess("start").filepath_param !== "p05_sample_path")
+      fail("after moving to pad 5 the borrowed filepath_param is still "
+         + c.metaIndex.getOrGuess("start").filepath_param);
+
+    /* A DECLARED key is never shadowed. */
+    if (c.metaIndex.getOrGuess("p01_vol").key !== "p01_vol")
+      fail("aliasing disturbed a declared key");
+  }
+
   /* ---- a level with NO child_index_param is untouched ------------------ */
   {
     const L2 = Object.assign({}, LEVEL);
@@ -206,6 +272,7 @@ Promise.all([
     console.log("  ok  a junk or missing index never moves the focus");
     console.log("  ok  the grid follows the module when it changes the focused child");
     console.log("  ok  choosing a child writes it back, so the two cannot disagree");
+    console.log("  ok  a generic child key borrows the concrete declaration, and follows");
     console.log("  ok  a level that declares none reads none");
     console.log("PASS: a module can own which child instance is focused");
   }

--- a/tests/host/test_child_index_param.sh
+++ b/tests/host/test_child_index_param.sh
@@ -252,6 +252,58 @@ Promise.all([
       fail("aliasing disturbed a declared key");
   }
 
+
+  /* ---- the GRAPHIC follows the focused child, without a page change -----
+   *
+   * A viz group memoises on fingerprint + page index, and NEITHER changes when
+   * the focused pad does. So the cached group went on naming the previous
+   * pad`s file as its extra key: the read rotation kept fetching pad 1 while
+   * pad 5 was on screen, and only jogging to another page and back busted the
+   * cache. Reported from the device as the waveform updating only after a
+   * detour.
+   *
+   * Asserted on the KEY THAT GETS READ, not on the cache: what the user sees
+   * is which file the rotation fetched, and a test that inspected the cache
+   * would pass on a correctly-rebuilt group whose value never arrived.
+   */
+  {
+    const CP3 = [{ key: "cur_pad", name: "Cur", type: "int", min: 1, max: 4 }];
+    for (let i = 1; i <= 4; i++) {
+      const n = String(i).padStart(2, "0");
+      CP3.push({ key: `p${n}_start`, name: "Start", type: "wav_position",
+                 filepath_param: `p${n}_sample_path`, min: 0, max: 1, step: 0.01 });
+      CP3.push({ key: `p${n}_sample_path`, name: "Sample", type: "filepath" });
+      CP3.push({ key: `p${n}_vol`, name: "Vol", type: "float", min: 0, max: 1, step: 0.01 });
+    }
+    const L4 = { label: "Pads", child_count: 4, child_label: "Pad",
+                 child_key_template: "p{index}_{key}", child_index_base: 1,
+                 child_index_digits: 2, child_index_param: "cur_pad",
+                 knobs: ["vol", "start"], params: ["vol", "start"] };
+    let pad = "1";
+    const c = PC.createController({
+      getParam: (k) => {
+        if (k.endsWith(":ui_hierarchy")) return JSON.stringify({ modes: null, levels: { root: L4 } });
+        if (k.endsWith(":chain_params")) return JSON.stringify(CP3);
+        if (k.endsWith(":cur_pad")) return pad;
+        if (k.endsWith(":preset_name")) return "";
+        if (k.endsWith(":is_loading")) return "0";
+        if (k.endsWith(":module")) return "m";
+        if (/sample_path$/.test(k)) return "/x/f.wav";
+        return "0.5";
+      }, setParam: () => {}, announce: () => {}, now: () => 0,
+    });
+    c.load({ slot: 0, component: "synth", prefix: "synth" });
+    c.setLayout("movy");
+    for (let i = 0; i < 40; i++) c.tick();
+    pad = "3";
+    for (let i = 0; i < 40; i++) c.tick();   /* NO page change */
+    const files = Object.keys(c.state.values).filter((k) => /sample_path$/.test(k));
+    if (files.indexOf("p03_sample_path") < 0)
+      fail("after the module moved the focus to pad 3, the graphic still asks for "
+         + JSON.stringify(files) + " -- the viz cache does not key on the focused child, "
+         + "so the waveform shows the previous pad until you jog away and back");
+  }
+
   /* ---- a level with NO child_index_param is untouched ------------------ */
   {
     const L2 = Object.assign({}, LEVEL);
@@ -273,6 +325,7 @@ Promise.all([
     console.log("  ok  the grid follows the module when it changes the focused child");
     console.log("  ok  choosing a child writes it back, so the two cannot disagree");
     console.log("  ok  a generic child key borrows the concrete declaration, and follows");
+    console.log("  ok  the graphic follows the focused child with no page change");
     console.log("  ok  a level that declares none reads none");
     console.log("PASS: a module can own which child instance is focused");
   }

--- a/tests/host/test_child_index_param.sh
+++ b/tests/host/test_child_index_param.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A module can own which child instance is focused.
+#
+# Without child_index_param the index is UI-only state, written in exactly one
+# place: a pick from the instance list. That is right for a synth whose "Part 2"
+# is a deliberate navigation choice and wrong for a drum module, where hitting a
+# pad is how you choose what you are editing. mrdrums is the case -- it follows
+# the pad you play -- so declaring a child level at all would have COST that
+# behaviour, and the declaration is what makes 209 per-pad params addressable
+# (and their modulation indicators visible). This is what makes it additive.
+#
+# Both directions are asserted, because either alone is satisfied by a
+# one-directional implementation:
+#   module -> UI   the rotation adopts the module's index
+#   UI -> module   a pick WRITES it, so the two can never disagree
+#
+# And the tri-state, which is the one that costs a user their edit: a failed or
+# nonsense read must NOT move the focus. Adopting 0 there re-keys every page on
+# screen and drops its cached values because a read timed out.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_pages/page_controller.mjs"),
+  import("./src/shared/param_pages/child_key.mjs"),
+]).then(([PC, CK]) => {
+  let bad = 0;
+  const fail = (m) => { console.log("FAIL: " + m); bad++; };
+
+  /* ---- the pure half ------------------------------------------------- */
+  const LEVEL = {
+    label: "Pads", child_count: 16, child_label: "Pad",
+    child_key_template: "p{index}_{key}",
+    child_index_base: 1, child_index_digits: 2,
+    child_index_param: "focused_pad",
+    knobs: ["vol", "start"],
+    params: [{ key: "vol" }, { key: "start" }],
+  };
+
+  if (CK.childIndexParam(LEVEL) !== "focused_pad")
+    fail("childIndexParam does not report the declared key");
+  /* A level with no children cannot have one, however it is spelled. */
+  if (CK.childIndexParam({ child_index_param: "x" }) !== null)
+    fail("a level with no children reported a child index param");
+
+  /* The wire speaks the MODULE numbering (pads are 1..16), the engine is
+   * zero-based. A round trip that agreed with itself would pass for any
+   * consistent-but-wrong base, so the wire value is asserted literally. */
+  if (CK.childIndexToWire(LEVEL, 0) !== "1")
+    fail("instance 0 must go on the wire as 1 with child_index_base 1, got "
+       + CK.childIndexToWire(LEVEL, 0));
+  if (CK.childIndexFromWire(LEVEL, "1") !== 0)
+    fail("wire 1 must read back as instance 0");
+  if (CK.childIndexFromWire(LEVEL, "16") !== 15)
+    fail("wire 16 must read back as instance 15");
+
+  /* Tri-state: none of these name an instance, and none may become 0. */
+  for (const junk of [null, undefined, "", "  ", "abc", "0", "17", "-1", "NaN"]) {
+    if (CK.childIndexFromWire(LEVEL, junk) !== null)
+      fail("childIndexFromWire accepted " + JSON.stringify(junk)
+         + " as an instance (got " + CK.childIndexFromWire(LEVEL, junk) + ")");
+  }
+
+  /* ---- driven through the real controller ----------------------------- */
+  const HIER = { modes: null, levels: { root: LEVEL } };
+  const CP = [];
+  for (let i = 1; i <= 16; i++) {
+    const n = String(i).padStart(2, "0");
+    CP.push({ key: `p${n}_vol`,   name: "Vol",   type: "float", min: 0, max: 1, step: 0.01 });
+    CP.push({ key: `p${n}_start`, name: "Start", type: "float", min: 0, max: 1, step: 0.01 });
+  }
+
+  let focused = "1";           /* what the MODULE says */
+  let focusedWrites = 0;
+  const reads = [];
+  const mk = () => {
+    const io = {
+      getParam: (k) => {
+        reads.push(k);
+        if (k.endsWith(":ui_hierarchy")) return JSON.stringify(HIER);
+        if (k.endsWith(":chain_params")) return JSON.stringify(CP);
+        if (k.endsWith(":focused_pad"))  return focused;
+        if (k.endsWith(":preset_name"))  return "";
+        if (k.endsWith(":is_loading"))   return "0";
+        if (k.endsWith(":module"))       return "mrdrums";
+        return "0.5";
+      },
+      setParam: (k, v) => {
+        if (k.endsWith(":focused_pad")) { focusedWrites++; focused = String(v); }
+      },
+      announce: () => {}, now: () => 0,
+    };
+    const c = PC.createController(io);
+    c.load({ slot: 0, component: "synth", prefix: "synth" });
+    c.setLayout("movy");
+    return c;
+  };
+
+  const spin = (c, n) => { for (let i = 0; i < n; i++) c.tick(); };
+  /* Which concrete key does knob 0 actually address? The MAPPING is the
+   * behaviour; the index cache is an implementation detail. */
+  const keyOf = (c) => {
+    const r = reads.filter((k) => /^synth:p\d\d_vol$/.test(k));
+    return r.length ? r[r.length - 1] : null;
+  };
+
+  {
+    const c = mk();
+    spin(c, 40);
+    if (keyOf(c) !== "synth:p01_vol")
+      fail("focused_pad=1 should address p01_vol, addressed " + keyOf(c));
+
+    /* MODULE MOVES THE FOCUS -- the pad you just played. */
+    focused = "5";
+    reads.length = 0;
+    spin(c, 40);
+    if (keyOf(c) !== "synth:p05_vol")
+      fail("the grid did not follow the module to pad 5; it addressed "
+         + keyOf(c) + " -- auto-select-pad would be dead");
+
+    /* A FAILED read must not move it back. */
+    const before = keyOf(c);
+    focused = "";
+    reads.length = 0;
+    spin(c, 40);
+    if (keyOf(c) !== before)
+      fail("an empty focused_pad read moved the focus to " + keyOf(c)
+         + " -- a timeout must never re-key the page");
+    focused = "nonsense";
+    reads.length = 0;
+    spin(c, 40);
+    if (keyOf(c) !== before)
+      fail("a nonsense focused_pad read moved the focus to " + keyOf(c));
+  }
+
+  /* ---- UI -> MODULE: a pick WRITES the param --------------------------
+   *
+   * Without this half the two sides can disagree: the user picks Pad 5 from
+   * the list, the grid re-keys locally, and the module goes on thinking Pad 1
+   * is focused -- so the next thing the module drives (or the next read of the
+   * param) yanks the user back. The param being the single source of truth in
+   * BOTH directions is what makes that impossible.
+   */
+  {
+    const c = mk();
+    spin(c, 20);
+    focusedWrites = 0;
+    /* The child picker (kind "items", childOf the level): enter it, move,
+     * and choose. */
+    const picker = c.pages.findIndex((pg) => pg.childOf);
+    if (picker < 0) fail("no child picker page was planned");
+    else {
+      c.goToPage(picker);
+      c.onClick();              /* enter the list */
+      c.onJog(2);               /* -> instance 2 */
+      c.onClick();              /* choose it */
+      if (focusedWrites === 0)
+        fail("choosing a child wrote nothing -- the module still thinks the "
+           + "old instance is focused and will yank the user back");
+      else {
+        /* Asserted as an INVARIANT between the two spellings, not against a
+         * hard-coded instance: how far one jog detent travels belongs to
+         * the list widget and changed this assertion once already. What must
+         * hold is that the wire value and the key the grid then addresses name
+         * the SAME pad -- an off-by-one in child_index_base breaks exactly
+         * that, and nothing else here would catch it. */
+        if (focused === "1")
+          fail("the pick did not move off the starting instance, so this "
+             + "assertion proves nothing");
+        reads.length = 0;
+        spin(c, 40);
+        const want = "synth:p" + String(Number(focused)).padStart(2, "0") + "_vol";
+        if (keyOf(c) !== want)
+          fail("wrote focused_pad=" + focused + " but the grid addresses "
+             + keyOf(c) + ", expected " + want
+             + " -- the wire numbering and the key template disagree");
+      }
+    }
+  }
+
+  /* ---- a level with NO child_index_param is untouched ------------------ */
+  {
+    const L2 = Object.assign({}, LEVEL);
+    delete L2.child_index_param;
+    HIER.levels.root = L2;
+    focusedWrites = 0;
+    reads.length = 0;
+    const c = mk();
+    spin(c, 40);
+    if (reads.some((k) => k.endsWith(":focused_pad")))
+      fail("a level without child_index_param still read one -- the rotation "
+         + "must cost nothing for the levels that do not declare it");
+    HIER.levels.root = LEVEL;
+  }
+
+  if (bad === 0) {
+    console.log("  ok  the wire speaks the module numbering, the engine is zero-based");
+    console.log("  ok  a junk or missing index never moves the focus");
+    console.log("  ok  the grid follows the module when it changes the focused child");
+    console.log("  ok  choosing a child writes it back, so the two cannot disagree");
+    console.log("  ok  a level that declares none reads none");
+    console.log("PASS: a module can own which child instance is focused");
+  }
+  process.exit(bad ? 1 : 0);
+});
+'

--- a/tests/host/test_child_levels.sh
+++ b/tests/host/test_child_levels.sh
@@ -47,7 +47,33 @@ cnt=$(command grep -nE "hierEditorChildCount = (levelDef\.child_count|childLevel
 ldl=$(command grep -n "loadHierarchyLevel()" <<<"$blk" | tail -n 1 | cut -d: -f1)
 [ -n "$cnt" ] && [ -n "$ldl" ] && [ "$cnt" -lt "$ldl" ] || \
   fail "the child count is set AFTER loadHierarchyLevel — the selector gate has already been evaluated"
+# The hand-off must also carry WHICH instance. Handing off -1 makes
+# loadHierarchyLevel open the child selector, so diving into a parameter landed
+# on a "which pad?" menu instead of the parameter -- reported from the device.
+command grep -q "hierEditorChildIndex = childLevelHasChildren(levelDef) ? childAt : -1" <<<"$blk" || \
+  fail "the grid hand-off does not carry the focused child index — a dive opens the child selector instead of the param"
+# ...and it must be CAPTURED before exitParamPages tears the controller down.
+cap=$(command grep -n "paramPagesChildIndex(page.level)" <<<"$blk" | head -n 1 | cut -d: -f1)
+ext=$(command grep -n "exitParamPages()" <<<"$blk" | head -n 1 | cut -d: -f1)
+[ -n "$cap" ] && [ -n "$ext" ] && [ "$cap" -lt "$ext" ] || \
+  fail "the child index is read AFTER exitParamPages — the controller is already gone"
+echo "  ok  the grid hand-off carries the focused child index, captured before teardown"
 echo "  ok  the grid hand-off carries child_count/child_label, before the level loads"
+
+# THE DIVE PATH carries it too. openParamEditorFromGrid is the function a click
+# on a divable cell goes through, and it had the identical defect: -1 raised the
+# child selector, so Sample Path opened "which pad?" instead of the file
+# browser. Both hand-offs, one rule.
+blk2=$(awk '/^function openParamEditorFromGrid\(/,/^}/' "$file")
+[ -n "$blk2" ] || fail "openParamEditorFromGrid is gone"
+command grep -q "hierEditorChildIndex = childLevelHasChildren(levelDef) ? childAt : -1" <<<"$blk2" || \
+  fail "the DIVE path does not carry the focused child index — a dive opens the child selector"
+cap2=$(command grep -n "paramPagesChildIndex(level)" <<<"$blk2" | head -n 1 | cut -d: -f1)
+ext2=$(command grep -n "exitParamPages()" <<<"$blk2" | head -n 1 | cut -d: -f1)
+[ -n "$cap2" ] && [ -n "$ext2" ] && [ "$cap2" -lt "$ext2" ] || \
+  fail "the dive path reads the child index AFTER exitParamPages — the controller is gone"
+echo "  ok  the dive path carries the focused child index too"
+
 
 # ---- (a) the level's knob pages resolve to CONCRETE keys --------------------
 node -e '

--- a/tests/host/test_child_levels.sh
+++ b/tests/host/test_child_levels.sh
@@ -33,12 +33,17 @@ fail() { echo "FAIL: $1" >&2; exit 1; }
 file="src/shadow/shadow_ui.js"
 blk=$(awk '/^function enterHierarchyEditorFromParamPages\(/,/^}/' "$file")
 [ -n "$blk" ] || fail "enterHierarchyEditorFromParamPages is gone"
-command grep -q "hierEditorChildCount = levelDef.child_count" <<<"$blk" || \
+# Matched on the ASSIGNMENT, not on how the count is derived: it went from
+# `levelDef.child_count` to childLevelCount(levelDef) when shadow_ui.js was
+# migrated onto child_key.mjs, and pinning the old expression made a strictly
+# broader implementation fail. What must hold is that the hand-off sets it,
+# and sets it before the level loads.
+command grep -qE "hierEditorChildCount = (levelDef\.child_count|childLevelCount\(levelDef\))" <<<"$blk" || \
   fail "the grid hand-off does not set hierEditorChildCount — a child level lands as a flat list of unprefixed keys"
 command grep -q "hierEditorChildLabel = levelDef.child_label" <<<"$blk" || \
   fail "the grid hand-off does not set hierEditorChildLabel"
 # It must be set BEFORE the level is loaded, or the gate has already run.
-cnt=$(command grep -n "hierEditorChildCount = levelDef.child_count" <<<"$blk" | head -n 1 | cut -d: -f1)
+cnt=$(command grep -nE "hierEditorChildCount = (levelDef\.child_count|childLevelCount\(levelDef\))" <<<"$blk" | head -n 1 | cut -d: -f1)
 ldl=$(command grep -n "loadHierarchyLevel()" <<<"$blk" | tail -n 1 | cut -d: -f1)
 [ -n "$cnt" ] && [ -n "$ldl" ] && [ "$cnt" -lt "$ldl" ] || \
   fail "the child count is set AFTER loadHierarchyLevel — the selector gate has already been evaluated"

--- a/tests/host/test_lfo_target_wav_position.sh
+++ b/tests/host/test_lfo_target_wav_position.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A wav_position must be offerable as a modulation target.
+#
+# lfoTargetParamsFor filters chain_params by TYPE, and the list was written
+# before wav_position existed. Excluding it does not merely hide a menu row: the
+# param cannot be routed, so an LFO aimed at a sample start has to be pointed at
+# the concrete per-pad key while the grid draws the ALIAS. `<alias>:modulated`
+# then answers 0, the read cursor never asks for `:base`, and the key never
+# enters refreshModulatedValues -- so the cell is fed the EFFECTIVE value by the
+# ordinary rotation at ~6Hz instead of the base plus a 44Hz dot.
+#
+# Reported from the device as a lost LFO dot and a choppy cell, and confirmed
+# there with param_tally: synth:pad_start and synth:pad_start:modulated both
+# read 6x/window, synth:pad_start:base never read at all.
+#
+# Driven through the REAL mrdrums chain_params rather than a synthetic list, so
+# the fixture cannot drift into declaring a type the fleet does not use.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+const src = fs.readFileSync("./src/shadow/shadow_ui.js", "utf8");
+const m = src.match(/function lfoTargetParamsFor[\s\S]*?\n}/);
+if (!m) fail("could not lift lfoTargetParamsFor out of shadow_ui.js");
+
+const contracts = JSON.parse(fs.readFileSync("./tests/fixtures/module-contracts.json", "utf8"));
+const mod = contracts.modules.find((x) => x.id === "mrdrums");
+if (!mod) fail("mrdrums is not in the fleet fixture");
+const cpRaw = typeof mod.chain_params === "string"
+  ? mod.chain_params : JSON.stringify(mod.chain_params);
+const cp = JSON.parse(cpRaw);
+
+/* The premise: mrdrums really does declare its alias as wav_position. If the
+ * module ever changes that, this test is measuring nothing and must say so
+ * rather than passing. */
+const alias = cp.find((p) => p.key === "pad_start");
+if (!alias) fail("mrdrums no longer declares pad_start");
+if (alias.type !== "wav_position")
+  fail("pad_start is now type " + alias.type + " -- this test no longer covers wav_position");
+
+const lfoTargetParamsFor = new Function(
+  "chainTargetGetParam", "debugLog", "LFO_TARGET_PARAMS",
+  m[0] + "; return lfoTargetParamsFor;"
+)(() => cpRaw, () => {}, []);
+
+const offered = lfoTargetParamsFor("synth", "synth", "test").map((x) => x.key);
+
+if (offered.indexOf("pad_start") < 0)
+  fail("a wav_position param is not offered as an LFO target -- sample start "
+     + "cannot be modulated, so its cell can never show a base or a dot");
+
+/* The ordinary types must still be there: widening the filter must not have
+ * replaced it. */
+for (const k of ["pad_vol", "pad_pan", "p01_start"])
+  if (offered.indexOf(k) < 0) fail("regression: " + k + " is no longer offered");
+
+/* And a NON-numeric param must still be excluded, or the picker fills with
+ * things the modulation engine cannot scale -- find_param_by_key needs a
+ * declared range. A filepath is the case in this very contract. */
+if (offered.indexOf("pad_sample_path") >= 0)
+  fail("a filepath is being offered as a modulation target");
+
+console.log("  ok  a wav_position is offerable as an LFO target");
+console.log("  ok  float/int/enum targets are unaffected");
+console.log("  ok  a filepath is still excluded");
+console.log("PASS: sample position can be modulated, so its cell can report it");
+'

--- a/tests/host/test_shadow_param_editor_routing.sh
+++ b/tests/host/test_shadow_param_editor_routing.sh
@@ -832,13 +832,22 @@ function gotoSlotFor(name) {
     return cols;
   }
 
-  /* A stub pair: exactly 4 rows in one column, in two adjacent pairs that are
-   * far apart -- i.e. NOT a contiguous run and NOT an every-other-row dot
-   * column. */
+  /* A COARSE DASH: runs of exactly 2, separated by gaps. That rhythm is what
+   * tells it apart from the two lines already in this plot -- the SOLID cursor
+   * (one run spanning the band) and the FINE spray dither (every run length 1).
+   * An ink-only check passes for all three. */
   const stubCols = (cols) => [...cols.entries()].filter(([, ys]) => {
     const t = [...new Set(ys)].sort((a, b) => a - b);
-    if (t.length !== 4) return false;
-    return t[1] === t[0] + 1 && t[3] === t[2] + 1 && (t[2] - t[1]) > 4;
+    if (t.length < 4) return false;
+    const runs = [];
+    for (const y of t) {
+      const last = runs[runs.length - 1];
+      if (last && y === last[last.length - 1] + 1) last.push(y);
+      else runs.push([y]);
+    }
+    if (runs.length < 2) return false;              /* solid */
+    if (runs.every((r) => r.length === 1)) return false;  /* fine dither */
+    return runs.every((r) => r.length <= 2);
   }).map(([x]) => x);
 
   const on  = captureCols(true);

--- a/tests/host/test_shadow_param_editor_routing.sh
+++ b/tests/host/test_shadow_param_editor_routing.sh
@@ -783,6 +783,93 @@ function gotoSlotFor(name) {
   values.spray = savedSpray;
 }
 
+/* ---- the editor says where a SOURCE has the position --------------------
+ *
+ * The editor is the screen you open specifically to SET this value. In edit
+ * mode the cursor is hierEditorEditValue, seeded from `:base` -- correctly,
+ * that is what the jog moves -- so with an LFO running the cursor sits still
+ * while the sound sweeps and nothing on screen says why.
+ *
+ * Asserted as a STUB PAIR, not merely as "extra ink": the mark has to be
+ * distinguishable from the two things already in this plot, a solid
+ * full-height cursor and dotted full-height spray fences. A column of 4 pixels
+ * split between the top and the bottom of the band is none of those, and a
+ * mark drawn as a rule would satisfy an ink-only check while reading as a
+ * third fence.
+ *
+ * The position is fed as "0.5" so it maps to mid-file (the value is
+ * normalised against the declared min/max, NOT read as a percentage): the base resolves to
+ * ratio 0 in this fixture (no real WAV behind the stub, see the spray case
+ * above), so a mid-file source is what makes the two columns DIFFER. Fed the
+ * same value as the base, the assertion could pass on the cursor.
+ */
+{
+  const savedPath = values.sample_path, savedPos = values.position;
+  const savedSpray2 = values.spray;
+  const PLOT_X0 = 4, INNER_W = 120;
+
+  function captureCols(modulated) {
+    values.sample_path = "/tmp/probe.wav";
+    values.spray = "0";                    /* no fences competing */
+    values.position = "0.5";               /* mid-file for the SOURCE */
+    if (modulated) values["position:modulated"] = "1";
+    else delete values["position:modulated"];
+    openGrid();
+    const slot = gotoSlotFor("position");
+    if (slot < 0) return null;
+    feed(noteOn(slot));
+    feed(click());
+    if (ctx.activeParamEditor() !== "wav_position") return null;
+    const cols = new Map();
+    const realPixel = globalThis.set_pixel;
+    globalThis.set_pixel = (x, y, c) => {
+      if (c) { if (!cols.has(x)) cols.set(x, []); cols.get(x).push(y); }
+      return 0;
+    };
+    ctx.drawScreen ? ctx.drawScreen() : globalThis.tick();
+    globalThis.set_pixel = realPixel;
+    feed(back());
+    return cols;
+  }
+
+  /* A stub pair: exactly 4 rows in one column, in two adjacent pairs that are
+   * far apart -- i.e. NOT a contiguous run and NOT an every-other-row dot
+   * column. */
+  const stubCols = (cols) => [...cols.entries()].filter(([, ys]) => {
+    const t = [...new Set(ys)].sort((a, b) => a - b);
+    if (t.length !== 4) return false;
+    return t[1] === t[0] + 1 && t[3] === t[2] + 1 && (t[2] - t[1]) > 4;
+  }).map(([x]) => x);
+
+  const on  = captureCols(true);
+  const off = captureCols(false);
+
+  if (!on || !off) {
+    fail("the modulation case could not reach the waveform editor");
+  } else {
+    const marks = stubCols(on);
+    if (marks.length !== 1) {
+      fail("a modulated wav_position drew " + marks.length + " source mark(s) in the " +
+           "editor, expected 1 — the screen you set the value on cannot say where " +
+           "the LFO has it (cols " + JSON.stringify(marks) + ")");
+    } else {
+      const want = PLOT_X0 + Math.round(0.5 * (INNER_W - 1));
+      if (Math.abs(marks[0] - want) > 1)
+        fail("the source mark is at x=" + marks[0] + ", expected ~" + want +
+             " — it is not tracking the modulated position");
+    }
+    /* And an UNMODULATED position draws none: the mark must state a fact, not
+     * decorate every wav_position in the fleet. */
+    if (stubCols(off).length !== 0)
+      fail("an unmodulated wav_position still drew a source mark");
+  }
+
+  values.sample_path = savedPath;
+  values.position = savedPos;
+  values.spray = savedSpray2;
+  delete values["position:modulated"];
+}
+
 /* ---- N. the editor inherits the PAGE knob row ---------------------------
  *
  * A declared `knobs` array is not the order the user was just looking at. The

--- a/tests/host/test_shadow_param_editor_routing.sh
+++ b/tests/host/test_shadow_param_editor_routing.sh
@@ -974,7 +974,63 @@ function gotoSlotFor(name) {
   }
 }
 
+/* ---- a dive on a CHILD LEVEL opens the editor, not nothing --------------
+ *
+ * The two halves of a dive speak different dialects. The GRID addresses the
+ * concrete key, because the controller resolved the child template
+ * (`synth:p01_sample_path`), while the editor selects out of what the LEVEL
+ * lists (`sample_path`). So indexOfHierParam missed, findLevelListingParam
+ * missed, and the click opened NOTHING -- activeParamEditor stayed null.
+ * Reported from the device as the file picker never firing.
+ *
+ * Driven for real rather than pinned: three source-level fixes to this same
+ * dive shipped without moving it, because a grep can confirm a line exists and
+ * cannot confirm an editor opened.
+ *
+ * LAST in the file, because it rewrites the shared fixture into a child level.
+ */
+{
+  HIERARCHY.levels.main.child_count = 4;
+  HIERARCHY.levels.main.child_label = "Pad";
+  HIERARCHY.levels.main.child_key_template = "p{index}_{key}";
+  HIERARCHY.levels.main.child_index_base = 1;
+  HIERARCHY.levels.main.child_index_digits = 2;
+  HIERARCHY.levels.main.child_index_param = "cur_pad";
+  CHAIN_PARAMS.push({ key: "cur_pad", name: "Current", type: "int", min: 1, max: 4 });
+  for (let i = 1; i <= 4; i++) {
+    const n = String(i).padStart(2, "0");
+    CHAIN_PARAMS.push({ key: `p${n}_sample_path`, name: `P${n} Sample`,
+                        type: "filepath", root: "/tmp", filter: ".wav" });
+    CHAIN_PARAMS.push({ key: `p${n}_gain`, name: `P${n} Gain`,
+                        type: "float", min: 0, max: 1, step: 0.01 });
+    values[`p${n}_sample_path`] = "";
+    values[`p${n}_gain`] = "0.5";
+  }
+  values.cur_pad = "1";
+  HIERARCHY.levels.main.knobs = ["gain", ...FILLER];
+  HIERARCHY.levels.main.params = [{ key: "gain" }, ...FILLER.map((k) => ({ key: k })),
+                                  { key: "sample_path" }];
+  HIERARCHY.levels.root.knobs = ["gain"];
+  HIERARCHY.levels.root.params = [{ level: "main", label: "Main" }];
+
+  openGrid();
+  const slot = gotoSlotFor("sample_path");
+  if (slot < 0) {
+    fail("a filepath on a child level is not reachable on the grid at all");
+  } else {
+    feed(noteOn(slot));
+    feed(click());
+    const editor = ctx.activeParamEditor();
+    if (editor !== "filepath") {
+      fail("diving a filepath on a CHILD level opened " + JSON.stringify(editor) +
+           ", expected \"filepath\" — the grid addresses the concrete key and the " +
+           "editor lists the generic one, so the lookup misses and nothing opens");
+    }
+    feed(back());
+  }
+}
+
 if (failures) process.exit(1);
 console.log("PASS: editor routing — a wav_position opens the waveform, a filepath opens " +
-            "the browser, a plain number stays put, and Back returns to the grid from each");
+            "the browser (child levels too), a plain number stays put, and Back returns");
 '

--- a/tests/host/test_viz_mod_base_marks.sh
+++ b/tests/host/test_viz_mod_base_marks.sh
@@ -101,14 +101,27 @@ Promise.all([
   if (!(highCols[0] > cols[0]))
     fail("a higher base must mark a column further right");
 
-  /* Stubs at the band edges, top AND bottom -- a single edge reads as an
-   * artifact of the waveform rather than as a mark. */
+  /* A COARSE DASH: 2 on, 2 off. Asserted as the RHYTHM, because that is what
+   * distinguishes it from the solid cursor and from the fine every-other-row
+   * spray fence -- a plain "there is ink in this column" check passes for all
+   * three. Runs of 1 (fine dither) or a single run spanning the band (solid)
+   * both fail here. */
   const rows = [...new Set(lowMark.map((p) => Number(p.split(",")[1])))].sort((a, b) => a - b);
   if (rows.length < 4)
-    fail("expected stubs at both band edges, got rows " + rows.join(","));
-  const span = rows[rows.length - 1] - rows[0];
-  if (span < 6)
-    fail("the stubs are not at opposite edges of the band (span " + span + "px)");
+    fail("the base mark is only " + rows.length + "px tall; expected a dashed column");
+  const runs = [];
+  for (const y of rows) {
+    const last = runs[runs.length - 1];
+    if (last && y === last[last.length - 1] + 1) last.push(y);
+    else runs.push([y]);
+  }
+  if (runs.length < 2)
+    fail("the base mark is a SOLID column -- indistinguishable from the cursor");
+  if (!runs.every((r) => r.length <= 2))
+    fail("the base mark has a run of " + Math.max(...runs.map((r) => r.length))
+       + "px; a coarse dash is 2 on, 2 off");
+  if (runs.some((r) => r.length === 1) && runs.every((r) => r.length === 1))
+    fail("the base mark is a FINE dither -- indistinguishable from a spray fence");
 
   /* Base == cursor draws no mark: the two coinciding IS the reading, and a
    * mark there would be drawn under the solid cursor anyway. */
@@ -189,7 +202,7 @@ Promise.all([
   console.log("  ok  a modulated fader marks its base, clear of the bar");
 
   console.log("  ok  a modulated sample cell marks its BASE, one column wide");
-  console.log("  ok  the mark tracks the base and sits at both band edges");
+  console.log("  ok  the mark tracks the base and reads as a coarse dash");
   console.log("  ok  an unmodulated page is untouched");
   console.log("PASS: covered graphics carry the modulation base the knob dot used to");
 });

--- a/tests/host/test_viz_mod_base_marks.sh
+++ b/tests/host/test_viz_mod_base_marks.sh
@@ -129,9 +129,68 @@ Promise.all([
   })();
   if (plainA.size === 0) fail("the unmodulated page drew nothing at all");
 
+
+  /* ---- THE FADER carries the same mark, in the one place nothing else draws.
+   *
+   * A fader is a knob in a different costume and is covered by its group in
+   * exactly the same way, so it loses the dot for exactly the same reason. The
+   * mark sits OUTSIDE the rails (the bar spans cx-3..cx+3, rails at cx+-4)
+   * because the interior is a dithered lattice that re-phases as the value
+   * moves -- a mark inside it would be least readable precisely when the value
+   * is moving, which is the only time it exists.
+   */
+  const fader = groups.find((g) => g.kind === "fader");
+  if (!fader) fail("mrdrums Main no longer plans a fader group");
+  const FK = fader.roles.value;
+
+  const finkFader = (baseAt, liveAt) => {
+    const vals = {};
+    for (const k of page.keys) vals[k] = "0.5";
+    vals[FK] = baseAt;
+    const fb = H.createFramebuffer();
+    R.renderPageMovy(H.drawContext(fb), {
+      page, metaIndex: ix, values: vals,
+      modValues: { [FK]: liveAt }, modulated: (k) => k === FK,
+      viz: groups, pageIndex: 0, pageCount: 1, header: "L",
+    });
+    const px = fb.pixels || fb.px;
+    const s = new Set();
+    for (let y = 0; y < 64; y++)
+      for (let x = 0; x < 128; x++) if (px[y * 128 + x]) s.add(x + "," + y);
+    return s;
+  };
+
+  const fSame = finkFader("0.8", "0.8");
+  const fLow  = finkFader("0.2", "0.8");
+  const fMid  = finkFader("0.5", "0.8");
+  const fLowM = only(fLow, fSame), fMidM = only(fMid, fSame);
+
+  if (fLowM.length === 0)
+    fail("a modulated fader draws NOTHING for its base -- the bar moves on its "
+       + "own with no way to see what you set");
+  /* Two stubs, one either side, on ONE row. */
+  const fRows = [...new Set(fLowM.map((q) => Number(q.split(",")[1])))];
+  if (fRows.length !== 1)
+    fail("the fader base mark spans " + fRows.length + " rows; it must be one");
+  const fCols = [...new Set(fLowM.map((q) => Number(q.split(",")[0])))].sort((a, b) => a - b);
+  if (fCols.length !== 4)
+    fail("expected two 2px stubs either side of the fader, got columns "
+       + JSON.stringify(fCols));
+  /* A GAP between them: contiguous would mean it crossed the bar. */
+  if (fCols[2] - fCols[1] < 5)
+    fail("the fader stubs are not clear of the bar (columns "
+       + JSON.stringify(fCols) + ") -- they would fight the dithered fill");
+  /* ...and it tracks the base: a HIGHER base marks a HIGHER row (smaller y). */
+  const fMidRow = [...new Set(fMidM.map((q) => Number(q.split(",")[1])))];
+  if (fMidRow.length !== 1 || !(fMidRow[0] < fRows[0]))
+    fail("the fader base mark does not track the base value (0.2 -> row "
+       + fRows[0] + ", 0.5 -> row " + JSON.stringify(fMidRow) + ")");
+
+  console.log("  ok  a modulated fader marks its base, clear of the bar");
+
   console.log("  ok  a modulated sample cell marks its BASE, one column wide");
   console.log("  ok  the mark tracks the base and sits at both band edges");
   console.log("  ok  an unmodulated page is untouched");
-  console.log("PASS: the sample graphic carries the modulation base the knob dot used to");
+  console.log("PASS: covered graphics carry the modulation base the knob dot used to");
 });
 '

--- a/tests/host/test_viz_sample_mod_base_mark.sh
+++ b/tests/host/test_viz_sample_mod_base_mark.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A COVERED cell has no modulation dot, so the graphic has to carry the base.
+#
+# The dot lives inside drawKnobWidget, and render_page_movy skips that call
+# entirely for a cell a viz group covers. That was invisible until 5f5fb11c let
+# a lone `wav_position` form a ONE-CELL sample group: mrdrums Sample Start had
+# been an ordinary knob -- pointer at the base, dot at the effective value --
+# and silently became a waveform whose cursor tracks the effective value with
+# the base nowhere on screen. Reported from the device as losing the knob LFO
+# indicator, with the label tilde still present (drawLabelCell sits OUTSIDE the
+# covered guard, which is exactly why only half the indication disappeared).
+#
+# Driven through the REAL mrdrums contract and the real planner/detector, not a
+# synthetic page: a hand-built one-key page does NOT form the sample group at
+# all, so an earlier version of this probe measured the knob pointer moving and
+# reported the mark working while it was absent.
+#
+# The cursor is held FIXED and only the base varies. Varying the modulation
+# instead moves the cursor, which changes far more pixels than the mark does
+# and passes with the mark deleted.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node -e '
+const fs = require("fs");
+Promise.all([
+  import("./tools/param-pages/harness.mjs"),
+  import("./src/shared/param_pages/render_page_movy.mjs"),
+  import("./src/shared/param_pages/param_meta.mjs"),
+  import("./src/shared/param_pages/page_plan.mjs"),
+  import("./src/shared/param_pages/viz.mjs"),
+]).then(([H, R, M, P, V]) => {
+  const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+  const pj = (v) => (typeof v === "string" ? JSON.parse(v) : v);
+
+  const j = JSON.parse(fs.readFileSync("./tests/fixtures/module-contracts.json", "utf8"));
+  const m = j.modules.find((x) => x.id === "mrdrums");
+  if (!m) fail("mrdrums is not in the fleet fixture");
+
+  const hier = pj(m.ui_hierarchy), cp = pj(m.chain_params);
+  const ix = M.buildMetaIndex({ hierarchy: hier, chainParams: cp });
+  const pages = P.planPages({ hierarchy: hier, chainParams: cp }).pages;
+  const page = pages.find((p) => p.keys && p.keys.indexOf("pad_start") >= 0);
+  if (!page) fail("no planned page carries pad_start");
+
+  const groups = (V.resolveViz({ keys: page.keys, metaIndex: ix }) || {}).groups || [];
+  const slot = page.keys.indexOf("pad_start");
+  const covering = groups.find((g) => g.kind === "sample"
+      && slot >= g.slotStart && slot < g.slotStart + g.slotSpan);
+  /* The premise. Without it every assertion below is about a plain knob and
+   * the test proves nothing -- which is how the first version passed. */
+  if (!covering) fail("pad_start is not covered by a sample group any more -- "
+      + "this test is measuring a knob, not a graphic");
+
+  const ink = (baseAt, liveAt) => {
+    const vals = {};
+    for (const k of page.keys) vals[k] = "0.5";
+    vals.pad_start = baseAt;
+    const fb = H.createFramebuffer();
+    R.renderPageMovy(H.drawContext(fb), {
+      page, metaIndex: ix, values: vals,
+      modValues: { pad_start: liveAt }, modulated: (k) => k === "pad_start",
+      viz: groups, pageIndex: 0, pageCount: 1, header: "L",
+    });
+    const px = fb.pixels || fb.px;
+    const s = new Set();
+    for (let y = 0; y < 64; y++)
+      for (let x = 0; x < 128; x++) if (px[y * 128 + x]) s.add(x + "," + y);
+    return s;
+  };
+  const only = (a, b) => [...a].filter((p) => !b.has(p));
+
+  /* Cursor pinned at 0.8 throughout; only the base moves. */
+  const atCursor = ink("0.8", "0.8");
+  const farLow   = ink("0.2", "0.8");
+  const farHigh  = ink("0.6", "0.8");
+
+  const lowMark = only(farLow, atCursor);
+  if (lowMark.length === 0)
+    fail("a modulated sample cell draws NOTHING for its base -- the graphic "
+       + "shows only where the LFO is, never where the knob is set");
+
+  /* ONE column: the mark is an annotation, not a third full-height line
+   * competing with the cursor and the spray fences. */
+  const cols = [...new Set(lowMark.map((p) => Number(p.split(",")[0])))];
+  if (cols.length !== 1)
+    fail("the base mark spans " + cols.length + " columns; it must be one");
+
+  /* ...and it must MOVE with the base, or it is a decoration pinned to the
+   * cell rather than a reading of the parameter. */
+  const highCols = [...new Set(only(farHigh, atCursor).map((p) => Number(p.split(",")[0])))];
+  if (highCols.length !== 1 || highCols[0] === cols[0])
+    fail("the base mark does not track the base value");
+  if (!(highCols[0] > cols[0]))
+    fail("a higher base must mark a column further right");
+
+  /* Stubs at the band edges, top AND bottom -- a single edge reads as an
+   * artifact of the waveform rather than as a mark. */
+  const rows = [...new Set(lowMark.map((p) => Number(p.split(",")[1])))].sort((a, b) => a - b);
+  if (rows.length < 4)
+    fail("expected stubs at both band edges, got rows " + rows.join(","));
+  const span = rows[rows.length - 1] - rows[0];
+  if (span < 6)
+    fail("the stubs are not at opposite edges of the band (span " + span + "px)");
+
+  /* Base == cursor draws no mark: the two coinciding IS the reading, and a
+   * mark there would be drawn under the solid cursor anyway. */
+  if (only(ink("0.8", "0.8"), ink("0.8", "0.8")).length !== 0)
+    fail("rendering is not deterministic");
+
+  /* NOTHING changes when no source is running. This is what keeps every
+   * pinned pixel baseline in the fleet valid. */
+  const plainA = (() => {
+    const vals = {}; for (const k of page.keys) vals[k] = "0.5";
+    const fb = H.createFramebuffer();
+    R.renderPageMovy(H.drawContext(fb), { page, metaIndex: ix, values: vals,
+      modValues: null, modulated: () => false, viz: groups,
+      pageIndex: 0, pageCount: 1, header: "L" });
+    const px = fb.pixels || fb.px; const s = new Set();
+    for (let y = 0; y < 64; y++) for (let x = 0; x < 128; x++) if (px[y * 128 + x]) s.add(x + "," + y);
+    return s;
+  })();
+  if (plainA.size === 0) fail("the unmodulated page drew nothing at all");
+
+  console.log("  ok  a modulated sample cell marks its BASE, one column wide");
+  console.log("  ok  the mark tracks the base and sits at both band edges");
+  console.log("  ok  an unmodulated page is untouched");
+  console.log("PASS: the sample graphic carries the modulation base the knob dot used to");
+});
+'


### PR DESCRIPTION
Two related threads, both found by using the device: modulation was invisible on any cell a graphic covers, and the child-key contract was only half-wired.

## Modulation indicators

A viz group **covers** its cells, so `drawKnobWidget` never runs for them — and that is the only code that draws the modulation dot. `drawLabelCell` sits *outside* the same guard, which is why exactly half the indication disappeared: the tilde stayed, the dot went.

- **A `wav_position` was never offerable as an LFO target.** `lfoTargetParamsFor` filtered `chain_params` by type against a list written before `wav_position` existed. The cost was not a missing menu row: the param could not be routed, so an LFO aimed at a sample start had to be pointed at the concrete per-pad key while the grid drew the alias — `<alias>:modulated` answered 0, the cursor never asked for `:base`, and the cell was fed the *effective* value by the ordinary rotation at ~6Hz instead of the base plus a 44Hz dot. Confirmed on hardware with `param_tally`: `synth:pad_start` and `synth:pad_start:modulated` both read 6×/window, `synth:pad_start:base` never.
- **The sample cell, the fader and the wave editor now carry the base**, in one visual language: a coarse dash, 2 on / 2 off. The rhythm is the point — up to three vertical marks can share one plot, and the cursor is solid while the spray fences are a fine dither.
- The wave editor's mark is read **once on entry** and deliberately goes stale; that frame resamples the WAV and a per-frame IPC read is ~2.8ms against a 1.68ms whole-page render.

## Child-key contract

`child_key.mjs` exists because none of the six modules needing repeated elements use the legacy `<child_prefix><index>_<key>` shape. Only the **planner** was ever migrated to it, so a level declaring `child_key_template` planned and drew correctly and then broke the moment you dived.

- **`child_index_param`** (new, optional): the module owns which instance is focused. Without it, adding a child level to a module that follows the played pad would *cost* that behaviour. The param is the single source of truth in both directions — the rotation reads it, a pick writes it — so a module moving the focus and a user picking from the list cannot disagree.
- **shadow_ui.js speaks the contract too** — nine sites. Two were more than a spelling change: the modulation-target enumeration skipped template levels entirely (it looked the generic key up in `chain_params`, where it is declared nowhere), and an already-concrete key must pass through.
- **A generic key borrows the concrete declaration**, structure only — never the name, because a per-instance declaration names its instance (`p01_pan` is literally "P01 Pan"). Seeded in `buildMetaIndex` so the **planner** sees it: a key's type decides its fate at plan time, and a guessed float was planned as a turnable knob instead of an opaque filepath cell.
- **The two halves of a dive spoke different dialects**: the grid addresses the resolved concrete key, the editor selects out of what the level lists. Nothing opened at all.
- **The viz cache must key on the focused child**, or the graphic names the previous instance's file until a page change busts it.
- **Listed is not reachable.** The instance picker is suppressed when the module owns the focus *and* offers the control itself — but `params[]` keys are dropped when `ui_`-prefixed, so a module could list its index param, be given no cell, and lose the only remaining way to change instance.

## Testing

192/192 shell tests and all compiled units green. Every fix here is mutation-tested; several of the tests replaced source-greps that had passed while the behaviour was broken — a grep can confirm a line exists, never that an editor opened. The dive fix in particular was found by standing the routing harness up with a child-level fixture rather than reasoning from source, after three earlier attempts shipped without moving it.

All of this is inert for every module in the fleet today: none declares `child_key_template`, and the base marks only draw when something is actually modulated.