### PR TITLE
shim: the shadow_ui MIDI ring is sized for SysEx bursts, and says when it drops

### DIFF
--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -48,6 +48,33 @@
  * ============================================================================ */
 
 #define MIDI_BUFFER_SIZE    256   /* Hardware mailbox MIDI area: 64 USB-MIDI packets */
+
+/* The shim -> shadow_ui MIDI ring, and NOT the mailbox size above.
+ *
+ * It was MIDI_BUFFER_SIZE, which made the ring 64 packets because that is how
+ * many fit in the hardware mailbox — a number with nothing to do with how much
+ * MIDI a tool can be sent between two drains. A Yamaha 5F bulk dump message is
+ * 158 bytes on the wire = 53 packets, so ONE nearly filled the ring and two
+ * back-to-back could not fit: shadow_ui_midi_publish() fell off the end of its
+ * scan and dropped whole packets, silently. Measured on a QY-70 at 6.9% of
+ * 3164 messages, every shortfall a multiple of 3 and every one on the largest
+ * message type (#358).
+ *
+ * Sharing the constant also made the obvious fix dangerous: MIDI_BUFFER_SIZE
+ * still bounds `memcpy(sh_midi, hw_midi, ...)` and `hotkey_prev`, which read
+ * the SPI mailbox, so enlarging IT would have read past MIDI_IN into the
+ * display status word. Hence a separate name rather than a bigger number.
+ *
+ * 1024 = 256 packets, ~4.8 of those dump messages, against 1.2 before. The
+ * cost is 768 bytes of shared memory.
+ *
+ * RESIZING THIS IS A LAYOUT CHANGE. The segment outlives the processes, so a
+ * shim that creates it at the new size and a shadow_ui built against the old
+ * one disagree — and the dangerous direction is a NEW consumer mapping 1024
+ * over a stale 256-byte segment, where every touch past the end is SIGBUS.
+ * shadow_shm_map() refuses a short attach rather than handing back that
+ * mapping; deploy the shim and shadow_ui together, as install.sh does. */
+#define SHADOW_UI_MIDI_BYTES 1024
 /* Hardware MIDI_OUT region is 20 × 4-byte USB-MIDI packets = 80 bytes.
  * The display buffer starts immediately after at offset 80. Writes to
  * MIDI_OUT must be bounded by this to avoid corrupting the display. */

--- a/src/host/shadow_shm_util.c
+++ b/src/host/shadow_shm_util.c
@@ -28,6 +28,27 @@ void *shadow_shm_map(const char *name, size_t size, int create, int zero)
         }
         return NULL;
     }
+    /* An ATTACH must not map more than the segment actually holds.
+     *
+     * These segments outlive the processes, so after a constant is enlarged a
+     * new consumer can meet a stale short one left by the previous shim. mmap
+     * accepts the length regardless — and every touch past the file's end is
+     * SIGBUS, in whichever process attached, at some arbitrary later moment.
+     * Refusing here turns that into a NULL the callers already handle (the
+     * feature goes quiet) plus a line saying exactly why. The creator below
+     * ftruncates, so it is never the one that trips this. */
+    if (!create) {
+        struct stat st;
+        if (fstat(fd, &st) == 0 && (size_t)st.st_size < size) {
+            unified_log("shm", LOG_LEVEL_ERROR,
+                        "%s is %lld bytes but %zu were requested - refusing to map "
+                        "past the end (stale segment from an older build; restart "
+                        "the shim so it is recreated)",
+                        name, (long long)st.st_size, size);
+            close(fd);
+            return NULL;
+        }
+    }
     if (create && ftruncate(fd, (off_t)size) != 0) {
         /* A full /dev/shm fails here; without this check the first page
          * touch on the mapping SIGBUSes instead of failing cleanly. */

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -544,6 +544,29 @@ static void ext_midi_drop_tick(void)
     LOG_DEBUG("shim", msg);
 }
 
+/* The same shape for the shadow_ui MIDI ring. A large SysEx burst -- a Yamaha
+ * 5F bulk dump is 53 USB-MIDI packets per message -- can outrun the drain, and
+ * a dropped packet leaves the message still well-framed and still parseable,
+ * so nothing downstream can tell. Only the dump's own declared byte count
+ * disagrees. Reporting the rate is what turns that into something a user can
+ * see without a capture rig (#358). */
+static void ui_midi_drop_tick(void)
+{
+    static int last_total = 0;
+    int total = shim_ui_midi_drops;
+    int delta = total - last_total;
+    if (delta <= 0) { last_total = total; return; }
+    last_total = total;
+
+    char msg[160];
+    snprintf(msg, sizeof(msg),
+             "ui-midi: %d shadow_ui ring drop(s) this window (%d total) - "
+             "MIDI to tools is being lost; a large SysEx burst is outrunning "
+             "the %d-packet ring",
+             delta, total, SHADOW_UI_MIDI_BYTES / 4);
+    LOG_DEBUG("shim", msg);
+}
+
 static void *worker_main(void *arg) {
     (void)arg;
 
@@ -680,7 +703,7 @@ static void *worker_main(void *arg) {
         if (tick % 5 == 0) rt_audit_tick();       /* ~1 Hz, no-op unless armed */
         if (tick % 5 == 0) spi_tally_tick();      /* ~1 Hz, no-op unless armed */
         align_capture_tick();                    /* 5 Hz: arm on trigger, drain when full */
-        if (tick % 5 == 0) ext_midi_drop_tick();  /* ~1 Hz, silent unless dropping */
+        if (tick % 5 == 0) { ext_midi_drop_tick(); ui_midi_drop_tick(); }
         if (tick % 7 == 0) shadow_poll_current_set(); /* ~1.4 s FS scan */
         tick++;
     }

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -63,6 +63,7 @@ extern volatile int shim_jack_persist;
  * delivered only on a non-zero return, so a DROP self-heals on the next turn —
  * but a burst of them means the mailbox is saturated and motors are lagging. */
 extern volatile int shim_ext_midi_drops;
+extern volatile int shim_ui_midi_drops;
 
 /* Last USB-C audio-out source seen by the RT path (0 = Mic, 1 = Main Out),
  * -1 until observed. Worker persists it on change and re-asserts it at boot —

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1423,6 +1423,9 @@ static ext_midi_ring_t overtake_ext_ring;
  * read, so the one failure mode this path has — a packet dropped, and whatever
  * it was reporting left stale — was invisible from the device. */
 volatile int shim_ext_midi_drops = 0;
+/* Packets the shadow_ui MIDI ring had no room for. Incremented on the SPI
+ * callback by shadow_ui_midi_publish; reported by the worker (#358). */
+volatile int shim_ui_midi_drops = 0;
 
 /* Audio-thread producer for an overtake DSP (host_api midi_send_external). */
 static int overtake_midi_send_external(const uint8_t *msg, int len) {
@@ -3018,7 +3021,7 @@ static inline void shadow_ui_midi_publish(uint8_t head, uint8_t status,
      * packet always carries at least one nonzero byte, so the all-zero case
      * is now rejected too. See src/host/shadow_midi_filter.c. */
     if (!shadow_midi_forwardable(head, status, d1, d2)) return;
-    for (int slot = 0; slot < MIDI_BUFFER_SIZE; slot += 4) {
+    for (int slot = 0; slot < SHADOW_UI_MIDI_BYTES; slot += 4) {
         if (__atomic_load_n(&shadow_ui_midi_shm[slot], __ATOMIC_ACQUIRE) == 0) {
             shadow_ui_midi_shm[slot + 1] = status;
             shadow_ui_midi_shm[slot + 2] = d1;
@@ -3028,6 +3031,15 @@ static inline void shadow_ui_midi_publish(uint8_t head, uint8_t status,
             return;
         }
     }
+    /* Ring full: this packet is gone.
+     *
+     * Falling off the end and returning is what made a 6.9% packet loss on
+     * QY-70 bulk dumps take two hardware captures to characterise instead of
+     * one glance at a log — framing still held and the message still parsed,
+     * so from the device an overflow was indistinguishable from a device that
+     * simply sent less. Count it here (this is the SPI callback, so no logging
+     * and no allocation) and let the worker report the rate at ~1 Hz. */
+    shim_ui_midi_drops++;
 }
 
 /* LED queue constants and state — moved to shadow_led_queue.c */
@@ -3321,7 +3333,7 @@ static void init_shadow_shm(void)
 
     /* Create/open UI MIDI shared memory */
     shadow_ui_midi_shm = (uint8_t *)shadow_shm_map(SHM_SHADOW_UI_MIDI,
-                                                   MIDI_BUFFER_SIZE, 1, 1);
+                                                   SHADOW_UI_MIDI_BYTES, 1, 1);
 
     /* Create/open display shared memory */
     shadow_display_shm = (uint8_t *)shadow_shm_map(SHM_SHADOW_DISPLAY,

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -71,7 +71,7 @@ static int open_shadow_shm(void) {
     shadow_display_shm = (uint8_t *)shadow_shm_map(SHM_SHADOW_DISPLAY, DISPLAY_BUFFER_SIZE, 0, 0);
     if (!shadow_display_shm) return -1;
 
-    shadow_ui_midi_shm = (uint8_t *)shadow_shm_map(SHM_SHADOW_UI_MIDI, MIDI_BUFFER_SIZE, 0, 0);
+    shadow_ui_midi_shm = (uint8_t *)shadow_shm_map(SHM_SHADOW_UI_MIDI, SHADOW_UI_MIDI_BYTES, 0, 0);
     if (!shadow_ui_midi_shm) return -1;
 
     shadow_control = (shadow_control_t *)shadow_shm_map(SHM_SHADOW_CONTROL, CONTROL_BUFFER_SIZE, 0, 0);
@@ -530,7 +530,7 @@ static JSValue js_shadow_set_overtake_mode(JSContext *ctx, JSValueConst this_val
         last_midi_ready = shadow_control->midi_ready;
         /* Clear MIDI buffer to start fresh */
         if (shadow_ui_midi_shm) {
-            memset(shadow_ui_midi_shm, 0, MIDI_BUFFER_SIZE);
+            memset(shadow_ui_midi_shm, 0, SHADOW_UI_MIDI_BYTES);
         }
     } else {
         /* Clear the full-overtake sysex-suppression opt-in here, the one point
@@ -3023,7 +3023,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
 static int process_shadow_midi(JSContext *ctx, JSValue *onInternal, JSValue *onExternal) {
     if (!shadow_ui_midi_shm) return 0;
     int handled = 0;
-    for (int i = 0; i < MIDI_BUFFER_SIZE; i += 4) {
+    for (int i = 0; i < SHADOW_UI_MIDI_BYTES; i += 4) {
         /* Acquire-load the gate byte: pairs with the producer's release-store
          * in shadow_ui_midi_publish() (schwung_shim.c). Ensures bytes 1-3 are
          * visible whenever byte 0 is nonzero. */

--- a/tests/host/test_ui_midi_ring_sizing.sh
+++ b/tests/host/test_ui_midi_ring_sizing.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The shadow_ui MIDI ring is sized for SysEx bursts, and is NOT the mailbox.
+#
+# It used to be MIDI_BUFFER_SIZE, which made it 64 packets because that is how
+# many fit in the hardware mailbox -- a number with nothing to do with how much
+# MIDI a tool can be sent between two drains. A Yamaha 5F bulk dump message is
+# 158 bytes on the wire = 53 packets, so ONE nearly filled the ring and two
+# back-to-back could not: shadow_ui_midi_publish() fell off the end of its scan
+# and dropped whole packets in silence. Measured on a QY-70 at 6.9% of 3164
+# messages, every shortfall a multiple of 3 (#358).
+#
+# THE TRAP THIS EXISTS FOR. MIDI_BUFFER_SIZE still bounds the hardware mailbox
+# copies -- `memcpy(sh_midi, hw_midi, ...)` and `hotkey_prev` -- so "just make
+# the buffer bigger" would have read past MIDI_IN into the display status word.
+# The two sizes must stay separate names, and this fails if the ring paths go
+# back to sharing the mailbox constant.
+#
+# Producer and consumer must also agree: they are different binaries mapping
+# one segment, and a mismatch is a silent partial drain, not an error.
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+H=src/host/shadow_constants.h
+SHIM=src/schwung_shim.c
+UI=src/shadow/shadow_ui.c
+
+# ---- the two sizes are separate, and the ring is the bigger one ------------
+ring=$(sed -n 's/^#define SHADOW_UI_MIDI_BYTES[[:space:]]*\([0-9]*\).*/\1/p' "$H")
+mail=$(sed -n 's/^#define MIDI_BUFFER_SIZE[[:space:]]*\([0-9]*\).*/\1/p' "$H")
+[ -n "$ring" ] || fail "SHADOW_UI_MIDI_BYTES is gone -- the ring is sharing the mailbox size again"
+[ -n "$mail" ] || fail "MIDI_BUFFER_SIZE is gone"
+
+# 53 packets is one dump message; two back-to-back is the case that overflowed.
+packets=$((ring / 4))
+[ "$packets" -ge 106 ] || fail "the ring holds $packets packets; two 53-packet dump \
+messages need 106, which is the burst that was measured dropping"
+
+# ---- the ring paths use the ring constant, not the mailbox one -------------
+# Producer: the SHM it creates and the slot scan it fills.
+grep -q 'SHM_SHADOW_UI_MIDI,$' "$SHIM" || grep -q 'SHM_SHADOW_UI_MIDI' "$SHIM" \
+    || fail "$SHIM no longer creates the UI MIDI segment"
+grep -q 'SHADOW_UI_MIDI_BYTES, 1, 1' "$SHIM" \
+    || fail "$SHIM does not CREATE the UI ring at SHADOW_UI_MIDI_BYTES"
+grep -q 'slot < SHADOW_UI_MIDI_BYTES' "$SHIM" \
+    || fail "shadow_ui_midi_publish does not scan the whole ring"
+
+# Consumer: the attach, the wholesale clear, and the drain bound.
+grep -q 'SHM_SHADOW_UI_MIDI, SHADOW_UI_MIDI_BYTES' "$UI" \
+    || fail "$UI does not ATTACH the UI ring at SHADOW_UI_MIDI_BYTES -- producer and \
+consumer disagreeing is a silent partial drain"
+grep -q 'i < SHADOW_UI_MIDI_BYTES' "$UI" \
+    || fail "process_shadow_midi does not drain the whole ring"
+grep -q 'memset(shadow_ui_midi_shm, 0, SHADOW_UI_MIDI_BYTES)' "$UI" \
+    || fail "$UI clears only part of the ring"
+
+# Nothing in the consumer should still reach for the mailbox size.
+if grep -q 'MIDI_BUFFER_SIZE' "$UI"; then
+    fail "$UI still uses MIDI_BUFFER_SIZE -- the UI ring and the hardware mailbox \
+are different buffers and must not share a size"
+fi
+
+# ---- the mailbox copies still use the MAILBOX size -------------------------
+# This is the half that would corrupt the display region if it drifted.
+grep -q 'memcpy(sh_midi, hw_midi, MIDI_BUFFER_SIZE)' "$SHIM" \
+    || fail "the hardware MIDI_IN copy no longer uses MIDI_BUFFER_SIZE -- if it \
+were widened to the ring size it would read past MIDI_IN into the display status"
+grep -q 'hotkey_prev\[MIDI_BUFFER_SIZE\]' "$SHIM" \
+    || fail "hotkey_prev no longer uses MIDI_BUFFER_SIZE"
+
+# ---- an overflow is counted, not silent ------------------------------------
+grep -q 'shim_ui_midi_drops++' "$SHIM" \
+    || fail "a full ring still drops in silence -- nothing counts it"
+grep -q 'ui_midi_drop_tick' src/host/shim_worker.c \
+    || fail "nothing reports the drop count; the counter alone is invisible"
+
+# ---- a short attach must be refused, not mapped ----------------------------
+# Enlarging a segment that outlives the process means a new consumer can meet a
+# stale short one, and mapping past its end is SIGBUS at an arbitrary later
+# moment in whichever process attached.
+grep -q 'fstat' src/host/shadow_shm_util.c \
+    || fail "shadow_shm_map does not check the segment length on attach -- a stale \
+short segment would SIGBUS instead of failing cleanly"
+
+echo "PASS: the UI MIDI ring is sized for bursts, separate from the mailbox, and counts drops"


### PR DESCRIPTION
Refs #358. Thanks @ryanmgilmore — the arithmetic and the signature both hold up.
One finding changed the shape of the fix, so flagging it up front.

## Option 2 as written would have been a bad time

`MIDI_BUFFER_SIZE` is **dual-purpose**. It is the shadow_ui ring size *and* the
hardware mailbox MIDI area — it still bounds:

```c
memcpy(sh_midi, hw_midi, MIDI_BUFFER_SIZE);   /* schwung_shim.c */
static uint8_t hotkey_prev[MIDI_BUFFER_SIZE];
```

Both read the SPI mailbox. Enlarging that constant would have walked them past
MIDI_IN into the display status word — the same confusion `CLAUDE.md` already
records ("Bound is `SHADOW_MIDI_IN_BYTES` (248 = 31 × 8), **NOT**
`MIDI_BUFFER_SIZE`").

So this splits the name first and enlarges only the ring. That is why the ring
being 64 packets was arbitrary in the first place: it was the mailbox's packet
count, which has nothing to do with how much MIDI a tool can be sent between
two drains.

## The fix

`SHADOW_UI_MIDI_BYTES = 1024` → **256 packets**, about 4.8 of your 147-byte dump
messages against 1.2 before. 768 bytes of shared memory. Producer and consumer
both move to it; the mailbox copies keep `MIDI_BUFFER_SIZE`.

**And the drop is counted** (your option 1, which belongs with the resize rather
than instead of it). The overflow happens on the SPI callback, so it only
increments a counter there — no logging, no allocation — and the worker reports
delta and total at ~1 Hz, silent when zero. Same shape as `ext_midi_drop_tick`
beside it:

```
ui-midi: 12 shadow_ui ring drop(s) this window (37 total) - MIDI to tools is
being lost; a large SysEx burst is outrunning the 256-packet ring
```

That is the half that made this cost you two captures instead of one glance at a
log.

## The layout risk, handled

You were right that this is the part that needs care. The segment outlives the
processes, and the dangerous direction is a **new consumer meeting a stale
short segment** from an older shim: `mmap` accepts the length regardless, and
every touch past EOF is SIGBUS at an arbitrary later moment. `shadow_shm_map`
now `fstat`s on the attach path and refuses a short segment, which turns that
into a NULL the callers already handle plus a line saying why. The creator
`ftruncate`s, so it never trips it.

Deploy shim and shadow_ui together — `install.sh` does.

## Not done: option 3

Draining more often is untouched. It looked like the one that needs a tick-budget
measurement rather than a reading, and the ring now has ~4x the headroom, so it
did not seem worth spending that budget speculatively.

## Tests

`tests/host/test_ui_midi_ring_sizing.sh` pins the two sizes apart, that the ring
holds the 106 packets your measured burst needs, that producer and consumer
agree (a mismatch is a silent partial drain, not an error), that the **mailbox**
copies still use the mailbox size, that a drop is counted and reported, and that
a short attach is refused. Confirmed to fail against pre-fix sources:

```
FAIL: SHADOW_UI_MIDI_BYTES is gone -- the ring is sharing the mailbox size again
```

`make -C tests/host test`, all `tests/host/*.sh`, and the ARM64 cross-compile
all clean.

## Verification status

Not verified against a real dump — I have no QY-70. The arithmetic says two
back-to-back 53-packet messages now fit where they did not, and the counter
means a remaining overflow will announce itself rather than hide. If you run it,
the counter line is the thing to watch: it should stay absent where you
previously measured 2.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)