### PR TITLE
plugin_api: midi_inject_to_move preserves the cable nibble, and cable 2 goes out USB-A

### DIFF
--- a/src/host/plugin_api_v1.h
+++ b/src/host/plugin_api_v1.h
@@ -174,18 +174,39 @@ typedef struct host_api_v1 {
      * NULL if host does not support tempo. */
     float (*get_bpm)(void);
 
-    /* Inject a USB-MIDI packet into Move's MIDI_IN as if it came from
-     * internal hardware (pads/knobs). The drain forces cable 0 so Move
-     * treats the event as native input — no MIDI_OUT cable-2 echo.
+    /* Inject a USB-MIDI packet into Move's MIDI_IN, as if it had arrived at
+     * the hardware.
+     *
+     * THE CABLE NIBBLE IS PRESERVED, AND IT CHOOSES THE ROUTE. The drain
+     * memcpy's the packet into a MIDI_IN slot verbatim
+     * (shadow_overtake_midi.c), so the caller — not the host — decides how
+     * Move reads it:
+     *
+     *   cable 0  Move treats the event as its own surface (pad/button).
+     *            Use this to simulate a press.
+     *   cable 2  Move routes it by CHANNEL to the track instrument, exactly
+     *            as it would an external USB-A device — AND ECHOES IT BACK
+     *            OUT MIDI_OUT CABLE 2, i.e. to whatever is plugged into
+     *            USB-A. This is how a chain MIDI FX in Pre mode reaches an
+     *            external synth; it is also a loop back into any chain slot
+     *            listening on that channel, so a note-generating caller must
+     *            filter its own echo (see pre_mode_is_echo in chain_midi.c).
+     *
+     * The channel byte must be the slot's RECV channel, not forward_channel
+     * — see slot_recv_channel below.
      *
      * msg: 4-byte USB-MIDI packet [cable|CIN, status, data1, data2]
-     *      The cable nibble is ignored (always forced to 0 by the drain).
      * len: must be 4
      * Returns: bytes queued, or 0 on failure (SHM unavailable, ring full).
      *
      * NULL if host does not support MIDI-IN injection (non-shadow host).
-     * Rate-limited to 8 packets/tick at the drain; callers should not
-     * burst more than that per render block. */
+     *
+     * DELIVERY IS NOT PER-TICK PACED, it is gated on MIDI_IN being idle: the
+     * drain runs only after two consecutive frames with every MIDI_IN slot
+     * empty, then fills consecutive slots and stops at the first occupied one
+     * (shadow_midi.c shadow_drain_midi_inject). Under sustained hardware input
+     * it may not run at all, so treat a queued packet as queued — never as
+     * delivered — and keep bursts small. */
     int (*midi_inject_to_move)(const uint8_t *msg, int len);
 
     /* Return the receive channel for the slot owning this plugin instance.


### PR DESCRIPTION
## What

The comment on `host_api_v1_t::midi_inject_to_move` has claimed the opposite of the implementation since #83:

> The drain forces cable 0 so Move treats the event as native input — no MIDI_OUT cable-2 echo.
> …
> The cable nibble is ignored (always forced to 0 by the drain).

Both halves were true when the call landed in `1e5bce95`, and stopped being true in `4ae7f8c7`, which switched the drain to preserve the cable and moved Pre-mode to cable 2. #83 swept the stale claim out of `src/host/shadow_midi.h` and `docs/API.md` and missed this copy — the one a module author reads.

## Why it matters

`drain_ring` (`shadow_overtake_midi.c:58`) does a plain `memcpy(slot, packet, 4)`. The cable nibble picks the route:

- **cable 0** — Move reads it as its own surface (pad/button).
- **cable 2** — Move routes by channel to the track instrument *and echoes it back out MIDI_OUT cable 2*, i.e. to USB-A.

That echo is the only reason a chain MIDI FX in **MFX Pre** mode reaches an external synth, and it is why `pre_mode_is_echo` / `pre_injected_notes` exist at all. A reader of this header would conclude neither is possible — which is exactly the wrong answer to give someone asking why their MIDI FX can't drive external gear.

Also drops *"Rate-limited to 8 packets/tick at the drain"*, which was never implemented on this path. Delivery is gated on MIDI_IN being idle for two consecutive frames and then stops at the first occupied slot (`shadow_drain_midi_inject`, `shadow_midi.c:800-821`), so under sustained hardware input it may not drain at all. Same moral as the `midi_send_external` contract directly above it: queued is not delivered.

`docs/ADDRESSING_MOVE_SYNTHS.md` already documents the cable-2 flow correctly; this brings the header in line with it.

## Scope

Comment-only. No code change.

Note for the fleet: module repos ship their own copy of `plugin_api_v1.h`, so their copies still carry the stale text. Not swept here.

## Test

- `make -C tests/host test` — all green
- `tests/host/*.sh` — 215 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXp8mQ4EJeCWSN2okyQxy7