### PR TITLE
module-catalog: add CW-78 (Roland CR-78 CompuRhythm)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1357,6 +1357,17 @@
       "min_host_version": "0.12.1"
     },
     {
+      "id": "cw78",
+      "name": "CW-78",
+      "description": "Roland CR-78 style drum machine. Fourteen voices, all synthesized, no samples — every one a circuit model built from the 1979 service notes and held to Roland's own factory alignment table. The machine's 34 preset rhythms ship with it, transcribed from the same document, transport-synced with the A/B variation lever live on all seventeen style buttons. Decay is loop gain on the kick, bongos, conga and snare shell rather than an envelope; one noise source feeds the hats, maracas, tambourine and the snare's snap as the hardware busses it. Seven distortion characters per voice and on the master, bit-exactly bypassed at zero; reverb and delay sends on every voice but the kick; one-knob bus compressor; CR-78-style remote web panel with the hardware's own rhythm buttons, Movy template.",
+      "author": "athousanddetails; every voice modelled from the Roland CR-78 service notes (June 1979), VG-11A voicing board",
+      "component_type": "sound_generator",
+      "github_repo": "athousanddetails/schwung-cw-78",
+      "default_branch": "main",
+      "asset_name": "cw78-module.tar.gz",
+      "min_host_version": "0.12.1"
+    },
+    {
       "id": "forgetful",
       "name": "Forgetful",
       "description": "One live input sent by hand into four tape memories, each one already forgetting itself — drifting out of tune, breaking up, until it's gone",


### PR DESCRIPTION
Adds **CW-78** to the catalog — a Roland CR-78 for the Move, fourth in the athousanddetails drum-machine family (9W9 / 6W6 / 8W8).

- Fourteen voices, all synthesized, no samples — every one a circuit model built from the 1979 CR-78 service notes and held to Roland's own factory alignment table (page 30 of that document gives per-voice frequency and decay; `voice_check` in the repo asserts every lane against it).
- The machine's **34 preset rhythms** ship with it, transcribed from the service notes' own notation, transport-synced.
- Same shell as the siblings so the kits feel identical under the hands: seven distortion characters (bit-exact bypass at zero), reverb/delay sends, one-knob comp, pad editor, remote web panel, Movy template. No voice DSP shared with any of them.

Repo: https://github.com/athousanddetails/schwung-cw-78
Release: [v1.0.0](https://github.com/athousanddetails/schwung-cw-78/releases/tag/v1.0.0) with `cw78-module.tar.gz` built by CI (glibc 2.29, gated ≤ 2.35). `release.json` in the repo tracks the latest.
Verified on hardware: on-device loadtest passes, ~1.4 % of one core on a busy pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)