### PR TITLE
SysEx data packets of three zero bytes are silently dropped

### DIFF
--- a/src/host/shadow_midi_filter.c
+++ b/src/host/shadow_midi_filter.c
@@ -15,10 +15,44 @@ int shadow_midi_forwardable(uint8_t head, uint8_t status, uint8_t d1, uint8_t d2
     }
 
     /* SysEx (CIN 0x04-0x07): payload bytes are legitimately < 0x80, so the
-     * bit-7 rule cannot apply here.  Every real SysEx packet still carries at
-     * least one nonzero byte (F0, F7, or data), so an all-zero payload is a
-     * stale slot rather than a message. */
-    return (status || d1 || d2) ? 1 : 0;
+     * bit-7 rule cannot apply here.
+     *
+     * The previous rule was "at least one nonzero byte", on the reasoning that
+     * a real SysEx packet always carries an F0, an F7, or data.  THAT IS FALSE
+     * FOR CIN 0x04, and the exception is not rare: 0x04 is a three-byte
+     * continuation whose payload is arbitrary 7-bit data, so `00 00 00` is a
+     * zeroed parameter run — which is most of a patch dump.  Dropping it
+     * corrupts the message SILENTLY: framing still holds because F0 and F7
+     * both arrive in other packets, and the device's own checksum still
+     * validates, because Roland and Yamaha checksums are sums mod 128 and the
+     * removed bytes sum to zero.  The receiver gets a short, well-formed,
+     * checksum-valid, WRONG message.
+     *
+     * Observed on a Roland JV-880 patch dump: every area reply short by an
+     * exact multiple of 3, deterministic per patch, varying with patch
+     * CONTENT.  The 9-byte SysEx prefix is a multiple of 3, so data offset 0
+     * falls on a packet boundary — across 15 captured messages not one
+     * ALIGNED all-zero triplet survived, while 47 UNALIGNED ones did.
+     *
+     * The stale-slot protection is kept, and for three of the four CINs it is
+     * now STRONGER than the nonzero test it replaces.  USB-MIDI fixes the
+     * length of an end-packet, so its final byte MUST be F7:
+     *
+     *   0x04  three data bytes, no constraint  -> anything, including 00 00 00
+     *   0x05  ends with one byte               -> a status byte (F7, or a
+     *                                             single-byte system message)
+     *   0x06  ends with two bytes              -> d1 == F7
+     *   0x07  ends with three bytes            -> d2 == F7
+     *
+     * Only 0x04 loses protection, and only against a stale slot whose CIN
+     * nibble lands on exactly 0x04 with a zeroed payload. */
+    switch (cin) {
+    case 0x04: return 1;
+    case 0x05: return (status & 0x80) ? 1 : 0;
+    case 0x06: return (d1 == 0xF7) ? 1 : 0;
+    case 0x07: return (d2 == 0xF7) ? 1 : 0;
+    default:   return 0;
+    }
 }
 
 int shadow_midi_in_slot_empty(const uint8_t *slot)

--- a/src/schwung_host.c
+++ b/src/schwung_host.c
@@ -2490,7 +2490,33 @@ int main(int argc, char *argv[])
             unsigned char midi_2 = *(byte + 3);
 
 
-            if (byte[1] + byte[2] + byte[3] == 0)
+            /*
+             * Skip UNUSED ring slots — but never a SysEx data packet that
+             * happens to carry three zero bytes.
+             *
+             * The slot-empty test is the one above, on the header byte: an
+             * unused slot is all zeroes, so `mapped_memory[i] == 0` already
+             * catches it. This second test looks at CONTENT, and for every
+             * CIN except SysEx that is harmless, because no channel-voice or
+             * system-common message is three zero bytes.
+             *
+             * SysEx is the exception, and it is not a rare one. Its data is
+             * arbitrary 7-bit bytes, so `00 00 00` is ordinary payload — a
+             * zeroed parameter run in a patch dump, which is most of a patch
+             * dump. Dropping those packets corrupts the message SILENTLY:
+             * framing still holds (F0..F7 arrive), and a Roland or Yamaha
+             * checksum still validates, because the bytes removed sum to
+             * zero. The receiver sees a short but well-formed message.
+             *
+             * Found via a Roland JV-880 patch dump over cable 2, where every
+             * reply was short by an exact multiple of 3 with a valid checksum,
+             * deterministic per patch and varying with patch CONTENT. The
+             * 9-byte SysEx prefix is a multiple of 3, so data offset 0 falls
+             * on a packet boundary: across 15 captured messages not one
+             * ALIGNED all-zero triplet survived, while 47 UNALIGNED ones did.
+             */
+            if (!(code_index_number >= 0x04 && code_index_number <= 0x07) &&
+                byte[1] + byte[2] + byte[3] == 0)
             {
                 continue;
             }

--- a/tests/host/test_shadow_midi_filter.c
+++ b/tests/host/test_shadow_midi_filter.c
@@ -36,15 +36,44 @@ static void test_voice_messages(void) {
 }
 
 static void test_sysex_zero_payload_dropped(void) {
-    /* THE BUG: these are the events that flooded the overtake tools. */
-    CHECK(!shadow_midi_forwardable(0x04, 0x00, 0x00, 0x00),
-          "SysEx start CIN with all-zero payload is a stale slot");
+    /* The stale slots that flooded the overtake tools, still dropped — but by
+     * the END-BYTE rule now, not by "some byte is nonzero".  For 0x05-0x07
+     * that is STRICTLY STRONGER: a stale slot has to forge an F7 in exactly
+     * the right position to pass, where before any stray bit anywhere did. */
     CHECK(!shadow_midi_forwardable(0x05, 0x00, 0x00, 0x00),
           "SysEx 1-byte-end CIN with all-zero payload is a stale slot");
     CHECK(!shadow_midi_forwardable(0x06, 0x00, 0x00, 0x00),
           "SysEx 2-byte-end CIN with all-zero payload is a stale slot");
     CHECK(!shadow_midi_forwardable(0x07, 0x00, 0x00, 0x00),
           "SysEx 3-byte-end CIN with all-zero payload is a stale slot");
+    /* And the cases the old nonzero rule let through, which the end-byte rule
+     * now catches — protection GAINED, not merely preserved. */
+    CHECK(!shadow_midi_forwardable(0x06, 0x11, 0x22, 0x00),
+          "2-byte-end whose final byte is not F7 is stale");
+    CHECK(!shadow_midi_forwardable(0x07, 0x11, 0x22, 0x33),
+          "3-byte-end whose final byte is not F7 is stale");
+    CHECK(!shadow_midi_forwardable(0x05, 0x40, 0x00, 0x00),
+          "1-byte-end carrying a data byte rather than a status byte is stale");
+}
+
+static void test_sysex_continuation_of_zeros_is_real_data(void) {
+    /* THE 2026-08-30 BUG, and the reason the rule above is per-CIN.
+     *
+     * CIN 0x04 is a three-byte continuation of arbitrary 7-bit data, so
+     * `00 00 00` is ordinary payload — a zeroed parameter run, which is most
+     * of a patch dump.  Dropping it corrupts the message silently: framing
+     * survives (F0/F7 ride in other packets) and the device checksum still
+     * validates, because the removed bytes sum to zero.
+     *
+     * Found on a JV-880 patch dump — every area reply short by an exact
+     * multiple of 3, checksums valid, deterministic per patch, varying with
+     * patch content, and no ALIGNED all-zero triplet surviving anywhere in 15
+     * captured messages while 47 unaligned ones did. */
+    CHECK(shadow_midi_forwardable(0x04, 0x00, 0x00, 0x00),
+          "a SysEx continuation of three zero data bytes is REAL DATA and "
+          "must be forwarded — dropping it silently truncates patch dumps");
+    CHECK(shadow_midi_forwardable(0x24, 0x00, 0x00, 0x00),
+          "the same on cable 2, which is where external gear replies arrive");
 }
 
 static void test_real_sysex_still_forwarded(void) {
@@ -71,6 +100,7 @@ int main(void) {
     test_empty_slot_dropped();
     test_voice_messages();
     test_sysex_zero_payload_dropped();
+    test_sysex_continuation_of_zeros_is_real_data();
     test_real_sysex_still_forwarded();
     test_non_packet_cins_dropped();
 

--- a/tests/host/test_sysex_zero_packet_not_dropped.sh
+++ b/tests/host/test_sysex_zero_packet_not_dropped.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Source pin: the cable drain's zero-payload skip must EXEMPT SysEx CINs.
+#
+# The drain loop lives inside main() and reads mapped_memory directly, so there
+# is no seam to unit-test it through. This pin is the repo's usual answer to
+# that, and the invariant it protects is one that is SILENT when wrong.
+#
+# The empty-slot test is the header-byte one (`mapped_memory[i] == 0`). The
+# payload test that follows it is belt-and-braces, and for every CIN except
+# SysEx it is harmless: no channel-voice or system-common message is three
+# zero bytes. SysEx data is arbitrary 7-bit bytes, so `00 00 00` is ordinary
+# payload -- a zeroed parameter run, which is most of a patch dump.
+#
+# Dropping such a packet corrupts the message without any sign: framing still
+# holds and the device's own checksum still validates, because the removed
+# bytes sum to zero. A receiver gets a short, well-formed, wrong message.
+#
+# Two things are asserted, and the second is the one that regresses:
+#   1. the payload skip still exists (it is correct for non-SysEx);
+#   2. it is GUARDED by a SysEx-CIN exemption on the same condition.
+set -u
+
+ROOT="$(dirname "$0")/../.."
+HOST="$ROOT/src/schwung_host.c"
+
+fails=0
+note() { echo "FAIL: $1"; fails=$((fails + 1)); }
+
+[ -f "$HOST" ] || { echo "FAIL: $HOST not found"; exit 1; }
+
+# The condition, with whitespace collapsed, so reflowing the source is allowed.
+flat="$(tr '\n' ' ' < "$HOST" | tr -s ' ')"
+
+grep -q "byte\[1\] + byte\[2\] + byte\[3\] == 0" "$HOST" \
+  || note "the zero-payload slot skip is gone entirely; it is still correct for non-SysEx CINs"
+
+case "$flat" in
+  *"code_index_number >= 0x04 && code_index_number <= 0x07"*") &&"*"byte[1] + byte[2] + byte[3] == 0"*)
+    ;;
+  *)
+    note "the zero-payload skip is not exempted for SysEx CINs 0x04-0x07 -- a SysEx data packet of three zero bytes will be dropped, silently and with a valid checksum"
+    ;;
+esac
+
+if [ "$fails" -eq 0 ]; then echo "PASS: SysEx data packets are exempt from the zero-payload slot skip"; fi
+exit "$fails"


### PR DESCRIPTION
# SysEx data packets of three zero bytes are silently dropped

## The bug

`shadow_midi_forwardable()` (`src/host/shadow_midi_filter.c`) rejects a SysEx
packet whose three payload bytes are all zero:

```c
/* Every real SysEx packet still carries at least one nonzero byte
 * (F0, F7, or data), so an all-zero payload is a stale slot. */
return (status || d1 || d2) ? 1 : 0;
```

**That assumption does not hold for CIN `0x04`.** `0x04` is a three-byte
continuation whose payload is arbitrary 7-bit data, so `00 00 00` is ordinary
content — a zeroed parameter run, which is most of a patch dump. The packet is
dropped in `shadow_ui_midi_publish()` before it ever reaches the ring.

The guard exists for a real reason and is not simply removed here: stale slots
in the never-cleared hardware MIDI_IN buffer were reaching overtake tools at
~10/s (91,056 events in one 2.5 h log — the figure cited in
`test_shadow_midi_filter.c`). See "The change" for how that protection is kept.

## Why it matters

**The corruption is silent.** The packet is dropped mid-message, so framing
still holds (`F0`..`F7` both arrive) and the message parses. Worse, the
device's own checksum still validates: both Roland and Yamaha checksums are
sums mod 128, and the bytes removed sum to zero. A receiver gets a short,
well-formed, checksum-valid, wrong message.

It reaches both consumers — `onMidiMessageExternal` for tools and `mm_on_midi`
for chain slots — so any module reading SysEx is affected.

## How it was found

A Roland JV-880 patch dump over cable 2, pulled into an overtake editor. All
five area replies came back short, and the pattern identifies the cause:

| area | before | after fix | expected |
|---|---|---|---|
| patch common | 34 | 34 | 34 |
| tone 1 | 107 | **116** | 116 |
| tone 2 | 107 | **116** | 116 |
| tone 3 | 104 | **116** | 116 |
| tone 4 | 104 | **116** | 116 |
| **total** | 456 | **498** | **498** |

Before the fix, across two different patches:

- every shortfall an exact multiple of 3 — whole packets, not truncation
- every checksum valid — consistent only with the removed bytes summing to zero
- byte-for-byte identical across repeated pulls of the same patch
- varying with patch *content*, and one area losing nothing at all

The confirming test is falsifiable. The 9-byte SysEx prefix
(`F0 41 dev model cmd` + 4 address bytes) is a multiple of 3, so data offset 0
falls on a packet boundary. If this guard is the cause, **no surviving message
may contain an ALIGNED all-zero triplet.** Across 15 captured messages, zero
aligned triplets survived — while 47 UNALIGNED ones did. Zeros are abundant in
the data; they are absent only where a packet boundary would have exposed them.

## The change

The nonzero test becomes a per-CIN rule. USB-MIDI fixes the length of an
end-packet, so its final byte must be `F7` — a far stronger test than "some
byte is nonzero":

| CIN | meaning | rule | vs. before |
|---|---|---|---|
| `0x04` | 3 data bytes | anything, including `00 00 00` | **the fix** |
| `0x05` | ends with 1 byte | must be a status byte | stronger |
| `0x06` | ends with 2 bytes | `d1 == F7` | stronger |
| `0x07` | ends with 3 bytes | `d2 == F7` | stronger |

Only `0x04` loses protection, and only against a stale slot whose CIN nibble
lands on exactly `0x04` with a zeroed payload. The other three are now harder
to spoof than they were.

`tests/host/test_shadow_midi_filter.c` gains the continuation case and three
cases the old rule let through — it fails on the current filter with 5 checks,
so this is protection **gained**, not merely preserved.

## The same drop exists in `schwung_host.c`

This erroneous drop of an all-zero payload is also present in
`src/schwung_host.c`, whose cable drain skips any packet with three zero
payload bytes before dispatching to `onMidiMessageExternal` and `mm_on_midi`.
It is fixed here the same way, with a source pin, since it is the same defect.

**Treat that half as unverified.** The binary it builds is not a running
process on the device this was tested on, so installing it changed nothing
observable — the shadow path above is the one the hardware result comes from.
Happy to split it into its own PR if you would rather keep this one to the
change that is measured.

## Verification

Installed on a Move and re-pulled the same JV-880 patch, with the editor
module left untouched (`--skip-modules`) so the host was the only variable.
The result numbers above were predicted before the pull.

Also: `make -C tests/host test` passes, all 202 `tests/host/*.sh` pass, the
`schwung-manager` Go checks pass, and `./scripts/build.sh` produces a clean
aarch64 tarball.

## AI disclosure

Developed with Claude Code (Anthropic). No Grok.
