### PR TITLE
catalog: gate tb3po on 1.0.0 — it needs knobStep

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -889,7 +889,7 @@
       "github_repo": "charlesvestal/schwung-tb3po",
       "default_branch": "main",
       "asset_name": "tb3po-module.tar.gz",
-      "min_host_version": "0.9.10"
+      "min_host_version": "1.0.0"
     },
     {
       "id": "breakbeat",


### PR DESCRIPTION
tb3po **v0.2.7** (just released) migrated off the removed `knobTick` export onto `knobStep`, which landed in `3546097d` at host 0.12.1 and first shipped in the **1.0.0** release. Its catalog floor still said `0.9.10`.

Left there, a host below 1.0.0 installing v0.2.7 hits the mirror image of the bug it fixes: a missing ES-module export, the UI loader refusing the script, and "Failed to load module" with nothing in any log to explain it.

`1.0.0` rather than `0.12.1` because a version floor is a claim about **releases**, and 0.12.1 was never one — nobody can be running it.

⚠️ **This is live-facing on merge** — the Module Store fetches `module-catalog.json` from `main` directly, so it takes effect without a host release. Flagging because Charles asked not to release Schwung yet; this is a catalog gate, not a release, but it does change what the store offers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RHkTCgWY2fDuac5GWPVHVM