### PR TITLE
Child levels: one pad list, placed before what it selects; no flash; a readable 1..16 knob

### DIFF
--- a/src/shared/knob_engine.mjs
+++ b/src/shared/knob_engine.mjs
@@ -62,8 +62,33 @@ export const ENUM_DELTA_DIV = 4;
 export const ARC_DELTA_SCALE = 0.5;
 /** A float/int knob's per-detent step, as a fraction of its own range. */
 export const MIN_STEP_RANGE_FRAC = 0.01;
-/** An int range this narrow or narrower is stepped like an enum. */
-export const NARROW_RANGE_MAX = 8;
+/**
+ * An int range this narrow or narrower is stepped like an enum.
+ *
+ * SIXTEEN, because that is where "which one of N things" stops and "a sweep"
+ * begins on this hardware. It was 8, which left every 1..16 selector at one
+ * value per detent -- and one flick of an encoder is a dozen detents, so a pad
+ * index or a MIDI channel flew past its whole range before you could read it.
+ * Reported from the device against mrdrums` Current Pad: "these numbers move
+ * crazy fast on a single detent".
+ *
+ * Measured over the fleet, the 9..16 band is 72 params and is ENTIRELY
+ * discrete identities -- `midi_ch[1..16]`, `ui_current_pad[1..16]`,
+ * `choke_group[0..16]`. The next band up (17..24, 17 params) is
+ * `pb_range[0..24]`, `pitch_env_depth[0..24]`: quantities you sweep, where
+ * four detents per unit would be an obstacle. So the boundary is evidence,
+ * not a round number.
+ *
+ * Deliberately NOT a second detent count. ENUM_DELTA_DIV stays 4 and is shared,
+ * for the reason the two-way latch pins its constant equal to the trigger`s: an
+ * enum and a pad index are the same gesture over the same kind of choice, and a
+ * user cannot learn two feels for controls that look alike.
+ *
+ * Note this does NOT align with shouldDrawBigNumber`s span of 24, and should
+ * not: how a value is DRAWN and how it STEPS are different questions, and the
+ * 17..24 band answers them differently on purpose.
+ */
+export const NARROW_RANGE_MAX = 16;
 
 /** schwung-movy model/knob-step.ts detentsPerStep, ported. */
 export function detentsPerStep(meta) {

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -1482,15 +1482,51 @@ export function createController(io = {}) {
         /* The borrowed metadata belonged to the instance we just left -- above
          * all filepath_param, which still names the previous pad's file. */
         installChildAliases();
+        /*
+         * ...EXCEPT THE SELECTOR ITSELF.
+         *
+         * `child_index_param` is not per-instance data -- it is the control
+         * that CHOOSES the instance, and it holds the same value before and
+         * after the change it just caused. Clearing it destroys the state of
+         * the knob under the user's hand mid-gesture: the accumulator and the
+         * cached value both vanish, so the next detent has no value to step
+         * from and writes nothing.
+         *
+         * The symptom is exact and was reproduced before it was fixed: eight
+         * detents on Current Pad produced ONE write. You could move one pad and
+         * then the control was dead. Reported from the device as not being able
+         * to reach other pads.
+         *
+         * `pendingWrite` is the sharpest edge of the three: the write that is
+         * still in flight IS the one that moved the focus, so dropping it
+         * cancels the user's own gesture.
+         */
+        const idxParam = childIndexParam(childLevelDef(levelName));
         for (const pg of s.pages) {
             if (pg.level !== levelName || !Array.isArray(pg.keys)) continue;
             for (const k of pg.keys) {
+                if (k === idxParam) continue;
                 delete s.values[k];
                 delete s.pendingWrite[k];
                 delete s.knobStates[k];
             }
         }
         s.cursor = 0;
+        /*
+         * ...and read the new instance NOW, before anything is drawn.
+         *
+         * Dropping the values is right -- they belong to the pad we just left
+         * -- but the rotation refills one key per tick, so every cell rendered
+         * `--` for ~10 ticks after each pad change. That is the "a page arrives
+         * with its values, not without them" problem in miniature, and
+         * warmCurrentPage already solves it: reported from the device as a
+         * flash of `--` between pads.
+         *
+         * Bounded the same way as the entry warm -- it stops at the first
+         * failed read -- so a module that has stopped answering costs one
+         * timeout per pad change rather than a page of them.
+         */
+        warmCurrentPage();
     }
 
     /**

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -84,33 +84,9 @@ function allListedKeys(hierarchy) {
  * stays, and a module gets the deduplication only by offering the control
  * itself.
  */
-/**
- * Which level "owns" pad selection for an index param: the one that LISTS it.
- *
- * Two levels sharing a focus need one picker, and putting it on whichever is
- * walked first landed it on `root` -- so the module opened on a pad LIST and
- * its actual knobs moved to a second page. A level that names the index param
- * in its own params/knobs is saying that selecting the instance is part of
- * what that level is for, which is a better answer than walk order.
- *
- * Raw membership, deliberately NOT the `ui_`-filtered reachability test: this
- * asks who OWNS the selection, not whether the key gets a cell.
- */
-function indexParamOwner(hierarchy, idxParam) {
-    for (const [key, lvl] of Object.entries((hierarchy && hierarchy.levels) || {})) {
-        if (!lvl || typeof lvl !== "object") continue;
-        const named = (e) => ((e && typeof e === "object") ? (e.level ? null : e.key) : e) === idxParam;
-        if ((lvl.params || []).some(named) || (lvl.knobs || []).some(named)) return key;
-    }
-    return null;
-}
-
-function childPickerNeeded(lvl, listedKeys, pickedFor, levelKey, hierarchy) {
+function childPickerNeeded(lvl, listedKeys, pickedFor) {
     const idxParam = childIndexParam(lvl);
     if (!idxParam) return true;
-    /* Defer to the level that declares it, when one does. */
-    const owner = indexParamOwner(hierarchy, idxParam);
-    if (owner && owner !== levelKey) return false;
     /*
      * ONE PICKER PER SHARED INDEX.
      *
@@ -715,7 +691,7 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
         /* Repeated elements declared once and multiplied by the host. The
          * level object travels with the page so the caller can resolve concrete
          * keys without re-reading the hierarchy (see child_key.mjs). */
-        if (hasChildren(lvl) && childPickerNeeded(lvl, listedKeys, pickedFor, levelKey, hierarchy)) {
+        if (hasChildren(lvl) && childPickerNeeded(lvl, listedKeys, pickedFor)) {
             const _idxParam = childIndexParam(lvl);
             if (_idxParam) pickedFor.add(_idxParam);
             /*
@@ -734,8 +710,20 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
              * commits to a local index that re-keys the level's own pages.
              * Both are expressed as fields on the page, not as a new kind.
              */
+            /*
+             * NAMED FOR WHAT IT SELECTS, not for its level.
+             *
+             * It inherited the level's name, so mrdrums' pad list was called
+             * "Main" -- a list of pads under the name of the page you were
+             * looking for. It is also the page BEFORE the ones it governs
+             * (firstGrid lands past it, so you jog back to reach it), and a
+             * page you arrive at by going backwards has to say what it is on
+             * its own. Reported from the device: it should be "Selected Pad".
+             */
             pages.push({
-                kind: PAGE_ITEMS, name: claimName(base), level: levelKey,
+                kind: PAGE_ITEMS,
+                name: claimName(`Selected ${lvl.child_label || "Item"}`),
+                level: levelKey,
                 childCount: childCount(lvl),
                 childLabel: lvl.child_label || "Item",
                 /* The SAME derived-list field the mode selector uses. One

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -84,9 +84,48 @@ function allListedKeys(hierarchy) {
  * stays, and a module gets the deduplication only by offering the control
  * itself.
  */
-function childPickerNeeded(lvl, listedKeys) {
+/**
+ * Which level "owns" pad selection for an index param: the one that LISTS it.
+ *
+ * Two levels sharing a focus need one picker, and putting it on whichever is
+ * walked first landed it on `root` -- so the module opened on a pad LIST and
+ * its actual knobs moved to a second page. A level that names the index param
+ * in its own params/knobs is saying that selecting the instance is part of
+ * what that level is for, which is a better answer than walk order.
+ *
+ * Raw membership, deliberately NOT the `ui_`-filtered reachability test: this
+ * asks who OWNS the selection, not whether the key gets a cell.
+ */
+function indexParamOwner(hierarchy, idxParam) {
+    for (const [key, lvl] of Object.entries((hierarchy && hierarchy.levels) || {})) {
+        if (!lvl || typeof lvl !== "object") continue;
+        const named = (e) => ((e && typeof e === "object") ? (e.level ? null : e.key) : e) === idxParam;
+        if ((lvl.params || []).some(named) || (lvl.knobs || []).some(named)) return key;
+    }
+    return null;
+}
+
+function childPickerNeeded(lvl, listedKeys, pickedFor, levelKey, hierarchy) {
     const idxParam = childIndexParam(lvl);
     if (!idxParam) return true;
+    /* Defer to the level that declares it, when one does. */
+    const owner = indexParamOwner(hierarchy, idxParam);
+    if (owner && owner !== levelKey) return false;
+    /*
+     * ONE PICKER PER SHARED INDEX.
+     *
+     * Two levels naming the same `child_index_param` are two views of one
+     * focus -- mrdrums has root and Pad Settings both following
+     * ui_current_pad -- so a picker on each is two lists selecting the same
+     * pad, in sync with each other and with the pad you played. Reported from
+     * the device as "why is main pad selection AND pad settings pad
+     * selection?".
+     *
+     * The FIRST level to plan one keeps it; the rest defer. Walk order is
+     * stable, so which level that is does not wander between plans.
+     */
+    if (pickedFor.has(idxParam)) return false;
+    /* ...and no picker at all when the module offers a real cell for it. */
     return !listedKeys.has(idxParam);
 }
 
@@ -345,6 +384,9 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
      * hierarchy, not on the level: the index param may be listed on a sibling
      * level, which is exactly where mrdrums puts it. */
     const listedKeys = allListedKeys(hierarchy);
+    /* child_index_param -> a picker page already exists for it. See
+     * childPickerNeeded: two levels sharing one focus need ONE list. */
+    const pickedFor = new Set();
     /*
      * Built once per plan so knob pages can be nudged into a drawable layout —
      * see alignGroupsToRows. Planning happens on component load, not per frame,
@@ -673,7 +715,9 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
         /* Repeated elements declared once and multiplied by the host. The
          * level object travels with the page so the caller can resolve concrete
          * keys without re-reading the hierarchy (see child_key.mjs). */
-        if (hasChildren(lvl) && childPickerNeeded(lvl, listedKeys)) {
+        if (hasChildren(lvl) && childPickerNeeded(lvl, listedKeys, pickedFor, levelKey, hierarchy)) {
+            const _idxParam = childIndexParam(lvl);
+            if (_idxParam) pickedFor.add(_idxParam);
             /*
              * A child selector IS an items page.
              *

--- a/tests/host/test_child_index_param.sh
+++ b/tests/host/test_child_index_param.sh
@@ -32,7 +32,8 @@ Promise.all([
   import("./src/shared/param_pages/page_controller.mjs"),
   import("./src/shared/param_pages/child_key.mjs"),
   import("./src/shared/param_pages/page_plan.mjs"),
-]).then(([PC, CK, PLAN]) => {
+  import("./src/shared/knob_engine.mjs"),
+]).then(([PC, CK, PLAN, KE]) => {
   let bad = 0;
   const fail = (m) => { console.log("FAIL: " + m); bad++; };
 
@@ -356,6 +357,36 @@ Promise.all([
          + "two controls for one fact");
   }
 
+
+  /* ---- a 1..16 selector steps like an enum, not like a sweep -----------
+   *
+   * One flick of an encoder is a dozen detents, so at one value per detent a
+   * pad index or a MIDI channel crosses its whole range before you can read
+   * it. Reported from the device as "these numbers move crazy fast on a single
+   * detent".
+   *
+   * The BOUNDARY is what is pinned, not the constant: 1..16 selectors gated,
+   * 0..24 quantities not. Measured over the fleet, 9..16 is entirely discrete
+   * identities and 17..24 is entirely things you sweep.
+   */
+  {
+    const gated = (min, max) => KE.detentsPerStep({ type: "int", min, max });
+    if (gated(1, 16) <= 1)
+      fail("a 1..16 selector steps once per detent — one flick crosses all 16");
+    if (gated(1, 16) !== gated(0, 4))
+      fail("a narrow int and a narrower one step differently — one gate, one feel");
+    /* ...and a sweep must NOT be gated, or it becomes 4x harder to move. */
+    if (gated(0, 24) !== 1)
+      fail("a 0..24 quantity is gated like a selector — pitch bend range and "
+         + "envelope depth are swept, not chosen");
+    if (gated(0, 136) !== 1)
+      fail("a wide int is gated — crossing it would take 500+ detents");
+    /* The gate is the ENUM gate, shared. Two numbers here would be two feels
+     * for controls that look alike. */
+    if (gated(1, 16) !== KE.ENUM_DELTA_DIV)
+      fail("the narrow-int gate is no longer the enum gate — they must stay one number");
+  }
+
   /* ---- a level with NO child_index_param is untouched ------------------ */
   {
     const L2 = Object.assign({}, LEVEL);
@@ -379,6 +410,7 @@ Promise.all([
     console.log("  ok  a generic child key borrows the concrete declaration, and follows");
     console.log("  ok  the graphic follows the focused child with no page change");
     console.log("  ok  the picker goes only when the index param really has a cell");
+    console.log("  ok  a 1..16 selector steps like an enum; a 0..24 sweep does not");
     console.log("  ok  a level that declares none reads none");
     console.log("PASS: a module can own which child instance is focused");
   }

--- a/tests/host/test_child_index_param.sh
+++ b/tests/host/test_child_index_param.sh
@@ -33,7 +33,8 @@ Promise.all([
   import("./src/shared/param_pages/child_key.mjs"),
   import("./src/shared/param_pages/page_plan.mjs"),
   import("./src/shared/knob_engine.mjs"),
-]).then(([PC, CK, PLAN, KE]) => {
+  import("./src/shared/param_pages/page_nav.mjs"),
+]).then(([PC, CK, PLAN, KE, NAV]) => {
   let bad = 0;
   const fail = (m) => { console.log("FAIL: " + m); bad++; };
 
@@ -387,6 +388,45 @@ Promise.all([
       fail("the narrow-int gate is no longer the enum gate — they must stay one number");
   }
 
+
+  /* ---- the selector is the page BEFORE what it selects ------------------
+   *
+   * A pad list is not somewhere you should land: with auto-select on you never
+   * need it. It sits at index 0 -- ahead of the pages it governs, so you jog
+   * BACK to reach it -- and firstGrid lands past it. Reported from the device
+   * as "should it be like page -1?".
+   *
+   * It is also named for WHAT IT SELECTS. Inheriting the level`s name called
+   * mrdrums` pad list "Main": a list of pads under the name of the page you
+   * were looking for. A page you arrive at by going backwards has to say what
+   * it is on its own.
+   */
+  {
+    const L5 = { label: "Pads", child_count: 16, child_label: "Pad",
+                 child_key_template: "p{index}_{key}", child_index_base: 1,
+                 child_index_digits: 2, child_index_param: "ui_cur",
+                 knobs: ["vol"], params: ["vol"] };
+    const CP5 = [{ key: "ui_cur", name: "Cur", type: "int", min: 1, max: 16 }];
+    for (let i = 1; i <= 16; i++)
+      CP5.push({ key: `p${String(i).padStart(2,"0")}_vol`, name: "Vol",
+                 type: "float", min: 0, max: 1, step: 0.01 });
+    const pages = PLAN.planPages({
+      hierarchy: { modes: null, levels: { root: L5 } }, chainParams: CP5 }).pages;
+
+    const at = pages.findIndex((p) => p.childOf);
+    if (at !== 0)
+      fail("the child selector is at page " + at + "; it must PRECEDE the pages "
+         + "it governs so it is reachable by jogging back and never in the way");
+    if (pages[at].name !== "Selected Pad")
+      fail("the selector is called " + JSON.stringify(pages[at].name)
+         + ", expected \"Selected Pad\" — it must name what it selects, not its level");
+    const land = NAV.firstGrid(pages);
+    if (land === at)
+      fail("the module LANDS on the pad list — with auto-select on you never need it");
+    if (pages[land].kind !== "knobs")
+      fail("landing page is " + pages[land].kind + ", expected a grid");
+  }
+
   /* ---- a level with NO child_index_param is untouched ------------------ */
   {
     const L2 = Object.assign({}, LEVEL);
@@ -411,6 +451,7 @@ Promise.all([
     console.log("  ok  the graphic follows the focused child with no page change");
     console.log("  ok  the picker goes only when the index param really has a cell");
     console.log("  ok  a 1..16 selector steps like an enum; a 0..24 sweep does not");
+    console.log("  ok  the selector precedes what it selects, and is not where you land");
     console.log("  ok  a level that declares none reads none");
     console.log("PASS: a module can own which child instance is focused");
   }


### PR DESCRIPTION
Follow-up to #328, all four found by using the child-level prototype on hardware.

## The selector is the page *before* what it selects

Two levels naming the same `child_index_param` are two views of one focus, so a picker on each is two lists selecting the same pad. Now there is one — at **page 0**, ahead of the pages it governs, named `Selected ${child_label}` rather than inheriting its level's name (a list of pads was called "Main").

With auto-select on you never need it, so it must not be somewhere you land; with auto-select off you need a way in. `firstGrid` already lands on "the first page worth showing: a grid if there is one", so a leading items page is skipped for free — **which retires an ownership rule I added and then removed in the same branch**: I had moved the picker onto whichever level *declares* the index param, to stop the module opening on the pad list. That problem never existed; I inferred the landing from page order instead of reading the function that decides it.

## No `--` flash between instances

Dropping the cached values on a focus change is right — they belong to the instance you left — but the rotation refills one key per tick, so every cell rendered `--` for ~10 ticks. `warmCurrentPage` already solves exactly this. Measured: 4 empty cells at the first change before, 0 after.

**And the selector itself is never dropped.** `child_index_param` is not per-instance data — it is the control that *chooses* the instance and holds the same value either side of the change it caused. Clearing it destroyed the state of the knob under the user's hand mid-gesture; `pendingWrite` is the sharpest edge, since the write still in flight is the one that moved the focus.

## `NARROW_RANGE_MAX` 8 → 16

One flick of an encoder is a dozen detents, so at one value per detent a pad index or MIDI channel crossed its whole range before you could read it. The gate already existed — `detentsPerStep` applies the enum's 4 detents to narrow ints — the threshold was just below what a 16-way selector needs.

The boundary is evidence, not a round number. Over the fleet:

| int range | count | character |
|---|---:|---|
| ≤8 | 101 | gated today |
| **9–16** | **72** | `midi_ch`, `ui_current_pad`, `choke_group` — discrete identities |
| 17–24 | 17 | `pb_range`, `pitch_env_depth` — swept quantities |
| 25+ | 1258 | sweeps |

Deliberately **not** a second detent count: `ENUM_DELTA_DIV` stays 4 and shared, for the reason the two-way latch pins its constant equal to the trigger's — an enum and a pad index are the same gesture, and a user cannot learn two feels for controls that look alike. It also does *not* align with `shouldDrawBigNumber`'s span of 24, and should not: how a value is drawn and how it steps are different questions, and 17–24 answers them differently.

## Testing

192/192 shell tests green. The gate is pinned as a **boundary in both directions** — reverting to 8 fails, over-widening to 48 fails on the sweeps. Position, name and landing are pinned *together*, because each passes without the others: a correctly-named list you land on is still wrong.