### PR TITLE
LEDs: the overtake queue never acknowledged what it accepted

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1183,6 +1183,36 @@ function activateLedQueue() {
             /* Non-LED messages (sysex, etc.) pass through immediately */
             return originalMidiInternalSend(arr);
         }
+        /*
+         * QUEUED IS ACCEPTED, AND THE CALLER NEEDS TO BE TOLD SO.
+         *
+         * This used to fall off the end and return undefined. Harmless while
+         * nothing read the result -- and then #319 made input_filter's setLED
+         * read it:
+         *
+         *     const sent = move_midi_internal_send(...);
+         *     ledCache[note] = sent ? color : -1;
+         *
+         * which is right against the real binding (false = the MIDI-out buffer
+         * was full, so don't record a colour we failed to make true) and wrong
+         * against this one. Every LED write under overtake recorded -1, so the
+         * cache never suppressed anything and EVERY module repainted its whole
+         * surface every frame -- ~58 writes into a 16-per-tick flush budget.
+         * Notes flush before CCs, so the budget went entirely to pads and steps
+         * and the button LEDs never flushed at all.
+         *
+         * That is the "LEDs don't work at all" failure that overtake authors
+         * have written progressive-init workarounds around; tb3po's refreshLeds
+         * carries a comment naming it. It hit every overtake module that paints
+         * through shared setLED -- davebox, tb3po, control, mark, mono, and the
+         * rest -- but NOT the ones declaring skip_led_clear (chorddex,
+         * song-mode), because those never activate this queue.
+         *
+         * `true` is honest: the packet is retained under its note/CC key and
+         * coalesced with any later write to the same key, so it IS delivered.
+         * The queue drops nothing on a full frame -- it only defers.
+         */
+        return true;
     };
 }
 

--- a/tests/host/test_led_queue_ack.sh
+++ b/tests/host/test_led_queue_ack.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The overtake LED queue must ACKNOWLEDGE what it accepts.
+#
+# activateLedQueue() in shadow_ui.js replaces move_midi_internal_send with a
+# wrapper that coalesces LED packets by note/CC and flushes a few per tick.
+# input_filter.mjs's setLED reads the return value to decide whether to cache
+# the colour it just wrote:
+#
+#     const sent = move_midi_internal_send(...);
+#     ledCache[note] = sent ? color : -1;
+#
+# That is right against the REAL binding, where false means the MIDI-out buffer
+# was full and the colour must not be recorded as shown. It is wrong against a
+# wrapper that queues the packet and returns undefined: the cache then records
+# -1 for every write, never suppresses a repaint, and every overtake module
+# repaints its whole surface every frame -- ~58 writes into a 16-per-tick flush
+# budget, with notes flushed before CCs so button LEDs never flush at all. The
+# surface reads as "LEDs don't work". Shipped in #319; hit davebox, tb3po,
+# control, mark, mono and every other overtake module painting through shared
+# setLED, but NOT the skip_led_clear ones (chorddex, song-mode) which never
+# activate this queue.
+#
+# This wires the REAL wrapper (extracted from shadow_ui.js) to the REAL setLED
+# and counts writes across identical frames. Behaviour, not a grep.
+
+node --input-type=module - <<'NODE'
+import fs from "fs";
+import path from "path";
+
+const JS = "src/shadow/shadow_ui.js";
+const src = fs.readFileSync(JS, "utf8");
+
+const start = src.indexOf("function activateLedQueue() {");
+if (start < 0) { console.error("FAIL: activateLedQueue not found in " + JS); process.exit(1); }
+const end = src.indexOf("\n}\n", start);
+if (end < 0) { console.error("FAIL: could not delimit activateLedQueue"); process.exit(1); }
+const body = src.slice(src.indexOf("{", start) + 1, end);
+
+/*
+ * activateLedQueue's FIRST statement is
+ *     originalMidiInternalSend = globalThis.move_midi_internal_send;
+ * so the binding it wraps must be installed on globalThis before we run it.
+ * Handing one in as a local is silently discarded — and that reads as the very
+ * failure this test is looking for, so getting it wrong fakes a FAIL.
+ */
+const makeQueue = (realBinding) => {
+    globalThis.move_midi_internal_send = realBinding;
+    new Function("globalThis",
+        `let ledQueueNotes = {}, ledQueueCCs = {}, ledQueueActive = false,
+             originalMidiInternalSend = null;
+         ${body}`)(globalThis);
+    if (typeof globalThis.move_midi_internal_send !== "function") {
+        console.error("FAIL: activateLedQueue did not install move_midi_internal_send");
+        process.exit(1);
+    }
+    return globalThis.move_midi_internal_send;
+};
+
+const fails = [];
+
+/* ---- 1. queued LED packets must be acknowledged ------------------------ */
+
+const queueWrapper = makeQueue(() => true);
+let queued = 0;
+globalThis.move_midi_internal_send = (arr) => { queued++; return queueWrapper(arr); };
+
+const { setLED, setButtonLED } = await import(
+    "file://" + path.resolve("src/shared/input_filter.mjs")
+);
+
+/* One overtake module's steady-state repaint: the same surface, unchanged. */
+function paintFrame() {
+    for (let n = 68; n < 100; n++) setLED(n, 0x7F);            /* 32 pads  */
+    for (let n = 16; n < 32; n++) setLED(n, 0x03);             /* 16 steps */
+    for (const cc of [40, 41, 42, 43, 49, 50, 51, 55, 56, 60]) setButtonLED(cc, 0x7F);
+}
+
+const FRAMES = 10;
+const PER_FRAME = 58;
+for (let f = 0; f < FRAMES; f++) paintFrame();
+
+if (queued !== PER_FRAME) {
+    fails.push(
+        `LED cache is dead under the overtake queue: ${queued} writes across ` +
+        `${FRAMES} identical frames, expected ${PER_FRAME} (first frame only). ` +
+        `activateLedQueue's wrapper must return a truthy value for a packet it ` +
+        `has accepted onto the queue — setLED reads it to decide whether to cache.`
+    );
+}
+
+/* ---- 2. a non-LED write still reports the real binding's result -------- */
+
+const passthrough = makeQueue(() => false);
+if (passthrough([0x04, 0xF0, 0x7E, 0x00]) !== false) {
+    fails.push("non-LED passthrough must return the real binding's result, not true");
+}
+
+/* ---- 3. and the LED path must not invent success when it cannot queue -- */
+
+const inactive = makeQueue(() => false);
+globalThis.move_midi_internal_send = inactive;
+/* An LED write IS queued, so it reports true even though the underlying
+ * binding would have refused — that is the point of the queue. Assert the
+ * wrapper is genuinely queueing rather than forwarding. */
+let forwarded = 0;
+const counting = makeQueue(() => { forwarded++; return false; });
+if (counting([0x09, 0x90, 70, 0x7F]) !== true) {
+    fails.push("an accepted LED packet must report true");
+}
+if (forwarded !== 0) {
+    fails.push("an LED packet must be queued, not forwarded to the binding");
+}
+
+if (fails.length) {
+    for (const f of fails) console.error("FAIL: " + f);
+    process.exit(1);
+}
+console.log("PASS: overtake LED queue acknowledges queued packets (" +
+            queued + " writes over " + FRAMES + " identical frames)");
+NODE


### PR DESCRIPTION
TB-3PO showed no LEDs at all; Charles guessed it affected davebox too. It does — and it is not the modules. #319 broke the LED cache for **every overtake module** three days ago.

## What broke

#319 made `input_filter`'s `setLED` honest about drops — record the colour only if the packet actually went out:

```js
const sent = move_midi_internal_send(...);
ledCache[note] = sent ? color : -1;
```

Correct against the real binding. But under overtake the binding is not the real one: `activateLedQueue()` swaps in a wrapper that coalesces LED packets by note/CC and flushes `LED_QUEUE_MAX_PER_TICK` (16) per tick. **The wrapper stored the packet and fell off the end, returning `undefined`.**

So every LED write under overtake recorded `-1`. The cache never suppressed a repaint, and a module painting its surface every frame paid full price every frame — **580 writes across 10 identical frames where 58 is correct.** Against a 16-per-tick budget that is permanent saturation, and because notes flush before CCs, the budget went entirely to pads and steps: **button LEDs never flushed at all.**

This is the failure overtake authors have been writing progressive LED-init workarounds around. tb3po's `refreshLeds` names it in so many words:

> `// LEDs every frame starves the queue (was the "LEDs don't work at all" bug).`

## Blast radius

Overtake modules painting through shared `setLED`: davebox, tb3po, control, mark, mono, oversmack, overwork, performance-fx, sidcontrol, arranger, juno_control.

**Not** the `skip_led_clear` ones (chorddex, song-mode) — they never activate the queue. That split is a useful discriminator when confirming on hardware.

## The fix

`return true` is honest rather than optimistic: the packet is retained under its note/CC key and coalesced with any later write to the same key, so it **is** delivered. A busy frame defers it; nothing drops it.

## Test

`tests/host/test_led_queue_ack.sh` extracts the shipping wrapper from `shadow_ui.js` and drives the real `setLED` through it, counting writes across identical frames — behaviour, not a grep for `return true`.

Two notes for whoever edits it next:
- `activateLedQueue`'s first statement re-reads the binding off `globalThis`, so a stub handed in as a local is silently discarded and the wrapper bails down its passthrough branch. That reads as exactly the bug under test, so **getting it wrong fakes a FAIL** (it did, twice, while this was being written).
- Mutation-checked both directions: **580 against unfixed main, 58 with the fix.**

## Verification

- `make -C tests/host test` — green
- all `tests/host/*.sh` — **202 pass, 0 fail**
- **Not deployed to hardware** at Charles's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHkTCgWY2fDuac5GWPVHVM