### PR TITLE
song-mode fired pads at the inject rate: it was writing its own input

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Display: `host_flush_display`, `host_set_refresh_rate(hz)`, `host_get_refresh_ra
 
 Filesystem: `host_file_exists`, `host_read_file`, `host_write_file`, `host_http_download`, `host_extract_tar(_strip)`, `host_ensure_dir`, `host_remove_dir`.
 
-Tool lifecycle: `host_exit_module()`. MIDI injection: `move_midi_inject_to_move([type, status, d1, d2])`. Overtake DSP `midi_inject_to_move` uses its own bounded queue so native Move output remains active without consuming the takeover test bus; UIs can detect this with `shadow_overtake_move_inject_active()`. Sampler: `host_sampler_start(path)`, `host_sampler_stop()`, `host_sampler_is_recording()`.
+Tool lifecycle: `host_exit_module()`. MIDI injection: `move_midi_inject_to_move([type, status, d1, d2])`. **Three producers inject into Move's MIDI_IN and each owns its own queue, because ownership follows WHO PUSHED and never what mode the surface is in** — the overtake test bus keeps `/schwung-midi-inject` (during overtake the shim pops it *onto the module*, as if a control had been pressed), an overtake DSP's `midi_inject_to_move` has an in-shim ring (`shadow_overtake_move_inject_active()` detects it), and the shadow UI's JS binding has `/schwung-midi-inject-ui`. Sharing the first of those with JS is what broke song-mode for a month: its injected Play CC never reached Move and came back into its own `onMidiMessageInternal`, toggling playback and re-injecting, so it fired pads as fast as the queue drained. See `docs/ADDRESSING_MOVE_SYNTHS.md`. Sampler: `host_sampler_start(path)`, `host_sampler_stop()`, `host_sampler_is_recording()`.
 
 CC 79 is the host volume knob by default. Modules can claim it via `capabilities.claims_master_knob: true`.
 

--- a/docs/ADDRESSING_MOVE_SYNTHS.md
+++ b/docs/ADDRESSING_MOVE_SYNTHS.md
@@ -142,11 +142,23 @@ see `docs/SPI_PROTOCOL.md`) — injecting pitched notes there won't reach
 track instruments.
 
 Overtake DSPs use a dedicated bounded queue for this callback. It drains
-directly into Move's MIDI input while the takeover is active. The shared JS
+directly into Move's MIDI input while the takeover is active. The shared
 injection queue remains owned by the takeover test-bus publisher during that
 time, so DSP output cannot loop back into its own `on_midi` input. A tool UI
 can check for `shadow_overtake_move_inject_active()` when it needs to support
 older hosts where this separation is not available.
+
+**A JS `move_midi_inject_to_move` has its own queue too, for the same reason.**
+There are three producers and only one of them is the test bus, so ownership of
+a queue follows *who pushed into it*, never what mode the surface is in — while
+overtake is active the shim pops the test bus's queue **onto the module**,
+publishing each packet as though a control had been pressed. From 2026-07-29 to
+2026-08-28 the JS binding shared that queue, and song-mode is what it cost: its
+pad and transport packets never reached Move, and its own injected Play CC
+arrived back in its `onMidiMessageInternal`, toggling playback and injecting
+again — firing pads as fast as the 50 ms inject throttle allowed. Nothing in JS
+changed; `move_midi_inject_to_move` now pushes to `/schwung-midi-inject-ui`,
+which the shim drains into Move in every mode.
 
 **Anything still queued when your module unloads is discarded**, so the next
 module to load does not replay your notes into Move. What is NOT undone is

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -27,7 +27,8 @@
 #define SHM_SHADOW_PARAM      "/schwung-param"        /* Shadow param requests */
 #define SHM_SHADOW_MIDI_OUT   "/schwung-midi-out"   /* MIDI output from shadow UI */
 #define SHM_SHADOW_MIDI_DSP   "/schwung-midi-dsp"   /* MIDI from shadow UI to DSP slots */
-#define SHM_SHADOW_MIDI_INJECT "/schwung-midi-inject" /* MIDI inject into Move's MIDI_IN */
+#define SHM_SHADOW_MIDI_INJECT "/schwung-midi-inject" /* MIDI inject into Move's MIDI_IN (test bus owns it during overtake) */
+#define SHM_SHADOW_MIDI_INJECT_UI "/schwung-midi-inject-ui" /* shadow UI's own inject — always bound for Move's firmware */
 #define SHM_SHADOW_EXT_MIDI_REMAP "/schwung-ext-midi-remap" /* Cable-2 channel remap table */
 #define SHM_SHADOW_SCREENREADER "/schwung-screenreader" /* Screen reader announcements */
 #define SHM_SHADOW_OVERLAY  "/schwung-overlay"  /* Overlay state (sampler/skipback) */

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -164,6 +164,7 @@ static shadow_midi_out_t **host_shadow_midi_out_shm;
 static uint8_t **host_shadow_ui_midi_shm;
 static shadow_midi_dsp_t **host_shadow_midi_dsp_shm;
 static shadow_midi_inject_t **host_shadow_midi_inject_shm;
+static shadow_midi_inject_t **host_shadow_midi_inject_ui_shm;
 static uint8_t *host_shadow_mailbox;
 
 /* Idle tracking */
@@ -192,6 +193,7 @@ void midi_routing_init(const midi_host_t *host)
     host_shadow_ui_midi_shm = host->shadow_ui_midi_shm;
     host_shadow_midi_dsp_shm = host->shadow_midi_dsp_shm;
     host_shadow_midi_inject_shm = host->shadow_midi_inject_shm;
+    host_shadow_midi_inject_ui_shm = host->shadow_midi_inject_ui_shm;
     host_shadow_mailbox = host->shadow_mailbox;
     host_slot_idle = host->slot_idle;
     host_slot_silence_frames = host->slot_silence_frames;
@@ -695,7 +697,9 @@ void shadow_drain_midi_inject(void)
     }
 
     uint8_t *midi_in = host_shadow_mailbox + MIDI_IN_OFFSET;
-    int injected = shadow_overtake_midi_drain(inject_shm, overtake_active,
+    shadow_midi_inject_t *ui_shm = host_shadow_midi_inject_ui_shm
+                                       ? *host_shadow_midi_inject_ui_shm : NULL;
+    int injected = shadow_overtake_midi_drain(inject_shm, ui_shm, overtake_active,
                                               midi_in, MIDI_IN_MAX_EVTS,
                                               MIDI_IN_MAX_BYTES);
 

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -87,6 +87,7 @@ typedef struct {
     uint8_t **shadow_ui_midi_shm;
     shadow_midi_dsp_t **shadow_midi_dsp_shm;
     shadow_midi_inject_t **shadow_midi_inject_shm;
+    shadow_midi_inject_t **shadow_midi_inject_ui_shm;
     uint8_t *shadow_mailbox;
     /* No Master FX capture pointer here on purpose: it used to be
      * a pointer to shadow_master_fx_slots[0].capture, cached at init into a

--- a/src/host/shadow_overtake_midi.c
+++ b/src/host/shadow_overtake_midi.c
@@ -65,6 +65,7 @@ static int drain_ring(shadow_midi_inject_t *ring,
 }
 
 int shadow_overtake_midi_drain(shadow_midi_inject_t *shared,
+                               shadow_midi_inject_t *ui,
                                int overtake_active,
                                uint8_t *midi_in,
                                int max_events,
@@ -91,6 +92,20 @@ int shadow_overtake_midi_drain(shadow_midi_inject_t *shared,
      * is about latency on the packets that can leave Move wedged. */
     if (!overtake_active)
         copied = drain_ring(shared, midi_in, copied, max_events, midi_in_bytes);
+
+    /* The shadow UI's ring drains in BOTH modes, and the ownership rule it
+     * expresses is "who PUSHED it", not "what mode are we in".
+     *
+     * `move_midi_inject_to_move` used to push into the SHARED ring, so from
+     * 2026-07-29 -- when the shim started popping that ring during overtake and
+     * republishing it to the module as if it were a hardware press -- song-mode
+     * lost both halves at once: its pad and Play packets never reached Move,
+     * AND they came straight back into its own onMidiMessageInternal. Its Play
+     * CC toggled its own playback and re-injected, so it fired pads as fast as
+     * the 50ms inject throttle allowed, on a loop that could only be broken by
+     * leaving the tool. Two producers cannot share one ring when the consumer
+     * is chosen by mode; the test bus keeps `shared`, and the UI gets this. */
+    copied = drain_ring(ui, midi_in, copied, max_events, midi_in_bytes);
 
     /* The dedicated ring drains in both modes. That is the whole point of the
      * split: while overtake owns the shared ring's consumer, an overtake DSP

--- a/src/host/shadow_overtake_midi.h
+++ b/src/host/shadow_overtake_midi.h
@@ -23,10 +23,16 @@ void shadow_overtake_midi_discard(void);
  * owns its test-bus consumer, and it goes FIRST when it is drained at all --
  * the shim's overtake-exit releases live in it. Returns packets copied.
  *
+ * `ui` is the shadow UI's own cross-process ring (`move_midi_inject_to_move`),
+ * and it drains in BOTH modes for the same reason the dedicated one does: it
+ * is a producer addressing Move's firmware, not the test bus. See the
+ * ownership note in shadow_overtake_midi.c.
+ *
  * Bounded by BOTH max_events and midi_in_bytes; pass SHADOW_MIDI_IN_BYTES.
  * The byte bound is not belt-and-braces: the RX display-status word sits
  * immediately after MIDI_IN. */
 int shadow_overtake_midi_drain(shadow_midi_inject_t *shared,
+                               shadow_midi_inject_t *ui,
                                int overtake_active,
                                uint8_t *midi_in,
                                int max_events,

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2922,6 +2922,7 @@ static uint8_t last_shadow_midi_out_ready = 0;
 static shadow_midi_dsp_t *shadow_midi_dsp_shm = NULL;  /* MIDI to DSP from shadow UI */
 static uint8_t last_shadow_midi_dsp_ready = 0;
 static shadow_midi_inject_t *shadow_midi_inject_shm = NULL;  /* MIDI inject into Move's MIDI_IN */
+static shadow_midi_inject_t *shadow_midi_inject_ui_shm = NULL;  /* shadow UI's own inject, never diverted to a module */
 static schwung_ext_midi_remap_t *ext_midi_remap_shm = NULL;  /* Cable-2 channel remap table */
 
 static uint32_t last_screenreader_sequence = 0;  /* Track last spoken message */
@@ -3428,6 +3429,17 @@ static void init_shadow_shm(void)
      * maps it, so initializing here once at startup is race-free. */
     if (shadow_midi_inject_shm) {
         shadow_midi_inject_init(shadow_midi_inject_shm);
+    }
+
+    /* The shadow UI's own inject ring. Separate segment, identical layout: the
+     * ring above is claimed by the overtake test bus (drained onto the module
+     * rather than into Move), and a JS `move_midi_inject_to_move` is addressing
+     * Move's FIRMWARE. Sharing one ring between the two producers made
+     * song-mode's own Play CC come back to it as a button press. */
+    shadow_midi_inject_ui_shm = (shadow_midi_inject_t *)shadow_shm_map(SHM_SHADOW_MIDI_INJECT_UI,
+                                                                       sizeof(shadow_midi_inject_t), 1, 1);
+    if (shadow_midi_inject_ui_shm) {
+        shadow_midi_inject_init(shadow_midi_inject_ui_shm);
     }
 
     /* Create/open cable-2 channel remap shared memory (active overtake module writes,
@@ -4797,6 +4809,7 @@ static void shim_init_subsystems(void)
             .shadow_ui_midi_shm = &shadow_ui_midi_shm,
             .shadow_midi_dsp_shm = &shadow_midi_dsp_shm,
             .shadow_midi_inject_shm = &shadow_midi_inject_shm,
+            .shadow_midi_inject_ui_shm = &shadow_midi_inject_ui_shm,
             .shadow_mailbox = shadow_buf,
             .slot_idle = shadow_slot_idle,
             .slot_silence_frames = shadow_slot_silence_frames,

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -44,6 +44,7 @@ static shadow_param_t *shadow_param = NULL;
 static shadow_midi_out_t *shadow_midi_out = NULL;
 static shadow_midi_dsp_t *shadow_midi_dsp = NULL;
 static shadow_midi_inject_t *shadow_midi_inject = NULL;
+static shadow_midi_inject_t *shadow_midi_inject_ui = NULL;
 static schwung_ext_midi_remap_t *ext_midi_remap = NULL;
 static shadow_screenreader_t *shadow_screenreader = NULL;
 static shadow_overlay_state_t *shadow_overlay = NULL;
@@ -85,6 +86,13 @@ static int open_shadow_shm(void) {
     shadow_midi_dsp = (shadow_midi_dsp_t *)shadow_shm_map(SHM_SHADOW_MIDI_DSP, sizeof(shadow_midi_dsp_t), 0, 0);
 
     shadow_midi_inject = (shadow_midi_inject_t *)shadow_shm_map(SHM_SHADOW_MIDI_INJECT, sizeof(shadow_midi_inject_t), 0, 0);
+
+    /* Our own inject ring. The shim drains this one into Move in every mode;
+     * the segment above is the overtake test bus's, which during overtake is
+     * republished to the module instead of reaching Move (see
+     * shadow_overtake_midi.c). Absent only against a shim too old to create it,
+     * where the push falls back and behaves as it did before. */
+    shadow_midi_inject_ui = (shadow_midi_inject_t *)shadow_shm_map(SHM_SHADOW_MIDI_INJECT_UI, sizeof(shadow_midi_inject_t), 0, 0);
 
     ext_midi_remap = (schwung_ext_midi_remap_t *)shadow_shm_map(SHM_SHADOW_EXT_MIDI_REMAP, sizeof(schwung_ext_midi_remap_t), 0, 0);
 
@@ -1551,11 +1559,20 @@ static JSValue js_host_ext_midi_remap_enable(JSContext *ctx, JSValueConst this_v
  *     through Move's track-input dispatcher and reaches the
  *     internal track synths. Use this when JS wants to play a Move
  *     track instrument as MIDI.
+ *
+ * Packets go into the UI's OWN ring (/schwung-midi-inject-ui), not the
+ * test bus's. While overtake is active the shim pops the test-bus ring
+ * onto the module — publishing it back to this very process as if a
+ * control had been pressed — so a tool that injects a button CC there is
+ * writing its own input. song-mode did, and its Play CC re-entered
+ * onMidiMessageInternal and toggled playback on a loop.
  */
 static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val,
                                            int argc, JSValueConst *argv) {
     (void)this_val;
-    if (!shadow_midi_inject) return JS_FALSE;
+    shadow_midi_inject_t *ring = shadow_midi_inject_ui ? shadow_midi_inject_ui
+                                                       : shadow_midi_inject;
+    if (!ring) return JS_FALSE;
     if (argc < 1) return JS_FALSE;
 
     JSValueConst arr = argv[0];
@@ -1587,7 +1604,7 @@ static JSValue js_move_midi_inject_to_move(JSContext *ctx, JSValueConst this_val
          * route (cable 0 = pad simulation, cable 2 = external MIDI in
          * to the track synth). See function docblock. */
 
-        if (shadow_midi_inject_push(shadow_midi_inject, packet) != 0) {
+        if (shadow_midi_inject_push(ring, packet) != 0) {
             /* Ring full (drain starved) — drop this packet and stop the
              * batch (subsequent packets would just back up). */
             break;

--- a/tests/host/test_overtake_midi_route.c
+++ b/tests/host/test_overtake_midi_route.c
@@ -11,6 +11,44 @@ static int fails = 0;
     if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); fails++; } \
 } while (0)
 
+/* The shadow UI's own ring is NOT the test bus, and must reach Move in both
+ * modes. move_midi_inject_to_move used to push into the shared ring, which the
+ * shim republishes to the module while overtake is active -- so song-mode's
+ * injected Play CC never reached Move and came back as if a button had been
+ * pressed, toggling playback and re-injecting: pads fired as fast as the queue
+ * drained. */
+static void test_ui_ring_reaches_move_during_overtake(void)
+{
+    shadow_midi_inject_t shared;
+    shadow_midi_inject_t ui;
+    uint8_t midi_in[31 * 8];
+    uint8_t shared_pkt[4] = { 0x29, 0x90, 72, 100 };
+    uint8_t ui_pkt[4] = { 0x0B, 0xB0, 85, 127 };   /* song-mode's Play toggle */
+    uint8_t peek[4];
+
+    shadow_midi_inject_init(&shared);
+    shadow_midi_inject_init(&ui);
+    shadow_overtake_midi_init();
+    memset(midi_in, 0, sizeof(midi_in));
+
+    CHECK(shadow_midi_inject_push(&shared, shared_pkt) == 0,
+          "shared test-bus packet queued");
+    CHECK(shadow_midi_inject_push(&ui, ui_pkt) == 0,
+          "shadow UI packet queued");
+
+    CHECK(shadow_overtake_midi_drain(&shared, &ui, 1, midi_in, 31,
+                                     sizeof(midi_in)) == 1,
+          "overtake drains the UI ring");
+    CHECK(memcmp(&midi_in[0], ui_pkt, 4) == 0,
+          "the UI packet reaches Move during overtake");
+    CHECK(midi_in[4] == 0, "injected timestamp is zero");
+    CHECK(shadow_midi_inject_peek(&shared, peek) == 1
+              && memcmp(peek, shared_pkt, 4) == 0,
+          "the test-bus ring is still left to its publisher");
+    CHECK(shadow_midi_inject_peek(&ui, peek) == 0,
+          "the UI packet is consumed");
+}
+
 static void test_active_overtake_uses_only_dedicated_queue(void)
 {
     shadow_midi_inject_t shared;
@@ -31,7 +69,7 @@ static void test_active_overtake_uses_only_dedicated_queue(void)
     CHECK(shadow_overtake_midi_send(dsp_off, 4) == 4,
           "overtake note-off queued");
 
-    CHECK(shadow_overtake_midi_drain(&shared, 1, midi_in, 31, sizeof(midi_in)) == 2,
+    CHECK(shadow_overtake_midi_drain(&shared, NULL, 1, midi_in, 31, sizeof(midi_in)) == 2,
           "active overtake drains both dedicated packets");
     CHECK(memcmp(&midi_in[0], dsp_on, 4) == 0,
           "dedicated note-on is first");
@@ -44,7 +82,7 @@ static void test_active_overtake_uses_only_dedicated_queue(void)
           "active overtake leaves shared queue for its publisher");
 
     memset(midi_in, 0, sizeof(midi_in));
-    CHECK(shadow_overtake_midi_drain(&shared, 0, midi_in, 31, sizeof(midi_in)) == 1,
+    CHECK(shadow_overtake_midi_drain(&shared, NULL, 0, midi_in, 31, sizeof(midi_in)) == 1,
           "inactive mode resumes the shared queue");
     CHECK(memcmp(&midi_in[0], shared_pkt, 4) == 0,
           "shared packet reaches Move after overtake exits");
@@ -71,7 +109,7 @@ static void test_full_queue_preserves_fifo(void)
           "dedicated ring rejects a packet when full");
 
     memset(midi_in, 0, sizeof(midi_in));
-    CHECK(shadow_overtake_midi_drain(NULL, 1, midi_in, 1, sizeof(midi_in)) == 1,
+    CHECK(shadow_overtake_midi_drain(NULL, NULL, 1, midi_in, 1, sizeof(midi_in)) == 1,
           "bounded drain copies only the requested packet count");
     CHECK(midi_in[2] == 1,
           "ring overflow does not disturb the oldest packet");
@@ -91,7 +129,7 @@ static void test_unload_discards_the_departed_modules_packets(void)
     shadow_overtake_midi_discard();
 
     memset(midi_in, 0, sizeof(midi_in));
-    CHECK(shadow_overtake_midi_drain(NULL, 1, midi_in, 31, sizeof(midi_in)) == 0,
+    CHECK(shadow_overtake_midi_drain(NULL, NULL, 1, midi_in, 31, sizeof(midi_in)) == 0,
           "after unload the ring has nothing to replay");
     CHECK(midi_in[0] == 0,
           "and the next module's first frame is clean");
@@ -116,7 +154,7 @@ static void test_shared_ring_outranks_the_dedicated_one_on_exit(void)
     CHECK(shadow_overtake_midi_send(leftover, 4) == 4, "DSP leftover queued");
     CHECK(shadow_midi_inject_push(&shared, release) == 0, "release queued");
 
-    CHECK(shadow_overtake_midi_drain(&shared, 0, midi_in, 31, sizeof(midi_in)) == 2,
+    CHECK(shadow_overtake_midi_drain(&shared, NULL, 0, midi_in, 31, sizeof(midi_in)) == 2,
           "both drain once overtake is over");
     CHECK(memcmp(&midi_in[0], release, 4) == 0,
           "the RELEASE goes out first, ahead of the departed DSP's note");
@@ -140,7 +178,7 @@ static void test_drain_is_bounded_by_bytes_not_just_events(void)
     memset(guarded, 0, sizeof(guarded));
     /* 31 events claimed, 3 slots of room. The byte bound is the only thing
      * standing between this and the word past the end. */
-    int n = shadow_overtake_midi_drain(NULL, 1, guarded, 31, usable);
+    int n = shadow_overtake_midi_drain(NULL, NULL, 1, guarded, 31, usable);
     CHECK(n == 3, "the byte bound wins over the event count");
 
     int past_end_clean = 1;
@@ -152,6 +190,7 @@ static void test_drain_is_bounded_by_bytes_not_just_events(void)
 int main(void)
 {
     test_active_overtake_uses_only_dedicated_queue();
+    test_ui_ring_reaches_move_during_overtake();
     test_full_queue_preserves_fifo();
     test_unload_discards_the_departed_modules_packets();
     test_shared_ring_outranks_the_dedicated_one_on_exit();

--- a/tests/host/test_overtake_move_inject_contract.sh
+++ b/tests/host/test_overtake_move_inject_contract.sh
@@ -19,4 +19,24 @@ fi
 grep -q 'shadow_overtake_move_inject_active()' "$API"
 grep -q 'dedicated.*queue' "$GUIDE"
 
+# The JS inject must NOT push into the test bus's ring. While overtake is
+# active the shim pops that ring onto the module, so a tool injecting a button
+# CC there writes its own input — song-mode's Play CC came straight back and
+# toggled its own playback on a loop.
+if ! grep -q 'shadow_midi_inject_ui' "$UI"; then
+    echo "FAIL: move_midi_inject_to_move does not use the shadow UI's own ring" >&2
+    exit 1
+fi
+if grep -q 'shadow_midi_inject_push(shadow_midi_inject,' "$UI"; then
+    echo "FAIL: the JS inject pushes straight into the test-bus ring" >&2
+    exit 1
+fi
+
+# ...and the shim's overtake republish must claim only the test-bus ring.
+if grep -q 'shadow_midi_inject_peek(shadow_midi_inject_ui_shm' "$SHIM"; then
+    echo "FAIL: the overtake republish consumes the shadow UI's ring" >&2
+    exit 1
+fi
+grep -q 'shadow_midi_inject_ui_shm' "$SHIM"
+
 echo "PASS: overtake Move-injection capability and ownership contract"


### PR DESCRIPTION
## The report

*"song mode is not getting bpm maybe? it's firing pads as quickly as it can"*

It is not the tempo. Song Mode's set reads `tempo: 115.00002875` (`barDurationMs` ≈ 2087), and its saved arrangement is `repeats: 1, barLengthMode: longest` — nothing that computes to zero. The wall-clock timer never gets to run at all.

## What the device log shows

```
15:37:42.138 song-mode: inject [11,176,85,127] remaining=1   ← injects Play (CC 85)
15:37:42.140 song-mode: startPlayback from entry 0           ← 2ms later it RECEIVES it
15:37:42.140 song-mode: triggerEntry 0 notes=[92,84,76,68]
15:37:42.247 song-mode: stopPlayback, returning to entry 0   ← the next one toggles back
```

Alternating `Playing from step 1` / `Stopped` about seven times a second, for as long as the tool is open, and **no `MIDI inject: drained` line anywhere in the window** — the packets never reached Move either.

## Root cause

`move_midi_inject_to_move` pushes into `/schwung-midi-inject`. Since fdb1a2de (2026-07-29, *"test-bus: let injected MIDI reach overtake modules"*) that ring belongs to the overtake test bus: while overtake is active, `shim_post_transfer` **pops** it and republishes each packet through `shadow_ui_midi_publish` — onto the module, as though a control had been pressed. `shadow_midi.c` states it plainly: *"nothing pushed there during overtake can reach Move's firmware any more."*

So song-mode lost both halves at once. Its pads and Play CC never reached Move, and its own Play CC came back into its `onMidiMessageInternal`, where the Play handler toggles playback — which injects another Play toggle. A loop bounded only by the 50 ms inject throttle.

## The fix

Ownership of an inject queue follows **who pushed**, never what mode the surface is in — that is the invariant the shared ring broke by acquiring a second producer. The overtake DSP path already learned this and has its own in-shim ring; the shadow UI now gets the cross-process equivalent, `/schwung-midi-inject-ui`. Same layout, new segment, drained into MIDI_IN in **both** modes by `shadow_overtake_midi_drain`, behind the same overtake-exit hold and MIDI_IN-busy defer guards as every other writer.

Additive on the wire — no existing SHM layout changes — so a stale shim is not a hazard: `shadow_ui` falls back to the old ring when the segment is absent and behaves exactly as it does today.

## Verification

- `test_overtake_midi_route` gains a case for the UI ring during overtake; **confirmed failing** with the drain removed.
- `test_overtake_move_inject_contract.sh` pins that the JS binding does not push into the test bus's ring, and that the republish does not consume the UI's; **confirmed failing** when the push is reverted.
- `make -C tests/host test` + all `tests/host/*.sh` green; ARM64 cross-compile clean.
- Deployed to hardware; both segments present, shim mirrored to `/usr/lib`. Song Mode playback still to be confirmed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sg9EfQU5x2YCsLA9SE6Ett