### PR TITLE
Built-in modules: short_name for the knob grid

### DIFF
--- a/src/modules/audio_fx/freeverb/module.json
+++ b/src/modules/audio_fx/freeverb/module.json
@@ -17,6 +17,7 @@
           "params": [
             {
               "key": "room_size",
+              "short_name": "ROOM",
               "name": "Room Size",
               "type": "float",
               "min": 0.0,
@@ -28,6 +29,7 @@
             },
             {
               "key": "damping",
+              "short_name": "DAMP",
               "name": "Damping",
               "type": "float",
               "min": 0.0,

--- a/src/modules/midi_fx/chord/module.json
+++ b/src/modules/midi_fx/chord/module.json
@@ -14,6 +14,7 @@
           "params": [
             {
               "key": "type",
+              "short_name": "Chord",
               "options_as_string": true,
               "name": "Type",
               "type": "enum",
@@ -47,6 +48,7 @@
             },
             {
               "key": "strum_dir",
+              "short_name": "Dir",
               "options_as_string": true,
               "name": "Strum Dir",
               "type": "enum",

--- a/src/modules/midi_fx/velocity_scale/module.json
+++ b/src/modules/midi_fx/velocity_scale/module.json
@@ -14,6 +14,7 @@
           "params": [
             {
               "key": "min",
+              "short_name": "Min",
               "name": "Min",
               "type": "int",
               "min": 1,
@@ -23,6 +24,7 @@
             },
             {
               "key": "max",
+              "short_name": "Max",
               "name": "Max",
               "type": "int",
               "min": 1,
@@ -41,6 +43,7 @@
             },
             {
               "key": "curve_preset",
+              "short_name": "Preset",
               "options_as_string": true,
               "name": "Curve Preset",
               "type": "enum",

--- a/src/modules/sound_generators/linein/module.json
+++ b/src/modules/sound_generators/linein/module.json
@@ -27,6 +27,7 @@
             },
             {
               "key": "input_mode",
+              "short_name": "Input",
               "label": "Input Mode",
               "type": "enum",
               "options": ["Stereo", "Mono (L)", "Mono (R)"],
@@ -45,6 +46,7 @@
             },
             {
               "key": "output_trim",
+              "short_name": "Output",
               "label": "Output Trim",
               "type": "float",
               "min": -24,
@@ -63,6 +65,7 @@
             },
             {
               "key": "gate_amount",
+              "short_name": "GATEAM",
               "label": "Gate Amount",
               "type": "float",
               "min": 0,
@@ -166,6 +169,7 @@
           "params": [
             {
               "key": "cable_comp",
+              "short_name": "Comp",
               "label": "Cable Comp",
               "type": "enum",
               "options": ["Off", "Low", "Med", "High"],
@@ -173,6 +177,7 @@
             },
             {
               "key": "soft_clip",
+              "short_name": "Clip",
               "label": "Soft Clip",
               "type": "enum",
               "options": ["Off", "On"],
@@ -193,6 +198,7 @@
             },
             {
               "key": "subsonic_freq",
+              "short_name": "Filter",
               "label": "Sub Filter",
               "type": "enum",
               "options": ["10 Hz", "15 Hz", "20 Hz", "30 Hz", "40 Hz"],
@@ -200,6 +206,7 @@
             },
             {
               "key": "hum_notch",
+              "short_name": "Notch",
               "label": "Hum Notch",
               "type": "enum",
               "options": ["Off", "On"],
@@ -207,6 +214,7 @@
             },
             {
               "key": "hum_freq",
+              "short_name": "Freq",
               "label": "Hum Freq",
               "type": "enum",
               "options": ["50 Hz", "60 Hz"],
@@ -220,6 +228,7 @@
           "params": [
             {
               "key": "hum_filter",
+              "short_name": "Filter",
               "label": "Hum Filter",
               "type": "enum",
               "options": ["Off", "50 Hz", "60 Hz"],


### PR DESCRIPTION
Adds `short_name` to the four built-in modules' parameters, matching the fleet-wide pass now open as PRs on 31 external repos.

16 labels across `chord`, `freeverb`, `linein` and `velocity_scale`. Additive only; the full name still appears in the header, with the value, whenever a knob is touched.

All `tests/host` green locally.