### PR TITLE
tools: the time estimate never read tool_config.processing_ratio

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -116,8 +116,28 @@ Tool modules (`"component_type": "tool"`) appear in the Tools menu and support a
 | `allow_new_file` | Show a "+ New File" action in the file browser |
 | `command` | Shell command to run for non-interactive tools |
 | `overtake` | `true` to use overtake display mode (full LED clear, ~500ms init delay, Shift+Vol+Jog-Click exit). Default is `false`. |
+| `stems` | Array of stem names a separation tool produces, used for the progress readout |
+| `processing_ratio` | Wall time as a fraction of the input's duration, used only for the "about N remaining" estimate. `0.5` means a 4-minute file takes about 2 minutes. Default `0.5`. |
 
 Interactive tools use `host_exit_module()` to return to the tools menu when the user presses Back.
+
+**`processing_ratio` is a measurement, not an aspiration, and it should err
+LONG.** An estimate that runs out while the tool is still working reads as a
+hang; one that finishes early reads as a pleasant surprise.
+
+A tool that ships several engines of different speeds puts a `processing_ratio`
+on each entry of `tool_config.engines[]` instead; the per-engine value wins over
+the module-level one.
+
+The module-level field went unread for the life of the field — `getToolProcessingRatio()`
+consulted only the per-engine value and otherwise returned a hardcoded `0.5`.
+It stayed invisible because the single module declaring it declared `0.5`, the
+same number as the default, so a working declaration and an ignored one were
+indistinguishable. It surfaced only when that module corrected itself to a
+measured figure and the on-screen estimate did not move.
+`tests/host/test_tool_processing_ratio.sh` now runs both copies of the function
+— `shadow_ui.js` drives the confirm screen, `shadow_ui_tools.mjs` the processing
+screen — against the same cases and fails if they disagree.
 
 ### Defaults
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -9372,8 +9372,22 @@ function getWavDurationSec(filePath) {
  * SpleeterRT (3-stem): ~0.5x realtime on Move's Cortex-A72.
  * Spleeter TFLite (4-stem): ~3.0x realtime. */
 function getToolProcessingRatio() {
+    /* A tool's wall time relative to the input's duration, used only for the
+     * "about N remaining" estimate.
+     *
+     * Order matters: a per-engine value is more specific than the module's, and
+     * a module that ships several engines (each with its own speed) declares
+     * both. tool_config.processing_ratio was declared by stems from the start
+     * but never read here — and because the value it declared, 0.5, happened to
+     * equal the hardcoded default below, the field looked like it worked. It
+     * only showed up when stems corrected itself to a measured figure and the
+     * estimate did not move. */
     if (toolSelectedEngine && toolSelectedEngine.processing_ratio) {
         return toolSelectedEngine.processing_ratio;
+    }
+    if (toolActiveTool && toolActiveTool.tool_config &&
+        toolActiveTool.tool_config.processing_ratio) {
+        return toolActiveTool.tool_config.processing_ratio;
     }
     return 0.5;  /* default for legacy/unknown engines */
 }

--- a/src/shadow/shadow_ui_tools.mjs
+++ b/src/shadow/shadow_ui_tools.mjs
@@ -35,9 +35,16 @@ function formatTime(seconds) {
 }
 
 function getToolProcessingRatio() {
-    const { toolSelectedEngine } = ctx;
+    /* Mirrors shadow_ui.js's copy — the two drive the same estimate on two
+     * different screens (confirm vs. processing), so they must agree.
+     * tests/host/test_tool_processing_ratio.sh fails on drift. */
+    const { toolSelectedEngine, toolActiveTool } = ctx;
     if (toolSelectedEngine && toolSelectedEngine.processing_ratio) {
         return toolSelectedEngine.processing_ratio;
+    }
+    if (toolActiveTool && toolActiveTool.tool_config &&
+        toolActiveTool.tool_config.processing_ratio) {
+        return toolActiveTool.tool_config.processing_ratio;
     }
     return 0.5;
 }

--- a/tests/host/test_tool_processing_ratio.sh
+++ b/tests/host/test_tool_processing_ratio.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The tool time estimate ("about N remaining").
+#
+# getToolProcessingRatio() exists TWICE — src/shadow/shadow_ui.js drives the
+# confirm screen, src/shadow/shadow_ui_tools.mjs drives the processing screen —
+# and both feed the same user-visible number. Drift between them shows up as an
+# estimate that changes when the screen does.
+#
+# The failure this pins: neither copy read tool_config.processing_ratio, only
+# the per-engine value. A module with no tool_config.engines[] therefore always
+# got the hardcoded 0.5. That went unnoticed for the life of the field because
+# the one module declaring it (stems) declared 0.5 — the same number as the
+# default — so the declaration and the fallback were indistinguishable until
+# stems corrected itself to a measured value and nothing moved.
+#
+# So this test does not grep for the property name. It extracts each function's
+# real source, runs it against three shapes of input, and requires both copies
+# to agree on all three.
+
+node - <<'NODE'
+const fs = require("fs");
+
+const JS  = "src/shadow/shadow_ui.js";
+const MJS = "src/shadow/shadow_ui_tools.mjs";
+
+const fails = [];
+
+/* Pull the function body out of each file and rebuild it against a stub scope,
+ * so what runs here is the shipped source rather than a restatement of it. */
+function extract(path, usesCtx) {
+    const src = fs.readFileSync(path, "utf8");
+    const start = src.indexOf("function getToolProcessingRatio()");
+    if (start < 0) { fails.push(`${path}: getToolProcessingRatio() not found`); return null; }
+    if (src.indexOf("function getToolProcessingRatio()", start + 1) >= 0) {
+        fails.push(`${path}: more than one getToolProcessingRatio()`);
+        return null;
+    }
+    /* brace-match to the end of the function */
+    let depth = 0, i = src.indexOf("{", start), end = -1;
+    for (; i < src.length; i++) {
+        if (src[i] === "{") depth++;
+        else if (src[i] === "}") { depth--; if (depth === 0) { end = i + 1; break; } }
+    }
+    if (end < 0) { fails.push(`${path}: unbalanced braces`); return null; }
+    const body = src.slice(start, end);
+    /* The .mjs copy destructures from ctx; the .js copy closes over globals.
+     * Give each the scope it expects. */
+    const prelude = usesCtx
+        ? "let ctx = { toolSelectedEngine: E, toolActiveTool: T };"
+        : "let toolSelectedEngine = E, toolActiveTool = T;";
+    return new Function("E", "T", `${prelude}\n${body}\nreturn getToolProcessingRatio();`);
+}
+
+const js  = extract(JS, false);
+const mjs = extract(MJS, true);
+
+if (js && mjs) {
+    const cases = [
+        {
+            name: "per-engine ratio wins over the module's",
+            engine: { processing_ratio: 0.25 },
+            tool:   { tool_config: { processing_ratio: 0.85 } },
+            expect: 0.25,
+        },
+        {
+            name: "tool_config.processing_ratio is honoured when there is no engine",
+            engine: null,
+            tool:   { tool_config: { processing_ratio: 0.85 } },
+            expect: 0.85,
+        },
+        {
+            name: "falls back to the default when neither declares one",
+            engine: null,
+            tool:   { tool_config: {} },
+            expect: 0.5,
+        },
+        {
+            name: "survives a tool with no tool_config at all",
+            engine: null,
+            tool:   {},
+            expect: 0.5,
+        },
+        {
+            name: "survives no active tool at all",
+            engine: null,
+            tool:   null,
+            expect: 0.5,
+        },
+    ];
+
+    for (const c of cases) {
+        const a = js(c.engine, c.tool);
+        const b = mjs(c.engine, c.tool);
+        if (a !== c.expect) fails.push(`${JS}: ${c.name} -> ${a}, expected ${c.expect}`);
+        if (b !== c.expect) fails.push(`${MJS}: ${c.name} -> ${b}, expected ${c.expect}`);
+        if (a !== b) fails.push(`copies disagree on "${c.name}": ${JS}=${a} ${MJS}=${b}`);
+    }
+}
+
+if (fails.length) {
+    for (const f of fails) console.error("FAIL: " + f);
+    process.exit(1);
+}
+console.log("PASS: tool processing ratio (both copies, 5 cases)");
+NODE


### PR DESCRIPTION
Separating a 154 s track was estimated at **"about 1m 15s"** and took **2m 20s**.

## Cause

```js
function getToolProcessingRatio() {
    if (toolSelectedEngine && toolSelectedEngine.processing_ratio) {
        return toolSelectedEngine.processing_ratio;
    }
    return 0.5;  /* default for legacy/unknown engines */
}
```

`toolSelectedEngine` comes from a `tool_config.engines[]` array. A module without one — stems has no `engines[]` — always falls through to the hardcoded `0.5`. **`tool_config.processing_ratio`, the field a module actually declares, is read by nothing.**

154 × 0.5 = 77 s = "1m 17s". That is the number on screen.

## Why it survived this long

The only module in the fleet declaring `processing_ratio` is stems, and it declared **`0.5`** — the same value as the hardcoded default. A working declaration and an ignored one produced byte-identical output. It became visible only when stems corrected itself to a measured `0.85` and the estimate didn't budge.

`processing_ratio` was also undocumented in `docs/MODULES.md`, so there was nothing to check it against.

## Fix

Module-level value as a fallback, per-engine still winning (a module shipping several engines of different speeds needs the more specific one). Applied to **both** copies — `shadow_ui.js` drives the confirm screen, `shadow_ui_tools.mjs` the processing screen, and both feed the same user-visible number.

## Test

`tests/host/test_tool_processing_ratio.sh` brace-matches each function out of its file, rebuilds it against a stub scope, and runs the **shipped source** against five input shapes, requiring both copies to agree on all five.

Deliberately not a grep: the property name `processing_ratio` appears in both files already, so a grep-based test would have passed the original bug. Verified by mutation — reverting the `.mjs` copy alone produces:

```
FAIL: shadow_ui_tools.mjs: tool_config.processing_ratio is honoured when there is no engine -> 0.5, expected 0.85
FAIL: copies disagree on "...": shadow_ui.js=0.85 shadow_ui_tools.mjs=0.5
```

Full host suite: 221 shell tests pass, `make -C tests/host test` green.

## Docs

`docs/MODULES.md` gains `processing_ratio` and `stems`, plus the note that the value should **err long** — an estimate that runs out while the tool is still working reads as a hang, one that finishes early doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CfVCRycPWeccfXgg7VrRKw