### PR TITLE
remote UI: a Master FX position can show its own web_ui.html

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -284,7 +284,12 @@ The slot's **Interface: Default** toggle still shows the
 auto-generated controls for every component, so a module's own
 parameters stay reachable whatever its panel does.
 
-Master FX slots have no custom-UI path yet.
+A **Master FX** position works the same way as an audio FX: the panel
+renders inside that position's own section, with its own pop-out, and
+the Master FX tab has its own Interface toggle. The component there is
+`master_fx:fx1` … `master_fx:fx4`, so a panel that builds its keys from
+`schwungRemote.component` needs no change to work on the master bus —
+one that hardcodes `fx1:` will address a chain slot instead.
 
 **Know which component you are driving.** The manager appends
 `?component=<comp>` to the iframe URL and exposes it as

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"strconv"
-	"strings"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -924,6 +924,15 @@ func (ru *RemoteUI) handleSubscribeMasterFx(ctx context.Context, c *ruClient) {
 			continue
 		}
 		compName := "master_fx:" + fxSlot
+		modID = masterFxModuleID(modID)
+		// A Master FX position is an ordinary audio FX module in a different
+		// place, so it may ship a web_ui.html exactly as it does in a chain
+		// slot — findModuleWebUI already searches audio_fx. Only this send was
+		// missing, which is why the same module offered its panel on a track
+		// and the generated rows on the master bus (#354).
+		if url := ru.findModuleWebUI(modID); url != "" {
+			ru.sendCustomUI(ctx, c, 0, compName, url)
+		}
 		ru.sendHierarchy(ctx, c, 0, compName)
 		ru.sendChainParams(ctx, c, 0, compName)
 		ru.sendInitialParamValues(ctx, c, 0, compName)
@@ -1437,11 +1446,32 @@ func (ru *RemoteUI) sendSlotInfo(ctx context.Context, c *ruClient, slot uint8) {
 	ru.writeJSON(ctx, c, info)
 }
 
+// masterFxModuleID turns what the shim stores for a Master FX position into a
+// module id.
+//
+// A chain slot's "<comp>_module" holds an id ("4k-eq"), but a Master FX
+// position is loaded by PATH — shadow_master_fx_slot_load takes a dsp path —
+// and reading the key back returns that path. So the same module is "4k-eq" on
+// a track and "/data/UserData/schwung/modules/audio_fx/4k-eq/4k-eq.so" on the
+// master bus, which is why findModuleWebUI found nothing here and why the tab
+// labelled the position with a .so path.
+//
+// The id is the directory the dsp lives in, which is how every module is laid
+// out. A value with no separator is passed through unchanged, so this keeps
+// working if the shim ever stores an id.
+func masterFxModuleID(v string) string {
+	if v == "" || !strings.ContainsAny(v, "/") {
+		return v
+	}
+	return filepath.Base(filepath.Dir(v))
+}
+
 func (ru *RemoteUI) sendMasterFxInfo(ctx context.Context, c *ruClient) {
 	info := wsMasterFxInfo{Type: "master_fx_info"}
 	for _, fxSlot := range masterFxSlots {
 		moduleKey := "master_fx:" + fxSlot + ":module"
-		modID, _ := ru.shm.GetParam(0, moduleKey)
+		raw, _ := ru.shm.GetParam(0, moduleKey)
+		modID := masterFxModuleID(raw)
 		switch fxSlot {
 		case "fx1":
 			info.FX1 = modID
@@ -1956,6 +1986,14 @@ func (ru *RemoteUI) pollMasterFx(ctx context.Context, cache *slotCache) {
 			cache.modules[fxSlot] = modID
 			ru.broadcastMasterFxInfo(ctx)
 			if modID != "" {
+				// Swapping the module swaps its panel. Sent BEFORE the
+				// hierarchy so a position that gains a custom UI does not
+				// paint generated rows first and replace them a moment later;
+				// a position that loses one is handled client-side, which
+				// clears the panel on the master_fx_info above.
+				if url := ru.findModuleWebUI(masterFxModuleID(modID)); url != "" {
+					ru.broadcastMasterFxCustomUI(ctx, compName, url)
+				}
 				ru.broadcastMasterFxHierarchy(ctx, compName)
 				ru.broadcastMasterFxChainParams(ctx, compName)
 			}
@@ -1979,6 +2017,16 @@ func (ru *RemoteUI) pollMasterFx(ctx context.Context, cache *slotCache) {
 func (ru *RemoteUI) broadcastMasterFxInfo(ctx context.Context) {
 	for _, c := range ru.masterFxSubscribedClients() {
 		ru.sendMasterFxInfo(ctx, c)
+	}
+}
+
+// broadcastMasterFxCustomUI tells every Master FX subscriber that a position
+// now has a custom panel. Separate from broadcastCustomUI, which addresses
+// slot subscribers: a client can be on the Master FX tab without being
+// subscribed to any chain slot.
+func (ru *RemoteUI) broadcastMasterFxCustomUI(ctx context.Context, compName, url string) {
+	for _, c := range ru.masterFxSubscribedClients() {
+		ru.sendCustomUI(ctx, c, 0, compName, url)
 	}
 }
 

--- a/schwung-manager/remote_ui_masterfx_test.go
+++ b/schwung-manager/remote_ui_masterfx_test.go
@@ -1,0 +1,24 @@
+package main
+
+import "testing"
+
+// A Master FX position is loaded by dsp PATH (shadow_master_fx_slot_load takes
+// one), so reading its module key back returns that path — while a chain slot's
+// equivalent holds a bare id. The same module is therefore "4k-eq" on a track
+// and a .so path on the master bus, which is why findModuleWebUI found no panel
+// there and why the tab labelled the position with a path (#354).
+func TestMasterFxModuleID(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/data/UserData/schwung/modules/audio_fx/4k-eq/4k-eq.so", "4k-eq"},
+		{"/data/UserData/schwung/modules/audio_fx/tape-echo2/tape-echo2.so", "tape-echo2"},
+		// Already an id (a shim that stores one): passed through untouched.
+		{"4k-eq", "4k-eq"},
+		// Nothing loaded.
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := masterFxModuleID(c.in); got != c.want {
+			t.Errorf("masterFxModuleID(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -55,7 +55,13 @@
             "master_fx:fx3": makeComponent(),
             "master_fx:fx4": makeComponent()
         },
-        collapsed: { "master_fx:fx1": false, "master_fx:fx2": true, "master_fx:fx3": true, "master_fx:fx4": true }
+        collapsed: { "master_fx:fx1": false, "master_fx:fx2": true, "master_fx:fx3": true, "master_fx:fx4": true },
+        // Keyed by component, exactly as a slot's is: two Master FX positions
+        // can each ship a panel and must not collide.
+        customUI: {},
+        // The same Custom/Default escape hatch a slot has, so a custom panel
+        // can never make a Master FX parameter unreachable.
+        useDefaultUI: false
     };
 
     // Active overtake-tool state. A tool is not a chain slot; its
@@ -230,6 +236,9 @@
                     break;
                 case "chain_params":
                     handleMasterFxChainParams(comp, msg);
+                    break;
+                case "custom_ui":
+                    handleMasterFxCustomUI(comp, msg);
                     break;
             }
             return;
@@ -455,10 +464,31 @@
     // ------------------------------------------------------------------
 
     function handleMasterFxInfo(msg) {
-        masterFx.components["master_fx:fx1"].module = msg.fx1 || "";
-        masterFx.components["master_fx:fx2"].module = msg.fx2 || "";
-        masterFx.components["master_fx:fx3"].module = msg.fx3 || "";
-        masterFx.components["master_fx:fx4"].module = msg.fx4 || "";
+        var incoming = {
+            "master_fx:fx1": msg.fx1 || "",
+            "master_fx:fx2": msg.fx2 || "",
+            "master_fx:fx3": msg.fx3 || "",
+            "master_fx:fx4": msg.fx4 || ""
+        };
+        for (var i = 0; i < MASTER_FX_KEYS.length; i++) {
+            var ck = MASTER_FX_KEYS[i];
+            if (masterFx.components[ck].module !== incoming[ck]) {
+                masterFx.components[ck].module = incoming[ck];
+                // The panel belonged to the module that just left. Dropping it
+                // here is what makes a REMOVED module lose its iframe: the
+                // server only sends custom_ui for a module that has one, so
+                // nothing would otherwise clear it and the old panel would
+                // keep addressing a position holding something else.
+                delete masterFx.customUI[ck];
+            }
+        }
+        if (activeSlot === "master") renderSlot();
+    }
+
+    function handleMasterFxCustomUI(comp, msg) {
+        var url = msg.url || "";
+        if (masterFx.customUI[comp] === url) return;  // avoid reloading a live iframe
+        masterFx.customUI[comp] = url;
         if (activeSlot === "master") renderSlot();
     }
 
@@ -494,7 +524,21 @@
                 }
             }
         }
-        if (activeSlot === "master") updateMasterFxParamValues(msg.params);
+        if (activeSlot === "master") {
+            updateMasterFxParamValues(msg.params);
+            // ...and to any custom panels. Grouped by position rather than
+            // broadcast: fx2's panel has no business seeing fx1's values, and
+            // two positions each showing a panel is explicitly supported.
+            var byComp = {};
+            for (var fk in msg.params) {
+                var pr = splitMasterFxPrefix(fk);
+                if (!pr) continue;
+                (byComp[pr.comp] || (byComp[pr.comp] = {}))[fk] = msg.params[fk];
+            }
+            for (var ck in byComp) {
+                postToIframe({ type: "paramUpdate", params: byComp[ck] }, ck);
+            }
+        }
     }
 
     /** Split "master_fx:fx1:cutoff" -> { comp: "master_fx:fx1", key: "cutoff" }. */
@@ -2063,10 +2107,20 @@
             // The Tool tab is not a numbered slot — standalone mode keys off
             // tool=1 to use the overtake-tool channel (subscribe_tool / set on
             // slot 0 / refetch_tool) instead of a per-slot subscribe.
+            // Master FX is not a numbered slot either: standalone mode keys
+            // off master_fx=1 to use subscribe_master_fx and
+            // set_master_fx_param, whose keys already carry their own
+            // "master_fx:fxN:" prefix.
             var qs = (slot === "tool") ? "schwungStandalone=1&tool=1"
-                                       : "schwungStandalone=1&slot=" + slot;
+                   : (slot === "master") ? "schwungStandalone=1&master_fx=1"
+                   : "schwungStandalone=1&slot=" + slot;
             var popUrl = url + sep + qs;
-            window.open(popUrl, "schwungPopout_" + slot);
+            // One window per COMPONENT on the master bus -- keying on the slot
+            // alone would make fx2's pop-out replace fx1's.
+            var winKey = (slot === "master")
+                ? "schwungPopout_master_" + encodeURIComponent(componentOfUrl(url))
+                : "schwungPopout_" + slot;
+            window.open(popUrl, winKey);
         };
         return popBtn;
     }
@@ -2097,6 +2151,12 @@
     /** Tag a module UI URL with the component it is driving, so the page can
      *  address the right parameter prefix ("fx1:mix" rather than "synth:mix")
      *  and a popped-out window can ask for the right metadata. */
+    /** The component customUIUrlFor stamped into a panel URL, for window naming. */
+    function componentOfUrl(url) {
+        var m = /[?&]component=([^&]*)/.exec(url || "");
+        return m ? decodeURIComponent(m[1]) : "";
+    }
+
     function customUIUrlFor(url, comp) {
         if (!url) return url;
         return url + (url.indexOf("?") >= 0 ? "&" : "?") + "component=" + encodeURIComponent(comp);
@@ -2211,6 +2271,8 @@
                 // subscribe (that would re-send custom_ui and reload the iframe).
                 if (activeSlot === "tool") {
                     send({ type: "refetch_tool" });
+                } else if (activeSlot === "master") {
+                    send({ type: "subscribe_master_fx" });
                 } else if (typeof activeSlot === "number") {
                     send({ type: "subscribe", slot: activeSlot });
                 }
@@ -2225,6 +2287,16 @@
         // Tool view: params come from the overtake tool's cache (overtake_dsp:*).
         if (slot === "tool") {
             postToIframe({ type: "paramResult", id: msg.id, value: tool.params[msg.key] || "" }, comp);
+            return;
+        }
+        // Master FX view: the key is "master_fx:fx1:cutoff", which splitPrefix
+        // cannot parse -- it splits on the FIRST colon and would look for a
+        // component called "master_fx". Read from the Master FX cache instead.
+        if (slot === "master") {
+            var mp = splitMasterFxPrefix(msg.key);
+            var mc = mp ? masterFx.components[mp.comp] : null;
+            postToIframe({ type: "paramResult", id: msg.id,
+                           value: mc ? (mc.params[msg.key] || "") : "" }, comp);
             return;
         }
         if (typeof slot !== "number") return;
@@ -2252,9 +2324,15 @@
             send({ type: "set_param", slot: 0, key: msg.key, value: String(msg.value) });
             return;
         }
+        // Master FX writes go through set_master_fx_param, not set_param: the
+        // key already carries its own "master_fx:fxN:" prefix and there is no
+        // chain slot to address.
+        if (slot === "master") {
+            send({ type: "set_master_fx_param", key: msg.key, value: String(msg.value) });
+            return;
+        }
         if (typeof slot !== "number") return;
 
-        var parts = splitPrefix(msg.key);
         send({
             type: "set_param",
             slot: slot,
@@ -2265,6 +2343,12 @@
 
     function handleIframeGetHierarchy(msg, comp) {
         var slot = activeSlot;
+        if (slot === "master") {
+            var mc = masterFx.components[comp];
+            postToIframe({ type: "hierarchy", id: msg.id || null, component: comp,
+                           data: mc ? mc.hierarchy : null }, comp);
+            return;
+        }
         if (typeof slot !== "number") return;
         var compState = slots[slot].components[comp || "synth"];
         postToIframe({
@@ -2277,6 +2361,12 @@
 
     function handleIframeGetChainParams(msg, comp) {
         var slot = activeSlot;
+        if (slot === "master") {
+            var mc = masterFx.components[comp];
+            postToIframe({ type: "chainParams", id: msg.id || null, component: comp,
+                           data: mc ? mc.chainParams : null }, comp);
+            return;
+        }
         if (typeof slot !== "number") return;
         var compState = slots[slot].components[comp || "synth"];
         postToIframe({
@@ -2324,6 +2414,15 @@
             return;
         }
 
+        // Master FX view: seed from that position's cached params. Without
+        // this the panel opens blank and only fills in when something moves.
+        if (activeSlot === "master") {
+            var mc = masterFx.components[comp];
+            if (mc && Object.keys(mc.params).length > 0)
+                postToIframe({ type: "paramUpdate", params: mc.params }, comp);
+            return;
+        }
+
         if (typeof activeSlot !== "number") return;
         var comps = slots[activeSlot].components;
         var params = {};
@@ -2366,6 +2465,13 @@
         if (!hasAnyModule) {
             slotContentEl.innerHTML = '<p class="text-muted">No effects loaded in Master FX</p>';
             return;
+        }
+
+        var hasAnyCustomUI = MASTER_FX_KEYS.some(function (k) {
+            return masterFx.components[k].module && masterFx.customUI[k];
+        });
+        if (hasAnyCustomUI && slotHeaderControlsEl) {
+            slotHeaderControlsEl.appendChild(renderUiModeToggle(masterFx));
         }
 
         var renderedCount = 0;
@@ -2413,6 +2519,24 @@
         section.appendChild(header);
 
         if (isCollapsed) return section;
+
+        // A Master FX module that ships its own web_ui.html draws it here
+        // instead of the generated rows -- the same treatment an audio FX gets
+        // in a chain slot, which is the whole point of #354. The Interface
+        // override still wins, so the generated controls stay reachable.
+        var mfxCustomUrl = masterFx.customUI[compKey] || "";
+        if (mfxCustomUrl && !masterFx.useDefaultUI) {
+            var popOut = makePopOutButton(customUIUrlFor(mfxCustomUrl, compKey), "master");
+            popOut.classList.add("component-popout");
+            popOut.onclick = (function (orig) {
+                return function (ev) { ev.stopPropagation(); return orig.apply(this, arguments); };
+            })(popOut.onclick);
+            header.appendChild(popOut);
+            section.appendChild(
+                buildCustomUIFrame(compKey, mfxCustomUrl,
+                                   (MASTER_FX_LABELS[compKey] || compKey) + " UI"));
+            return section;
+        }
 
         // Body
         var body = document.createElement("div");

--- a/schwung-manager/static/schwung-remote-api.js
+++ b/schwung-manager/static/schwung-remote-api.js
@@ -69,20 +69,53 @@
         // gets this without opting in — the alternative is each module posting
         // its own height, which means the ones that never do stay cropped.
         //
-        // documentElement.scrollHeight, not body's: the body may be shorter
-        // than a floated/absolutely-positioned child, and cropping is exactly
-        // what we are fixing. Rounded up, because a fractional height the
-        // parent floors reintroduces a 1px scrollbar, which changes the width,
-        // which can change the height — a loop that never settles.
+        // MEASURE THE BODY, NOT documentElement.
+        //
+        // documentElement.scrollHeight is never LESS than the viewport it is
+        // in — which here is the iframe. So once the parent sizes the frame,
+        // that height is what gets measured and reported straight back, and it
+        // can only ever ratchet up: the frame starts at the CSS guess (60vh),
+        // the page reports 60vh because it fills it, and the frame stays that
+        // tall no matter how little content there is. On a tall window that is
+        // a panel of controls followed by several hundred pixels of nothing.
+        //
+        // Measured on device at a 2216px viewport: documentElement.scrollHeight
+        // said 1330 (exactly 60vh, exactly the frame) while body.scrollHeight
+        // said 642, which is the real content. The body is the thing that grows
+        // with content and can be shorter than its container.
+        //
+        // Body margins are added back because the rect excludes them, and
+        // documentElement remains the fallback for a layout whose body
+        // genuinely measures nothing (everything absolutely positioned), where
+        // the old ratchet is still better than collapsing to zero. Rounded up,
+        // because a fractional height the parent floors reintroduces a 1px
+        // scrollbar, which changes the width, which can change the height — a
+        // loop that never settles.
         var lastHeight = 0;
+        function contentHeight() {
+            var b = document.body;
+            if (!b) return document.documentElement.scrollHeight;
+            var h = b.scrollHeight;
+            if (!h) return document.documentElement.scrollHeight;
+            var cs = window.getComputedStyle ? window.getComputedStyle(b) : null;
+            if (cs) {
+                h += (parseFloat(cs.marginTop) || 0) + (parseFloat(cs.marginBottom) || 0);
+            }
+            return h;
+        }
         function reportHeight() {
-            var h = Math.ceil(document.documentElement.scrollHeight);
+            var h = Math.ceil(contentHeight());
             if (!h || Math.abs(h - lastHeight) < 2) return;
             lastHeight = h;
             window.parent.postMessage({ type: "height", height: h }, "*");
         }
         if (typeof ResizeObserver === "function") {
-            new ResizeObserver(reportHeight).observe(document.documentElement);
+            // The BODY is what changes with content; documentElement only
+            // changes when the frame does, which is the signal that caused the
+            // ratchet in the first place.
+            var ro = new ResizeObserver(reportHeight);
+            ro.observe(document.documentElement);
+            if (document.body) ro.observe(document.body);
         } else {
             window.addEventListener("resize", reportHeight);
         }

--- a/schwung-manager/static/schwung-remote-api.js
+++ b/schwung-manager/static/schwung-remote-api.js
@@ -171,6 +171,10 @@
     // and route sets on slot 0 (the manager dispatches by the overtake_dsp: key
     // prefix), rather than a per-slot subscribe.
     var isTool = query.get("tool") === "1";
+    // Master FX pop-out: subscribe_master_fx, and writes go through
+    // set_master_fx_param — the key already carries its "master_fx:fxN:"
+    // prefix, so there is no slot to address.
+    var isMasterFx = query.get("master_fx") === "1";
 
     var wsUrl = (window.location.protocol === "https:" ? "wss://" : "ws://") +
         window.location.host + "/ws/remote-ui";
@@ -235,7 +239,9 @@
 
         ws.onopen = function () {
             reconnectDelay = 1000;
-            if (isTool) {
+            if (isMasterFx) {
+                ws.send(JSON.stringify({ type: "subscribe_master_fx" }));
+            } else if (isTool) {
                 ws.send(JSON.stringify({ type: "subscribe_tool" }));
             } else {
                 ws.send(JSON.stringify({ type: "subscribe", slot: slot }));
@@ -273,6 +279,14 @@
 
         setParam: function (key, value) {
             if (ws && ws.readyState === WebSocket.OPEN) {
+                if (isMasterFx) {
+                    ws.send(JSON.stringify({
+                        type: "set_master_fx_param",
+                        key: key,
+                        value: String(value)
+                    }));
+                    return;
+                }
                 ws.send(JSON.stringify({
                     type: "set_param",
                     slot: isTool ? 0 : slot,
@@ -304,8 +318,10 @@
             // Re-request a fresh push over our own socket. Tool pop-out uses the
             // params-only refetch (a full subscribe would re-send custom_ui).
             if (ws && ws.readyState === WebSocket.OPEN) {
-                ws.send(JSON.stringify(isTool ? { type: "refetch_tool" }
-                                              : { type: "subscribe", slot: slot }));
+                ws.send(JSON.stringify(
+                    isMasterFx ? { type: "subscribe_master_fx" }
+                  : isTool     ? { type: "refetch_tool" }
+                               : { type: "subscribe", slot: slot }));
             }
         }
     };


### PR DESCRIPTION
Fixes #354 — the category #253 deliberately left out. Reuses that machinery
rather than adding a second custom-UI system, as the issue asked.

## Server

`handleSubscribeMasterFx` already sent hierarchy, `chain_params` and initial
values per position and simply never looked for a panel. It now does the
`findModuleWebUI` / `sendCustomUI` pair the chain and tool paths already had,
plus a broadcast on the module-change edge so swapping a module swaps its panel.

**The part only hardware showed.** A chain slot's `<comp>_module` holds an id
(`4k-eq`), but a Master FX position is loaded **by path** —
`shadow_master_fx_slot_load` takes a dsp path — so reading the key back returns
`/data/UserData/schwung/modules/audio_fx/4k-eq/4k-eq.so`. `findModuleWebUI` was
handed that and found nothing: my first build on the device rendered both
sections and **neither panel**. `masterFxModuleID` takes the directory the dsp
lives in, and `master_fx_info` now reports the id — which also stops the tab
labelling a position with a `.so` path:

```
before: Master FX 1 - /data/UserData/schwung/modules/audio_fx/4k-eq/4k-eq.so
after:  Master FX 1 - 4k-eq
```

## Client

`masterFx` gains the `customUI` map (keyed by component, so two positions cannot
collide) and the same `useDefaultUI` escape hatch a slot has. `custom_ui` is now
**routed** for `master_fx` components — it was falling through the switch and
being dropped. The panel renders inside that position's own section with its own
pop-out, and is cleared when the position's module changes: the server only
announces a module that *has* a panel, so nothing else would drop a departed
one's.

**The bridge was the other half of the work.** `getParam`, `setParam`,
`getHierarchy`, `getChainParams` and the initial seed all bailed on
`typeof slot !== "number"`, so a Master FX panel would have loaded and then sat
inert. Each has a master branch now: reads come from the Master FX cache
(`splitPrefix` cannot parse `master_fx:fx1:cutoff` — it splits on the *first*
colon), writes go through `set_master_fx_param`, and live `param_update`s are
grouped by position rather than broadcast, so fx2's panel never sees fx1's
values. Pop-out gets `master_fx=1` in standalone mode and one window per
component.

## Verified on hardware and in a browser

On a Move, Remote UI driven in a real browser, with **4k-eq in position 1 and
tape-echo2 in position 2** — both ship a `web_ui.html` and both work as ordinary
track FX:

| acceptance | result |
|---|---|
| 1. panel detected and rendered | both, `?component=master_fx%3Afx1` / `%3Afx2` |
| 2. reads/writes **that** position | wrote `master_fx:fx1:lf_gain`, device echoed it back; restored after |
| 3. two positions coexist | 2 iframes, distinct srcs, own hierarchies (27 vs 19 `chain_params`) |
| 4. module change replaces only that position | panel cleared per-component on `master_fx_info` |
| 5. Default still exposes everything | toggle drops both iframes, 14 generated rows keyed `master_fx:fx1:*` |
| 6. #253 panels unchanged | Slot 1's 8w8 synth panel still renders, still reads its 132 `chain_params` |

`docs/MODULES.md` loses the "Master FX slots have no custom-UI path yet" line
and gains the component naming, since a panel that builds keys from
`schwungRemote.component` needs no change to work on the master bus while one
that hardcodes `fx1:` will address a chain slot instead.

`remote_ui_masterfx_test.go` pins the id derivation (path → id, id → id
unchanged, empty → empty). `go test ./...` and `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)