### PR TITLE
catalog: correct default_branch for fork and noisemaker

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1031,7 +1031,7 @@
       "author": "andree182",
       "component_type": "midi_fx",
       "github_repo": "andree182/schwung-fork",
-      "default_branch": "master",
+      "default_branch": "main",
       "asset_name": "fork-module.tar.gz",
       "min_host_version": "0.8.8"
     },
@@ -1196,7 +1196,7 @@
       "author": "Patrick Kunz / TAL (engine) · port: legsmechanical",
       "component_type": "sound_generator",
       "github_repo": "legsmechanical/schwung-noisemaker",
-      "default_branch": "main",
+      "default_branch": "master",
       "asset_name": "noisemaker-module.tar.gz",
       "min_host_version": "0.11.0"
     },


### PR DESCRIPTION
Two catalog entries named a branch the repo does not use, so the manager's `release.json` fetch 404s:

| module | catalog | actual |
|---|---|---|
| `fork` | `master` | **`main`** |
| `noisemaker` | `main` | **`master`** |

`noisemaker` only installed because the 404 falls through to the `releases/latest/download/` fallback, which ignores `release.json` entirely — so its version, `name`, `description` and any `install_path` never reach the installer, and the update check has nothing to compare against. It looked healthy only because the fallback happened to be correct.

Found while auditing all 118 catalogued repos after a full install of the catalog. These were the only two branch mismatches.

## Verification
- `python3 -c "json.load(...)"` — catalog parses, still 122 modules
- `release.json` resolves HTTP 200 at both corrected branches
- `tests/store/*.sh` — both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWkTahHYHVVFdVCEooDDkB