### PR TITLE
Drop the [User Presets] row from the module swap list

### DIFF
--- a/docs/SHADOW_UI.md
+++ b/docs/SHADOW_UI.md
@@ -160,7 +160,7 @@ how long these two modules take to answer.
 
 ### User Presets
 
-Per-component preset snapshots for any chain module (synth, audio FX, or MIDI FX). Reached from a component's module-swap list in the shadow UI — an indented `[User Presets]` row tucked under the loaded module, or the component's own knob-grid "My Presets" page's `Load…` action. A preset captures that component's opaque `<prefix>:state` blob (`synth` / `fx1`..`fx4` / `midi_fx1`) — the same string slot autosave and chain patches use — saved to `/data/UserData/schwung/presets/<module-id>/<name>.json`. Keyed by **module id**, so a preset saved on a module in one slot is offered wherever that module is loaded (cross-slot reuse).
+Per-component preset snapshots for any chain module (synth, audio FX, or MIDI FX). Reached from the component's own knob-grid **"My Presets"** page — its `Preset` row / `Load…` action. That is the only door: the module-swap list used to carry an indented `[User Presets]` row as a second one, and it was removed once My Presets became a page on the component itself. A swap list is for swapping, and the presets now sit one jog from the controls they belong to, beside the Save / Save As / Delete that were already there. A preset captures that component's opaque `<prefix>:state` blob (`synth` / `fx1`..`fx4` / `midi_fx1`) — the same string slot autosave and chain patches use — saved to `/data/UserData/schwung/presets/<module-id>/<name>.json`. Keyed by **module id**, so a preset saved on a module in one slot is offered wherever that module is loaded (cross-slot reuse).
 
 **The browser is exactly ONE thing: choose a preset.** Picking a row LOADS it
 immediately and commits — there is no per-preset Load/Delete detail screen.
@@ -186,9 +186,9 @@ A committed Load, or a completed Delete (still reached exclusively from the
 grid's My Presets page, via `enterPresetDeleteConfirm` — the SAME
 confirm-delete screen as before, just with no detail screen left in front of
 it), both exit through `VIEWS.CHAIN_EDIT`. `maybeReturnToComponentGrid` (see
-below) is what routes a grid-driven arrival back onto the My Presets page
-specifically, by NAME; a `[User Presets]`-row arrival (no grid open) lands
-plainly on the chain editor, as it always did.
+below) is what routes the arrival back onto the My Presets page
+specifically, by NAME, and falls through to the plain chain editor when the
+position no longer holds a module to show one for (Remove Module).
 
 ### Every component's knob grid ends with two pages it never declared
 
@@ -256,9 +256,9 @@ plan — the same rule as "a plan is a statement about what a module declares",
 under "A param read has THREE answers" in `CLAUDE.md`.
 
 **Scope is exactly the 4 chain slots' real components.** Master FX chain
-components are excluded — `__user_presets__` is injected in
-`enterComponentSelect` only, so Master FX has no user presets today and this
-inherits that gap rather than widening it. Slot Settings and Master FX
+components are excluded — user presets have only ever been offered for the 4
+chain slots' components, never for a Master FX position, so this inherits that
+gap rather than widening it. Slot Settings and Master FX
 Settings are excluded because they are settings, not modules: no module id to
 key a preset folder on, nothing to swap. The exclusion lives in ONE helper,
 `componentParamPagesIo` in `src/shadow/shadow_ui.js`, called from every

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1965,10 +1965,10 @@ function paramPagesChromeFor(componentKey) {
  * ONE helper, called from every enterParamPages site that opens a chain
  * component (as opposed to a synthesised contract like Slot Settings or
  * Global Settings, which supply their own io and never reach here). Master FX
- * is excluded HERE rather than remembered at each call site: __user_presets__
- * is injected in enterComponentSelect only, never in enterMasterFxModuleSelect,
- * so Master FX has no user presets today and this inherits that gap rather
- * than widening it. masterFxIndexFromComponentKey is the same test
+ * is excluded HERE rather than remembered at each call site: user presets have
+ * only ever been offered for the four chain slots' components, never for a
+ * Master FX position, so this inherits that gap rather than widening it.
+ * masterFxIndexFromComponentKey is the same test
  * paramPagesChromeFor already uses to tell the two chains apart.
  *
  * `setParam` marks the write PENDING for the debounced `*` refresh
@@ -10274,34 +10274,23 @@ function enterComponentSelect(slotIndex, componentIndex) {
     /* Scan for available modules of this type */
     availableModules = scanModulesForType(comp.key);
 
-    /* Surface this component's User Presets manager (see shadow_ui_presets.mjs)
-     * as an indented row tucked directly beneath the loaded module — for any
-     * loaded chain component (synth, audio FX, MIDI FX). It rides alongside the
-     * module it belongs to (rather than at the top of the swap list) so the
-     * picker reads "<loaded module> / its presets" in place. Only shown when a
-     * module is loaded, since a preset snapshots its <component>:state. */
-    let presetsRowIndex = -1;
-    {
-        const loaded = getChainComponentModule(chainConfigs[slotIndex], comp.key);
-        const loadedId = loaded && loaded.module;
-        if (loadedId) {
-            const presetsRow = {
-                id: "__user_presets__",
-                /* No module abbrev needed — the indented row sits directly
-                 * under the module it belongs to, so context is implicit. */
-                name: "  [User Presets]"
-            };
-            /* Slot it right under the loaded module's entry; if that module
-             * isn't in the scan list (e.g. uninstalled), fall back to the top. */
-            const loadedIdx = availableModules.findIndex(m => m.id === loadedId);
-            presetsRowIndex = loadedIdx >= 0 ? loadedIdx + 1 : 0;
-            availableModules.splice(presetsRowIndex, 0, presetsRow);
-        }
-    }
+    /* Where the loaded module sits in the scan list, or -1 if nothing is
+     * loaded (or the loaded module is no longer installed). The rows added
+     * below are tucked directly under it, and it is where the cursor starts.
+     *
+     * This list used to carry an indented `[User Presets]` row here too. It
+     * doesn't any more: User Presets is the component's own "My Presets"
+     * trailing page in the knob grid, one jog from the module's own controls,
+     * which is both nearer to the sound it belongs to and where Save / Save As
+     * / Delete already live. A swap list is for swapping. */
+    const loaded = getChainComponentModule(chainConfigs[slotIndex], comp.key);
+    const loadedId = loaded && loaded.module;
+    const loadedIdx = loadedId
+        ? availableModules.findIndex(m => m.id === loadedId)
+        : -1;
 
     /*
-     * Move Left / Move Right, tucked under the loaded module beside its
-     * presets.
+     * Move Left / Move Right, tucked under the loaded module.
      *
      * They exist so Shift+jog is not the ONLY way to reorder a chain: a
      * modifier gesture with no discoverable equivalent is a feature only the
@@ -10311,23 +10300,17 @@ function enterComponentSelect(slotIndex, componentIndex) {
      * why the synth has neither: it is not a list position, and the sections
      * either side of it are not the same kind of thing.
      */
-    availableModules.splice(presetsRowIndex >= 0 ? presetsRowIndex + 1 : 0, 0,
-        ...chainMoveEntries(chainConfigs[slotIndex], comp.key));
+    const moveEntries = chainMoveEntries(chainConfigs[slotIndex], comp.key);
+    availableModules.splice(loadedIdx >= 0 ? loadedIdx + 1 : 0, 0, ...moveEntries);
 
-    selectedModuleIndex = 0;
-
-    if (presetsRowIndex >= 0) {
-        /* A module is loaded — default the cursor to its presets row (entering
-         * here is usually to reach presets, not to swap modules). */
-        selectedModuleIndex = presetsRowIndex;
-    } else {
-        /* Nothing loaded — default the cursor to the current module if any. */
-        const current = getChainComponentModule(chainConfigs[slotIndex], comp.key);
-        if (current && current.module) {
-            const idx = availableModules.findIndex(m => m.id === current.module);
-            if (idx >= 0) selectedModuleIndex = idx;
-        }
-    }
+    /* Default the cursor to the loaded module — the list opens showing you
+     * what is there now, with the moves right beneath it.
+     *
+     * With no loaded module to sit on (an empty position, or one whose module
+     * has been uninstalled since) the moves went in at the top instead, so
+     * step PAST them: a list must never open with the cursor on "Move Left".
+     * moveEntries is empty for an unoccupied position, so that case is 0. */
+    selectedModuleIndex = loadedIdx >= 0 ? loadedIdx : moveEntries.length;
 
     setView(VIEWS.COMPONENT_SELECT);
     needsRedraw = true;
@@ -10351,14 +10334,6 @@ function applyComponentSelection() {
     /* Was this picker opened from a `+` box? Read BEFORE the choice is applied,
      * because applying it fills the very hole this recognises. */
     const pending = pendingChainInsertFor(slotChainTarget(selectedSlot), comp.key);
-
-    /* Check if user selected this component's User Presets manager */
-    if (selected && selected.id === "__user_presets__") {
-        const loaded = getChainComponentModule(chainConfigs[selectedSlot], comp.key);
-        enterPresetBrowser(selectedSlot, comp.key, loaded && loaded.module,
-                           getComponentParamPrefix(comp.key));
-        return;
-    }
 
     /* Check if user selected "[Get more...]" - enter store picker */
     if (selected && selected.id === "__get_more__") {

--- a/src/shadow/shadow_ui_presets.mjs
+++ b/src/shadow/shadow_ui_presets.mjs
@@ -41,16 +41,16 @@
  * current] if i load without saving" — the verbs had moved to the grid page
  * but the browser still offered its own copies.
  *
- * Entry points: Shift+Click any loaded chain component (synth / FX / MIDI FX)
- * -> module picker -> "[User Presets]" (indented row tucked just beneath the
- * loaded module; injected in enterComponentSelect as the __user_presets__
- * synthetic entry and cursor-defaulted there, routed from
- * applyComponentSelection with the component key + DSP prefix + module id) --
- * AND the knob grid's "My Presets" page's "Load…" action, which reaches
- * enterPresetBrowser directly. Either way, picking a row here loads it and
- * returns to the chain editor; maybeReturnToComponentGrid in shadow_ui.js
- * is what routes that arrival back onto the My Presets page for the
- * grid-driven flow (see its own note on the restorePageName it uses).
+ * Entry point: the component's knob-grid "My Presets" page — its Preset row
+ * (and the equivalent "Load…" action), which reaches enterPresetBrowser
+ * directly. That is now the ONLY way in. The module picker used to carry an
+ * indented "[User Presets]" row as a second door; it was removed once My
+ * Presets became a page on the component itself, since a swap list is for
+ * swapping and the presets belong beside the module's own controls.
+ *
+ * Picking a row here loads it and returns to the chain editor;
+ * maybeReturnToComponentGrid in shadow_ui.js is what routes that arrival back
+ * onto the My Presets page (see its own note on the restorePageName it uses).
  *
  * State accessors come from the shared `ctx` (populated by shadow_ui.js); see
  * shadow_ui_ctx.mjs. As with the other view modules, only touch ctx.* inside
@@ -686,10 +686,10 @@ export function handlePresetsSelect() {
      * click does nothing, and NOTHING is announced. Reported from hardware
      * once already for the old save row ("when I choose save, simply nothing
      * happens") — the state is contradictory and worth saying so: this screen
-     * is only reachable through a [User Presets] row, or the grid's Load…
-     * action, that are shown ONLY when the same lookup found a module, so
-     * arriving here without one means the config changed underneath us
-     * between building the picker and this click.
+     * is only reachable through the grid's My Presets page, which is planned
+     * ONLY when the same lookup found a module, so arriving here without one
+     * means the config changed underneath us between building that page and
+     * this click.
      */
     if (!presetModule) {
         announce("No module in this slot");
@@ -714,9 +714,9 @@ export function handlePresetsSelect() {
         announce(`Loaded ${entry.name}`);
         /* CHAIN_EDIT is the convergence point every hand-off from the grid's
          * My Presets page returns through — maybeReturnToComponentGrid (in
-         * shadow_ui.js) is what routes a grid-driven arrival back onto that
-         * page specifically; a [User Presets]-row arrival (no grid open)
-         * lands plainly on the chain editor, as it always has. */
+         * shadow_ui.js) is what routes the arrival back onto that page
+         * specifically, and falls through to the plain chain editor when the
+         * position no longer holds a module to show. */
         setView(VIEWS.CHAIN_EDIT);
     }
     ctx.needsRedraw = true;
@@ -754,9 +754,10 @@ export function handlePresetDetailSelect() {
 
 export function handlePresetsBack() {
     const { setView, VIEWS } = ctx;
-    /* Entered from the module picker (Shift+Click on the synth block) or the
-     * grid's Load… action; Back cancels the whole flow — revert any active
-     * audition to the original sound — and exits to the chain editor. */
+    /* Entered from the grid's My Presets page; Back cancels the whole flow —
+     * revert any active audition to the original sound — and exits through
+     * the chain editor (maybeReturnToComponentGrid routes it back to the
+     * page it came from). */
     revertToOriginal();
     setView(VIEWS.CHAIN_EDIT);
     announce("Chain Editor");


### PR DESCRIPTION
User Presets is now the **My Presets** page at the end of every loaded component's knob grid — one jog from that module's own controls, beside the Save / Save As / Delete that were already there. The module picker's indented `[User Presets]` row was the older door to the same browser, and a swap list is for swapping.

- Picker loses the synthetic `__user_presets__` entry and its branch in `applyComponentSelection`.
- What was anchored to that row moves onto the loaded module: **Move Left / Move Right** tuck under the module, and the cursor opens **on the loaded module** rather than on its presets.
- Nothing loaded (or the loaded module uninstalled since) puts the moves at the top, so the cursor steps past them — a list must not open on "Move Left". `moveEntries` is empty for an unoccupied position, so an empty slot opens on the first real row exactly as before.
- `enterPresetBrowser` keeps its one remaining call site (the grid's My Presets page), so the browser, its audition and its return-to-grid routing are unchanged.

Docs: `docs/SHADOW_UI.md` User Presets section rewritten to the single door; the manual's "Module presets" section is updated in `../schwung-catalog-site` (separate repo, uncommitted).

Tests: `make -C tests/host test` + all `tests/host/*.sh` green.

Not yet verified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QDzEvKRCa5uv2zLreUYewP