### PR TITLE
A chain slot can receive SysEx, if it asks

### DIFF
--- a/docs/SYSEX.md
+++ b/docs/SYSEX.md
@@ -214,8 +214,11 @@ is loaded, and they exercise the contention no harder.
 
 ## Testing your own module
 
-Two probes ship in-tree, scoring against one shared generator so a result from
-either is directly comparable:
+Two probes live in-tree, scoring against one shared generator so a result from
+either is directly comparable. **They are test fixtures and a release never
+carries them** — build with `SCHWUNG_BUILD_TEST_MODULES=1 ./scripts/build.sh`,
+the same gate gesture-test uses. Without it a SysEx tool would sit in every
+user'''s Tools menu and a probe in every user'''s MIDI FX picker.
 
 - `src/modules/tools/sysex-test` — the JS/tool path. Pads pick a payload size
   (64 / 158 / 316 / 632 B); any other pad sends. The screen shows TX bytes and

--- a/docs/SYSEX.md
+++ b/docs/SYSEX.md
@@ -132,6 +132,12 @@ with no bound on what a broken sender can make it hold.
 `F0` reaches `process_midi`. Before the capability: silence. After: an echo for
 every message.
 
+**Watch `rx_f0_seen`, not the ECHO, when the question is "how many".** The echo
+fires per `F0`, so one delivery and six look identical; the counter reads 2N for
+N messages and makes a duplication bug unmissable. That distinction is the whole
+reason a real duplication bug survived a review and a hardware check
+(#367) — the probe was adequate, the check chosen for it was not.
+
 `onMidiMessageExternal([b0,b1,b2])` hands you three bytes with the **CIN already
 stripped**, and nothing reassembles the run for you. There is no length field
 to trust — an end-packet's trailing bytes are padding. Your assembler needs

--- a/docs/SYSEX.md
+++ b/docs/SYSEX.md
@@ -105,12 +105,32 @@ Both cable-2 dispatchers gate on `cin < 0x08 || cin > 0x0E`
 `shadow_ui_midi_publish`, sits inside `if (overtake_mode && shadow_ui_midi_shm)`
 in `schwung_shim.c`.
 
-**A chain slot is therefore write-only for SysEx.** If you are building an
-editor as a slot module and waiting for the device to answer, that is the whole
-bug — no amount of fixing your encoding will help. Build it as an overtake
-tool, or expect send-only. `modules/midi_fx/sysex_probe` exists to keep that
-honest: it emits an ECHO the moment an `F0` reaches `process_midi`, so the
-claim is falsifiable rather than a code reading.
+A chain slot was therefore **write-only for SysEx** — an editor built as one
+waited forever for a reply, and no encoding fix helped. That was never a design
+decision: the gate is a *channel-voice-only* filter written for channel routing,
+with no comment, no capability and no test behind it. SysEx just fell out the
+bottom of it.
+
+**A slot can now opt in**, with `capabilities.wants_sysex: true` in its
+module.json. Slots that do not ask see exactly what they saw before: nothing.
+
+Opt-in rather than broadcast, for a specific reason: SysEx payload bytes are
+`< 0x80`, so a module switching on `msg[0] & 0xF0` would read data as a status
+type it half-recognises. A module has to have been written for this.
+
+**There is no channel to route on**, which is why a receive-channel setting
+cannot select a destination and why setting a slot to Ch 1 does nothing. So
+SysEx is broadcast to every slot that opted in, and a module tells its own
+messages apart by manufacturer ID — which is what that ID is for.
+
+You receive **fragments, not messages**: 1–3 payload bytes per call, exactly as
+a tool does, and you reassemble them yourself with the four rules below.
+Buffering in the shim would mean per-slot reassembly state on the realtime path
+with no bound on what a broken sender can make it hold.
+
+`modules/midi_fx/sysex_probe` keeps this honest — it emits an ECHO the moment an
+`F0` reaches `process_midi`. Before the capability: silence. After: an echo for
+every message.
 
 `onMidiMessageExternal([b0,b1,b2])` hands you three bytes with the **CIN already
 stripped**, and nothing reassembles the run for you. There is no length field

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -613,20 +613,30 @@ else
     echo "Skipping velocity scale MIDI FX (up to date)"
 fi
 
-# Build SysEx Probe MIDI FX — the slot-module half of the SysEx test rig.
+# Build SysEx Probe MIDI FX — a hardware TEST FIXTURE, not a shipped module.
+#
 # A slot reaches USB-A through host->midi_send_external (the ROUTE_EXTERNAL
-# ring), not through the shadow_ui path a JS tool uses, so it has to be
-# measured separately. See src/modules/midi_fx/sysex_probe/dsp/sysex_probe.c.
-if needs_rebuild build/modules/midi_fx/sysex_probe/dsp.so \
-    src/modules/midi_fx/sysex_probe/dsp/sysex_probe.c src/host/midi_fx_api_v1.h \
-    src/host/plugin_api_v1.h; then
-    echo "Building sysex probe MIDI FX..."
-    "${CROSS_PREFIX}gcc" -g -O3 -shared -fPIC \
-        src/modules/midi_fx/sysex_probe/dsp/sysex_probe.c \
-        -o build/modules/midi_fx/sysex_probe/dsp.so \
-        -Isrc -lm
-else
-    echo "Skipping sysex probe MIDI FX (up to date)"
+# ring), not the shadow_ui path a JS tool uses, so the two doors have to be
+# measured separately; this is the slot-side half. See
+# src/modules/midi_fx/sysex_probe/dsp/sysex_probe.c and docs/SYSEX.md.
+#
+# Gated on SCHWUNG_BUILD_TEST_MODULES for the same reason as gesture-test: a
+# release must never carry it. Without the gate it would appear in every user's
+# MIDI FX picker, and the tool half in every user's Tools menu, which is how
+# ui-test/seq-test/config-test/splash-test would ship too if they were not
+# scrubbed below.
+if [ -n "${SCHWUNG_BUILD_TEST_MODULES:-}" ]; then
+    if needs_rebuild build/modules/midi_fx/sysex_probe/dsp.so \
+        src/modules/midi_fx/sysex_probe/dsp/sysex_probe.c src/host/midi_fx_api_v1.h \
+        src/host/plugin_api_v1.h; then
+        echo "Building sysex probe MIDI FX (test fixture)..."
+        "${CROSS_PREFIX}gcc" -g -O3 -shared -fPIC \
+            src/modules/midi_fx/sysex_probe/dsp/sysex_probe.c \
+            -o build/modules/midi_fx/sysex_probe/dsp.so \
+            -Isrc -lm
+    else
+        echo "Skipping sysex probe MIDI FX (up to date)"
+    fi
 fi
 
 echo "Building Sound Generator plugins..."
@@ -839,6 +849,17 @@ rm -rf \
     ./build/modules/tools/splash-test \
     ./build/modules/store \
     2>/dev/null || true
+
+# The SysEx test rig ships only when explicitly asked for. sysex-test is JS and
+# is copied by the generic module loop above rather than compiled, so a build
+# gate alone cannot keep it out -- it has to be scrubbed here. Both go together:
+# they are the two halves of one measurement (docs/SYSEX.md).
+if [ -z "${SCHWUNG_BUILD_TEST_MODULES:-}" ]; then
+    rm -rf \
+        ./build/modules/tools/sysex-test \
+        ./build/modules/midi_fx/sysex_probe \
+        2>/dev/null || true
+fi
 
 # Make shell scripts in modules executable
 find ./build/modules -type f -name "*.sh" -exec chmod +x {} \;

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -3569,3 +3569,38 @@ void shadow_inprocess_handle_param_request(void) {
 
     shadow_param_publish_response(req_id);
 }
+
+
+/*
+ * Keep shadow_chain_slots[].wants_sysex current, one slot per call.
+ *
+ * Refreshed on a rotation rather than hooked to a load, because a slot's
+ * answer changes on every synth load, MIDI FX load, unload, insert, remove and
+ * move -- six call sites with nothing else in common, and a seventh added later
+ * would silently not update the flag. Asking is cheap and cannot go stale: the
+ * chain host is in-process here, so this is a direct call, not the ~2.8 ms
+ * shadow_ui IPC round-trip that "get_param" usually implies.
+ *
+ * One slot per frame answers every slot ~86x/second. The cost of being a frame
+ * late is that a component loaded this instant misses SysEx for a few
+ * milliseconds; the cost of hooking it wrongly is that it misses SysEx forever,
+ * which is the failure this whole change exists to remove.
+ */
+void shadow_chain_refresh_wants_sysex_tick(void)
+{
+    static int next = 0;
+    int i = next;
+    next = (next + 1) % SHADOW_CHAIN_INSTANCES;
+
+    if (!shadow_chain_slots[i].instance || !shadow_plugin_v2 ||
+        !shadow_plugin_v2->get_param) {
+        shadow_chain_slots[i].wants_sysex = 0;
+        return;
+    }
+    char buf[8];
+    int len = shadow_plugin_v2->get_param(shadow_chain_slots[i].instance,
+                                          "wants_sysex", buf, sizeof(buf));
+    if (len <= 0) { shadow_chain_slots[i].wants_sysex = 0; return; }
+    buf[len < (int)sizeof(buf) ? len : (int)sizeof(buf) - 1] = '\0';
+    shadow_chain_slots[i].wants_sysex = (atoi(buf) == 1);
+}

--- a/src/host/shadow_chain_mgmt.h
+++ b/src/host/shadow_chain_mgmt.h
@@ -346,6 +346,10 @@ void shadow_slot_load_capture(int slot, int patch_index);
 /* --- Boot --- */
 int shadow_inprocess_load_chain(void);
 
+/* Round-robin refresh of per-slot capabilities.wants_sysex. Call once per
+ * SPI frame; it advances one slot per call. */
+void shadow_chain_refresh_wants_sysex_tick(void);
+
 /* --- UI requests --- */
 void shadow_inprocess_handle_ui_request(void);
 

--- a/src/host/shadow_chain_types.h
+++ b/src/host/shadow_chain_types.h
@@ -40,6 +40,11 @@ typedef struct shadow_chain_slot_t {
     int feedback_hold;      /* 1 = booted muted as a line-input feedback guard; JS clears once jack state is safe */
     int forward_channel;    /* -2 = passthrough, -1 = auto, 0-15 = forward MIDI to this channel */
     int transpose;          /* semitone offset applied to incoming note-on/off/poly-AT, range -12..+12 */
+    /* 1 = some component in this slot declared capabilities.wants_sysex, so
+     * cable-2 SysEx fragments are delivered to it. Read from the chain host at
+     * load; slots that did not ask see no SysEx at all, which is the behaviour
+     * every slot had before. */
+    int wants_sysex;
     char patch_name[64];
     shadow_capture_rules_t capture;  /* MIDI controls this slot captures when focused */
     slot_fade_t fade;                /* fade envelope for seamless transitions */

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -436,14 +436,52 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
  *
  * RT: bounded loop over 4 slots, one on_midi call each, no allocation.
  */
-void shadow_chain_dispatch_sysex_to_slots(const uint8_t *pkt)
+/* Its own dedup ring, and INSIDE the dispatcher rather than at the call sites.
+ *
+ * Two separate ways a fragment gets delivered more than once, and one ring here
+ * closes both (ryanmgilmore, review of #367):
+ *
+ *  1. Every caller `continue`s before its walker's own
+ *     event_dedup_check_and_record, so a MIDI_IN slot that survives into the
+ *     next frame is dispatched AGAIN, every frame it survives. The comment
+ *     above those walks says events "persist across frames" and that the
+ *     timestamp-keyed dedup is what makes that safe -- channel voice is
+ *     protected by it and SysEx was skipping past it.
+ *
+ *  2. shadow_dispatch_direct_external_midi and
+ *     shadow_dispatch_cable2_channeled_slots read the SAME buffer in the SAME
+ *     frame. The first returns early only when no slot is receive=All +
+ *     forward=THRU -- the MPE configuration the manual recommends. Configure
+ *     one and both walkers run, so every fragment is dispatched twice. Their
+ *     two per-walker rings cannot see each other, so ORDERING THE CALLS AFTER
+ *     THE DEDUP DOES NOT FIX THIS ONE. A ring here does, and it also survives
+ *     a third call site being added later.
+ *
+ * DUPLICATION IS WORSE THAN LOSS HERE. The module reassembles for itself and
+ * rule one is "start on 0xF0", so a repeated F0 silently RESTARTS the message
+ * and a repeated body byte corrupts it. What comes out is a plausible message
+ * that is fiction, rather than an obvious gap. sysex_probe cannot see any of
+ * this: it echoes if process_midi is EVER handed an F0, so one delivery and six
+ * look identical to it.
+ */
+static event_dedup_entry_t g_sysex_dedup[EVENT_DEDUP_RING_SIZE];
+static int g_sysex_dedup_head = 0;
+
+void shadow_chain_dispatch_sysex_to_slots(const uint8_t *slot8)
 {
     const plugin_api_v2_t *pv2 = *host_plugin_v2;
-    if (!pv2 || !pv2->on_midi || !pkt) return;
+    if (!pv2 || !pv2->on_midi || !slot8) return;
+
+    /* Once per PHYSICAL event. Keyed on the whole 8-byte MIDI_IN slot -- the
+     * 4-byte packet plus the 4-byte XMOS timestamp -- which is why the
+     * parameter is the slot and not the packet. A zero timestamp (an injected
+     * packet) bypasses the ring by design, same as the voice path. */
+    if (event_dedup_check_and_record(g_sysex_dedup, &g_sysex_dedup_head, slot8))
+        return;
 
     /* USB-MIDI fixes the payload length by CIN -- there is no length byte to
      * trust, and the trailing bytes of an end-packet are padding. */
-    uint8_t cin = pkt[0] & 0x0F;
+    uint8_t cin = slot8[0] & 0x0F;
     int n;
     switch (cin) {
     case 0x04: n = 3; break;
@@ -456,7 +494,7 @@ void shadow_chain_dispatch_sysex_to_slots(const uint8_t *pkt)
     for (int i = 0; i < SHADOW_CHAIN_INSTANCES; i++) {
         if (!host_chain_slots[i].wants_sysex) continue;
         if (!host_chain_slots[i].active || !host_chain_slots[i].instance) continue;
-        uint8_t msg[3] = { pkt[1], pkt[2], pkt[3] };
+        uint8_t msg[3] = { slot8[1], slot8[2], slot8[3] };
         pv2->on_midi(host_chain_slots[i].instance, msg, n,
                      MOVE_MIDI_SOURCE_EXTERNAL);
     }

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -460,9 +460,16 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
  * DUPLICATION IS WORSE THAN LOSS HERE. The module reassembles for itself and
  * rule one is "start on 0xF0", so a repeated F0 silently RESTARTS the message
  * and a repeated body byte corrupts it. What comes out is a plausible message
- * that is fiction, rather than an obvious gap. sysex_probe cannot see any of
- * this: it echoes if process_midi is EVER handed an F0, so one delivery and six
- * look identical to it.
+ * that is fiction, rather than an obvious gap.
+ *
+ * AND THE INSTRUMENT MATTERS MORE THAN THE TOOL. Both the review and this
+ * comment first said sysex_probe could not detect the doubling; that was wrong,
+ * and the distinction is worth keeping. Its ECHO cannot -- it fires per F0, so
+ * one delivery and six look identical -- but its rx_f0_seen COUNTER can, and 2N
+ * for N messages is unmissable. The probe was adequate; the check chosen for it
+ * was not. Confirmed on hardware afterwards with a QY-70 over USB-A: 405
+ * messages into an overtake editor, 409 F0s into a slot, ratio 1.01 where
+ * duplication would have read ~810.
  */
 static event_dedup_entry_t g_sysex_dedup[EVENT_DEDUP_RING_SIZE];
 static int g_sysex_dedup_head = 0;

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -406,6 +406,62 @@ void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *mi
     }
 }
 
+
+/*
+ * Deliver one cable-2 SysEx packet to the slots that asked for SysEx.
+ *
+ * SEPARATE from shadow_chain_dispatch_midi_to_slots on purpose. That function
+ * is channel machinery end to end -- it matches the slot's receive channel,
+ * remaps the status nibble, applies per-slot transpose, and broadcasts to audio
+ * FX. Not one of those operations is meaningful on a SysEx fragment, whose
+ * bytes are data: remapping would rewrite payload, and transpose reads msg[1]
+ * as a note number. Threading a "but not for SysEx" flag through all of it
+ * would leave five branches that must each stay correct forever.
+ *
+ * THERE IS NO CHANNEL TO ROUTE ON. A SysEx message carries no channel byte, so
+ * no receive-channel setting can select a destination for it -- which is why
+ * setting a slot to Ch 1 does nothing, and why this broadcasts to every slot
+ * that opted in rather than picking one. A module tells its own messages apart
+ * by manufacturer ID, which is what that ID is for.
+ *
+ * Opt-in, so a slot that never asked sees exactly what it saw before: nothing.
+ * That matters because these bytes are < 0x80, and a module that switches on
+ * `msg[0] & 0xF0` would read payload as a status type it half-recognises.
+ *
+ * The fragment is passed through UNASSEMBLED, with its real length, because
+ * the whole message can span many SPI frames and buffering it here would mean
+ * the shim holding per-slot reassembly state on the RT path with no bound on
+ * what a hostile or broken sender can make it hold. A tool module already
+ * reassembles for itself (docs/SYSEX.md); a slot module does the same.
+ *
+ * RT: bounded loop over 4 slots, one on_midi call each, no allocation.
+ */
+void shadow_chain_dispatch_sysex_to_slots(const uint8_t *pkt)
+{
+    const plugin_api_v2_t *pv2 = *host_plugin_v2;
+    if (!pv2 || !pv2->on_midi || !pkt) return;
+
+    /* USB-MIDI fixes the payload length by CIN -- there is no length byte to
+     * trust, and the trailing bytes of an end-packet are padding. */
+    uint8_t cin = pkt[0] & 0x0F;
+    int n;
+    switch (cin) {
+    case 0x04: n = 3; break;
+    case 0x05: n = 1; break;
+    case 0x06: n = 2; break;
+    case 0x07: n = 3; break;
+    default: return;
+    }
+
+    for (int i = 0; i < SHADOW_CHAIN_INSTANCES; i++) {
+        if (!host_chain_slots[i].wants_sysex) continue;
+        if (!host_chain_slots[i].active || !host_chain_slots[i].instance) continue;
+        uint8_t msg[3] = { pkt[1], pkt[2], pkt[3] };
+        pv2->on_midi(host_chain_slots[i].instance, msg, n,
+                     MOVE_MIDI_SOURCE_EXTERNAL);
+    }
+}
+
 /* Broadcast a 1-byte system-realtime message to every active chain slot.
  * Realtime must NOT go through shadow_chain_dispatch_midi_to_slots: the
  * per-slot channel remap rewrites the status low nibble (0xF8 -> 0xF0|ch)
@@ -845,6 +901,12 @@ void shadow_dispatch_direct_external_midi(void)
 
         /* Only external USB MIDI (cable 2) */
         if (cable != 0x02) continue;
+        /* SysEx (0x04-0x07) has no channel and none of the routing below
+         * applies to it; hand it to the slots that opted in and move on. */
+        if (cin >= 0x04 && cin <= 0x07) {
+            shadow_chain_dispatch_sysex_to_slots(&in_src[i]);
+            continue;
+        }
         if (cin < 0x08 || cin > 0x0E) continue;
 
         uint8_t status = in_src[i + 1];
@@ -959,6 +1021,13 @@ void shadow_dispatch_cable2_channeled_slots(void)
         uint8_t type   = status & 0xF0;
         uint8_t d1     = in_src[i + 2];
         uint8_t d2     = in_src[i + 3];
+
+        /* SysEx first: it is channel-less, so the channel routing below can
+         * never select a destination for it. */
+        if (cin >= 0x04 && cin <= 0x07) {
+            shadow_chain_dispatch_sysex_to_slots(&in_src[i]);
+            continue;
+        }
 
         /* Channel voice messages only */
         if (cin < 0x08 || cin > 0x0E) continue;

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -116,6 +116,10 @@ uint8_t shadow_chain_remap_channel(int slot, uint8_t status);
  * (they receive MIDI via the direct MIDI_IN path instead). */
 void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *midi_log_count, int skip_direct);
 
+/* Deliver one cable-2 SysEx packet to slots whose module declared
+ * capabilities.wants_sysex. Fragments, not reassembled messages. */
+void shadow_chain_dispatch_sysex_to_slots(const uint8_t *pkt);
+
 /* Broadcast a 1-byte system-realtime message (0xF8/0xFA/0xFB/0xFC) to every
  * active chain slot, bypassing per-slot channel remap (which would corrupt the
  * status byte). For internally generated transport clock. */

--- a/src/host/shadow_midi.h
+++ b/src/host/shadow_midi.h
@@ -117,8 +117,12 @@ uint8_t shadow_chain_remap_channel(int slot, uint8_t status);
 void shadow_chain_dispatch_midi_to_slots(const uint8_t *pkt, int log_on, int *midi_log_count, int skip_direct);
 
 /* Deliver one cable-2 SysEx packet to slots whose module declared
- * capabilities.wants_sysex. Fragments, not reassembled messages. */
-void shadow_chain_dispatch_sysex_to_slots(const uint8_t *pkt);
+ * capabilities.wants_sysex. Fragments, not reassembled messages.
+ *
+ * Takes an 8-BYTE MIDI_IN SLOT, not a 4-byte packet: it dedups on the packet
+ * plus the XMOS timestamp that follows it, so a 4-byte buffer would read past
+ * the end. Callers walk MIDI_IN at the 8-byte stride and pass &in_src[i]. */
+void shadow_chain_dispatch_sysex_to_slots(const uint8_t *slot8);
 
 /* Broadcast a 1-byte system-realtime message (0xF8/0xFA/0xFB/0xFC) to every
  * active chain slot, bypassing per-slot channel remap (which would corrupt the

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -551,6 +551,7 @@ int v2_load_synth(chain_instance_t *inst, const char *module_name) {
     /* Parse default_forward_channel from capabilities in module.json */
     inst->synth_default_forward_channel = -1;  /* Default: no forwarding preference */
     inst->synth_consumes_line_input = 0;       /* Default: not a line-input consumer */
+    inst->synth_wants_sysex = 0;               /* Default: no raw SysEx */
     {
         char json_path[MAX_PATH_LEN];
         snprintf(json_path, sizeof(json_path), "%s/module.json", synth_path);
@@ -593,6 +594,16 @@ int v2_load_synth(chain_instance_t *inst, const char *module_name) {
                                 inst->synth_consumes_line_input = 1;
                                 v2_chain_log(inst, "Synth consumes line input (feedback risk on boot)");
                             }
+                        }
+                    }
+                    /* Opt-in for raw SysEx, same both-spellings rule as
+                     * the MIDI FX path in chain_midi.c. */
+                    {
+                        int wants = 0;
+                        if ((json_get_bool_in_section(json, "capabilities", "wants_sysex", &wants) == 0
+                             || json_get_int_in_section(json, "capabilities", "wants_sysex", &wants) == 0)
+                            && wants) {
+                            inst->synth_wants_sysex = 1;
                         }
                     }
                     free(json);
@@ -1392,6 +1403,21 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
     }
     if (strcmp(key, "midi_fx_pre_mode") == 0) {
         return snprintf(buf, buf_len, "%d", inst->midi_fx_pre_mode ? 1 : 0);
+    }
+    if (strcmp(key, "wants_sysex") == 0) {
+        /* Does ANY component in this slot want raw SysEx?
+         *
+         * One answer per slot rather than per position, because SysEx carries
+         * no channel and therefore nothing to route on -- there is no way to
+         * address a position with it. The slot either has a component that
+         * asked for SysEx or it does not, and the shim broadcasts to the ones
+         * that did. A module distinguishes its own messages by manufacturer
+         * ID, which is what that ID is for. */
+        int want = inst->synth_wants_sysex;
+        for (int i = 0; !want && i < inst->midi_fx_count; i++) {
+            if (inst->midi_fx_wants_sysex[i]) want = 1;
+        }
+        return snprintf(buf, buf_len, "%d", want);
     }
     if (strcmp(key, "midi_fx:pre_capable") == 0) {
         /* Hint from the loaded MIDI FX's module.json. Aggregated as OR

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -251,7 +251,8 @@ typedef struct chain_instance {
     void *synth_instance;
     char current_synth_module[MAX_NAME_LEN];
     int synth_default_forward_channel;  /* -1 = no default, 0-15 = channel */
-    int synth_consumes_line_input;      /* 1 = pulls line-in/mic (feedback risk on boot) */
+    int synth_consumes_line_input;
+    int synth_wants_sysex;   /* capabilities.wants_sysex on the synth */      /* 1 = pulls line-in/mic (feedback risk on boot) */
 
     /* Audio FX state */
     void *fx_handles[MAX_AUDIO_FX];
@@ -360,6 +361,10 @@ typedef struct chain_instance {
      * Informs the Shadow UI default on first placement; does not gate the
      * per-slot toggle (legacy FX can still be switched to Pre manually). */
     int midi_fx_pre_capable[MAX_MIDI_FX];
+    /* Opt-in: this component wants raw SysEx fragments delivered to its
+     * on_midi/process_midi. Off by default and per POSITION, so it permutes
+     * with everything else in chain_reorder.c. */
+     int midi_fx_wants_sysex[MAX_MIDI_FX];
 
     /* Pre-mode echo refcount: per-note counter tracking notes we injected
      * into Move's MIDI_IN cable 2. Move plays the injection and echoes it

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -302,6 +302,7 @@ int v2_load_midi_fx_slot(chain_instance_t *inst, int slot, const char *fx_name) 
      * This informs the Shadow UI default on first placement; does not gate
      * the per-slot Pre/Post toggle (the user can still flip it manually). */
     inst->midi_fx_pre_capable[slot] = 0;
+    inst->midi_fx_wants_sysex[slot] = 0;
     char mj_path[MAX_PATH_LEN];
     snprintf(mj_path, sizeof(mj_path), "%s/module.json", fx_dir);
     FILE *mj = fopen(mj_path, "r");
@@ -318,6 +319,17 @@ int v2_load_midi_fx_slot(chain_instance_t *inst, int slot, const char *fx_name) 
                 if (json_get_int_in_section(mj_buf, "capabilities", "pre_capable", &cap) == 0
                     && cap) {
                     inst->midi_fx_pre_capable[slot] = 1;
+                }
+                /* Opt-in for raw SysEx. Accept the JSON boolean AND the 1/0
+                 * spelling: json_get_int_in_section would atoi("true") to 0,
+                 * which is the same trap the audio_in parse hit and is why
+                 * json_get_bool_in_section exists. Trying both means a module
+                 * author cannot get this subtly wrong and be silently ignored. */
+                int wants = 0;
+                if ((json_get_bool_in_section(mj_buf, "capabilities", "wants_sysex", &wants) == 0
+                     || json_get_int_in_section(mj_buf, "capabilities", "wants_sysex", &wants) == 0)
+                    && wants) {
+                    inst->midi_fx_wants_sysex[slot] = 1;
                 }
                 free(mj_buf);
             }
@@ -376,6 +388,7 @@ void v2_unload_midi_fx_slot(chain_instance_t *inst, int slot) {
     inst->mod_param_refresh_ms_midi_fx[slot] = 0;
     inst->midi_fx_ui_hierarchy[slot][0] = '\0';
     inst->midi_fx_pre_capable[slot] = 0;
+    inst->midi_fx_wants_sysex[slot] = 0;
     inst->midi_fx_bypassed[slot] = 0;
 
     /* Stale refcount entries from a now-unloaded MIDI FX would orphan future

--- a/src/modules/chain/dsp/chain_reorder.c
+++ b/src/modules/chain/dsp/chain_reorder.c
@@ -84,6 +84,7 @@ static int chain_perm_collect_midi_fx(chain_instance_t *inst, chain_perm_array_t
     out[n++] = (chain_perm_array_t)PERM_OWNED(inst->midi_fx_ui_hierarchy, CHAIN_UI_HIERARCHY_LEN);
     out[n++] = (chain_perm_array_t)PERM_FIELD(inst->mod_param_refresh_ms_midi_fx);
     out[n++] = (chain_perm_array_t)PERM_FIELD(inst->midi_fx_pre_capable);
+    out[n++] = (chain_perm_array_t)PERM_FIELD(inst->midi_fx_wants_sysex);
     out[n++] = (chain_perm_array_t)PERM_FIELD(inst->midi_fx_bypassed);
     return n;
 }

--- a/src/modules/midi_fx/sysex_probe/module.json
+++ b/src/modules/midi_fx/sysex_probe/module.json
@@ -7,6 +7,7 @@
   "capabilities": {
     "chainable": true,
     "component_type": "midi_fx",
+    "wants_sysex": true,
     "ui_hierarchy": {
       "levels": {
         "root": {

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -5592,6 +5592,9 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
     /* Advance the external-dispatch ring's age counter once per frame. */
     shadow_external_dispatch_tick();
 
+    /* One slot per frame learns whether its components want raw SysEx. */
+    shadow_chain_refresh_wants_sysex_tick();
+
     /* MIDI channel indicator: scan external (cable 2) MIDI_IN and MIDI_OUT for
      * note events and record the channels for the on-screen "i<IN> o<OUT>"
      * overlay. IN = what the controller sends; OUT = what Schwung emits back to

--- a/tests/host/test_chain_midi_fx_slot.c
+++ b/tests/host/test_chain_midi_fx_slot.c
@@ -57,6 +57,18 @@ CHAIN_INTERNAL int json_get_int_in_section(const char *json, const char *section
     (void)json; (void)section_key; (void)key; (void)out;
     return -1;
 }
+/* This file deliberately does not link chain_json.c, so every JSON accessor
+ * chain_midi.c reaches for needs a stub here. capabilities.wants_sysex is read
+ * with BOTH accessors -- json_get_int_in_section atoi()s "true" to 0 -- so
+ * adding the bool one broke the link and nothing local caught it: this repo's
+ * hooks are the opt-in kind (scripts/install-hooks.sh) and were not installed
+ * in the worktree the change was made in. CI caught it, which is the backstop
+ * working, but a link error is a cheap thing to find locally. */
+CHAIN_INTERNAL int json_get_bool_in_section(const char *json, const char *section_key,
+                                            const char *key, int *out) {
+    (void)json; (void)section_key; (void)key; (void)out;
+    return -1;
+}
 CHAIN_INTERNAL void chain_mod_clear_target_entries(chain_instance_t *inst,
                                                    const char *target, int restore_base) {
     (void)inst; (void)target; (void)restore_base;

--- a/tests/host/test_sysex_slot_dedup.sh
+++ b/tests/host/test_sysex_slot_dedup.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A SysEx fragment reaches an opted-in slot ONCE per physical event.
+#
+# Channel-voice events are protected by event_dedup_check_and_record, and the
+# comment above the MIDI_IN walk says exactly why that is load-bearing:
+#
+#     Don't break on zero -- Move's firmware partially consumes MIDI_IN and
+#     events at higher offsets may shift down or PERSIST ACROSS FRAMES; we rely
+#     on the timestamp-keyed dedup to skip duplicates regardless of where the
+#     event lives.
+#
+# Two ways SysEx can escape that, and neither is loud:
+#
+#   1. DISPATCHED BEFORE THE DEDUP. A `continue` that runs ahead of
+#      event_dedup_check_and_record hands the same fragment to the module again
+#      on every frame the MIDI_IN slot survives.
+#
+#   2. DISPATCHED FROM BOTH WALKERS. shadow_dispatch_direct_external_midi and
+#      shadow_dispatch_cable2_channeled_slots read the SAME buffer in the SAME
+#      frame; the first returns early only when no slot is receive=All +
+#      forward=THRU. Configure a slot for MPE -- which the manual recommends --
+#      and both walk it, so a fragment dispatched from each arrives twice. The
+#      two per-dispatcher rings cannot see each other, so moving the call after
+#      the dedup does NOT fix this one.
+#
+# Duplication is worse than loss here. A module reassembles for itself, and its
+# first rule is "start on 0xF0" -- so a repeated F0 silently RESTARTS the
+# message and a repeated body byte corrupts it. The result is a plausible
+# message that is fiction, not an obvious gap.
+#
+# A probe that echoes on seeing an F0 cannot detect either: it proves reception,
+# and one delivery and six look identical to it.
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+host="src/host/shadow_midi.c"
+[ -f "$host" ] || fail "$host is gone"
+
+grep -q "shadow_chain_dispatch_sysex_to_slots" "$host" || \
+  fail "shadow_chain_dispatch_sysex_to_slots is gone -- slots cannot receive SysEx"
+
+# ---------------------------------------------------------------------------
+# 0. The cleanest fix is a dedup INSIDE the dispatcher: it covers both walkers
+#    at once and cannot be reintroduced by a third call site added later. If
+#    that is how it is done, the ordering questions below do not arise.
+# ---------------------------------------------------------------------------
+dispatch_blk=$(awk '/^void shadow_chain_dispatch_sysex_to_slots/,/^}/' "$host")
+if grep -q "event_dedup_check_and_record\|sysex_dedup" <<<"$dispatch_blk"; then
+    deduped_inside=1
+else
+    deduped_inside=0
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Otherwise: within each walker, the dispatch must come AFTER the dedup.
+# ---------------------------------------------------------------------------
+check_order() {
+    [ "$deduped_inside" = 1 ] && return 0
+    local fn="$1"
+    local body
+    body=$(awk "/^void ${fn}\\(void\\)/,/^}/{ print NR\": \"\$0 }" "$host")
+    [ -n "$body" ] || fail "$fn is gone from $host"
+
+    # Not every walker has to dispatch SysEx; but one that does must dedup first.
+    local disp dedup
+    disp=$(grep -n "shadow_chain_dispatch_sysex_to_slots" <<<"$body" | head -n 1 | cut -d: -f2 || true)
+    [ -n "${disp:-}" ] || return 0
+
+    dedup=$(grep -n "event_dedup_check_and_record" <<<"$body" | head -n 1 | cut -d: -f2 || true)
+    [ -n "${dedup:-}" ] || \
+      fail "$fn dispatches SysEx but never dedups at all -- every frame the MIDI_IN slot survives re-delivers it"
+
+    [ "$disp" -gt "$dedup" ] || \
+      fail "$fn dispatches SysEx at line $disp, BEFORE its dedup at line $dedup -- a fragment in a slot that persists across frames is handed to the module again every frame"
+}
+
+check_order shadow_dispatch_direct_external_midi
+check_order shadow_dispatch_cable2_channeled_slots
+
+# ---------------------------------------------------------------------------
+# 2. Two walkers, two rings: dispatching from both delivers twice regardless.
+# ---------------------------------------------------------------------------
+sites=$(grep -c "^[^*]*shadow_chain_dispatch_sysex_to_slots(&" "$host" || true)
+if [ "$deduped_inside" = 0 ] && [ "${sites:-0}" -gt 1 ]; then
+    grep -q "g_sysex_dedup" "$host" || \
+      fail "SysEx is dispatched from $sites walkers, which both read the same MIDI_IN buffer in the same frame, and there is no shared SysEx dedup ring -- with a receive=All + forward=THRU slot present, every fragment is delivered twice"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The properties that are already right, so they stay right.
+# ---------------------------------------------------------------------------
+
+# Opt-in. SysEx payload bytes are < 0x80, so a module switching on
+# `msg[0] & 0xF0` reads data as a status type it half-recognises.
+blk=$(awk '/^void shadow_chain_dispatch_sysex_to_slots/,/^}/' "$host")
+grep -q "wants_sysex" <<<"$blk" || \
+  fail "the dispatcher no longer gates on wants_sysex -- every chain module would start receiving SysEx"
+
+# Length comes from the CIN. There is no length byte to trust, and the trailing
+# bytes of an end-packet are padding, not data.
+grep -q "case 0x05: n = 1" <<<"$blk" || \
+  fail "the CIN-to-length mapping is gone; a 1-byte tail would be read as 3 and pad the message with junk"
+
+# A per-position array that does not permute is the documented way to make a
+# chain shape edit silently mis-attribute state.
+reorder="src/modules/chain/dsp/chain_reorder.c"
+[ -f "$reorder" ] || fail "$reorder is gone"
+grep -q "wants_sysex" "$reorder" || \
+  fail "wants_sysex is not permuted in $reorder -- an fx:insert/remove/move would move the capability to the wrong position"
+
+echo "PASS: a SysEx fragment reaches an opted-in slot once per physical event"


### PR DESCRIPTION
**Stacked on #364** — targets that branch, so the diff here is just this feature. Merge #364 first.

> **Updated after @ryanmgilmore's review.** All three of his findings were verified independently and all three held; the dedup fix and his test are in. See [the review](https://github.com/charlesvestal/schwung/pull/367#pullrequestreview) and [my reply](https://github.com/charlesvestal/schwung/pull/367#issuecomment-5475028936).

## The finding

> "a chain slot can't receive sysex? is that...expected? i just explicitly set midi in to ch1"

No, and nobody decided it. Both cable-2 dispatchers gate on `cin < 0x08 || cin > 0x0E` — a **channel-voice-only** filter written for channel routing. SysEx fell out the bottom of it, with no comment, no capability and no test behind the behaviour.

And **setting a receive channel cannot help**: SysEx carries no channel byte, so it's excluded by CIN before any channel test runs. There was no setting that would have worked, which is what makes this hard to diagnose from outside — you build a JV-880 or D-50 editor as a slot module, it sends fine, and never hears an answer.

## The change

Opt-in via `capabilities.wants_sysex: true`. A slot that doesn't ask sees exactly what it saw before.

Opt-in rather than broadcast-to-all for a specific reason: SysEx payload bytes are `< 0x80`, so a module switching on `msg[0] & 0xF0` would read data as a status type it half-recognises. This has to be something a module was written for.

**There's nothing to route on**, so it broadcasts to every slot that opted in; a module tells its own messages apart by manufacturer ID.

Three things worth reviewing:

- `shadow_chain_dispatch_sysex_to_slots` is **separate** from `shadow_chain_dispatch_midi_to_slots`, not a flag threaded through it. That function is channel machinery end to end — receive-channel match, status-nibble remap, per-slot transpose, audio-FX broadcast — and none of it is meaningful on a fragment whose bytes are data. Remapping would rewrite payload; transpose reads `msg[1]` as a note number.
- It **dedups internally**, keyed on the whole 8-byte MIDI_IN slot (packet + XMOS timestamp), which is why it takes a slot rather than a 4-byte packet. Two reasons, both from the review: every caller `continue`s before its own walker's dedup, so a fragment in a slot that survives into the next frame was re-delivered *every frame it survived*; and both walkers read the same buffer in the same frame whenever any slot is receive=All + forward=THRU — the MPE configuration the manual recommends — so each fragment was dispatched twice. **Their per-walker rings can't see each other, so ordering the calls after the dedup would not have fixed the second one.** A ring in the callee fixes both and survives a third call site.
- Fragments are delivered **unassembled**, with their CIN-derived length. Buffering in the shim means per-slot reassembly state on the RT path with no bound on what a broken sender can make it hold. (A *bounded per-port* assembler — ryanmgilmore's suggestion — is a different and better shape; it's a follow-up, not this PR, because it changes the module-facing contract.)

**Duplication is worse than loss here**, which is the part I hadn't followed through: the module reassembles for itself and rule one is *start on `0xF0`*, so a repeated `F0` silently restarts the message and a repeated body byte corrupts it. The output is a plausible message that is fiction — the same failure class this pair of PRs exists to remove.

`midi_fx_wants_sysex[]` is in `chain_reorder.c`'s permutation array, per the rule in CLAUDE.md.

## Tests

`tests/host/test_sysex_slot_dedup.sh` is **@ryanmgilmore's**, taken as offered and attributed. It accepts *any* correct fix rather than mandating one, and it also pins what this branch already got right — the opt-in gate, the CIN-to-length mapping, and `wants_sysex` permuting. I checked it can fail before trusting it: removing the dedup call fails it at the exact line numbers it names.

`test_chain_midi_fx_slot` was broken by this branch (a `json_get_bool_in_section` link error) and is fixed by stubbing it alongside the `_int` stub — that file deliberately doesn't link `chain_json.c`. For the record it wasn't a `--no-verify`: this repo's hooks are opt-in (`scripts/install-hooks.sh`) and weren't installed in the worktree.

All `tests/host/*.sh` green. CI green.

## Verified on hardware

Same probe, same test, either side of the capability: **silence before, an ECHO for every message after.** After the dedup fix: **three messages in, exactly three ECHOes out.**

`modules/midi_fx/sysex_probe` emits that ECHO the moment an `F0` reaches `process_midi`, so this stays falsifiable rather than a code reading.

## What I have NOT tested

- A slot that does **not** declare the capability, under this build. The before/after covers it, but a dedicated negative run would be better.
- **The MPE double-delivery path directly** — the fix is proven by the test and by reasoning, not by a Move with a LinnStrument-style slot configured receive=All + forward=THRU while a dump arrives. That's the highest-value thing someone with the hardware could do.
- Any real device answering a real dump into a slot module. @ryanmgilmore, your D-50 editor is the obvious first user.
- Reassembly across a chain shape edit (insert/remove/move) while a dump is mid-flight.

Note that `sysex_probe` **cannot** see a duplication bug — it echoes if `process_midi` is *ever* handed an `F0`, so one delivery and six look identical to it. It answers "did this arrive", not "how many times".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DQQ2H8bnfpXwGM5ZZQsd78