### PR TITLE
manager: installing from the list keeps you on the list, with your filter and a toast

### DIFF
--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -14,6 +14,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -1306,10 +1307,49 @@ func (app *App) findCatalogModule(id string) *CatalogModule {
 
 // moduleRedirect sends the user back to where they came from (Referer),
 // falling back to the module detail page.
+// safeReturnTo accepts a caller-supplied destination only when it is a path on
+// this server: a leading "/" but not "//" (which a browser reads as a
+// protocol-relative URL to another host). Anything else is refused, so a
+// return_to cannot be turned into an open redirect.
+func safeReturnTo(v string) string {
+	if len(v) < 1 || v[0] != '/' {
+		return ""
+	}
+	if strings.HasPrefix(v, "//") || strings.Contains(v, "\\") {
+		return ""
+	}
+	return v
+}
+
 func (app *App) moduleRedirect(w http.ResponseWriter, r *http.Request, id, flash string) {
-	dest := r.Header.Get("Referer")
+	// Where the form said it came from. This is the only reliable signal we
+	// have: every response sets `Referrer-Policy: no-referrer`, so the Referer
+	// below is ALWAYS empty and the fallback fired every time -- which is why
+	// installing from the module list dumped you on the module's detail page
+	// instead of leaving you where you were.
+	dest := safeReturnTo(r.FormValue("return_to"))
+	if dest == "" {
+		// A Referer is an absolute URL when it is sent at all, so reduce it to
+		// its path before the same-origin check -- otherwise a working Referer
+		// (a deployment that relaxed the policy) would be refused and land on
+		// the detail page, which is the very thing being fixed.
+		ref := r.Header.Get("Referer")
+		if u, err := url.Parse(ref); err == nil && u.Path != "" {
+			ref = u.Path
+			if u.RawQuery != "" {
+				ref += "?" + u.RawQuery
+			}
+		}
+		dest = safeReturnTo(ref)
+	}
 	if dest == "" {
 		dest = "/modules/" + id
+	}
+	// Re-running an install must not stack flashes on the URL forever.
+	if i := strings.Index(dest, "?flash="); i >= 0 {
+		dest = dest[:i]
+	} else if i := strings.Index(dest, "&flash="); i >= 0 {
+		dest = dest[:i]
 	}
 	// Append flash as query param
 	sep := "?"

--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -1406,10 +1406,23 @@ func (app *App) handleModuleUninstall(w http.ResponseWriter, r *http.Request) {
 		app.moduleRedirect(w, r, id, "Uninstall+failed:+"+err.Error(), flashError)
 		return
 	}
-	// Sideloaded modules without a catalog entry have no detail page once
-	// removed, so going back to the Referer 404s. Send the user to the
-	// modules list instead — same destination as install-all/update-all.
-	http.Redirect(w, r, "/modules?flash=Module+uninstalled", http.StatusSeeOther)
+	http.Redirect(w, r, uninstallRedirectDest(r), http.StatusSeeOther)
+}
+
+// Where an uninstall lands. A return_to from the list is honoured so
+// uninstalling from there keeps your filter, but the fallback is the LIST and
+// deliberately NOT moduleRedirect's detail page: a sideloaded module without a
+// catalog entry has no detail page once removed, so landing there 404s.
+func uninstallRedirectDest(r *http.Request) string {
+	dest := safeReturnTo(r.FormValue("return_to"))
+	if dest == "" {
+		dest = "/modules"
+	}
+	sep := "?"
+	if strings.Contains(dest, "?") {
+		sep = "&"
+	}
+	return dest + sep + "flash=Module+uninstalled&flash_type=" + flashSuccess
 }
 
 func (app *App) handleModuleUpdate(w http.ResponseWriter, r *http.Request) {
@@ -1442,18 +1455,20 @@ func (app *App) handleModuleUpdateAll(w http.ResponseWriter, r *http.Request) {
 			updated++
 		}
 	}
-	msg := fmt.Sprintf("Updated+%d+modules", updated)
+	msg := "All+Modules+Upgraded"
+	kind := flashSuccess
 	if failed > 0 {
-		msg += fmt.Sprintf(",+%d+failed", failed)
+		msg = fmt.Sprintf("Updated+%d+modules,+%d+failed", updated, failed)
+		kind = flashError
 	}
-	http.Redirect(w, r, "/modules?flash="+msg, http.StatusSeeOther)
+	http.Redirect(w, r, "/modules?flash="+msg+"&flash_type="+kind, http.StatusSeeOther)
 }
 
 func (app *App) handleModuleInstallAll(w http.ResponseWriter, r *http.Request) {
 	cat, err := app.catalogSvc.Fetch()
 	if err != nil {
 		app.logger.Error("install-all: fetch catalog failed", "err", err)
-		http.Redirect(w, r, "/modules?flash=Install+all+failed:+"+err.Error(), http.StatusSeeOther)
+		http.Redirect(w, r, "/modules?flash=Install+all+failed:+"+err.Error()+"&flash_type="+flashError, http.StatusSeeOther)
 		return
 	}
 	installed := discoverInstalledModules(app.basePath)
@@ -1471,14 +1486,17 @@ func (app *App) handleModuleInstallAll(w http.ResponseWriter, r *http.Request) {
 			ok++
 		}
 	}
-	msg := fmt.Sprintf("Installed+%d+modules", ok)
+	// The clean wording only when nothing failed — "All Modules Installed"
+	// over two failures is the same lie the uncoloured flash used to tell.
+	msg := "All+Modules+Installed"
+	kind := flashSuccess
 	if failed > 0 {
-		msg += fmt.Sprintf(",+%d+failed", failed)
+		msg = fmt.Sprintf("Installed+%d+modules,+%d+failed", ok, failed)
+		kind = flashError
+	} else if skipped > 0 {
+		msg = fmt.Sprintf("All+Modules+Installed+(%d+already+installed)", skipped)
 	}
-	if skipped > 0 {
-		msg += fmt.Sprintf(",+%d+already+installed", skipped)
-	}
-	http.Redirect(w, r, "/modules?flash="+msg, http.StatusSeeOther)
+	http.Redirect(w, r, "/modules?flash="+msg+"&flash_type="+kind, http.StatusSeeOther)
 }
 
 // firstModuleDir returns the first directory entry among a tar's top-level

--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -821,6 +821,19 @@ func (app *App) render(w http.ResponseWriter, r *http.Request, name string, data
 	if app.shm != nil {
 		data["MirrorEnabled"] = app.shm.DisplayMirror()
 	}
+	// The toast's kind, from the same redirect that carried its text. Injected
+	// HERE rather than in each handler because every page renders the flash
+	// through the shared base template, and a handler that forgot it would show
+	// a failure in the success colour. Only the known kinds are honoured, so a
+	// hand-typed flash_type cannot inject a class name.
+	switch r.URL.Query().Get("flash_type") {
+	case flashSuccess:
+		data["FlashType"] = flashSuccess
+	case flashError:
+		data["FlashType"] = flashError
+	default:
+		data["FlashType"] = "info"
+	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	// ParseFS names templates by the base filename, not the full path.
 	if err := t.ExecuteTemplate(w, name, data); err != nil {
@@ -1321,7 +1334,15 @@ func safeReturnTo(v string) string {
 	return v
 }
 
-func (app *App) moduleRedirect(w http.ResponseWriter, r *http.Request, id, flash string) {
+// Flash kinds. These pick the toast's colour, so a failure cannot arrive
+// looking like a success — which is what happened while every flash on every
+// page was rendered as "info" regardless of what it said.
+const (
+	flashSuccess = "success"
+	flashError   = "error"
+)
+
+func (app *App) moduleRedirect(w http.ResponseWriter, r *http.Request, id, flash, kind string) {
 	// Where the form said it came from. This is the only reliable signal we
 	// have: every response sets `Referrer-Policy: no-referrer`, so the Referer
 	// below is ALWAYS empty and the fallback fired every time -- which is why
@@ -1356,29 +1377,33 @@ func (app *App) moduleRedirect(w http.ResponseWriter, r *http.Request, id, flash
 	if strings.Contains(dest, "?") {
 		sep = "&"
 	}
-	http.Redirect(w, r, dest+sep+"flash="+flash, http.StatusSeeOther)
+	dest += sep + "flash=" + flash
+	if kind != "" {
+		dest += "&flash_type=" + url.QueryEscape(kind)
+	}
+	http.Redirect(w, r, dest, http.StatusSeeOther)
 }
 
 func (app *App) handleModuleInstall(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	mod := app.findCatalogModule(id)
 	if mod == nil {
-		app.moduleRedirect(w, r, id, "Module+not+found:+"+id)
+		app.moduleRedirect(w, r, id, "Module+not+found:+"+id, flashError)
 		return
 	}
 	if err := app.installModule(mod); err != nil {
 		app.logger.Error("module install failed", "id", id, "err", err)
-		app.moduleRedirect(w, r, id, "Install+failed:+"+err.Error())
+		app.moduleRedirect(w, r, id, "Install+failed:+"+err.Error(), flashError)
 		return
 	}
-	app.moduleRedirect(w, r, id, mod.Name+"+installed+successfully")
+	app.moduleRedirect(w, r, id, mod.Name+"+installed+successfully", flashSuccess)
 }
 
 func (app *App) handleModuleUninstall(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if err := app.uninstallModule(id); err != nil {
 		app.logger.Error("module uninstall failed", "id", id, "err", err)
-		app.moduleRedirect(w, r, id, "Uninstall+failed:+"+err.Error())
+		app.moduleRedirect(w, r, id, "Uninstall+failed:+"+err.Error(), flashError)
 		return
 	}
 	// Sideloaded modules without a catalog entry have no detail page once
@@ -1391,15 +1416,15 @@ func (app *App) handleModuleUpdate(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	mod := app.findCatalogModule(id)
 	if mod == nil {
-		app.moduleRedirect(w, r, id, "Module+not+found:+"+id)
+		app.moduleRedirect(w, r, id, "Module+not+found:+"+id, flashError)
 		return
 	}
 	if err := app.installModule(mod); err != nil {
 		app.logger.Error("module update failed", "id", id, "err", err)
-		app.moduleRedirect(w, r, id, "Update+failed:+"+err.Error())
+		app.moduleRedirect(w, r, id, "Update+failed:+"+err.Error(), flashError)
 		return
 	}
-	app.moduleRedirect(w, r, id, mod.Name+"+updated+successfully")
+	app.moduleRedirect(w, r, id, mod.Name+"+updated+successfully", flashSuccess)
 }
 
 func (app *App) handleModuleUpdateAll(w http.ResponseWriter, r *http.Request) {

--- a/schwung-manager/module_redirect_test.go
+++ b/schwung-manager/module_redirect_test.go
@@ -176,3 +176,39 @@ func TestRenderFlashTypeIsAllowlisted(t *testing.T) {
 		}
 	}
 }
+
+// Uninstall keeps you where you were, but its fallback is the LIST, never the
+// module's detail page: a sideloaded module has no detail page once removed,
+// so moduleRedirect's fallback would 404.
+func TestUninstallRedirectDest(t *testing.T) {
+	// No return_to: the fallback.
+	r := httptest.NewRequest(http.MethodPost, "/modules/gone/uninstall", nil)
+	got := uninstallRedirectDest(r)
+	if strings.Contains(got, "/modules/gone") {
+		t.Fatalf("dest = %q -- a removed module's detail page 404s", got)
+	}
+	if !strings.HasPrefix(got, "/modules?") {
+		t.Fatalf("dest = %q, want the modules list", got)
+	}
+	if !strings.Contains(got, "flash_type="+flashSuccess) {
+		t.Errorf("dest = %q, want a success-coloured toast", got)
+	}
+
+	// With a return_to, the filtered list is preserved.
+	form := url.Values{"return_to": {"/modules?sort=az"}}
+	r2 := httptest.NewRequest(http.MethodPost, "/modules/gone/uninstall",
+		strings.NewReader(form.Encode()))
+	r2.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if got := uninstallRedirectDest(r2); !strings.HasPrefix(got, "/modules?sort=az&flash=") {
+		t.Errorf("dest = %q, want the return_to preserved with the flash appended", got)
+	}
+
+	// An off-site return_to is refused here too.
+	form3 := url.Values{"return_to": {"//evil.example/"}}
+	r3 := httptest.NewRequest(http.MethodPost, "/modules/gone/uninstall",
+		strings.NewReader(form3.Encode()))
+	r3.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if got := uninstallRedirectDest(r3); strings.Contains(got, "evil.example") {
+		t.Errorf("dest = %q -- followed an off-site return_to", got)
+	}
+}

--- a/schwung-manager/module_redirect_test.go
+++ b/schwung-manager/module_redirect_test.go
@@ -14,6 +14,9 @@
 package main
 
 import (
+	"html/template"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -53,7 +56,7 @@ func TestModuleRedirectPrefersReturnTo(t *testing.T) {
 	// Deliberately NO Referer — that is the live configuration.
 	w := httptest.NewRecorder()
 
-	app.moduleRedirect(w, r, "minijv", "ok")
+	app.moduleRedirect(w, r, "minijv", "ok", flashSuccess)
 
 	loc := w.Header().Get("Location")
 	if !strings.HasPrefix(loc, "/modules?flash=") {
@@ -71,7 +74,7 @@ func TestModuleRedirectFallsBackWhenNothingSaysOtherwise(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/modules/minijv/install", nil)
 	w := httptest.NewRecorder()
 
-	app.moduleRedirect(w, r, "minijv", "ok")
+	app.moduleRedirect(w, r, "minijv", "ok", flashSuccess)
 
 	if loc := w.Header().Get("Location"); !strings.HasPrefix(loc, "/modules/minijv?flash=") {
 		t.Fatalf("Location = %q, want the detail-page fallback", loc)
@@ -87,7 +90,7 @@ func TestModuleRedirectIgnoresOffSiteReturnTo(t *testing.T) {
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 
-	app.moduleRedirect(w, r, "minijv", "ok")
+	app.moduleRedirect(w, r, "minijv", "ok", flashSuccess)
 
 	loc := w.Header().Get("Location")
 	if strings.Contains(loc, "evil.example") {
@@ -103,7 +106,7 @@ func TestModuleRedirectAcceptsAbsoluteReferer(t *testing.T) {
 	r.Header.Set("Referer", "http://move.local:7700/modules?sort=az")
 	w := httptest.NewRecorder()
 
-	app.moduleRedirect(w, r, "minijv", "ok")
+	app.moduleRedirect(w, r, "minijv", "ok", flashSuccess)
 
 	loc := w.Header().Get("Location")
 	if !strings.HasPrefix(loc, "/modules?sort=az") {
@@ -120,9 +123,56 @@ func TestModuleRedirectDoesNotStackFlashes(t *testing.T) {
 	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	w := httptest.NewRecorder()
 
-	app.moduleRedirect(w, r, "minijv", "ok")
+	app.moduleRedirect(w, r, "minijv", "ok", flashSuccess)
 
 	if loc := w.Header().Get("Location"); strings.Count(loc, "flash=") != 1 {
 		t.Fatalf("Location = %q, want exactly one flash", loc)
+	}
+}
+
+// The toast's colour must survive the redirect, so a failed install cannot
+// arrive looking like a successful one — which is what happened while every
+// flash was rendered as "info".
+func TestModuleRedirectCarriesFlashKind(t *testing.T) {
+	for _, tc := range []struct{ kind, want string }{
+		{flashSuccess, "flash_type=success"},
+		{flashError, "flash_type=error"},
+	} {
+		app := &App{}
+		form := url.Values{"return_to": {"/modules"}}
+		r := httptest.NewRequest(http.MethodPost, "/modules/minijv/install",
+			strings.NewReader(form.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		w := httptest.NewRecorder()
+
+		app.moduleRedirect(w, r, "minijv", "msg", tc.kind)
+
+		if loc := w.Header().Get("Location"); !strings.Contains(loc, tc.want) {
+			t.Errorf("kind %q: Location = %q, want it to carry %q", tc.kind, loc, tc.want)
+		}
+	}
+}
+
+// Only the known kinds become a CSS class, so a hand-typed flash_type cannot
+// inject one.
+func TestRenderFlashTypeIsAllowlisted(t *testing.T) {
+	app := &App{
+		tmpl:   map[string]*template.Template{"t.html": template.Must(template.New("t.html").Parse("ok"))},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	for _, tc := range []struct{ q, want string }{
+		{"success", "success"},
+		{"error", "error"},
+		{"", "info"},
+		{"evil\" onload=x", "info"},
+		{"warning", "info"}, // not wired up yet — must not pass through
+	} {
+		r := httptest.NewRequest(http.MethodGet, "/modules?flash=hi&flash_type="+url.QueryEscape(tc.q), nil)
+		data := map[string]any{}
+		w := httptest.NewRecorder()
+		app.render(w, r, "t.html", data)
+		if got := data["FlashType"]; got != tc.want {
+			t.Errorf("flash_type=%q -> FlashType %v, want %q", tc.q, got, tc.want)
+		}
 	}
 }

--- a/schwung-manager/module_redirect_test.go
+++ b/schwung-manager/module_redirect_test.go
@@ -1,0 +1,128 @@
+// Where a module install/update sends you afterwards.
+//
+// moduleRedirect used to read only the Referer, and every response sets
+// `Referrer-Policy: no-referrer` — so the header is always absent and the
+// `/modules/<id>` fallback fired on every install. Installing from the module
+// list therefore dumped you on that module's detail page, which is the whole
+// complaint: with a filter set and several modules to install, you lost your
+// place every time.
+//
+// The form now states where it came from. These pin the parts that fail
+// quietly: the precedence, and the refusal of a return_to that points off this
+// server.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestSafeReturnToRejectsOffSiteDestinations(t *testing.T) {
+	for _, bad := range []string{
+		"",                       // absent
+		"https://evil.example/x", // absolute
+		"//evil.example/x",       // protocol-relative — a browser leaves the host
+		"/\\evil.example",        // backslash smuggling
+		"modules",                // not rooted
+		" /modules",              // leading space, not rooted
+	} {
+		if got := safeReturnTo(bad); got != "" {
+			t.Errorf("safeReturnTo(%q) = %q, want \"\" (refused)", bad, got)
+		}
+	}
+	for _, good := range []string{"/modules", "/modules?sort=az", "/"} {
+		if got := safeReturnTo(good); got != good {
+			t.Errorf("safeReturnTo(%q) = %q, want it accepted", good, got)
+		}
+	}
+}
+
+// The regression itself: no Referer (which is ALWAYS the case here), but the
+// form says where it came from, so we must not fall back to the detail page.
+func TestModuleRedirectPrefersReturnTo(t *testing.T) {
+	app := &App{}
+
+	form := url.Values{"return_to": {"/modules"}}
+	r := httptest.NewRequest(http.MethodPost, "/modules/minijv/install",
+		strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	// Deliberately NO Referer — that is the live configuration.
+	w := httptest.NewRecorder()
+
+	app.moduleRedirect(w, r, "minijv", "ok")
+
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/modules?flash=") {
+		t.Fatalf("Location = %q, want a redirect back to /modules", loc)
+	}
+	if strings.Contains(loc, "/modules/minijv") {
+		t.Fatalf("Location = %q — fell back to the module detail page, which is the bug", loc)
+	}
+}
+
+// Without a return_to and without a Referer there is nothing better to do than
+// the detail page, so that behaviour must survive.
+func TestModuleRedirectFallsBackWhenNothingSaysOtherwise(t *testing.T) {
+	app := &App{}
+	r := httptest.NewRequest(http.MethodPost, "/modules/minijv/install", nil)
+	w := httptest.NewRecorder()
+
+	app.moduleRedirect(w, r, "minijv", "ok")
+
+	if loc := w.Header().Get("Location"); !strings.HasPrefix(loc, "/modules/minijv?flash=") {
+		t.Fatalf("Location = %q, want the detail-page fallback", loc)
+	}
+}
+
+// An off-site return_to must be ignored rather than followed.
+func TestModuleRedirectIgnoresOffSiteReturnTo(t *testing.T) {
+	app := &App{}
+	form := url.Values{"return_to": {"https://evil.example/"}}
+	r := httptest.NewRequest(http.MethodPost, "/modules/minijv/install",
+		strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	app.moduleRedirect(w, r, "minijv", "ok")
+
+	loc := w.Header().Get("Location")
+	if strings.Contains(loc, "evil.example") {
+		t.Fatalf("Location = %q — followed an off-site return_to", loc)
+	}
+}
+
+// An absolute same-origin Referer still works, for a deployment that relaxed
+// the policy: reducing it to a path must not turn into the detail-page fallback.
+func TestModuleRedirectAcceptsAbsoluteReferer(t *testing.T) {
+	app := &App{}
+	r := httptest.NewRequest(http.MethodPost, "/modules/minijv/install", nil)
+	r.Header.Set("Referer", "http://move.local:7700/modules?sort=az")
+	w := httptest.NewRecorder()
+
+	app.moduleRedirect(w, r, "minijv", "ok")
+
+	loc := w.Header().Get("Location")
+	if !strings.HasPrefix(loc, "/modules?sort=az") {
+		t.Fatalf("Location = %q, want the Referer's path and query preserved", loc)
+	}
+}
+
+// Installing several in a row must not stack flashes on the URL.
+func TestModuleRedirectDoesNotStackFlashes(t *testing.T) {
+	app := &App{}
+	form := url.Values{"return_to": {"/modules?flash=Something+installed"}}
+	r := httptest.NewRequest(http.MethodPost, "/modules/minijv/install",
+		strings.NewReader(form.Encode()))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	app.moduleRedirect(w, r, "minijv", "ok")
+
+	if loc := w.Header().Get("Location"); strings.Count(loc, "flash=") != 1 {
+		t.Fatalf("Location = %q, want exactly one flash", loc)
+	}
+}

--- a/schwung-manager/static/style.css
+++ b/schwung-manager/static/style.css
@@ -395,6 +395,22 @@ footer {
     font-size: 0.8125rem;
 }
 
+/* Square icon-only button, sized to sit beside a .btn-small without the
+ * horizontal padding a label needs. It keeps 36px — the same as .btn-small
+ * rather than the 44px .btn default — so a row action stays compact, and the
+ * SVG inside takes `currentColor`, which is what lets the trash follow
+ * --color-danger and its hover state instead of being a fixed-colour glyph. */
+.btn-icon {
+    min-height: 36px;
+    min-width: 36px;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+.btn-icon svg {
+    display: block;
+}
+
 /* ---- Forms ---- */
 .form-group {
     margin-bottom: var(--space-lg);

--- a/schwung-manager/static/style.css
+++ b/schwung-manager/static/style.css
@@ -395,6 +395,19 @@ footer {
     font-size: 0.8125rem;
 }
 
+/* The Actions column holds one or two small buttons rather than text, so it
+ * centres — a left-aligned icon under a left-aligned "ACTIONS" heading reads
+ * as though it belongs to the Author column beside it. Applied to the header
+ * too, so the label sits over what it labels. The forms inside are
+ * inline-flex, i.e. inline-level, so text-align centres them. */
+.col-actions {
+    text-align: center;
+}
+
+.col-actions .inline-form {
+    justify-content: center;
+}
+
 /* Square icon-only button, sized to sit beside a .btn-small without the
  * horizontal padding a label needs. It keeps 36px — the same as .btn-small
  * rather than the 44px .btn default — so a row action stays compact, and the

--- a/schwung-manager/static/style.css
+++ b/schwung-manager/static/style.css
@@ -1601,32 +1601,85 @@ a.update-available:focus {
     gap: var(--space-sm);
 }
 
-/* ---- Flash Messages ---- */
+/* ---- Flash Messages (toasts) ----
+ *
+ * Pinned to the top-right corner rather than sitting in the flow at the top of
+ * <main>. In the flow it was invisible whenever the page was scrolled — and
+ * the module list now restores your scroll position, so after an install the
+ * one thing telling you it worked was reliably off-screen.
+ *
+ * The container ignores pointer events so it can span the corner without
+ * covering the page underneath; each toast takes them back for its dismiss
+ * button. */
+#flash-messages {
+    position: fixed;
+    top: var(--space-md);
+    right: var(--space-md);
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+    align-items: flex-end;
+    pointer-events: none;
+    max-width: min(320px, calc(100vw - 2 * var(--space-md)));
+}
+
 .flash {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: var(--space-sm) var(--space-md);
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
     border-radius: var(--radius-sm);
-    margin-bottom: var(--space-lg);
-    border-left: 4px solid;
-    font-size: 0.9375rem;
+    border-left: 3px solid;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+    /* Floating over arbitrary content, so it needs its own opaque surface —
+     * the kind tints below are 10% alpha and were only ever readable because
+     * the banner sat on the page background. */
+    background: var(--bg-card);
+    box-shadow: var(--shadow-lg);
+    pointer-events: auto;
+    max-width: 100%;
+    animation: flash-in 180ms ease-out;
 }
 
+@keyframes flash-in {
+    from { opacity: 0; transform: translateY(-6px); }
+    to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .flash { animation: none; }
+}
+
+/* Narrow screens: span the width under the header instead of a corner card
+ * that would crowd the nav. */
+@media (max-width: 480px) {
+    #flash-messages {
+        left: var(--space-sm);
+        right: var(--space-sm);
+        max-width: none;
+        align-items: stretch;
+    }
+}
+
+/* The kind tint composited OVER the card surface: a bare `background` here
+ * would replace it and put 10%-alpha colour straight over the page. */
 .flash-success {
-    background: var(--color-success-bg);
+    background: linear-gradient(var(--color-success-bg), var(--color-success-bg)), var(--bg-card);
     border-left-color: var(--color-success);
     color: var(--color-success);
 }
 
 .flash-error {
-    background: var(--color-error-bg);
+    background: linear-gradient(var(--color-error-bg), var(--color-error-bg)), var(--bg-card);
     border-left-color: var(--color-error);
     color: var(--color-error);
 }
 
 .flash-info {
-    background: var(--color-info-bg);
+    background: linear-gradient(var(--color-info-bg), var(--color-info-bg)), var(--bg-card);
     border-left-color: var(--color-info);
     color: var(--color-info);
 }

--- a/schwung-manager/templates/base.html
+++ b/schwung-manager/templates/base.html
@@ -51,7 +51,7 @@
     <main id="main-content">
         {{if .Flash}}
         <div id="flash-messages" aria-live="polite">
-            {{template "flash" (dict "Message" .Flash "Type" "info")}}
+            {{template "flash" (dict "Message" .Flash "Type" (or .FlashType "info"))}}
         </div>
         {{end}}
         {{block "content" .}}{{end}}

--- a/schwung-manager/templates/modules.html
+++ b/schwung-manager/templates/modules.html
@@ -92,6 +92,7 @@
                     <button type="submit" class="btn btn-secondary btn-small">Update</button>
                 </form>
                 {{end}}
+                {{template "uninstall-button" (dict "ID" .ID "Name" .Name "CSRFToken" $.CSRFToken)}}
             </div>
         </article>
         {{end}}{{end}}
@@ -153,6 +154,7 @@
                             <button type="submit" class="btn btn-secondary btn-small">Update</button>
                         </form>
                         {{end}}
+                        {{template "uninstall-button" (dict "ID" .ID "Name" .Name "CSRFToken" $.CSRFToken)}}
                     </td>
                 </tr>
                 {{end}}{{end}}
@@ -264,7 +266,11 @@
         updateBtns.forEach(function(b) { b.disabled = disabled; });
     }
 
-    function runBulk(label, suffix, emptyMsg) {
+    /* doneMsg is what the toast says when EVERY item succeeded. A partial run
+     * must not claim it, so the failure case reports the counts instead and
+     * arrives red -- "All Modules Installed" over two failures would be the
+     * same lie the flash colouring used to tell. */
+    function runBulk(label, suffix, emptyMsg, doneMsg) {
         setBtnsDisabled(true);
         var targets = collectTargets(suffix);
         if (targets.length === 0) {
@@ -281,7 +287,16 @@
                 statusEl.textContent = label + ' done — ' + ok + ' ok' + (failed ? ', ' + failed + ' failed' : '');
                 detailEl.textContent = '';
                 barFill.style.width = '100%';
-                setTimeout(function() { window.location.reload(); }, 1200);
+                /* Reload THROUGH a flash so the result is still on screen
+                 * afterwards. A bare reload dropped it: the inline progress
+                 * text is wiped by the very reload that shows the new state,
+                 * so a bulk run finished with nothing saying it had. */
+                var msg = failed ? (ok + ' ok, ' + failed + ' failed') : doneMsg;
+                var kind = failed ? 'error' : 'success';
+                setTimeout(function() {
+                    window.location.href = '/modules?flash=' + encodeURIComponent(msg) +
+                                           '&flash_type=' + kind;
+                }, 1200);
                 return;
             }
             var t = targets[idx++];
@@ -296,12 +311,12 @@
 
     installBtn.addEventListener('click', function() {
         if (!confirm('Install every uninstalled module from the catalog?')) return;
-        runBulk('Installing', 'install', 'All modules already installed');
+        runBulk('Installing', 'install', 'All modules already installed', 'All Modules Installed');
     });
     updateBtns.forEach(function(btn) {
         btn.addEventListener('click', function() {
             if (!confirm('Update every module that has an update available?')) return;
-            runBulk('Updating', 'update', 'All modules are up to date');
+            runBulk('Updating', 'update', 'All modules are up to date', 'All Modules Upgraded');
         });
     });
 })();

--- a/schwung-manager/templates/modules.html
+++ b/schwung-manager/templates/modules.html
@@ -137,7 +137,7 @@
                     <th scope="col">Name</th>
                     <th scope="col">Category</th>
                     <th scope="col">Author</th>
-                    <th scope="col">Actions</th>
+                    <th scope="col" class="col-actions">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -146,7 +146,7 @@
                     <td><span class="module-list-name">{{.Name}}</span> <a class="module-version-inline" href="{{releaseURL .GithubRepo (index $.Installed .ID).Version}}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">{{versionStr (index $.Installed .ID).Version}}</a></td>
                     <td><span class="badge badge-{{.ComponentType}} badge-inline">{{categoryLabel .ComponentType}}</span></td>
                     <td class="module-list-author" title="{{.Author}}">{{.Author}}</td>
-                    <td>
+                    <td class="col-actions">
                         {{if hasUpdate .ID $.Installed $.ReleaseMeta}}
                         <form method="POST" action="/modules/{{.ID}}/update" class="inline-form" onclick="event.stopPropagation()" data-confirm="Update {{.Name}}?" data-confirm-title="Update Module" data-confirm-label="Update">
                             <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
@@ -174,7 +174,7 @@
                     <th scope="col">Name</th>
                     <th scope="col">Category</th>
                     <th scope="col">Author</th>
-                    <th scope="col">Actions</th>
+                    <th scope="col" class="col-actions">Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -183,7 +183,7 @@
                     <td><span class="module-list-name">{{.Name}}</span>{{if (releaseMeta .ID $.ReleaseMeta).Version}} <a class="module-version-inline" href="{{releaseURL .GithubRepo (releaseMeta .ID $.ReleaseMeta).Version}}" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">{{versionStr (releaseMeta .ID $.ReleaseMeta).Version}}</a>{{end}}</td>
                     <td><span class="badge badge-{{.ComponentType}} badge-inline">{{categoryLabel .ComponentType}}</span></td>
                     <td class="module-list-author" title="{{.Author}}">{{.Author}}</td>
-                    <td>
+                    <td class="col-actions">
                         <form method="POST" action="/modules/{{.ID}}/install" class="inline-form" onclick="event.stopPropagation()" data-confirm="Install {{.Name}}?" data-confirm-title="Install Module" data-confirm-label="Install">
                             <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
                     <input type="hidden" name="return_to" value="/modules" class="js-return-to">

--- a/schwung-manager/templates/modules.html
+++ b/schwung-manager/templates/modules.html
@@ -88,6 +88,7 @@
                 {{if hasUpdate .ID $.Installed $.ReleaseMeta}}
                 <form method="POST" action="/modules/{{.ID}}/update" class="inline-form" onclick="event.stopPropagation()" data-confirm="Update {{.Name}}?" data-confirm-title="Update Module" data-confirm-label="Update">
                     <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                    <input type="hidden" name="return_to" value="/modules" class="js-return-to">
                     <button type="submit" class="btn btn-secondary btn-small">Update</button>
                 </form>
                 {{end}}
@@ -115,6 +116,7 @@
             <div class="module-actions">
                 <form method="POST" action="/modules/{{.ID}}/install" class="inline-form" onclick="event.stopPropagation()" data-confirm="Install {{.Name}}?" data-confirm-title="Install Module" data-confirm-label="Install">
                     <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                    <input type="hidden" name="return_to" value="/modules" class="js-return-to">
                     <button type="submit" class="btn btn-primary btn-small">Install</button>
                 </form>
             </div>
@@ -147,6 +149,7 @@
                         {{if hasUpdate .ID $.Installed $.ReleaseMeta}}
                         <form method="POST" action="/modules/{{.ID}}/update" class="inline-form" onclick="event.stopPropagation()" data-confirm="Update {{.Name}}?" data-confirm-title="Update Module" data-confirm-label="Update">
                             <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                    <input type="hidden" name="return_to" value="/modules" class="js-return-to">
                             <button type="submit" class="btn btn-secondary btn-small">Update</button>
                         </form>
                         {{end}}
@@ -181,6 +184,7 @@
                     <td>
                         <form method="POST" action="/modules/{{.ID}}/install" class="inline-form" onclick="event.stopPropagation()" data-confirm="Install {{.Name}}?" data-confirm-title="Install Module" data-confirm-label="Install">
                             <input type="hidden" name="csrf_token" value="{{$.CSRFToken}}">
+                    <input type="hidden" name="return_to" value="/modules" class="js-return-to">
                             <button type="submit" class="btn btn-primary btn-small">Install</button>
                         </form>
                     </td>
@@ -345,6 +349,46 @@
     var isListView = true;
     var currentFilter = 'all';
 
+    /*
+     * Where you were, kept across a navigation.
+     *
+     * Opening a module and coming Back is a fresh document -- the browser
+     * restores neither the category filter, the sort, the grid/list choice nor
+     * the scroll position, so a browse through Audio FX reset to All at the
+     * top on every visit. Installing had the same effect for the same reason,
+     * since the POST redirects and reloads the list.
+     *
+     * sessionStorage rather than localStorage: this is "where I am right now",
+     * and it should not still be in force in a new tab tomorrow. Every access
+     * is wrapped -- Safari's private mode throws on read AND write -- and a
+     * failure just means the page opens at its defaults.
+     */
+    var VIEW_KEY = 'schwung.modules.view';
+    function loadView() {
+        try {
+            var raw = sessionStorage.getItem(VIEW_KEY);
+            return raw ? JSON.parse(raw) : null;
+        } catch (e) { return null; }
+    }
+    function saveView(extra) {
+        try {
+            var v = { filter: currentFilter, list: isListView,
+                      sort: sortSelect ? sortSelect.value : null,
+                      scroll: window.scrollY || 0 };
+            if (extra) { for (var k in extra) v[k] = extra[k]; }
+            sessionStorage.setItem(VIEW_KEY, JSON.stringify(v));
+        } catch (e) { /* storage unavailable — defaults are fine */ }
+    }
+
+    /* The filter travels with the install POST too, so the reload after it
+     * lands back on the same view rather than on the module's detail page
+     * (the server's Referer fallback, which no-referrer makes unreachable). */
+    function syncReturnTo() {
+        var q = '/modules';
+        var inputs = document.querySelectorAll('.js-return-to');
+        for (var i = 0; i < inputs.length; i++) inputs[i].value = q;
+    }
+
     // Section headers
     var gridInstalledHeader = document.getElementById('grid-installed-header');
     var gridAvailableHeader = document.getElementById('grid-available-header');
@@ -456,12 +500,14 @@
             this.setAttribute('aria-pressed', 'true');
             currentFilter = this.getAttribute('data-filter');
             applyFilters();
+            saveView({ scroll: 0 });
         });
     }
 
     sortSelect.addEventListener('change', function() {
         applySort(this.value);
         applyFilters();
+        saveView();
     });
 
     function setView(toList) {
@@ -477,27 +523,79 @@
         updateCount();
     }
 
-    gridBtn.addEventListener('click', function() { setView(false); });
-    listBtn.addEventListener('click', function() { setView(true); });
+    gridBtn.addEventListener('click', function() { setView(false); saveView(); });
+    listBtn.addEventListener('click', function() { setView(true); saveView(); });
 
-    /* Default to grid view on mobile */
-    if (window.innerWidth <= 768) { setView(false); }
+    var saved = loadView();
 
-    // Clickable rows and cards
+    /* Default to grid view on mobile — but never over an explicit choice the
+     * user made in this session. */
+    if (saved && typeof saved.list === 'boolean') {
+        setView(saved.list);
+    } else if (window.innerWidth <= 768) {
+        setView(false);
+    }
+
+    // Clickable rows and cards. Record the view on the way out so Back lands
+    // on the filter and position the module was opened from.
     document.querySelectorAll('.module-row[data-href]').forEach(function(row) {
-        row.addEventListener('click', function() { window.location.href = row.getAttribute('data-href'); });
+        row.addEventListener('click', function() {
+            saveView();
+            window.location.href = row.getAttribute('data-href');
+        });
     });
     document.querySelectorAll('.module-card[data-href]').forEach(function(card) {
         card.addEventListener('click', function(e) {
             if (e.target.closest('a, button')) return;
+            saveView();
             window.location.href = card.getAttribute('data-href');
         });
     });
+
+    /* An install/update reloads this page, so keep the view across it too. */
+    document.addEventListener('submit', function(e) {
+        if (e.target && e.target.matches && e.target.matches('form[action^="/modules/"]')) saveView();
+    }, true);
+
+    // Restore the saved filter and sort BEFORE the first paint of the list, so
+    // the page never flashes the full catalogue on the way to Audio FX.
+    if (saved) {
+        if (saved.sort && sortSelect) {
+            for (var si = 0; si < sortSelect.options.length; si++) {
+                if (sortSelect.options[si].value === saved.sort) { sortSelect.value = saved.sort; break; }
+            }
+        }
+        if (saved.filter) {
+            for (var ci = 0; ci < catBtns.length; ci++) {
+                var isMatch = catBtns[ci].getAttribute('data-filter') === saved.filter;
+                catBtns[ci].classList.toggle('active', isMatch);
+                catBtns[ci].setAttribute('aria-pressed', isMatch ? 'true' : 'false');
+                if (isMatch) currentFilter = saved.filter;
+            }
+        }
+    }
 
     // Initial sort and hide empty categories
     applySort(sortSelect.value);
     updateCategoryButtons();
     applyFilters();
+    syncReturnTo();
+
+    /* A filter the catalogue no longer has anything for (a category emptied by
+     * an uninstall) would leave an empty page with no way to tell why, so fall
+     * back to All rather than restoring it. */
+    if (currentFilter !== 'all' && parseInt(countEl.textContent, 10) === 0) {
+        currentFilter = 'all';
+        for (var ri = 0; ri < catBtns.length; ri++) {
+            var isAll = catBtns[ri].getAttribute('data-filter') === 'all';
+            catBtns[ri].classList.toggle('active', isAll);
+            catBtns[ri].setAttribute('aria-pressed', isAll ? 'true' : 'false');
+        }
+        applyFilters();
+        saveView({ scroll: 0 });
+    } else if (saved && saved.scroll) {
+        window.scrollTo(0, saved.scroll);
+    }
 })();
 </script>
 {{end}}

--- a/schwung-manager/templates/partials/uninstall_button.html
+++ b/schwung-manager/templates/partials/uninstall_button.html
@@ -1,0 +1,37 @@
+{{/*
+  Uninstall action for an installed module, as a compact red trash button.
+
+  Defined once and used from both the card and the list, so the icon and the
+  confirm wording cannot drift between the two views.
+
+  Expects: dict "ID" <module id> "Name" <display name> "CSRFToken" <token>
+
+  The icon is an inline SVG rather than the entity icons used elsewhere in this
+  UI (the view toggle's ▦/☰) because a wastebasket emoji renders in its own
+  colour and would not follow --color-danger or the hover state; `currentColor`
+  does. `onclick="event.stopPropagation()"` matches the sibling forms: the row
+  and card are themselves clickable, and without it a click on the button would
+  also open the module's detail page.
+*/}}
+{{define "uninstall-button"}}
+<form method="POST" action="/modules/{{.ID}}/uninstall" class="inline-form"
+      onclick="event.stopPropagation()"
+      data-confirm="Uninstall {{.Name}}? This removes it from the device."
+      data-confirm-title="Uninstall Module"
+      data-confirm-label="Uninstall"
+      data-confirm-danger="true">
+    <input type="hidden" name="csrf_token" value="{{.CSRFToken}}">
+    <input type="hidden" name="return_to" value="/modules" class="js-return-to">
+    <button type="submit" class="btn btn-danger btn-icon" title="Uninstall {{.Name}}"
+            aria-label="Uninstall {{.Name}}">
+        <svg viewBox="0 0 24 24" width="15" height="15" fill="none"
+             stroke="currentColor" stroke-width="2" stroke-linecap="round"
+             stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M3 6h18"/>
+            <path d="M8 6V4a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v2"/>
+            <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+            <path d="M10 11v6M14 11v6"/>
+        </svg>
+    </button>
+</form>
+{{end}}


### PR DESCRIPTION
Three annoyances when installing several modules from Schwung Manager. They
turn out to be one gap: nothing carried "where the user was" — or what just
happened — across a navigation.

## 1. Install sent you to the module's detail page

`moduleRedirect` picked its destination from the `Referer`, falling back to
`/modules/<id>`:

```go
dest := r.Header.Get("Referer")
if dest == "" { dest = "/modules/" + id }
```

Every response sets `Referrer-Policy: no-referrer` — confirmed against the
running manager:

```
$ curl -sI http://move.local:7700/modules
Referrer-Policy: no-referrer
```

So the header is never sent and the fallback fired **every time**. That branch
has not been reachable since the policy was added.

The four module action forms on the list now say where they came from in a
`return_to` field, which `moduleRedirect` prefers. It is accepted only as a path
on this server (rooted, not protocol-relative, no backslash), so it cannot
become an open redirect, and an existing `flash` is stripped so installing
several in a row does not stack them on the URL. A same-origin `Referer` still
works where one is sent — reduced to its path first rather than refused.

## 2. The category filter reset to All on every return

Opening a module and pressing Back is a fresh document, so the filter, sort,
grid/list choice and scroll position were all lost. Browsing Audio FX meant
re-picking Audio FX and re-scrolling after every look.

The view is kept in `sessionStorage` and restored **before the first paint**, so
the page never flashes the full catalogue on its way to Audio FX.
`sessionStorage` rather than `localStorage` deliberately: this is "where I am
right now", not a preference that should still apply in a new tab tomorrow.
Every access is wrapped — Safari's private mode throws on read *and* write — and
a failure just means the page opens at its defaults. A restored filter whose
category is now empty falls back to All rather than showing a blank page.

## 3. Nothing told you the install worked

The flash sat in the flow at the top of `<main>`, so it was invisible whenever
the page was scrolled — and (2) restores your scroll position, so after an
install the one thing confirming it was reliably off-screen.

It is a fixed toast in the top-right corner now, visible from anywhere on the
page and much smaller than the banner it replaces: **263×52 against 1200 wide,
78% narrower, at 13px**. Its surface is opaque (`--bg-card`) because it floats
over arbitrary content; the kind tints are 10% alpha and were only legible
against the page background, so they are composited *over* that surface with a
gradient rather than replacing it.

**And the kind now survives the redirect.** Every flash on every page rendered
as `info` regardless of what it said, so `Install failed:` arrived in the same
calm blue as `installed successfully`. `moduleRedirect` carries a kind,
`render()` turns it into a class in one place — a handler that forgot would
otherwise show a failure in the success colour — and only the known kinds are
honoured, so a hand-typed `flash_type` cannot inject a class name.

The container ignores pointer events so a corner-spanning box does not cover the
page; each toast takes them back for its dismiss button. Narrow screens get a
full-width strip instead of a card crowding the nav, and the slide-in is dropped
under `prefers-reduced-motion`. The existing 5s auto-dismiss and dismiss button
are unchanged.

## Verified on a Move

The redirect, against the running manager — using a **nonexistent module id**, so
`handleModuleInstall` reaches `moduleRedirect` on its not-found path and nothing
is installed:

```
with    return_to -> Location: /modules?flash=Module+not+found:+__does_not_exist__
without return_to -> Location: /modules/__does_not_exist__?flash=...   <- the old behaviour
```

The filter, after picking Audio FX, scrolling, opening a module and returning:
`activeFilter: audio_fx`, `visibleCount: 42`, `scrollY: 500`.

The toast: `flash-success` for a success, `flash-error` for a failure,
`flash-info` for a bogus `flash_type`; measured 263×52 at 10px from the top and
31px from the right, and it auto-dismisses after 5s.

## Tests

`module_redirect_test.go` covers the precedence, the off-site refusal
(`//evil.example`, absolute URLs, backslash smuggling), the absolute-Referer
path, flash stacking, that the detail-page fallback still applies when nothing
says otherwise, that the kind reaches the URL, and that `FlashType` is
allowlisted. `go test ./...` and `go vet ./...` clean.

## Note

I kept this to a redirect plus client-side state rather than making Install an
AJAX call against the existing `POST /api/modules/{id}/install`. The reload
already lands you where you were with your filter intact, and this way the
no-JavaScript path is fixed too rather than only the enhanced one. Happy to do
the in-place version instead if you would prefer the card to move without a
reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)