### PR TITLE
param_format: a number is an INDEX, a name is a name

### DIFF
--- a/src/shared/param_format.mjs
+++ b/src/shared/param_format.mjs
@@ -211,9 +211,35 @@ export function formatParamForSet(rawValue, meta) {
     }
     if (meta.type === "int") return String(Math.round(Number(rawValue)));
     if (meta.type === "enum") {
+        /*
+         * A NUMBER IS AN INDEX. A NAME IS A NAME. The two are not interchangeable
+         * and the option text cannot arbitrate between them.
+         *
+         * This used to try `options.indexOf(String(rawValue))` FIRST, for any
+         * value. Every caller in this repo hands over `knobStep()` output — an
+         * index, a number — so an index whose numeral happened to appear among
+         * the options was resolved as that OPTION'S POSITION instead:
+         *
+         *   options ["-100","-50","0","+50","+100"], user picks -100 (index 0)
+         *   -> indexOf("0") is 2 -> the module is told 2, i.e. "0"
+         *
+         * Measured over tests/fixtures/module-contracts.json, 40 enum params in
+         * the fleet write a wrong value that way — minijv's four lfo1offsets,
+         * v_octave, transpose, the chord_pc family — and it is SILENT, because
+         * the cell goes on showing the value the grid believes it wrote. An
+         * enum of ["0","1"] is unharmed only by the coincidence that there the
+         * text equals the index.
+         *
+         * The label lookup itself is not wrong; its PRECEDENCE was. It exists
+         * for enums a plugin wires by name, and `enumWiresNames` is the
+         * declared signal for exactly that — so a string is read as a label
+         * only when the plugin actually speaks names, and a number is always
+         * an index.
+         */
         let idx;
-        if (Array.isArray(meta.options)) {
-            const labelIdx = meta.options.indexOf(String(rawValue));
+        const wiresNames = enumWiresNames(meta);
+        if (Array.isArray(meta.options) && typeof rawValue === "string" && wiresNames) {
+            const labelIdx = meta.options.indexOf(rawValue);
             idx = labelIdx >= 0 ? labelIdx : Math.round(Number(rawValue));
         } else {
             idx = Math.round(Number(rawValue));

--- a/tests/host/test_enum_write_index.sh
+++ b/tests/host/test_enum_write_index.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# AN ENUM WRITE MUST NOT RESOLVE AN INDEX AS AN OPTION NAME.
+#
+# formatParamForSet used to try options.indexOf(String(rawValue)) FIRST, for
+# any value. Every caller in this repo hands it knobStep() output -- an index,
+# a number -- so an index whose numeral appeared among the options resolved to
+# that option's POSITION instead. Picking "-100" out of
+# ["-100","-50","0","+50","+100"] wrote 2, because "0" sits at index 2.
+#
+# It is silent: the cell goes on showing the value the grid believes it wrote.
+#
+# This test is built from the REAL fleet contract rather than invented cases,
+# so it measures the thing that actually shipped. It asserts three properties:
+#
+#   1. every declared enum in the fleet round-trips index -> wire -> index
+#   2. the two shapes that provably broke are pinned by name
+#   3. an enum a plugin wires by NAME still accepts both an index and a label,
+#      which is what the label branch was added for and must keep doing
+
+node --input-type=module -e '
+import fs from "node:fs";
+const { formatParamForSet } = await import("./src/shared/param_format.mjs");
+
+let bad = 0;
+const fail = (m) => { console.error("FAIL " + m); bad++; };
+
+/* 1. Every enum in the fleet fixture. */
+const raw = fs.readFileSync("tests/fixtures/module-contracts.json", "utf8");
+let enums = 0, checked = 0;
+(function walk(n) {
+    if (Array.isArray(n)) { n.forEach(walk); return; }
+    if (!n || typeof n !== "object") return;
+    if (n.type === "enum" && Array.isArray(n.options) && n.options.length) {
+        enums++;
+        /* Only index-wired enums write a bare index; a names-wired one writes
+         * the name, which is checked separately below. */
+        if (!n.options_as_string && n.wire_format !== "name") {
+            for (let i = 0; i < n.options.length; i++) {
+                const wire = formatParamForSet(i, n);
+                if (Number(wire) !== i) {
+                    fail("index " + i + " of " + (n.key || "?") +
+                         " [" + n.options.slice(0, 6).join(",") + "] wrote " + wire);
+                    i = n.options.length;
+                }
+                checked++;
+            }
+        }
+    }
+    for (const v of Object.values(n)) walk(v);
+})(JSON.parse(raw));
+if (enums < 100) fail("fixture yielded only " + enums + " enums - is it still the fleet contract?");
+
+/* 2. The two shapes that provably broke. */
+const offset = { type: "enum", options: ["-100", "-50", "0", "+50", "+100"] };
+if (formatParamForSet(0, offset) !== "0") {
+    fail("minijv lfo1offset shape: picking -100 wrote " + formatParamForSet(0, offset));
+}
+const chan = { type: "enum", options: Array.from({ length: 16 }, (_, i) => String(i + 1)) };
+for (let i = 0; i < 16; i++) {
+    if (Number(formatParamForSet(i, chan)) !== i) {
+        fail("channel shape: index " + i + " wrote " + formatParamForSet(i, chan));
+        break;
+    }
+}
+
+/* 3. The label branch still serves what it was added for. */
+const named = { type: "enum", options: ["Sine", "Saw"], options_as_string: true };
+if (formatParamForSet(1, named) !== "Saw") fail("names-wired enum lost the index path");
+if (formatParamForSet("Saw", named) !== "Saw") fail("names-wired enum lost the label path");
+
+if (bad) process.exit(1);
+console.log("PASS: enum writes resolve an index as an index (" + enums +
+            " fleet enums, " + checked + " index round trips)");
+'


### PR DESCRIPTION
`formatParamForSet` tried `options.indexOf(String(rawValue))` **first**, for any
value. Every caller in this repo hands it `knobStep()` output — an index, a
number — so an index whose numeral happened to appear among the options was
resolved as that *option's position* instead.

```
options ["-100","-50","0","+50","+100"], user picks -100 (index 0)
  -> indexOf("0") is 2 -> the module is told 2, i.e. "0"
```

Measured over `tests/fixtures/module-contracts.json`, **40 enum params in the
fleet write a wrong value** this way — minijv's four `lfo1offset`s, `v_octave`,
`transpose`, the `chord_pc_*` family. It is silent: the cell goes on showing
the value the grid believes it wrote. An enum of `["0","1"]` is unharmed only
by the coincidence that there the option text equals its own index.

## The fix

The label lookup is not wrong; its **precedence** was. It was added for enums a
plugin wires by NAME, and `enumWiresNames(meta)` is the declared signal for
exactly that — so a string is read as a label only when the plugin actually
speaks names, and a number is always an index. Both paths of a names-wired enum
are pinned by the test.

No caller in the repo passes an option name today (they all pass `knobStep()`
output), so nothing observable changes except that indices stop being
corrupted.

## How it was found

TB-3PO needs MIDI channel as a 1..16 enum so it can be dived into with the
option picker. It asked for channel 8 and the module got 7. Wrong for 15 of 16
channels, on the knob *and* in the picker.

## Verification

- `tests/host/test_enum_write_index.sh` is built from the fleet contract rather
  than invented cases: **1177 enums, 12997 index round trips**, plus the two
  shapes that provably broke, plus both paths of a names-wired enum
- restoring the old precedence fails it on the four minijv offsets
- `make -C tests/host test` and every `tests/host/*.sh` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BT7KUpVLAQ6Da6hPPT9Rd