### PR TITLE
shim: Move's selected track follows a track long-press slot switch

### DIFF
--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -820,6 +820,11 @@ static uint8_t track_longpress_fired[4];
  * Once set, that track's long-press is suppressed for the remainder of the press,
  * so adjusting a track's volume never opens the shadow UI. Cleared on press/release. */
 static uint8_t track_vol_touched_during_press[4];
+/* Set when a track long-press fires and a synthetic tap has been injected to
+ * Move (see the fire site): the user's REAL release for that track is then
+ * swallowed, so Move never sees an orphan release for a press it already had
+ * closed. Cleared when the swallowed release goes by. */
+static uint8_t track_swallow_release[4];
 
 static struct timespec menu_press_time;
 static uint8_t menu_longpress_pending;
@@ -6296,7 +6301,34 @@ pre_done:
                     launch_shadow_ui_reset_backoff();
                     launch_shadow_ui();
                 }
-                shadow_log("Track long-press: opening slot settings");
+                /* Make MOVE's selected track follow the slot.
+                 *
+                 * Without this the long-press switches the shadow UI to slot i
+                 * while Move stays on the previous track — and with a HiJack
+                 * kit the pads play the SELECTED track's rack, so the editor
+                 * shows one module and the pads play another. The field
+                 * report: "it does change to slot 2 on schwung, but still
+                 * shows me the [old] pads".
+                 *
+                 * Move selects a track on a TAP (press+release inside its own
+                 * threshold); the 500 ms hold that got us here does not read
+                 * as one. So: close the real hold with a synthetic release,
+                 * then inject a crisp press+release pair — a tap Move cannot
+                 * mistake — and swallow the user's eventual real release so
+                 * Move is not handed a release for a press it never saw
+                 * open. Ring order is preserved by the MPSC writer, and the
+                 * drain feeds MIDI_IN after filtering, so the three packets
+                 * land in sequence. */
+                if (shadow_midi_inject_shm) {
+                    uint8_t cc = (uint8_t)(43 - i);   /* CC43=Track1 ... CC40=Track4 */
+                    uint8_t rel[4] = {0x0B, 0xB0, cc, 0};
+                    uint8_t prs[4] = {0x0B, 0xB0, cc, 127};
+                    shadow_midi_inject_push(shadow_midi_inject_shm, rel);
+                    shadow_midi_inject_push(shadow_midi_inject_shm, prs);
+                    shadow_midi_inject_push(shadow_midi_inject_shm, rel);
+                    track_swallow_release[i] = 1;
+                }
+                shadow_log("Track long-press: opening slot settings (Move track follows)");
             }
         }
         /* Menu button */
@@ -7422,7 +7454,20 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                     /* Long-press detection for Track buttons */
                     if (LONG_PRESS_ACTIVE() && shadow_ui_enabled) {
                         int lp_slot = 43 - d1;
+                        /* A fired long-press already closed this press for
+                         * Move with a synthetic release and tapped the track
+                         * on its behalf — the real release must not reach
+                         * Move on top of that. Same double-zero as the
+                         * Shift+Vol+Track block above: the shadow buffer is
+                         * what Move reads, src keeps the debug scan honest. */
+                        if (!pressed && track_swallow_release[lp_slot]) {
+                            track_swallow_release[lp_slot] = 0;
+                            uint8_t *sh = shadow + MIDI_IN_OFFSET;
+                            sh[j] = 0; sh[j+1] = 0; sh[j+2] = 0; sh[j+3] = 0;
+                            src[j] = 0; src[j+1] = 0; src[j+2] = 0; src[j+3] = 0;
+                        }
                         if (pressed) {
+                            track_swallow_release[lp_slot] = 0;
                             /* Start long-press timer */
                             clock_gettime(CLOCK_MONOTONIC, &track_press_time[lp_slot]);
                             track_longpress_pending[lp_slot] = 1;


### PR DESCRIPTION
## The report (from the device, v1.0)

> I am on Slot 1 in Schwung, and the pads are the respective ones. I long-press slot 2 — it does change to slot 2 on Schwung, but still shows me the past pads. To fix it, I have to first press the track button to change track, then long-press to enter that Schwung slot.

## Root cause

Long-pressing a Track button jumps the shadow UI to that slot, but **Move's own selected track stays where it was** — and the pads always play the *selected track's* instrument, so the editor shows one slot's module while the pads keep driving the previous track. Move selects a track on a **tap**; the 500 ms hold that fires the shadow switch doesn't read as one, so the pass-through press never selects.

## The fix

When the track long-press fires, the shim now:

1. closes the real hold with a synthetic release,
2. injects a crisp press+release pair through the existing MIDI-inject ring (`shadow_midi_inject_shm`) — a tap Move cannot mistake, so its selected track follows the slot,
3. swallows the user's eventual real release (same double-buffer zeroing the Shift+Vol+Track block already uses), so Move is never handed a release for a press it already saw closed.

46 lines, all in `schwung_shim.c`. Ring ordering is preserved by the MPSC writer and the drain feeds MIDI_IN after filtering, so the three packets land in sequence.

## Not touched

- Short tap still selects a track natively (press/release pass through as before).
- Track+Volume still adjusts track volume without opening the shadow UI (the existing sticky suppression is upstream of the fire site).
- Shift+Vol+Track keeps its existing behaviour (it blocks the CC entirely; if you want the track to follow there too, happy to extend — kept this PR to the reported gesture).

## Tested

On hardware: built from v1.0.0 + this patch, deployed to a Move, verified by the reporting user — long-press now switches slot **and** track in one gesture; tap, Track+Volume and Shift+Track behave as before. Also cross-compiled clean via `./scripts/build.sh` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)