### PR TITLE
ui: Back out of Global Settings returns to the Tool it was opened over

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -9135,15 +9135,65 @@ function cancelToolProcess() {
  */
 const GLOBAL_SETTINGS_COMPONENT = "global_settings";
 
+/*
+ * Where leaving Global Settings goes, when it is not "out of shadow mode".
+ *
+ * VIEWS.OVERTAKE_MODULE when Settings was opened OVER a foregrounded Tool,
+ * -1 otherwise. Captured on the way IN, because `view` is what distinguishes
+ * the two cases and enterParamPages overwrites it.
+ *
+ * NOT `overtakeModuleLoaded` on its own: hideToolOvertake parks a Tool with
+ * that flag still true (deliberately — it is how a re-launch detects the live
+ * session), so a Tool hidden behind the Tools menu would be restored by a
+ * Back the user aimed at Settings.
+ */
+let globalSettingsReturnView = -1;
+
+/*
+ * Leaving Global Settings hands the surface back to WHOEVER OWNS IT.
+ *
+ * `shadow_request_exit()` is one statement — `display_mode = 0` — and it gives
+ * the OLED to Move. That is right when Settings sits over the shadow UI, and
+ * wrong when a Tool is running: Shift+Vol+Step2 opens Settings straight over a
+ * live Tool (the JUMP_TO_SETTINGS branch does no overtake bookkeeping at all,
+ * unlike JUMP_TO_TOOLS beside it), so Back dropped the user on Move's
+ * instrument screen with the Tool still loaded and no way back to it but
+ * re-entering by hand (#339).
+ *
+ * Returning is only a view change: entering Settings never tore the Tool down,
+ * so its callbacks and page state are untouched and only its tick was gated on
+ * the view. The Tool is re-checked HERE rather than trusted from entry, since
+ * it can be exited from inside Settings.
+ *
+ * ONE helper, called by both exit sites, so a third cannot quietly exit past a
+ * running Tool again.
+ */
+function leaveGlobalSettings() {
+    const returnToTool = (globalSettingsReturnView === VIEWS.OVERTAKE_MODULE) &&
+                         overtakeModuleLoaded && overtakeModuleCallbacks;
+    globalSettingsReturnView = -1;
+    if (returnToTool) {
+        setView(VIEWS.OVERTAKE_MODULE);
+        needsRedraw = true;
+        return;
+    }
+    if (typeof shadow_request_exit === "function") shadow_request_exit();
+}
+
 function enterGlobalSettingsGrid(restorePageName) {
+    /* Captured BEFORE enterParamPages moves the view off the Tool. */
+    globalSettingsReturnView =
+        (view === VIEWS.OVERTAKE_MODULE && overtakeModuleLoaded && overtakeModuleCallbacks)
+            ? VIEWS.OVERTAKE_MODULE : -1;
     /* A fresh entry is not a return from a modal. Whatever hand-off was
      * outstanding has been served by getting here. */
     globalModalFromGrid = false;
     enterParamPages(0, GLOBAL_SETTINGS_COMPONENT, GLOBAL_SETTINGS_COMPONENT,
                     restorePageName || null, globalGridIoFor(),
                     /* No moduleKey: there is no module behind this contract to
-                     * abbreviate. Back leaves shadow mode, which is not a view,
-                     * so it is an onExit rather than a returnView. */
+                     * abbreviate. Back usually leaves shadow mode, which is not
+                     * a view, so it is an onExit rather than a returnView —
+                     * leaveGlobalSettings picks the destination. */
                     { label: "Global", name: "Settings",
                       /* PINNED TO THE LIST, whatever Param View says.
                        *
@@ -9158,9 +9208,7 @@ function enterGlobalSettingsGrid(restorePageName) {
                        * pin — their Volume, Mute and Solo really are
                        * performance controls. */
                       layout: LAYOUT_LIST,
-                      onExit: () => {
-                          if (typeof shadow_request_exit === "function") shadow_request_exit();
-                      } });
+                      onExit: () => { leaveGlobalSettings(); } });
     needsRedraw = true;
 }
 
@@ -17551,9 +17599,9 @@ function handleBack() {
                     const frame = helpNavStack[helpNavStack.length - 1];
                     announce(frame.title + ", " + frame.items[frame.selectedIndex].title);
                 }
-            } else if (typeof shadow_request_exit === "function") {
+            } else {
                 /* Nothing left on this view to back out of. */
-                shadow_request_exit();
+                leaveGlobalSettings();
             }
             break;
     }

--- a/tests/host/test_global_settings_back_restores_tool.sh
+++ b/tests/host/test_global_settings_back_restores_tool.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Back out of Global Settings must return to a Tool it was opened OVER (#339).
+#
+# `shadow_request_exit()` is one statement -- `display_mode = 0` -- and it hands
+# the OLED to Move. Global Settings called it unconditionally, from two places.
+# That is correct over the shadow UI and wrong over a running Tool:
+# Shift+Vol+Step2 opens Settings straight over one (the JUMP_TO_SETTINGS branch
+# does no overtake bookkeeping, unlike JUMP_TO_TOOLS beside it), so Back left
+# the user on Move's instrument screen with the Tool still loaded and no way
+# back but re-entering it by hand.
+#
+# shadow_ui.js is the QuickJS monolith -- it cannot be imported in a bare node
+# process, so this is a SOURCE-level contract, the same shape as
+# test_shutdown_prompt_suspends_overtake.sh next to it.
+#
+# What each assertion is protecting:
+#
+#   1. Both exits go through the one helper. A third exit site added later that
+#      calls shadow_request_exit directly reintroduces the bug for whatever
+#      path it serves, silently -- the symptom is indistinguishable from the
+#      old behaviour.
+#   2. The destination is latched on the way IN. `view` is the only thing that
+#      separates "Settings over a live Tool" from "Settings over the Tools
+#      menu", and enterParamPages overwrites it, so reading it at exit is too
+#      late.
+#   3. The latch is NOT overtakeModuleLoaded alone. hideToolOvertake parks a
+#      Tool with that flag deliberately left true, so a Tool sitting behind the
+#      Tools menu would be restored by a Back the user aimed at Settings.
+#   4. The Tool is re-checked at exit. It can be torn down from inside
+#      Settings, and restoring a view whose callbacks are gone draws a dead
+#      screen that still owns the OLED.
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+F=src/shadow/shadow_ui.js
+
+command -v node >/dev/null 2>&1 || fail "node is required"
+node --check "$F" || fail "$F does not parse"
+
+# ------------------------------------------------------------------ 1. one door
+helper_calls=$(command grep -c 'leaveGlobalSettings()' "$F" || true)
+[ "$helper_calls" -ge 3 ] \
+    || fail "expected the definition plus both exit sites to name leaveGlobalSettings, found $helper_calls"
+
+command grep -q 'onExit: () => { leaveGlobalSettings(); }' "$F" \
+    || fail "the Global Settings page chrome no longer exits through leaveGlobalSettings"
+
+# The Back handler for the view itself. Several `case VIEWS.GLOBAL_SETTINGS:`
+# arms exist (draw, jog, back) and the jog arm reads helpNavStack too, so the
+# discriminator is the POP -- only Back unwinds the stack. Deliberately not
+# keyed on leaveGlobalSettings: selecting the block by the thing under test
+# would pass vacuously the day the call is removed.
+back_case=$(awk '
+  /case VIEWS\.GLOBAL_SETTINGS:/ { inb = 1; buf = ""; next }
+  inb { buf = buf $0 "\n" }
+  inb && /^ +break;/ { if (buf ~ /helpNavStack\.pop\(\)/) { printf "%s", buf; exit } ; inb = 0 }
+' "$F")
+
+[ -n "$back_case" ] || fail "could not isolate the Global Settings Back handler"
+
+printf '%s' "$back_case" | command grep -q 'leaveGlobalSettings()' \
+    || fail "the Global Settings Back handler does not exit through leaveGlobalSettings"
+
+printf '%s' "$back_case" | command grep -q 'shadow_request_exit' \
+    && fail "the Global Settings Back handler still calls shadow_request_exit directly -- it exits past a running Tool"
+
+# ---------------------------------------------------------- 2/3. the latch shape
+helper=$(awk '/^function leaveGlobalSettings\(\)/ { inb = 1 } inb { print } inb && /^}/ && !/^function/ { if (seen) exit } inb { seen = 1 }' "$F")
+[ -n "$helper" ] || fail "could not isolate leaveGlobalSettings()"
+
+printf '%s' "$helper" | command grep -q 'globalSettingsReturnView === VIEWS.OVERTAKE_MODULE' \
+    || fail "leaveGlobalSettings does not branch on the latched return view"
+
+printf '%s' "$helper" | command grep -q 'setView(VIEWS.OVERTAKE_MODULE)' \
+    || fail "leaveGlobalSettings never restores the Tool view"
+
+# The latch is written before enterParamPages in the entry, not after.
+entry=$(awk '/^function enterGlobalSettingsGrid\(/ { inb = 1 } inb { print; if (/enterParamPages\(/) exit }' "$F")
+printf '%s' "$entry" | command grep -q 'globalSettingsReturnView' \
+    || fail "enterGlobalSettingsGrid does not latch the return view BEFORE enterParamPages moves the view"
+
+printf '%s' "$entry" | command grep -q 'view === VIEWS.OVERTAKE_MODULE' \
+    || fail "the latch does not read the view it was opened over -- overtakeModuleLoaded alone also matches a PARKED tool"
+
+# ------------------------------------------------------- 4. re-checked at exit
+printf '%s' "$helper" | command grep -q 'overtakeModuleLoaded' \
+    || fail "leaveGlobalSettings does not re-check that the Tool is still loaded"
+
+printf '%s' "$helper" | command grep -q 'overtakeModuleCallbacks' \
+    || fail "leaveGlobalSettings does not re-check the Tool's callbacks -- restoring a torn-down Tool draws a dead screen holding the OLED"
+
+# The latch must be cleared on BOTH paths, or a later Settings entry from the
+# shadow UI inherits a stale destination and refuses to leave shadow mode.
+clears=$(printf '%s' "$helper" | command grep -c 'globalSettingsReturnView = -1' || true)
+[ "$clears" -ge 1 ] || fail "leaveGlobalSettings never clears the latch"
+
+echo "PASS: leaving Global Settings returns to the Tool it was opened over"


### PR DESCRIPTION
Fixes #339.

## The bug

`shadow_request_exit()` is one statement — `display_mode = 0` — and it hands the
OLED back to Move. Global Settings called it **unconditionally, from two
places**: the page chrome's `onExit`, and the `case VIEWS.GLOBAL_SETTINGS` Back
handler's fallback.

That is right when Settings sits over the shadow UI. It is wrong when a Tool is
running, and Shift+Vol+Step2 opens Settings straight over a live one — the
`JUMP_TO_SETTINGS` branch does no overtake bookkeeping at all, unlike
`JUMP_TO_TOOLS` immediately beside it, which calls `completeOvertakeExit(true)`.
So Back dropped the user on Move's stock instrument screen with the Tool still
loaded and its DSP still running, exactly as reported.

The reporter's own guess was right: the Settings path bypasses the co-run
overlay and its exit restores the native display owner.

## The fix

Both exits go through one `leaveGlobalSettings()`, which returns to the Tool
when Settings was opened over one and exits shadow mode otherwise. Returning is
only a view change — entering Settings never tore the Tool down, so its
callbacks and page state are untouched and only its tick was gated on the view.
That satisfies "runtime/page/state preserved" without any save/restore.

Two details that are load-bearing:

**The destination is latched on the way IN.** `view` is the only thing that
separates "Settings over a live Tool" from "Settings over the Tools menu", and
`enterParamPages` overwrites it, so reading it at exit is too late.

**The latch is deliberately not `overtakeModuleLoaded` alone.** `hideToolOvertake`
parks a Tool with that flag still true — that is how a re-launch detects the
live session — so keying on it would restore a Tool sitting behind the Tools
menu on a Back the user aimed at Settings. The Tool is also re-checked at exit
rather than trusted from entry, since it can be exited from inside Settings, and
restoring a view whose callbacks are gone would draw a dead screen still holding
the OLED.

## Why not `shadow_corun_open("global_settings", ...)`

That overlay is for a tool that **opts in** by calling it, and it flips
`keep_mask` on the strength of a cede mask the tool declared. A tool that never
called `shadow_corun_begin_cede` has none, so forcing the overlay from the shim
shortcut would split input on an undefined mask. This change leaves the co-run
path completely untouched — a tool that opens Settings via `shadow_corun_open`
still returns through `shadow_corun_close` as before.

## Tests

`tests/host/test_global_settings_back_restores_tool.sh` — source-level contract,
same shape as `test_shutdown_prompt_suspends_overtake.sh` next to it, since
`shadow_ui.js` cannot be imported in a bare node process. It pins both exit
sites, the entry latch, and the two guards, and selects the Back handler by
`helpNavStack.pop()` rather than by the call under test so it cannot pass
vacuously. **Confirmed to fail against pre-fix HEAD** ("found 0").

`make -C tests/host test` plus all 203 `tests/host/*.sh` green.

## Verification status

Honest note: the reported gesture is **not drivable from software** — while a
Tool is up, injected MIDI is popped onto the module rather than reaching the
shim's shortcut detector, so the test bus cannot press Shift+Vol+Step2. The
root cause is confirmed by reading (`js_shadow_request_exit` is literally
`display_mode = 0`) and the fix is pinned by the contract test, but the
end-to-end gesture needs a human on the device. Being checked on hardware now;
I will follow up here with the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)