### PR TITLE
shadow_ui: Back from Knob Editor restores the grid, not the legacy list

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -17360,10 +17360,14 @@ function handleBack() {
             break;
         }
         case VIEWS.KNOB_EDITOR:
-            /* Return to chain settings */
-            setView(VIEWS.CHAIN_SETTINGS);
-            announce("Chain Settings");
-            needsRedraw = true;
+            /* Re-derive Slot Settings rather than hardcoding the legacy list
+             * view: enterChainSettings is the one place that gates grid vs.
+             * list (paramPagesEnabled()/param_view), and the grid is the
+             * DEFAULT entry into Slot Settings for virtually everyone (TTS
+             * off). Hardcoding VIEWS.CHAIN_SETTINGS here dropped every such
+             * user onto the list on the way back out, regardless of which
+             * one they actually came from. */
+            enterChainSettings(knobEditorSlot);
             break;
         case VIEWS.KNOB_PARAM_PICKER:
             if (knobParamPickerFolder !== null) {


### PR DESCRIPTION
## Summary

- Slot Settings' knob grid (`VIEWS.PARAM_PAGES`) is the default entry point for virtually every user (`paramPagesEnabled()` is true unless the screen reader is on), so Slot Settings → Knobs → Back almost always means "I was on the grid."
- The Knob Editor's Back handler hardcoded `setView(VIEWS.CHAIN_SETTINGS)` — the older, list-only settings screen — with no origin check, dropping the user onto the list regardless of which one they actually came from.
- `enterChainSettings(slot)` is the one place that already gates grid vs. list (the same `paramPagesEnabled()`/`param_view` check the component editor uses). Calling it instead of hardcoding the view re-derives the correct one every time, the same way every other re-entry into Slot Settings already does.

## Test plan

- [x] Full `tests/host/*.sh` suite run: no new failures vs. the pre-existing baseline on `main` (including `test_shadow_slot_actions.sh` and `test_shadow_param_editor_routing.sh`, which exercise `enterChainSettings`/`KNOB_EDITOR`).
- [x] Full ARM64 cross-compile build (`./scripts/build.sh`) succeeds.
- [x] Deployed to a real Move device; confirmed the process restarts cleanly.
- [x] Manual on-device check: with Param View = Knobs (default) and screen reader off, open Slot Settings (lands on the grid) → Knobs → Back, confirm it returns to the grid rather than the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)