### PR TITLE
catalog: gate tb3po on 1.1.0 — it needs the embeddable knob grid

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -889,7 +889,7 @@
       "github_repo": "charlesvestal/schwung-tb3po",
       "default_branch": "main",
       "asset_name": "tb3po-module.tar.gz",
-      "min_host_version": "1.0.0"
+      "min_host_version": "1.1.0"
     },
     {
       "id": "breakbeat",


### PR DESCRIPTION
TB-3PO v0.3.0 drives `page_controller` and renders through `movyBandLayout` and `movyHeaderFor`, neither of which exists before 1.1.0.

On an older host it installs cleanly and then fails at import — exactly how v0.2.7 went. The gate has to move before the module is released, or the store offers it to people on 1.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BT7KUpVLAQ6Da6hPPT9Rd