### PR TITLE
manager: a flash is shown once, not on every refresh after it

### DIFF
--- a/schwung-manager/templates/partials/flash.html
+++ b/schwung-manager/templates/partials/flash.html
@@ -5,6 +5,28 @@
 </div>
 <script>
 (function() {
+    /*
+     * A flash is shown ONCE. It travels in the URL (post/redirect/get), so the
+     * message is still in the address bar after the redirect and every reload
+     * renders it again -- "Ruminant updated successfully" reappearing on a
+     * refresh long after the install, which reads as the action having run
+     * again.
+     *
+     * Strip it as soon as it is shown rather than when it is dismissed: a
+     * refresh during the five seconds it is up should not bring it back
+     * either. replaceState adds no history entry, so Back is unaffected, and
+     * only these two parameters are removed -- a sort or filter in the same
+     * query survives.
+     */
+    try {
+        var u = new URL(window.location.href);
+        if (u.searchParams.has('flash') || u.searchParams.has('flash_type')) {
+            u.searchParams.delete('flash');
+            u.searchParams.delete('flash_type');
+            history.replaceState(null, '', u.pathname + u.search + u.hash);
+        }
+    } catch (e) { /* no URL/history: the toast simply repeats on refresh */ }
+
     var el = document.currentScript.previousElementSibling;
     if (el) {
         setTimeout(function() {


### PR DESCRIPTION
Follow-up to #357 — reported as soon as that landed on a device: the toast comes
back on **every reload**, long after the install, which reads as the action
having run again.

## Why

The flash travels in the URL (post/redirect/get), so after the redirect the
message is still in the address bar and every load renders it. That was true
before #357 too, but harmless while the flash was an inline banner at the top of
a page you had already scrolled past. Making it a corner toast is what turned it
into something you see every time.

## The fix

Strip `flash` and `flash_type` from the URL as soon as the toast is **shown**,
not when it is dismissed — so a refresh during the five seconds it is up does
not bring it back either. `replaceState` adds no history entry, so Back is
unaffected, and only those two parameters are removed: a `sort` or filter in the
same query survives.

Wrapped, because a missing `URL`/`history` should degrade to the old behaviour
rather than throw and take the auto-dismiss timer below it down as well.

## Verified on a Move

```
arriving from the redirect  -> toast rendered, url is /modules?sort=az
after reload                -> no toast, and no flash container in the page at all
```

The second line is the one that matters: the container is not rendered, so the
message is gone at the source rather than merely auto-dismissed — the server
never sees a flash parameter on the reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)