### PR TITLE
catalog: stems is 0.85x realtime, not 0.5x

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -538,7 +538,7 @@
     {
       "id": "stems",
       "name": "Stems",
-      "description": "Separate audio into stems: drums, vocals, accompaniment (0.5x realtime)",
+      "description": "Separate audio into stems: drums, vocals, accompaniment (0.85x realtime)",
       "author": "charlesvestal",
       "component_type": "tool",
       "github_repo": "charlesvestal/schwung-stems",


### PR DESCRIPTION
The store description for `stems` has claimed 0.5x realtime since the module shipped. Measured on device with the shipped engine:

| input | wall | ratio |
|---|---|---|
| 30 s | 22 s | 0.73x |
| 60 s | 43 s | 0.72x |
| 240 s (chunked) | 205 s | 0.85x |

`stems` v0.4.0 moved its own `processing_ratio` — which drives the on-screen "about N remaining" estimate — from 0.5 to 0.85; this is the catalog half of the same correction.

Companion to charlesvestal/schwung-stems#2, which fixes the exit-137 OOM that prompted the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfVCRycPWeccfXgg7VrRKw