### PR TITLE
chain: clear knob mappings on slot clear, not just LFOs/FX/synth

### DIFF
--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -909,6 +909,24 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
         memset(inst->lfos, 0, sizeof(inst->lfos));
         memset(inst->lfo_base_values, 0, sizeof(inst->lfo_base_values));
         memset(inst->lfo_base_valid, 0, sizeof(inst->lfo_base_valid));
+        /*
+         * Knob mappings go too, for the identical reason the LFOs do: they
+         * are per-SLOT state, not per-module, so unloading everything they
+         * could point at used to leave a mapping "assigned" to a component
+         * that no longer exists.
+         *
+         * Reported from the device: a knob assigned to a param in one Set
+         * still read (and, if turned, still forwarded to whatever now
+         * occupies that position) after switching to an empty Set. Two-pass
+         * set switching only calls load_file when the new Set has SAVED
+         * slot state; an empty Set has none, so pass 2 never runs and this
+         * clear is the only reset the mapping gets. Loading a patch assigns
+         * the whole array from the patch (chain_patch.c, `memcpy(inst->
+         * knob_mappings, patch->knob_mappings, ...)`), so nothing a patch
+         * defines can be lost by clearing first.
+         */
+        memset(inst->knob_mappings, 0, sizeof(inst->knob_mappings));
+        inst->knob_mapping_count = 0;
         inst->current_patch = -1;
         inst->dirty = 0;
         malloc_trim(0);

--- a/tests/host/test_clear_resets_knob_mappings.sh
+++ b/tests/host/test_clear_resets_knob_mappings.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A slot `clear` must reset that slot's knob mappings — same defect class as
+# test_clear_resets_lfos.sh, same fix shape, one component later.
+#
+# Knob mappings are per-SLOT state, not per-module, so unloading the synth and
+# every FX used to leave a knob "assigned" to a component that no longer
+# exists. Two-pass set switching only calls load_file when the new Set has
+# SAVED slot state; an empty Set has none, so pass 2 never runs for that slot
+# and `clear` is the only reset a mapping gets. Reported from the device: a
+# knob assigned to a param in one Set still read as assigned (and, if turned,
+# still forwarded to whatever now occupied that position) after switching to
+# an empty Set.
+#
+# Zeroing is safe rather than lossy: loading a patch assigns the whole array
+# from the patch, so nothing a patch defines can be lost by clearing first.
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+f="src/modules/chain/dsp/chain_host.c"
+
+blk=$(awk '/strcmp\(key, "clear"\) == 0/,/malloc_trim\(0\)/' "$f")
+[ -n "$blk" ] || fail "the clear handler is gone from $f"
+
+command grep -q "memset(inst->knob_mappings, 0, sizeof(inst->knob_mappings))" <<<"$blk" || \
+  fail "clear does not reset inst->knob_mappings — a new set keeps the old set's knob assignments"
+command grep -q "inst->knob_mapping_count = 0;" <<<"$blk" || \
+  fail "clear does not reset knob_mapping_count — a stale mapping stays iterable after the reset"
+
+# It must clear AFTER the unloads, not before: a mapping's target is only
+# meaningless once the modules are gone, and ordering it first would be a
+# silent no-op the moment an unload path grows a knob-mapping write of its own.
+u=$(command grep -n "v2_unload_synth(inst)" <<<"$blk" | head -n 1 | cut -d: -f1)
+k=$(command grep -n "memset(inst->knob_mappings" <<<"$blk" | head -n 1 | cut -d: -f1)
+[ -n "$u" ] && [ -n "$k" ] && [ "$u" -lt "$k" ] || \
+  fail "the knob-mapping reset runs before the modules are unloaded"
+
+# And a patch load must still assign the whole array, which is what makes
+# zeroing safe. If that ever becomes a merge, clearing first LOSES settings.
+command grep -q "memcpy(inst->knob_mappings, patch->knob_mappings," src/modules/chain/dsp/chain_patch.c || \
+  fail "a patch load no longer assigns the knob_mappings array wholesale — clearing first is then lossy"
+
+echo "  ok  clear resets knob_mappings, after the unloads"
+echo "  ok  a patch load still assigns the array wholesale, so clearing first loses nothing"
+echo "PASS: a cleared slot carries no knob assignment into the next set"


### PR DESCRIPTION
## Summary

- A slot's `clear` verb (used by two-pass Set switching) already reset `synth`/FX/MIDI FX and, since a previous fix, the two LFOs — but never `inst->knob_mappings`.
- Two-pass set switching only calls `load_file` when the new Set has **saved** slot state. An empty Set has none, so `clear` is the *only* reset a knob mapping gets. Result: a knob assigned to a param in one Set kept reading as assigned (and, if turned, kept forwarding to whatever now occupied that position) after switching to an empty Set.
- This is the exact same defect class already fixed for LFOs in this same function (see the comment: *"when i created a new set, the LFO was still active and targeting the now empty synth slot"*) — `knob_mappings` just never got the matching treatment.
- Zeroing is safe rather than lossy: `v2_load_from_patch_info` already assigns the whole `knob_mappings` array wholesale from a loaded patch, so nothing a patch defines can be lost by clearing first.

## Test plan

- [x] Added `tests/host/test_clear_resets_knob_mappings.sh`, mirroring the existing `test_clear_resets_lfos.sh`: pins that the reset is present, ordered after the module unloads, and that a patch load still assigns the array wholesale (so clearing first stays non-lossy).
- [x] Full `tests/host/*.sh` suite run: no new failures vs. the pre-existing baseline on `main`.
- [x] Full ARM64 cross-compile build (`./scripts/build.sh`) succeeds.
- [x] Deployed to a real Move device; confirmed the process restarts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)