### PR TITLE
Fleet audit sheet: every page of every module, one module at a time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,26 @@ catalog-out/
 # Generated audit sheets (tools/param-pages/audit_sheet.mjs) — 759 PNGs.
 # Regenerate rather than commit; the report is derived from the fixture.
 out/
+
+# Proprietary module assets (ROMs, soundfonts, sample banks) are NEVER stored
+# in this repo. They are referenced by absolute path from the untracked
+# assets.local.json and pushed straight to the device. Enforced by
+# tests/host/test_no_bundled_assets.sh, which checks what git TRACKS — this
+# list is the first line of defence, not the only one.
+*.sf2
+*.sfz
+*.rom
+*.syx
+*.bin
+*.wav
+*.aif
+*.aiff
+*.ogg
+*.flac
+*.mp3
+*.m4a
+*.nam
+*.pcm
+*.rx2
+*.rex
+tools/param-pages/assets.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ graphify-out/
 
 # SCH-50 UI differentiation catalog renders (contact sheets are committed)
 catalog-out/
+
+# Generated audit sheets (tools/param-pages/audit_sheet.mjs) — 759 PNGs.
+# Regenerate rather than commit; the report is derived from the fixture.
+out/

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -361,6 +361,26 @@ export function labelForCell(text, cellW = CELL_W) {
 }
 
 /**
+ * Did the label have to be SQUEEZED — devowelled or cut — to fit its cell?
+ *
+ * Not the same question as "is this label abbreviated", and the difference is
+ * the whole point. The word table turning Attack into ATK is the design
+ * working; comparing against labelUnsqueezed() reports that as a change and
+ * fires on 651 of the fleet's 759 pages, which is a finding nobody can read.
+ * What a reviewer wants is the residue: the label that the table could not
+ * save and shortenLabel had to cut into something that may no longer be a
+ * word. So the comparison is taken AFTER the word pass, against the same
+ * budget labelForCell uses.
+ *
+ * @returns {boolean}
+ */
+export function labelSqueezed(text, cellW = CELL_W) {
+    const labelWidth = Math.min(cellW, fontWidth4x5("M".repeat(LABEL_CHARS)));
+    const worded = caps(preAbbreviate(text, labelWidth));
+    return shortenLabel(LBL_MEASURE, worded, labelWidth) !== worded;
+}
+
+/**
  * What the word pass produced, BEFORE any squeezing to fit.
  *
  * The reference the test compares labelForCell against, and it has to be a
@@ -1774,13 +1794,43 @@ function drawAlsoOpensMark(ctx, g, col, rowY) {
  * does today apart from the enum square's new static width, which is what keeps
  * the harness, the tests and the device unaffected until a caller opts in.
  */
+export const WIDGET_OPAQUE  = "opaque";   /* drawOpaqueBox  — a path/canvas, chevron box */
+export const WIDGET_BUTTON  = "button";   /* drawButton     — a write-only trigger */
+export const WIDGET_ENUM    = "enum";     /* drawEnumSquare — a named option */
+export const WIDGET_BIGNUM  = "bignum";   /* drawBigNumber  — a small int, read as a number */
+export const WIDGET_KNOB    = "knob";     /* drawArcKnob    — a position on a range */
+
+/**
+ * Which widget a cell draws, from its meta alone.
+ *
+ * Extracted from drawKnobWidget's branch chain rather than restated beside it,
+ * and drawKnobWidget switches on THIS — so a tool that reports "what type is
+ * this cell" cannot drift from what the device draws. A second copy of the
+ * order is exactly the failure this codebase keeps finding: the audit sheet
+ * exists to catch a parameter rendered as the wrong type, and it would have
+ * been reading its own re-implementation of the rule.
+ *
+ * Value-independent by construction. Every branch below tests `meta`, never
+ * the reading — which is what makes it answerable for a page nobody has read
+ * a value for yet.
+ */
+export function widgetKindFor(meta) {
+    if (!meta) return WIDGET_KNOB;
+    if (meta.kind === KIND_OPAQUE) return WIDGET_OPAQUE;
+    if (meta.writeOnly) return WIDGET_BUTTON;
+    if (meta.kind === KIND_ENUM) return WIDGET_ENUM;
+    if (shouldDrawBigNumber(meta)) return WIDGET_BIGNUM;
+    return WIDGET_KNOB;
+}
+
 export function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, cellText, btnPhase,
                                anim, nowMs, animKey) {
     const kx = cellLeft(g, col) + Math.floor((g.cellW - KW) / 2), ky = rowY;
     /* Anything that cannot show two values at once shows the live one, so it
      * animates under modulation instead of freezing on the base. */
     const shown = (liveRaw === null || liveRaw === undefined) ? raw : liveRaw;
-    if (meta.kind === KIND_OPAQUE) { drawOpaqueBox(ctx, kx, ky, shown, cellText); return; }
+    const widget = widgetKindFor(meta);
+    if (widget === WIDGET_OPAQUE) { drawOpaqueBox(ctx, kx, ky, shown, cellText); return; }
     /*
      * A TRIGGER is a button, so the cell shows the ACTION, not the value.
      *
@@ -1799,7 +1849,7 @@ export function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, ce
      * wants its own wording can supply short_options[1], which is the existing
      * hook for "what this widget should say in three characters".
      */
-    if (meta.writeOnly) {
+    if (widget === WIDGET_BUTTON) {
         /* The cell's own label underneath names the action ("Clear", "Rnd
          * Preset"), so the bang carries no text — which also sidesteps the
          * module's idle spelling entirely. euclidrum's is an em-dash the 5x7
@@ -1811,7 +1861,7 @@ export function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, ce
                    btnPhase || { pressed: false, filled: false, burst: -1 });
         return;
     }
-    if (meta.kind === KIND_ENUM) {
+    if (widget === WIDGET_ENUM) {
         /* A plugin may report an enum as its option NAME rather than as an
          * index (see learnEnumWireFormat) — resolve either to the index, or
          * `short_options` is skipped for exactly the modules whose values are
@@ -1844,7 +1894,7 @@ export function drawKnobWidget(ctx, g, col, rowY, meta, raw, modRaw, liveRaw, ce
      * shouldDrawBigNumber. Checked here, after the opaque/writeOnly/enum branches
      * that own their cells outright, and before the arc it replaces.
      */
-    if (shouldDrawBigNumber(meta)) {
+    if (widget === WIDGET_BIGNUM) {
         drawBigNumber(ctx, cellLeft(g, col) + Math.floor(g.cellW / 2), ky,
                       bigNumberText(meta, raw));
         return;

--- a/tests/host/test_audit_sheet.sh
+++ b/tests/host/test_audit_sheet.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The fleet audit sheet (tools/param-pages/audit_sheet.mjs).
+#
+# The sheet exists to answer "is any page in the fleet drawn as the wrong TYPE
+# or in a broken LAYOUT", so the thing worth pinning is not that it runs — it
+# is that its two render-time probes CAN FAIL. A probe that measures the wrong
+# thing reports green forever, and this repo has shipped several: the audit
+# would then certify 759 pages it never actually checked.
+#
+# So both probes are exercised by MUTATION:
+#
+#   clipped      a framebuffer written outside 128x64 must count it. The whole
+#                claim of the layout check is that drawing off-panel is
+#                detectable at all, and it is silent by construction on the
+#                device (the master-FX diagram drew nine boxes into a
+#                five-box row with no error).
+#   guessed-meta a contract with a key stripped from chain_params must report
+#                that key as invented. This is the 0.058750-into-an-enum bug,
+#                and on a rendered page it is INVISIBLE — it draws as an
+#                ordinary knob — so the report is the only place it can show.
+#
+# Plus the single-source claim: widgetKindFor is what drawKnobWidget switches
+# on, so a cell type in the sheet is the renderer answering, not this tool
+# restating the rules. If someone re-inlines the branch chain, the sheet can
+# drift from the device without anything failing — hence the call-site pin.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the audit sheet tests" >&2
+  exit 1
+fi
+
+fail=0
+
+# ---- 1. the clipped probe counts an off-panel write -----------------------
+node --input-type=module -e '
+import { createFramebuffer } from "./tools/param-pages/harness.mjs";
+const fb = createFramebuffer();
+if (fb.clipped() !== 0) { console.log("FAIL: fresh framebuffer already reports clipping"); process.exit(1); }
+fb.setPixel(200, 10, 1);
+fb.setPixel(-1, 0, 1);
+fb.setPixel(0, 999, 1);
+if (fb.clipped() !== 3) {
+  console.log("FAIL: clipped() counted " + fb.clipped() + " of 3 off-panel writes");
+  process.exit(1);
+}
+console.log("PASS: clipped() counts off-panel writes (the layout probe can fail)");
+' || fail=1
+
+# ---- 2. guessed-meta fires when a key loses its chain_params entry --------
+# Mutating a real fleet contract rather than a hand-built one: the finding has
+# to survive the shape the fixture actually has.
+node --input-type=module -e '
+import { buildMetaIndex } from "./src/shared/param_pages/param_meta.mjs";
+import { planPages, PAGE_KNOBS } from "./src/shared/param_pages/page_plan.mjs";
+import fs from "node:fs";
+
+const fx = JSON.parse(fs.readFileSync("tests/fixtures/module-contracts.json", "utf8"));
+const mod = fx.modules.find((m) => m.id === "obxd");
+if (!mod) { console.log("FAIL: fixture has no obxd to mutate"); process.exit(1); }
+
+const guessedKeys = (m) => {
+  const idx = buildMetaIndex({ hierarchy: m.ui_hierarchy, chainParams: m.chain_params });
+  const { pages } = planPages({ hierarchy: m.ui_hierarchy, chainParams: m.chain_params });
+  const out = [];
+  for (const p of pages) {
+    if (p.kind !== PAGE_KNOBS) continue;
+    for (const k of (p.keys || [])) {
+      if (k && idx.getOrGuess(k) && idx.getOrGuess(k).guessed) out.push(k);
+    }
+  }
+  return out;
+};
+
+if (guessedKeys(mod).length !== 0) {
+  console.log("FAIL: unmutated obxd already reports guessed metadata");
+  process.exit(1);
+}
+
+/* Strip ONE described key. The page still plans it; nothing describes it.
+ *
+ * The victim has to be a key that lands on a KNOBS page. The first entry in
+ * obxd chain_params is `preset`, which is the browser list_param and lives on
+ * a PAGE_PRESET — stripping it produces no guessed knob and the mutation
+ * reports a false green, which is the exact failure this test exists to
+ * prevent, one level up. */
+const { pages: basePages } = planPages({ hierarchy: mod.ui_hierarchy, chainParams: mod.chain_params });
+const onKnobs = new Set();
+for (const p of basePages) {
+  if (p.kind === PAGE_KNOBS) for (const k of (p.keys || [])) if (k) onKnobs.add(k);
+}
+const victim = mod.chain_params.find((p) => p && p.key && onKnobs.has(p.key));
+if (!victim) { console.log("FAIL: obxd has no chain_params key on a knobs page to mutate"); process.exit(1); }
+const mutated = { ...mod, chain_params: mod.chain_params.filter((p) => p !== victim) };
+const after = guessedKeys(mutated);
+if (!after.includes(victim.key)) {
+  console.log("FAIL: stripping " + victim.key + " from chain_params was not reported as guessed");
+  process.exit(1);
+}
+console.log("PASS: guessed-meta fires on a stripped contract entry (" + victim.key + ")");
+' || fail=1
+
+# ---- 3. the widget name is the renderer answering -------------------------
+node --input-type=module -e '
+import { widgetKindFor, WIDGET_OPAQUE, WIDGET_BUTTON, WIDGET_ENUM, WIDGET_BIGNUM, WIDGET_KNOB }
+  from "./src/shared/param_pages/render_page_movy.mjs";
+import { KIND_ENUM, KIND_OPAQUE, KIND_NUMBER } from "./src/shared/param_pages/param_meta.mjs";
+
+const cases = [
+  [{ kind: KIND_OPAQUE, type: "filepath" }, WIDGET_OPAQUE, "a sample path is a box, not a knob"],
+  [{ kind: KIND_ENUM, type: "enum", writeOnly: true, options: ["-", "Go"] }, WIDGET_BUTTON,
+   "write-only outranks enum: a trigger is a button"],
+  [{ kind: KIND_ENUM, type: "enum", options: ["Sine", "Saw"] }, WIDGET_ENUM, "an enum is a square"],
+  [{ kind: KIND_NUMBER, type: "int", min: 1, max: 8 }, WIDGET_BIGNUM, "a small int reads as a number"],
+  [{ kind: KIND_NUMBER, type: "float", min: 0, max: 1, step: 0.01 }, WIDGET_KNOB, "a range is an arc"],
+];
+let bad = 0;
+for (const [meta, want, why] of cases) {
+  const got = widgetKindFor(meta);
+  if (got !== want) { console.log("FAIL: " + why + " — got " + got + ", want " + want); bad++; }
+}
+if (bad) process.exit(1);
+console.log("PASS: widgetKindFor classifies all 5 widget branches in dispatch order");
+' || fail=1
+
+# The classifier must remain the thing the DRAW path switches on. Re-inlining
+# the branch chain would leave the sheet reporting a type nobody draws.
+if ! grep -q "const widget = widgetKindFor(meta);" src/shared/param_pages/render_page_movy.mjs; then
+  echo "FAIL: drawKnobWidget no longer calls widgetKindFor — the audit sheet would be reporting its own copy of the rules"
+  fail=1
+else
+  echo "PASS: drawKnobWidget dispatches through widgetKindFor"
+fi
+
+# ---- 4. the sheet covers the whole fleet, and every planned page ----------
+node --input-type=module -e '
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { planPages } from "./src/shared/param_pages/page_plan.mjs";
+
+const out = fs.mkdtempSync(path.join(os.tmpdir(), "audit-"));
+try {
+  execFileSync("node", ["tools/param-pages/audit_sheet.mjs", "--json", "--out", out],
+               { stdio: "pipe" });
+  const rep = JSON.parse(fs.readFileSync(path.join(out, "report.json"), "utf8"));
+  const fx = JSON.parse(fs.readFileSync("tests/fixtures/module-contracts.json", "utf8"));
+  const want = fx.modules.filter((m) => m.status !== "load-failed");
+
+  if (rep.modules.length !== want.length) {
+    console.log("FAIL: sheet covered " + rep.modules.length + " modules, fixture has " + want.length);
+    process.exit(1);
+  }
+  /* Every page the planner produces must be in the sheet. A sheet that
+   * silently renders a subset reads as full coverage, which is the whole
+   * failure mode an audit cannot afford. */
+  for (const m of rep.modules) {
+    const src = fx.modules.find((x) => x.id === m.id);
+    const n = planPages({ hierarchy: src.ui_hierarchy, chainParams: src.chain_params }).pages.length;
+    if (m.pages.length !== n) {
+      console.log("FAIL: " + m.id + " planned " + n + " pages, sheet has " + m.pages.length);
+      process.exit(1);
+    }
+  }
+  const pages = rep.modules.reduce((a, m) => a + m.pages.length, 0);
+  console.log("PASS: sheet covers " + rep.modules.length + " modules and all " + pages + " planned pages");
+} finally {
+  fs.rmSync(out, { recursive: true, force: true });
+}
+' || fail=1
+
+exit $fail

--- a/tests/host/test_no_bundled_assets.sh
+++ b/tests/host/test_no_bundled_assets.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# NO PROPRIETARY ASSET IS EVER COMMITTED.
+#
+# The fleet audit wants modules captured with their real ROMs, soundfonts and
+# sample banks loaded, because a module captured cold reports a contract that
+# is not the one users see — sf2 with no soundfont present declares three
+# parameters. The assets that fix that are JV-880 ROMs, commercial soundfonts
+# and sample libraries: not ours to redistribute, and large.
+#
+# So they are NEVER COPIED INTO THE TREE. They are referenced by absolute path
+# from tools/param-pages/assets.local.json, which is itself ignored, and pushed
+# to the device by provision_assets.sh. Nothing under this repo ever holds one.
+#
+# That rule is worth exactly as much as its enforcement, which is why this is a
+# test and not a paragraph in a README. A .gitignore does not protect against
+# `git add -f`, against a pattern nobody updated when a new extension showed
+# up, or against an asset landing somewhere the pattern does not reach. This
+# checks what git is ACTUALLY TRACKING, which is the only thing that can end up
+# pushed.
+#
+# If this fails, do not add an exclusion — remove the file:
+#   git rm --cached <path>
+# and if it has already been pushed, the history needs rewriting, because a
+# blob stays fetchable long after the commit that removed it.
+
+# Extensions that are asset payloads rather than source. Deliberately broad:
+# a false positive costs one conversation, a false negative ships a ROM.
+ASSET_RE='\.(sf2|sfz|rom|syx|bin|wav|aiff?|ogg|flac|mp3|m4a|nam|pcm|dat|rx2|rex|exl|sysex)$'
+
+fail=0
+
+tracked=$(git ls-files | grep -Ei "$ASSET_RE" || true)
+if [ -n "$tracked" ]; then
+  echo "FAIL: asset payload(s) are TRACKED BY GIT:"
+  echo "$tracked" | sed 's/^/    /'
+  echo "  Remove with: git rm --cached <path>   (do not add an ignore rule)"
+  fail=1
+else
+  echo "PASS: no asset payloads tracked by git"
+fi
+
+# The local asset map holds absolute paths into someone's music library. It is
+# not itself an asset, but it is nobody else's business and it is machine
+# specific, so it must stay untracked too.
+if git ls-files --error-unmatch tools/param-pages/assets.local.json >/dev/null 2>&1; then
+  echo "FAIL: tools/param-pages/assets.local.json is tracked — it is machine-local by design"
+  fail=1
+else
+  echo "PASS: assets.local.json is not tracked"
+fi
+
+# The ignore rules have to actually cover the extensions above, or the only
+# thing standing between a ROM and a commit is whoever is typing. Checked with
+# check-ignore against a probe path per extension rather than by reading the
+# patterns, so it tests the behaviour git will have, not our reading of it.
+missing=""
+for ext in sf2 sfz rom syx bin wav aiff ogg flac mp3 nam pcm rx2; do
+  if ! git check-ignore -q "probe-asset.$ext" 2>/dev/null; then
+    missing="$missing $ext"
+  fi
+done
+if [ -n "$missing" ]; then
+  echo "FAIL: .gitignore does not cover:$missing"
+  echo "  A tracked-file check alone catches the mistake only AFTER someone makes it."
+  fail=1
+else
+  echo "PASS: .gitignore covers every asset extension the tracked-file check looks for"
+fi
+
+exit $fail

--- a/tools/param-pages/assets.example.json
+++ b/tools/param-pages/assets.example.json
@@ -1,0 +1,56 @@
+{
+  "_comment": [
+    "TEMPLATE. Copy to assets.local.json (which is gitignored) and edit the paths.",
+    "",
+    "WHY THIS EXISTS. The fleet audit renders each module's DECLARED contract, and",
+    "for an asset-driven module that contract depends on what is loaded. sf2 with an",
+    "empty soundfonts/ directory declares three parameters — preset, octave_transpose,",
+    "gain — and the audit faithfully draws that, which looks exactly like a module",
+    "with a broken UI rather than a module with nothing to play. Same class: sfz's",
+    "knob_0..knob_7 are SFZ-opcode controls that get their names from the loaded",
+    "instrument, and granny/mrsample need a sample before their surface is real.",
+    "",
+    "WHY PATHS AND NOT FILES. These are JV-880 ROMs, commercial soundfonts and",
+    "sample libraries: not ours to redistribute, and hundreds of megabytes. They are",
+    "never copied into this repo. provision_assets.sh reads this file and pushes them",
+    "from wherever they live on your machine STRAIGHT TO THE DEVICE, and",
+    "tests/host/test_no_bundled_assets.sh fails the build if one ever lands in the",
+    "tree — it checks what git tracks, so it catches `git add -f` too.",
+    "",
+    "The Node harness never reads these. It does not run the DSP; it renders a",
+    "captured contract. Assets matter at CAPTURE time, on the device, which is what",
+    "provision_assets.sh + dump_contracts_device.js are for."
+  ],
+
+  "device_module_root": "/data/UserData/schwung/modules/sound_generators",
+
+  "modules": {
+    "sf2": {
+      "device_dir": "sf2/soundfonts",
+      "note": "TinySoundFont reads every .sf2 here. Empty = a three-parameter module.",
+      "files": [
+        "/path/to/your/SoundFonts/GeneralUser GS v1.471.sf2"
+      ]
+    },
+    "sfz": {
+      "device_dir": "sfz/instruments",
+      "note": "One directory per instrument, each containing its .sfz and its samples.",
+      "files": []
+    },
+    "minijv": {
+      "device_dir": "minijv/roms",
+      "note": "jv880_waverom1/2.bin, jv880_rom1/2.bin, jv880_nvram.bin.",
+      "files": []
+    },
+    "dexed": {
+      "device_dir": "dexed/banks",
+      "note": "DX7 .syx cartridge banks, 32 voices each.",
+      "files": []
+    },
+    "osirus": {
+      "device_dir": "osirus/roms",
+      "note": "virus_b.BIN / virus_c.BIN.",
+      "files": []
+    }
+  }
+}

--- a/tools/param-pages/audit_sheet.mjs
+++ b/tools/param-pages/audit_sheet.mjs
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+/**
+ * audit_sheet.mjs — render EVERY page of EVERY module and put them in front of
+ * a reviewer one module at a time.
+ *
+ *   node tools/param-pages/audit_sheet.mjs                    whole fleet -> out/audit/
+ *   node tools/param-pages/audit_sheet.mjs obxd minijv        just these
+ *   node tools/param-pages/audit_sheet.mjs --cat audio_fx     one category
+ *   node tools/param-pages/audit_sheet.mjs --json             report only, no PNGs
+ *   node tools/param-pages/audit_sheet.mjs --fixture PATH     audit a fresh dump
+ *   node tools/param-pages/audit_sheet.mjs --out DIR --scale 4
+ *
+ * Then open out/audit/index.html.
+ *
+ * WHY THIS EXISTS, given preview.mjs already draws a module's pages: because
+ * the question here is not "what does obxd look like" but "is anything in the
+ * fleet drawn as the wrong TYPE or in a broken LAYOUT", and that question is
+ * 759 pages long. A reviewer will not run 95 commands, and the fleet has
+ * already taught this codebase that reviewing widgets from their code rather
+ * than their render lets real defects through. So: every page, rendered, with
+ * the module's findings beside it and a per-module reviewed/flagged mark that
+ * survives closing the tab.
+ *
+ * WHAT THE PICTURES ARE, precisely. Values are synthesised (fake_values.mjs) —
+ * this is a LAYOUT audit, not a patch audit. A knob pointing somewhere odd is
+ * the dice; a knob where an enum belongs is a defect. The per-cell widget name
+ * printed beside each page comes from widgetKindFor(), the same function
+ * drawKnobWidget switches on, so "what type is this cell" is answered by the
+ * renderer rather than by this file's opinion of the rules.
+ *
+ * WHAT IT DOES NOT COVER. Overtake modules — they own the whole surface and
+ * have no knob grid to plan. Anything the fixture did not capture. And the
+ * fixture is a CAPTURE: a module that changed its contract since is drawn as
+ * it was, which reads exactly like a bug that has already been fixed. The
+ * provenance line prints on every run, and it is the first thing to check
+ * before believing a finding.
+ *
+ * Node-only. Nothing here ships to the device.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createFramebuffer, drawContext } from "./harness.mjs";
+import { fakeValue } from "./fake_values.mjs";
+import { planPages, PAGE_KNOBS } from "../../src/shared/param_pages/page_plan.mjs";
+import { buildMetaIndex } from "../../src/shared/param_pages/param_meta.mjs";
+import { renderPageMovy, widgetKindFor, labelForCell, labelSqueezed }
+    from "../../src/shared/param_pages/render_page_movy.mjs";
+import { resolveViz } from "../../src/shared/param_pages/viz.mjs";
+import { createController, LAYOUT_LIST } from "../../src/shared/param_pages/page_controller.mjs";
+import { createFakeDevice } from "./fake_device.mjs";
+import { validateContract } from "../../src/shared/param_pages/validate_contract.mjs";
+
+const ROOT = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
+
+const argv = process.argv.slice(2);
+const has = (f) => argv.includes("--" + f);
+const opt = (f, d = null) => { const i = argv.indexOf("--" + f); return i >= 0 && argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[i + 1] : d; };
+const OPTS_WITH_VALUE = new Set(["out", "scale", "fixture", "cat"]);
+const ids = argv.filter((a, i) => !a.startsWith("--") && !(i > 0 && argv[i - 1].startsWith("--") && OPTS_WITH_VALUE.has(argv[i - 1].slice(2))));
+
+const FIXTURE = opt("fixture", path.join(ROOT, "tests", "fixtures", "module-contracts.json"));
+const OUT = opt("out", path.join(ROOT, "out", "audit"));
+const SCALE = parseInt(opt("scale", "4"), 10);
+const JSON_ONLY = has("json");
+
+const fx = JSON.parse(fs.readFileSync(FIXTURE, "utf8"));
+
+/* ------------------------------------------------------------------ *
+ * Provenance. Same reasoning as validate.mjs: a capture that is months
+ * stale reports a module as it WAS, and that is indistinguishable from a
+ * live defect unless the run says so out loud, every time.
+ * ------------------------------------------------------------------ */
+const STALE_AFTER_DAYS = 30;
+function provenance() {
+    const when = fx.generated_at ? new Date(fx.generated_at) : null;
+    if (!when || Number.isNaN(when.getTime())) {
+        return { line: "capture: date unknown — a checked-in fixture, not a device", stale: true, iso: null };
+    }
+    const days = Math.floor((Date.now() - when.getTime()) / 86400000);
+    const age = days <= 0 ? "today" : days === 1 ? "1 day ago" : `${days} days ago`;
+    return {
+        line: `capture: ${when.toISOString().slice(0, 10)} (${age}), ${fx.modules.length} modules — a fixture, not a live device`,
+        stale: days >= STALE_AFTER_DAYS,
+        iso: when.toISOString(),
+    };
+}
+
+/* ------------------------------------------------------------------ *
+ * Render-time findings.
+ *
+ * Deliberately ONLY the things a contract check cannot see.
+ * validate_contract.mjs already answers every question that can be
+ * answered from the declaration — unreachable params, empty ranges,
+ * undrawable text, missing hierarchy — and its findings are carried
+ * through untouched below. Restating any of them here would give a
+ * reviewer two spellings of one defect and a reason to trust neither.
+ *
+ * What is left needs a framebuffer:
+ *
+ *   clipped   the page drew OUTSIDE 128x64. The master-FX diagram taught
+ *             this one: a row that overflows cannot report that it did,
+ *             it just draws off-screen with no error. Counted by the
+ *             harness framebuffer, so it catches any drawing at all
+ *             leaving the panel, not a shape somebody predicted.
+ *   guessed   a cell whose meta was INVENTED — no chain_params entry, so
+ *             the grid supplied `float 0..1 step 0.01`. This is the
+ *             documented 0.058750-into-an-enum bug, and on a picture it
+ *             is invisible: it draws as a perfectly ordinary knob.
+ *   squeeze   the label was devowelled or cut to fit its cell. Reported on
+ *             the cell, never as a finding — see the note at its call site.
+ * ------------------------------------------------------------------ */
+const RANK = { error: 0, warn: 1, info: 2 };
+
+function renderModule(mod) {
+    const { pages, warnings } = planPages({ hierarchy: mod.ui_hierarchy, chainParams: mod.chain_params });
+    const metaIndex = buildMetaIndex({ hierarchy: mod.ui_hierarchy, chainParams: mod.chain_params });
+
+    /* Contract findings, as-is, from the one validator. */
+    const findings = validateContract({ id: mod.id, hierarchy: mod.ui_hierarchy, chainParams: mod.chain_params })
+        .findings.map((f) => ({ ...f, page: null }));
+    for (const w of warnings) findings.push({ level: "info", rule: "planner", message: w, page: null });
+
+    const rendered = [];
+    for (let i = 0; i < pages.length; i++) {
+        const p = pages[i];
+        const keys = p.keys || [];
+        const values = {};
+        for (const k of keys) values[k] = fakeValue(k, metaIndex.getOrGuess(k));
+
+        const fb = createFramebuffer();
+        const title = `T1 > ${String(mod.name || mod.id).toUpperCase()}`;
+        const footer = [["JOG", "PG"], ["SHFT", "SECT"], ["CLK", "MENU"]];
+
+        if (p.kind === PAGE_KNOBS) {
+            const { groups } = resolveViz({ keys, metaIndex });
+            renderPageMovy(drawContext(fb), {
+                page: p, metaIndex, values, title,
+                pageIndex: i, pageCount: pages.length, touched: -1, viz: groups, footer,
+            });
+        } else {
+            /*
+             * A menu / preset / items page has no grid form, so it is drawn
+             * by the REAL controller against a fake device serving this
+             * module's own contract — the same path preview.mjs takes. Hand
+             * -rendering it here would be previewing a re-implementation of
+             * page_controller.mjs, and the point of the sheet is that the
+             * picture is the device's.
+             */
+            const dev = createFakeDevice({ id: mod.id, prefix: "synth", initial: values, serveLists: true });
+            const ctrl = createController({
+                getParam: dev.getParam, setParam: dev.setParam, announce: () => {}, now: dev.now,
+            });
+            ctrl.load({ prefix: "synth" });
+            ctrl.setLayout(LAYOUT_LIST);
+            ctrl.goToPage(i, { remember: false });
+            /* One read per tick is the whole point of the cursor — give the
+             * page as many ticks as it has values to land, as the device does. */
+            for (let t = 0; t < keys.length + 3; t++) ctrl.tick();
+            ctrl.render(drawContext(fb), { title, footer });
+        }
+
+        /* Per-cell widget, named by the renderer's own classifier. */
+        const cells = keys.map((k) => {
+            if (!k) return null;
+            const meta = metaIndex.getOrGuess(k);
+            const label = (meta && meta.name) || k;
+            const drawn = labelForCell(label);
+            return {
+                key: k,
+                label,
+                drawn,
+                widget: p.kind === PAGE_KNOBS ? widgetKindFor(meta) : "row",
+                type: (meta && meta.type) || "?",
+                guessed: !!(meta && meta.guessed),
+                squeezed: p.kind === PAGE_KNOBS && labelSqueezed(label),
+                options: meta && Array.isArray(meta.options) ? meta.options.length : null,
+            };
+        });
+
+        const clipped = fb.clipped();
+        if (clipped > 0) {
+            findings.push({ level: "error", rule: "clipped", page: i,
+                            message: `page ${i} "${p.name}" drew ${clipped} px outside the 128x64 panel` });
+        }
+        const guessed = cells.filter((c) => c && c.guessed).map((c) => c.key);
+        if (guessed.length) {
+            findings.push({ level: "warn", rule: "guessed-meta", page: i,
+                            message: `page ${i} "${p.name}": invented metadata for ${guessed.join(", ")} — drawn as a plain 0..1 knob because chain_params does not describe it` });
+        }
+        /*
+         * A squeezed label is NOT pushed as a finding.
+         *
+         * It fires on 597 of the fleet's 759 pages, because a five-character
+         * cell is genuinely that tight — as a list it buries the 35 findings
+         * that need a decision under 597 that do not. It is real information,
+         * so it stays: on the CELL, beside the picture, where the reviewer can
+         * see SCATTE and the word it came from in the same glance. That is
+         * where a truncation is judged anyway.
+         */
+
+        const entry = {
+            index: i, kind: p.kind, name: p.name || "", keys: keys.length,
+            authored: p.authored !== false, cells, clipped,
+        };
+        if (!JSON_ONLY) {
+            const dir = path.join(OUT, mod.id);
+            fs.mkdirSync(dir, { recursive: true });
+            const file = path.join(dir, `${String(i).padStart(3, "0")}.png`);
+            fs.writeFileSync(file, fb.toPng(SCALE));
+            entry.png = `${mod.id}/${path.basename(file)}`;
+        }
+        rendered.push(entry);
+    }
+
+    findings.sort((a, b) => (RANK[a.level] - RANK[b.level]) || ((a.page ?? -1) - (b.page ?? -1)));
+    return {
+        id: mod.id, name: mod.name || mod.id, category: mod.category,
+        version: mod.version || null, pages: rendered, findings,
+    };
+}
+
+/* ------------------------------------------------------------------ */
+
+const prov = provenance();
+console.log(prov.line);
+if (prov.stale) {
+    console.log("  ⚠ a module migrated since then is drawn as it WAS — refresh with");
+    console.log("    tools/param-pages/dump_contracts_device.js before trusting a finding");
+}
+
+let picked = fx.modules.filter((m) => m.status !== "load-failed");
+if (opt("cat")) picked = picked.filter((m) => m.category === opt("cat"));
+if (ids.length) {
+    picked = ids.map((id) => {
+        const m = fx.modules.find((x) => x.id === id);
+        if (!m) { console.error(`no module "${id}" in the fixture`); process.exit(2); }
+        return m;
+    });
+}
+picked.sort((a, b) => a.category.localeCompare(b.category) || a.id.localeCompare(b.id));
+
+const report = { generated_from: FIXTURE, capture: prov.iso, modules: [] };
+let pageTotal = 0;
+for (const m of picked) {
+    const r = renderModule(m);
+    report.modules.push(r);
+    pageTotal += r.pages.length;
+    const bad = r.findings.filter((f) => f.level !== "info").length;
+    console.log(`  ${r.id.padEnd(20)} ${String(r.pages.length).padStart(3)} pages` +
+                (bad ? `   ${bad} finding(s)` : ""));
+}
+
+fs.mkdirSync(OUT, { recursive: true });
+fs.writeFileSync(path.join(OUT, "report.json"), JSON.stringify(report, null, 2));
+if (!JSON_ONLY) {
+    fs.writeFileSync(path.join(OUT, "index.html"), buildIndex(report, prov));
+}
+console.log(`\n${picked.length} modules, ${pageTotal} pages -> ${OUT}`);
+if (!JSON_ONLY) console.log(`open ${path.join(OUT, "index.html")}`);
+
+/* ------------------------------------------------------------------ *
+ * The reviewer's surface.
+ *
+ * One module on screen at a time, because that is how the review is
+ * actually done — a wall of 759 thumbnails is a picture of the fleet, not
+ * a tool for auditing it. [ and ] step modules, and the reviewed / flagged
+ * marks persist in localStorage so a fleet pass survives closing the tab.
+ * The PNGs are referenced, not inlined: 759 data URIs is a document no
+ * browser enjoys and a diff nobody can read.
+ * ------------------------------------------------------------------ */
+function esc(s) {
+    return String(s).replace(/[&<>"]/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
+}
+
+function buildIndex(rep, prv) {
+    const data = JSON.stringify(rep).replace(/</g, "\\u003c");
+    return `<!doctype html><meta charset="utf-8"><title>Schwung knob-grid audit</title>
+<style>
+:root{--bg:#14161a;--fg:#e8e8ea;--dim:#8a8f98;--line:#2a2e35;--warn:#e0a33e;--err:#e05555;--ok:#4caf6d}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--fg);font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace}
+header{position:sticky;top:0;background:var(--bg);border-bottom:1px solid var(--line);padding:10px 16px;z-index:2}
+h1{font-size:14px;margin:0 0 4px}
+.prov{color:var(--dim);font-size:11px}
+.stale{color:var(--warn)}
+.wrap{display:grid;grid-template-columns:230px 1fr;min-height:calc(100vh - 60px)}
+nav{border-right:1px solid var(--line);overflow-y:auto;max-height:calc(100vh - 60px);position:sticky;top:60px}
+nav button{display:block;width:100%;text-align:left;background:none;border:0;color:var(--fg);
+  font:inherit;padding:4px 10px;cursor:pointer;border-left:3px solid transparent}
+nav button:hover{background:#1c1f25}
+nav button.sel{background:#22262d;border-left-color:#6aa9ff}
+nav .cat{color:var(--dim);font-size:10px;padding:10px 10px 2px;text-transform:uppercase;letter-spacing:.08em}
+nav .done{color:var(--ok)} nav .flag{color:var(--err)}
+main{padding:16px 20px;overflow-x:hidden}
+.modhead{display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-bottom:10px}
+.modhead h2{font-size:18px;margin:0}
+.modhead .meta{color:var(--dim)}
+.marks button{background:#1c1f25;border:1px solid var(--line);color:var(--fg);font:inherit;
+  padding:3px 10px;border-radius:4px;cursor:pointer;margin-left:6px}
+.marks button.on{background:#2b6b45;border-color:#357f52}
+.marks button.on.flagbtn{background:#6b2b2b;border-color:#7f3535}
+.findings{margin:0 0 14px;padding:8px 12px;border:1px solid var(--line);border-radius:5px;background:#181b20}
+.findings div{margin:2px 0}
+.lv{display:inline-block;min-width:52px;font-size:10px;letter-spacing:.06em}
+.error .lv{color:var(--err)} .warn .lv{color:var(--warn)} .info .lv{color:var(--dim)}
+.rule{color:#6aa9ff}
+.pages{display:flex;flex-wrap:wrap;gap:16px}
+figure{margin:0;width:512px;max-width:100%}
+figure img{width:100%;image-rendering:pixelated;display:block;background:#000;border:1px solid var(--line)}
+figure.bad img{border-color:var(--err)}
+figcaption{color:var(--dim);font-size:11px;padding:4px 2px 0}
+.cells{color:var(--dim);font-size:11px;display:flex;flex-wrap:wrap;gap:2px 10px}
+.cells span b{color:var(--fg);font-weight:400}
+.cells span.g{color:var(--warn)}
+.cells span.sq i{color:#5d6570;font-style:normal}
+.cells span.sq i::before{content:"\\2190"}
+.w-enum{color:#c58fe0}.w-knob{color:#6aa9ff}.w-bignum{color:#4caf6d}.w-opaque{color:#e0a33e}.w-button{color:#e07f7f}
+kbd{background:#22262d;border:1px solid var(--line);border-radius:3px;padding:0 4px}
+</style>
+<header>
+<h1>Schwung knob-grid audit — ${rep.modules.length} modules</h1>
+<div class="prov${prv.stale ? " stale" : ""}">${esc(prv.line)}${prv.stale ? " · refresh with dump_contracts_device.js before trusting a finding" : ""}
+ · values are synthesised: judge layout and widget type, not the reading
+ · <kbd>[</kbd> <kbd>]</kbd> module &nbsp; <kbd>r</kbd> reviewed &nbsp; <kbd>f</kbd> flag &nbsp; <kbd>i</kbd> info findings</div>
+</header>
+<div class="wrap"><nav id="nav"></nav><main id="main"></main></div>
+<script>
+const REPORT = ${data};
+const KEY = "schwung-audit-marks";
+let marks = {};
+try { marks = JSON.parse(localStorage.getItem(KEY) || "{}"); } catch (e) { marks = {}; }
+const saveMarks = () => localStorage.setItem(KEY, JSON.stringify(marks));
+let sel = 0;
+/* info findings are 90% of the list (viz-inferred alone is 599) and none of
+ * them ask for a decision, so they are off until asked for. */
+let showInfo = false;
+
+function drawNav() {
+  const nav = document.getElementById("nav");
+  nav.innerHTML = "";
+  let cat = null;
+  REPORT.modules.forEach((m, i) => {
+    if (m.category !== cat) {
+      cat = m.category;
+      const h = document.createElement("div");
+      h.className = "cat"; h.textContent = cat;
+      nav.appendChild(h);
+    }
+    const b = document.createElement("button");
+    const mk = marks[m.id] || {};
+    b.className = (i === sel ? "sel " : "") + (mk.flag ? "flag" : mk.done ? "done" : "");
+    b.textContent = (mk.flag ? "\\u2691 " : mk.done ? "\\u2713 " : "  ") + m.id + "  (" + m.pages.length + ")";
+    b.onclick = () => { sel = i; render(); };
+    nav.appendChild(b);
+  });
+  const cur = nav.querySelector("button.sel");
+  if (cur) cur.scrollIntoView({ block: "nearest" });
+}
+
+function render() {
+  const m = REPORT.modules[sel];
+  const mk = marks[m.id] || {};
+  const main = document.getElementById("main");
+  const f = m.findings.filter(x => showInfo || x.level !== "info").map(x =>
+    '<div class="' + x.level + '"><span class="lv">' + x.level.toUpperCase() + '</span> ' +
+    '<span class="rule">' + x.rule + '</span> ' + esc(x.message) + '</div>').join("");
+  const pages = m.pages.map(p => {
+    const cells = (p.cells || []).filter(Boolean).map(c =>
+      '<span class="' + (c.guessed ? "g " : "") + (c.squeezed ? "sq" : "") +
+      '" title="' + esc(c.key) + ' \u2014 ' + esc(c.type) +
+      (c.options ? ', ' + c.options + ' options' : '') + '">' +
+      '<b class="w-' + c.widget + '">' + c.widget + '</b> ' + esc(c.drawn) +
+      (c.squeezed ? '<i>' + esc(c.label) + '</i>' : '') +
+      (c.guessed ? " (guessed)" : "") + '</span>').join("");
+    return '<figure' + (p.clipped ? ' class="bad"' : '') + '>' +
+      (p.png ? '<img loading="lazy" src="' + p.png + '" alt="page ' + p.index + '">' : '') +
+      '<figcaption>' + p.index + ' &middot; ' + p.kind + ' &middot; "' + esc(p.name) + '" &middot; ' +
+      p.keys + ' keys' + (p.authored ? '' : ' &middot; OVERFLOW (planner-paginated)') +
+      (p.clipped ? ' &middot; CLIPPED ' + p.clipped + 'px' : '') +
+      '<div class="cells">' + cells + '</div></figcaption></figure>';
+  }).join("");
+  main.innerHTML =
+    '<div class="modhead"><h2>' + esc(m.name) + '</h2>' +
+    '<span class="meta">' + m.id + ' &middot; ' + m.category +
+    (m.version ? ' &middot; v' + esc(m.version) : '') + ' &middot; ' + m.pages.length + ' pages</span>' +
+    '<span class="marks"><button class="' + (mk.done ? "on" : "") + '" onclick="mark(\\'done\\')">reviewed</button>' +
+    '<button class="flagbtn ' + (mk.flag ? "on" : "") + '" onclick="mark(\\'flag\\')">flag</button>' +
+    '<button class="' + (showInfo ? "on" : "") + '" onclick="toggleInfo()">info</button></span></div>' +
+    (f ? '<div class="findings">' + f + '</div>'
+       : '<div class="findings"><span class="lv">\u2014</span> no findings above info level</div>') +
+    '<div class="pages">' + pages + '</div>';
+  main.scrollTop = 0;
+  window.scrollTo(0, 0);
+  drawNav();
+  /*
+   * replaceState, not an assignment to location.hash.
+   *
+   * (No backticks or dollar-braces in this half of the file: everything below
+   * buildIndex lives inside ONE template literal, so either would end the
+   * string mid-page and the error surfaces hundreds of lines away.)
+   *
+   * Assigning the hash pushes a history entry per module, so Back walks
+   * backwards through the fleet one module at a time instead of leaving the
+   * sheet — 95 presses to get out. The hash is here to make a finding
+   * SHAREABLE ("look at #sfz"), not to be a navigation stack.
+   */
+  history.replaceState(null, "", "#" + m.id);
+}
+
+/* A hash typed or pasted into an ALREADY-OPEN tab is a same-document change:
+ * no reload, so the load-time hash read below never runs again and the link
+ * silently does nothing. Which is the case that matters, because the link is
+ * shared to someone who already has the sheet open. */
+addEventListener("hashchange", () => {
+  const id = location.hash.slice(1);
+  const i = REPORT.modules.findIndex(m => m.id === id);
+  if (i >= 0 && i !== sel) { sel = i; render(); }
+});
+
+function mark(what) {
+  const id = REPORT.modules[sel].id;
+  marks[id] = marks[id] || {};
+  marks[id][what] = !marks[id][what];
+  saveMarks(); render();
+}
+function toggleInfo(){ showInfo = !showInfo; render(); }
+function esc(s){ return String(s).replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+
+addEventListener("keydown", e => {
+  if (e.target.tagName === "INPUT") return;
+  if (e.key === "]") { sel = Math.min(REPORT.modules.length - 1, sel + 1); render(); }
+  else if (e.key === "[") { sel = Math.max(0, sel - 1); render(); }
+  else if (e.key === "r") mark("done");
+  else if (e.key === "f") mark("flag");
+  else if (e.key === "i") toggleInfo();
+});
+
+const want = location.hash.slice(1);
+if (want) { const i = REPORT.modules.findIndex(m => m.id === want); if (i >= 0) sel = i; }
+render();
+</script>`;
+}

--- a/tools/param-pages/fake_device.mjs
+++ b/tools/param-pages/fake_device.mjs
@@ -44,8 +44,9 @@ export function moduleById(id) {
  * @param {string} o.id          module to load into the slot
  * @param {string} [o.prefix]    param prefix, default "synth"
  * @param {object} [o.initial]   key -> initial raw value
+ * @param {boolean} [o.serveLists] answer the RUNTIME list params (see below)
  */
-export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
+export function createFakeDevice({ id, prefix = "synth", initial = {}, serveLists = false } = {}) {
     let mod = moduleById(id);
     const store = Object.create(null);
     const reads = [];
@@ -112,6 +113,45 @@ export function createFakeDevice({ id, prefix = "synth", initial = {} } = {}) {
          * in the fleet implements is_loading, so a test can turn it off and
          * prove the behaviour under test does not secretly depend on it. */
         if (bare === "is_loading") return servesIsLoading ? (loading ? "1" : "0") : "";
+
+        /*
+         * RUNTIME LISTS, opt-in.
+         *
+         * A preset browser's contents never come from the contract — they come
+         * from the loaded plugin at runtime, so an unserved one draws a page
+         * with a "--" where the name goes and nothing else. That empty frame is
+         * indistinguishable from a module whose preset page is genuinely
+         * broken, which is worse than not drawing it: an audit that invents a
+         * defect costs more than one that omits a page.
+         *
+         * The capture knows the param NAMES and the COUNT (dump_contracts
+         * records both, and deliberately not the names — minijv has 2427 and
+         * serves them one at a time). That is enough to draw the real chrome:
+         * the count drives the scrollbar and the index, and a synthetic name
+         * fills the row. The names are as fake as every value here; the
+         * LAYOUT is the device's.
+         *
+         * Off by default so no existing test's read counts move.
+         */
+        if (serveLists && mod.presets) {
+            const ps = mod.presets;
+            if (bare === ps.count_param) return String(ps.count || 0);
+            if (bare === ps.list_param && store[bare] === undefined) return "0";
+            if (ps.name_param && bare === ps.name_param) {
+                const idx = parseInt(store[ps.list_param] ?? "0", 10) || 0;
+                const names = ps.names;
+                return Array.isArray(names) && names[idx] !== undefined
+                    ? String(names[idx])
+                    : `Preset ${String(idx + 1).padStart(3, "0")}`;
+            }
+        }
+        if (serveLists && bare.endsWith("_items")) {
+            /* An items page reads a JSON array of {index,label}. Nothing in the
+             * capture records one, so this is shape-only: enough rows to show
+             * the list's scrolling and truncation behaviour. */
+            return JSON.stringify(Array.from({ length: 12 },
+                (_, i) => ({ index: i, label: `Item ${i + 1}` })));
+        }
 
         /* A lagging param serves its stale value for a few reads — this is the
          * race that makes write-back suppression necessary rather than tidy. */

--- a/tools/param-pages/fake_values.mjs
+++ b/tools/param-pages/fake_values.mjs
@@ -1,0 +1,34 @@
+/**
+ * fake_values.mjs — deterministic stand-in readings for a page nobody has read.
+ *
+ * A preview has no device, so every widget still needs *something* to point at.
+ * These are synthesised: enough to judge a LAYOUT, never enough to judge a
+ * patch. Deterministic per key, so the same module renders identically on every
+ * run and a diff between two runs means the drawing changed rather than the
+ * dice.
+ *
+ * Lives here rather than in preview.mjs because the audit sheet renders the
+ * same pages and would otherwise have its own copy — and two value generators
+ * means the audit's picture of a cell is not the picture preview.mjs shows for
+ * the same cell, which is exactly the drift that makes a reviewer distrust
+ * both. One generator, one picture.
+ *
+ * Node-only. Nothing here ships to the device.
+ */
+
+/**
+ * @param {string} key   the param key, the only entropy source
+ * @param {object} meta  from metaIndex.getOrGuess(key), or null
+ * @returns {string} a wire-format value, as a plugin would report it
+ */
+export function fakeValue(key, meta) {
+    let h = 0;
+    for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
+    const t = (h % 1000) / 1000;
+    if (!meta) return String(t.toFixed(3));
+    if (meta.kind === "opaque") return "/data/UserData/Samples/kick_01.wav";
+    const min = typeof meta.min === "number" ? meta.min : 0;
+    const max = typeof meta.max === "number" ? meta.max : 1;
+    const v = min + (max - min) * t;
+    return meta.type === "int" || meta.type === "enum" ? String(Math.round(v)) : v.toFixed(3);
+}

--- a/tools/param-pages/preview.mjs
+++ b/tools/param-pages/preview.mjs
@@ -49,6 +49,7 @@ import { createController, LAYOUT_LIST } from "../../src/shared/param_pages/page
 import { resolveViz } from "../../src/shared/param_pages/viz.mjs";
 import { createFakeDevice } from "./fake_device.mjs";
 import { makeRecord, presetRowValue } from "../../src/shared/param_pages/current_preset.mjs";
+import { fakeValue } from "./fake_values.mjs";
 
 const ROOT = path.dirname(path.dirname(path.dirname(fileURLToPath(import.meta.url))));
 const FIXTURE = path.join(ROOT, "tests", "fixtures", "module-contracts.json");
@@ -82,18 +83,6 @@ if (!mod) {
     process.exit(2);
 }
 
-/* Deterministic pseudo-values so a page looks alive and reruns identically. */
-function fakeValue(key, meta) {
-    let h = 0;
-    for (let i = 0; i < key.length; i++) h = (h * 31 + key.charCodeAt(i)) >>> 0;
-    const t = (h % 1000) / 1000;
-    if (!meta) return String(t.toFixed(3));
-    if (meta.kind === "opaque") return "/data/UserData/Samples/kick_01.wav";
-    const min = typeof meta.min === "number" ? meta.min : 0;
-    const max = typeof meta.max === "number" ? meta.max : 1;
-    const v = min + (max - min) * t;
-    return meta.type === "int" || meta.type === "enum" ? String(Math.round(v)) : v.toFixed(3);
-}
 
 /*
  * A representative "My Presets" / "Module" trailing set — same shape

--- a/tools/param-pages/provision_assets.sh
+++ b/tools/param-pages/provision_assets.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# provision_assets.sh — push module assets from your machine to the Move, so a
+# contract dump captures each module LOADED rather than cold.
+#
+#   tools/param-pages/provision_assets.sh --dry-run     # default: show, do nothing
+#   tools/param-pages/provision_assets.sh --go
+#   tools/param-pages/provision_assets.sh --go sf2      # one module
+#
+# Reads tools/param-pages/assets.local.json (gitignored — copy assets.example.json).
+#
+# WHY. An asset-driven module declares a different contract depending on what it
+# has loaded. sf2 with an empty soundfonts/ directory declares three parameters,
+# and the audit sheet draws exactly that — indistinguishable, in a picture, from
+# a module whose UI is broken. The fix is not a harness change: the Node harness
+# never runs the DSP, it renders a captured contract. The assets have to be on
+# the DEVICE before dump_contracts_device.js reads it.
+#
+# The assets NEVER pass through the repo. They go from wherever they live on
+# your machine to the device, and tests/host/test_no_bundled_assets.sh fails the
+# build if one ever appears in the tree.
+#
+# DRY RUN IS THE DEFAULT, deliberately. This writes into a live device's module
+# tree and some of these files are hundreds of megabytes over scp; seeing the
+# plan before it runs costs one command and has saved this repo from worse.
+
+cd "$(dirname "$0")/../.."
+
+MAP="tools/param-pages/assets.local.json"
+DEVICE="${SCHWUNG_DEVICE:-ableton@move.local}"
+GO=0
+ONLY=""
+
+for a in "$@"; do
+  case "$a" in
+    --go) GO=1 ;;
+    --dry-run) GO=0 ;;
+    --*) echo "unknown option: $a" >&2; exit 2 ;;
+    *) ONLY="$a" ;;
+  esac
+done
+
+if [ ! -f "$MAP" ]; then
+  echo "no $MAP" >&2
+  echo "  copy tools/param-pages/assets.example.json to it and fill in your paths." >&2
+  echo "  it is gitignored: the assets themselves never enter this repo." >&2
+  exit 2
+fi
+
+# Parsed with node rather than jq: node is already required by every other tool
+# in this directory, jq is not, and a missing jq would fail here as "no such
+# module" rather than as "install jq".
+plan=$(node -e '
+const fs = require("fs");
+const map = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+const only = process.argv[2] || "";
+const root = map.device_module_root;
+for (const [id, m] of Object.entries(map.modules || {})) {
+  if (only && id !== only) continue;
+  for (const f of (m.files || [])) {
+    if (!f || f.startsWith("/path/to/")) continue;   /* untouched template row */
+    console.log([id, root + "/" + m.device_dir, f].join("\t"));
+  }
+}
+' "$MAP" "$ONLY")
+
+if [ -z "$plan" ]; then
+  echo "nothing to push${ONLY:+ for $ONLY} — every files[] entry is empty or still a template path"
+  exit 0
+fi
+
+missing=0
+total=0
+echo "device: $DEVICE"
+echo
+printf '%-10s %-46s %10s  %s\n' MODULE DEST SIZE SOURCE
+while IFS=$'\t' read -r id dest src; do
+  if [ ! -e "$src" ]; then
+    printf '%-10s %-46s %10s  %s\n' "$id" "$dest" "MISSING" "$src"
+    missing=1
+    continue
+  fi
+  bytes=$(du -sk "$src" | cut -f1)
+  total=$((total + bytes))
+  printf '%-10s %-46s %9sM  %s\n' "$id" "$dest" "$((bytes / 1024))" "$(basename "$src")"
+done <<< "$plan"
+echo
+echo "total: $((total / 1024)) MB"
+
+if [ "$missing" -ne 0 ]; then
+  echo "FAIL: a source path does not exist — fix $MAP before pushing" >&2
+  exit 1
+fi
+
+if [ "$GO" -ne 1 ]; then
+  echo
+  echo "dry run. re-run with --go to push."
+  exit 0
+fi
+
+# Device free space is checked before writing, not after failing. The root FS is
+# usually 100% full; /data is the only place with room, and these files are big
+# enough to fill even that if nobody looks.
+avail=$(ssh "$DEVICE" "df -k /data/UserData | tail -n 1 | awk '{print \$4}'")
+if [ -n "$avail" ] && [ "$avail" -lt "$((total + 262144))" ]; then
+  echo "FAIL: device has $((avail / 1024)) MB free on /data, pushing $((total / 1024)) MB" >&2
+  exit 1
+fi
+
+while IFS=$'\t' read -r id dest src; do
+  echo "==> $id: $(basename "$src")"
+  ssh "$DEVICE" "mkdir -p '$dest'"
+  scp -r "$src" "$DEVICE:$dest/"
+done <<< "$plan"
+
+echo
+echo "pushed. now re-capture the contracts so the audit sees the loaded state:"
+echo "  see tools/param-pages/dump_contracts_device.js"


### PR DESCRIPTION
Renders all 759 pages across the 95 fleet modules and puts them behind one page, one module at a time, with the existing contract findings attached and reviewed/flagged marks that persist.

    node tools/param-pages/audit_sheet.mjs              # whole fleet -> out/audit/
    node tools/param-pages/audit_sheet.mjs obxd minijv  # just these
    node tools/param-pages/audit_sheet.mjs --cat audio_fx
    node tools/param-pages/audit_sheet.mjs --json       # report only, CI-able
    node tools/param-pages/audit_sheet.mjs --fixture PATH

4.6 s for the fleet, 5.3 MB of PNGs (gitignored — regenerate, do not commit).

### The pictures are the device's

Grid pages go through `renderPageMovy`; every other page kind is driven through the real controller against a fake device serving that module's own contract. `widgetKindFor()` is **extracted from** `drawKnobWidget` rather than restated beside it, and `drawKnobWidget` now switches on it — a sheet whose job is catching a parameter drawn as the wrong type must not be reading its own copy of the rules. Pixel-neutral: `widget_sheet --check` passes unchanged.

### Only two new findings

Both need a framebuffer; everything else is carried through from `validate_contract` rather than given a second spelling.

- **`clipped`** — drawing outside 128x64, which is silent by construction (the master-FX diagram drew nine boxes into a five-box row with no error). Zero across the fleet, and the probe is mutation-tested so that zero means something.
- **`guessed-meta`** — a cell whose metadata was invented. Invisible in the picture, because it draws as an ordinary knob.

A squeezed label is reported **on the cell, never as a finding**: it fires on 597 of 759 pages and would bury the 35 findings that need a decision.

### What it found on the current fixture

35 non-info findings. `sfz` draws eight identical unlabelled `KNOB 0..7` dials on its Main page, every one invented metadata; `clap` has two; `osirus` and `sfz` each declare a knob with `max <= min`; `forge`, `aphex`, `signal` and `euclidrum` put characters in labels the 5x7 atlas cannot draw.

### Testing

`tests/host/test_audit_sheet.sh` pins both render-time probes by **mutation** rather than by running green, plus the `widgetKindFor` call site and full fleet/page coverage. The guessed-meta probe caught itself during development by picking a victim that lived on a preset page and reporting a false green.

193/193 host tests pass; C units pass.

### Note

The fixture is from 2026-08-22 and predates the child-key, LFO-grouping and two-option-enum work. The planner and renderers are current; each module's declared contract may not be. Every run prints its provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhFJbKhSQonAzL4SbTsN9v