### PR TITLE
viz: a release role is evidence of a sustain stage, so A/D/R is not a flat line

### DIFF
--- a/src/shared/param_pages/viz_draw.mjs
+++ b/src/shared/param_pages/viz_draw.mjs
@@ -534,7 +534,37 @@ function drawPartialEnv(ctx, leftX, xEnd, topY, baseY, present, roles, values, m
     const has = (r) => present.includes(r);
     const val = {};
     for (const r of present) val[r] = frac(metaIndex, roles[r], values);
-    const susY = has("sustain") ? baseY - Math.round(val.sustain * usableH) : baseY;
+
+    /*
+     * A RELEASE ROLE IS EVIDENCE OF A SUSTAIN STAGE, even with no sustain role.
+     *
+     * "No sustain role" was read as "sustain is zero". For an A/D envelope that
+     * is right -- a percussive shape decays to silence and there is nothing to
+     * release. It stops being right the moment `release` is declared, because
+     * release means "fall from the held level to zero": if the held level were
+     * already zero there would be nothing to release from and the role would be
+     * meaningless.
+     *
+     * So an A/D/R was drawn decaying to the floor, no plateau, and a release
+     * running along the bottom from one floor point to another -- a flat line.
+     * Reported against a Yamaha QY-70 editor, whose XG Multi Part offsets are
+     * EG Attack, EG Decay and EG Release and nothing else: the sustain LEVEL
+     * lives in the voice and is not addressable, but hold a note and it holds.
+     * The stage exists; the editor just cannot read its height.
+     *
+     * The height is therefore a PICTURE, not a measurement -- half scale, which
+     * leaves decay and release both clearly legible. Nothing reads it as a
+     * value: it is only geometry, and `val.sustain` stays undefined.
+     */
+    const IMPLIED_SUSTAIN = 0.5;
+    const impliedSustain = !has("sustain") && has("decay") && has("release");
+    /* A/D with no release must still fall to the floor -- that case was right. */
+    const susY = has("sustain") ? baseY - Math.round(val.sustain * usableH)
+               : impliedSustain ? baseY - Math.round(IMPLIED_SUSTAIN * usableH)
+               : baseY;
+    /* The plateau is what makes the stage visible as HELD rather than as a kink
+     * between two falls, so the implied case draws one too. */
+    const drawsPlateau = has("sustain") || impliedSustain;
 
     /*
      * ATTACK IS NOT GUARANTEED.
@@ -577,7 +607,7 @@ function drawPartialEnv(ctx, leftX, xEnd, topY, baseY, present, roles, values, m
     } else if (has("sustain")) {
         pts.push([cur, susY]);
     }
-    if (has("sustain")) {
+    if (drawsPlateau) {
         const plateauEnd = has("release") ? Math.round(leftX + span * 0.7) : rightX;
         if (plateauEnd > cur) { pts.push([plateauEnd, susY]); cur = plateauEnd; }
     }
@@ -599,7 +629,7 @@ function drawPartialEnv(ctx, leftX, xEnd, topY, baseY, present, roles, values, m
      * where braids showed it, since braids declares attack/decay/sustain and no
      * release. A boundary at the boundary of the picture marks nothing.
      */
-    if (has("sustain") && cur < rightX - 1) knockoutV(ctx, cur, susY + 1, baseY - 1);
+    if (drawsPlateau && cur < rightX - 1) knockoutV(ctx, cur, susY + 1, baseY - 1);
 }
 
 /* ----------------------------------------------------------------- filter */

--- a/tests/host/test_env_implied_sustain.sh
+++ b/tests/host/test_env_implied_sustain.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# An A/D/R envelope must not be drawn as a flat line along the floor (#359).
+#
+# "No sustain role" was read as "sustain is zero". That is right for A/D -- a
+# percussive shape decays to silence and there is nothing to release -- and
+# wrong the moment `release` is declared, because release means "fall from the
+# held level to zero". If the held level were already zero there would be
+# nothing to release from. So the presence of `release` is itself the evidence
+# that a sustain STAGE exists, whether or not its LEVEL is a parameter.
+#
+# Reported against a Yamaha QY-70 editor, whose XG Multi Part offsets are EG
+# Attack, EG Decay and EG Release and nothing else: the sustain level lives in
+# the voice and is not addressable, but hold a note and it holds.
+#
+# SYNTHETIC GROUPS, deliberately. The 100-module fleet capture contains ZERO
+# A/D/R-without-sustain envelopes -- checked -- so there is no fixture to drive
+# this from, and a test that quietly covered nothing would be worse than none.
+# The shape is copied from a real detected group (slicer "Params - 2").
+#
+# Both halves are needed. Asserting only "A/D/R is off the floor" passes with
+# every envelope pinned to the ceiling, so A/D is required to still REACH the
+# floor -- that case was correct before and must stay correct.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { drawVizGroup, VIZ_ROWS } from "./src/shared/param_pages/viz_draw.mjs";
+import { buildMetaIndex } from "./src/shared/param_pages/param_meta.mjs";
+
+let fail = 0;
+const bad = (m) => { console.log("FAIL: " + m); fail++; };
+const ok  = (m) => console.log("  ok  " + m);
+
+/* A contract whose keys carry the envelope roles by name. */
+const chainParams = [
+    { key: "eg_attack",  name: "Attack",  type: "float", min: 0, max: 1, step: 0.01 },
+    { key: "eg_decay",   name: "Decay",   type: "float", min: 0, max: 1, step: 0.01 },
+    { key: "eg_sustain", name: "Sustain", type: "float", min: 0, max: 1, step: 0.01 },
+    { key: "eg_release", name: "Release", type: "float", min: 0, max: 1, step: 0.01 },
+];
+const metaIndex = buildMetaIndex({ chainParams });
+
+const H = VIZ_ROWS + 2;
+function render(roles, vals) {
+    const keys = Object.values(roles);
+    const g = { kind: "envelope", group: null, roles, keys,
+                slotStart: 0, slotSpan: keys.length, source: "detected" };
+    const W = Math.max(32, g.slotSpan * 32);
+    const px = new Uint8Array(W * H);
+    const ctx = { fillRect(x, y, w, h, c) {
+        for (let j = y; j < y + h; j++)
+            for (let i = x; i < x + w; i++)
+                if (i >= 0 && i < W && j >= 0 && j < H) px[j * W + i] = c ? 1 : 0;
+    } };
+    const values = {};
+    for (const k of keys) values[k] = String(vals[k] !== undefined ? vals[k] : 0.5);
+    drawVizGroup(ctx, { x: 0, y: 0, w: W, h: H }, g, values, metaIndex, null, undefined);
+    return { px, W };
+}
+
+/* The topmost lit row in each column: the outline of the curve. Rows count
+ * DOWN, so a smaller number is higher on screen. */
+function topRow(r, x) {
+    for (let y = 0; y < H; y++) if (r.px[y * r.W + x]) return y;
+    return null;
+}
+/* How high the curve stands, in rows above the lowest row it ever reaches. */
+function profile(r) {
+    const tops = [];
+    for (let x = 0; x < r.W; x++) tops.push(topRow(r, x));
+    return tops;
+}
+
+const ADR = { attack: "eg_attack", decay: "eg_decay", release: "eg_release" };
+const AD  = { attack: "eg_attack", decay: "eg_decay" };
+const ADSR = { attack: "eg_attack", decay: "eg_decay",
+               sustain: "eg_sustain", release: "eg_release" };
+
+/* ---- the reported case ------------------------------------------------- */
+{
+    const r = render(ADR, { eg_attack: 0.3, eg_decay: 0.4, eg_release: 0.5 });
+    const tops = profile(r);
+    const floor = Math.max(...tops.filter((v) => v !== null));
+
+    /* The right-hand HALF of the picture is where decay has finished and the
+     * release runs. Under the bug every column there sits on the floor. */
+    const rightHalf = [];
+    for (let x = Math.floor(r.W / 2); x < r.W; x++) if (tops[x] !== null) rightHalf.push(tops[x]);
+    const aboveFloor = rightHalf.filter((v) => v < floor - 1).length;
+
+    if (aboveFloor === 0)
+        bad("an A/D/R envelope is still flat along the floor after decay -- " +
+            "there is no nonzero portion that reads as sustained");
+    else
+        ok("an A/D/R envelope holds above the floor before releasing (" +
+           aboveFloor + " columns)");
+
+    /* And it must still COME DOWN -- an implied sustain that never releases
+     * would be its own wrong picture. */
+    if (tops[r.W - 1] === null || tops[r.W - 1] < floor - 1)
+        bad("the A/D/R release never reaches the floor");
+    else
+        ok("the A/D/R release still falls to the floor");
+}
+
+/* ---- the case that was already right ----------------------------------- */
+{
+    const r = render(AD, { eg_attack: 0.3, eg_decay: 0.4 });
+    const tops = profile(r);
+    const floor = Math.max(...tops.filter((v) => v !== null));
+    /* A/D has nothing to release: it decays to silence and must REACH bottom. */
+    const last = tops[r.W - 1];
+    if (last !== null && last < floor - 1)
+        bad("an A/D envelope no longer decays to the floor -- the implied " +
+            "sustain leaked into the case that has no release");
+    else
+        ok("an A/D envelope still decays to the floor");
+}
+
+/* ---- a declared sustain still wins ------------------------------------- */
+{
+    const lo = render(ADSR, { eg_attack: 0.3, eg_decay: 0.4, eg_sustain: 0.05, eg_release: 0.5 });
+    const hi = render(ADSR, { eg_attack: 0.3, eg_decay: 0.4, eg_sustain: 0.95, eg_release: 0.5 });
+    const mid = Math.floor(lo.W * 0.55);
+    const loTop = topRow(lo, mid), hiTop = topRow(hi, mid);
+    if (loTop === null || hiTop === null || !(hiTop < loTop))
+        bad("a DECLARED sustain no longer sets the plateau height (low=" +
+            loTop + " high=" + hiTop + ") -- the implied value overrode a real one");
+    else
+        ok("a declared sustain value still sets the plateau height");
+}
+
+if (fail) { console.log("FAILURES: " + fail); process.exit(1); }
+console.log("PASS: a release role implies a sustain stage to draw");
+'


### PR DESCRIPTION
Fixes #359. Thanks @ryanmgilmore — the analysis and the suggested shape were
right; this implements it with one addition, noted below.

## The bug

`drawPartialEnv` read "no sustain role" as "sustain is zero":

```js
const susY = has("sustain") ? baseY - Math.round(val.sustain * usableH) : baseY;
```

So an A/D/R envelope decayed to the floor, drew no plateau, and then released
from a point on the floor to another point on the floor — a flat line along the
bottom.

That default is correct for **A/D**: a percussive shape decays to silence and
there is nothing to release. It stops being correct the moment `release` is
declared, because release means "fall from the held level to zero" — if the
held level were already zero there would be nothing to release from and the
role would be meaningless. The presence of `release` is itself the evidence
that a sustain **stage** exists, whether or not its **level** is a parameter.

The QY-70 case makes that concrete: its XG Multi Part offsets are EG Attack, EG
Decay and EG Release and nothing else. The sustain level lives in the voice and
is not addressable — but hold a note and it holds. The stage exists; the editor
cannot read its height.

## The fix

```js
const IMPLIED_SUSTAIN = 0.5;
const impliedSustain = !has("sustain") && has("decay") && has("release");
const susY = has("sustain") ? baseY - Math.round(val.sustain * usableH)
           : impliedSustain ? baseY - Math.round(IMPLIED_SUSTAIN * usableH)
           : baseY;
```

`K = 0.5`, as suggested — a picture, not a measurement. Nothing reads it as a
value: it is only geometry and `val.sustain` stays `undefined`.

**One addition to the suggested shape:** the implied case also draws the
plateau. With only `susY` raised, decay runs straight into release and the
result is a kink between two falls rather than anything that reads as *held* —
which is the complaint ("no nonzero portion of envelope that would look to be
sustained"). Since the argument is that a sustain *stage* exists, drawing the
stage follows from it. Both the plateau and its end marker now key off
`drawsPlateau = has("sustain") || impliedSustain`.

A/D with no release still falls to the floor.

## Tests

`tests/host/test_env_implied_sustain.sh` pins the reported case, that the
release still reaches the floor, that A/D is untouched, and that a **declared**
sustain still sets the height (so the implied value can never override a real
one). Confirmed to fail against pre-fix HEAD on the reported case:

```
FAIL: an A/D/R envelope is still flat along the floor after decay --
      there is no nonzero portion that reads as sustained
```

It drives **synthetic** groups, deliberately. On your scope question: I checked,
and the 100-module fleet capture contains **zero** A/D/R-without-sustain
envelopes — so there is no fixture to drive this from, and a test that quietly
covered nothing would be worse than none. The group shape is copied from a real
detected one (slicer, "Params - 2"). That also means the defect is invisible to
the fleet capture and only reachable from a module like the QY-70 editor, which
is consistent with your not being able to quote a number.

`make -C tests/host test` plus all `tests/host/*.sh` green.

Not verified on hardware — I have no QY-70. If you still have the editor to
hand, that is the case that reproduces it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)