### PR TITLE
catalog: add Wayward

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1377,6 +1377,17 @@
       "default_branch": "main",
       "asset_name": "forgetful-module.tar.gz",
       "min_host_version": "0.12.1"
+    },
+    {
+      "id": "wayward",
+      "name": "Wayward",
+      "description": "Six loops recorded from the input, each keeping its own tempo, sliding out of alignment and back over minutes \u2014 tape phasing on eight knobs",
+      "author": "kliegsablaze",
+      "component_type": "audio_fx",
+      "github_repo": "kliegsablaze/wayward",
+      "default_branch": "main",
+      "asset_name": "wayward-module.tar.gz",
+      "min_host_version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **Wayward** to the module catalog — an `audio_fx` module for the Ableton Move.

Six loops recorded from the input, each looped at its own tempo. Set them to 100, 101, 102, 103, 104, 105 BPM and they start together, come apart, and arrive back where they began minutes later. Nothing is time-stretched to fit: a window shorter than its beat is padded with silence, one that is longer is cut off at the wrap, so every loop is a sound and a rest and the rests carry the pattern.

- **Repo:** https://github.com/kliegsablaze/wayward
- **Release:** [v0.8.1](https://github.com/kliegsablaze/wayward/releases/tag/v0.8.1), with `wayward-module.tar.gz` attached and `release.json` on `main`
- **Manual:** https://kliegsablaze.github.io/wayward/

### On `min_host_version: 1.0.0`

Higher than my other module asks for, and deliberately so. The Loop page is a
child level — all six loops on one page with the selector in the first cell —
and although `child_key.mjs` goes back to 0.12.0, the two pieces that make a
selector work *on the page it governs* do not:

- `syncChildIndexFromModule`, the poll that makes the host follow the module's
  own `child_index_param`
- the `dropChildLevelCache` skip for the index param — without it the selector
  goes dead after a single move, which is the behaviour the comment there
  describes being reported from a device

Both first appear in `v1.0.0`; `git ls-tree v0.12.1` has `child_key.mjs` but no
`syncChildIndexFromModule` anywhere in the tree. On 0.12.x the page would render
and then refuse to change loops, so gating it at 1.0.0 seemed better than
shipping something that looks installed and is not usable.

The module also relies on `child_key_overrides` mapping the selector key to
itself, so the template does not rewrite `loop_select` into
`loop1_loop_select`. That has been in since 0.12.0 and works exactly as
documented — thank you for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JQWtdzWmME5KDtTnqqavuG