### PR TITLE
param_pages: the enum peek is a library call, not a host one

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -466,6 +466,15 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   draw path — values arrive on touch-down, on the rotation, or in the entry warm.
 - **A read that did not answer must never become a picture.** Placeholder frames
   animated the first page of 46 of 95 fleet modules in.
+- **`render()` is not the whole draw.** Nothing in `src/shared/param_pages/`
+  clears the screen — that is what lets `render(ctx, {rect, bands})` place a
+  page inside a caller's chrome — so anything full-screen is the frame owner's
+  second call: `controller.renderOverlays(ctx, { clearScreen })`. Today that is
+  the enum peek. It lived in `shadow_ui_param_pages.mjs`, where it was
+  invisible to every module binding the controller from its own `ui_chain.js`:
+  the peek was tracked on each detent, `applyInput` swallowed the Back that
+  dismissed it, and it was painted nowhere. CW-78 and 6W6 both shipped that
+  way.
 - **Two-option enums: the GRID flips on click, a LIST focuses instead** — and a
   detent TOGGLES, latched to one flick. `flipsOnClick` defines "is a two-way",
   not "flip".

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -582,6 +582,29 @@ globalThis.chain_ui = {
 };
 ```
 
+#### If your `ui_chain.js` draws the knob grid (`param_pages`)
+
+A module may bind Schwung's own page engine instead of drawing its own screens
+— import `page_controller.mjs` from `/data/UserData/schwung/shared/param_pages/`
+and you get the whole knob grid, the widgets, the viz graphics, the section
+picker and the gestures for free.
+
+**Then two calls are yours, not one:**
+
+```javascript
+clear_screen();                                   /* the frame is YOURS */
+controller.render(ctx, { title: title() });
+controller.renderOverlays(ctx, { clearScreen: clear_screen });
+```
+
+The library never clears the screen — that is what lets `render()` place a page
+inside a rect you own — so anything full-screen is handed back to you.
+Today that is the enum peek: turn a multi-option enum and its option list
+should rise over the grid for ~700 ms. Skip `renderOverlays` and the controller
+still tracks the peek and still swallows the Back that dismisses it; it is
+simply never painted, with no error anywhere. Two shipped modules had exactly
+that bug.
+
 #### Back-button handling (`handleBack`)
 
 A chain module's `ui_chain.js` may export `handleBack()`. When the shadow UI is in

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -467,6 +467,34 @@ at a time. `dismissPeek` goes through `enumPeek()` so an EXPIRED peek is not a
 layer: swallowing one press is a layer, swallowing two is a trap, and this
 screen has no other way out.
 
+**`render()` is not the whole draw — the peek is `renderOverlays()`.** Nothing
+in `src/shared/param_pages/` clears the screen; grep it. That is the contract
+`render(ctx, {rect, bands})` depends on — a consumer hosting a page inside its
+own chrome must get the body alone — and it is why a FULL-SCREEN overlay cannot
+live inside `render()`. So the peek is a second call the frame owner makes:
+
+```javascript
+clear_screen();
+controller.render(ctx, { title });
+controller.renderOverlays(ctx, { clearScreen: clear_screen });
+```
+
+Pass no `clearScreen` and it declines to draw rather than interleaving its list
+with the grid underneath, which is what an embedded consumer wants.
+
+**A module binding the controller from its own `ui_chain.js` owes that second
+call**, and until 2026-09 nothing said so: the draw lived in
+`shadow_ui_param_pages.mjs`, so for every other consumer the controller tracked
+a peek on each enum detent that was painted nowhere, while `applyInput`
+dutifully routed Back to `dismissPeek()` to take down a panel nobody could see.
+Silent, no error, not visible from the API. CW-78 and 6W6 both shipped that way
+— correct integrations in every other respect, which is the point: the
+obligation had to become a FUNCTION rather than a paragraph.
+`tests/host/test_enum_peek.sh` now draws through a real framebuffer, because
+the rows go through `menu_layout` (global `print`) while the header is a pixel
+font that never calls `print` at all — a recording `print()` reports a
+headerless screen as complete.
+
 **A parameter drawn across MORE THAN ONE CELL does not peek** (`drawnWide`).
 The peek exists because a 30px cell cannot show a list; once the picture has
 the room, a panel over the top hides the rest of the row to show nothing new.

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -51,9 +51,6 @@ import { invalidateLedCache } from '/data/UserData/schwung/shared/input_filter.m
  * shadow_ui.js is the only file in the shadow UI that node never imports. */
 import { wavPeaksTick, wavPeaksDone } from '/data/UserData/schwung/shared/param_pages/wav_peaks.mjs';
 import { VIZ_SAMPLE } from '/data/UserData/schwung/shared/param_pages/viz.mjs';
-/* The enum option screen, shared with the picker view in shadow_ui.js — one
- * screen, two entries, opposite commit semantics. See enum_list.mjs. */
-import { drawEnumList } from '/data/UserData/schwung/shared/param_pages/enum_list.mjs';
 import { flipsOnClick, isTurnable } from '/data/UserData/schwung/shared/param_pages/param_meta.mjs';
 import { announce } from '/data/UserData/schwung/shared/screen_reader.mjs';
 import { log, isLoggingEnabled } from '/data/UserData/schwung/shared/logger.mjs';
@@ -1054,29 +1051,22 @@ export function drawParamPages() {
      * Full-screen rather than a card: while you are turning a knob you are not
      * reading the rest of the grid, and a card-sized rect would show fewer
      * options than the picker does, which is the whole thing the list is for.
-     * Sharing enum_list.mjs is what keeps the two one screen; the only
-     * difference is the header word.
      *
      * Drawn AFTER the grid and over it, so a frame in which the peek expires
      * falls back to a complete page rather than to a hole.
+     *
+     * The draw itself lives in the controller (renderOverlays) rather than
+     * here, because this file is not the only consumer: a module binding
+     * page_controller from its own ui_chain.js owns its frame too, and while
+     * the peek lived in this file it simply did not exist for those modules —
+     * tracked on every detent, painted never. It is delegated, not moved: the
+     * clear stays OURS, because clearing the screen is what a frame owner does
+     * and the library must never assume it owns one.
      */
-    const peek = controller.enumPeek();
-    if (peek) {
-        clear_screen();
-        drawEnumList({ fillRect: fill_rect, print, textWidth: text_width }, {
-            title: peek.title,
-            /* Not "SELECT". Nothing is being selected — the value is already
-             * set — and naming a gesture the screen does not have is how a
-             * user learns to press a button that does nothing. */
-            headerRight: "TURNING",
-            options: peek.options,
-            index: peek.index,
-            /* Cursor and live value are the SAME here, unlike the picker where
-             * the `*` marks what Back would return you to. */
-            markIndex: peek.index,
-            footer: [["TURN", "SET"]],
-        });
-    }
+    controller.renderOverlays(
+        { fillRect: fill_rect, print, textWidth: text_width },
+        { clearScreen: clear_screen }
+    );
     return true;
 }
 

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -41,6 +41,7 @@ import { renderPageMovy, drawFooter, drawHeader as drawHeaderMovy, drawBankBar,
 import { resolveViz, vizDiveTarget, VIZ_SWITCH } from "./viz.mjs";
 import { createAnimState } from "./anim_state.mjs";
 import { drawMenuList } from "../menu_layout.mjs";
+import { drawEnumList } from "./enum_list.mjs";
 
 export { LAYOUT_MOVY };
 
@@ -3670,6 +3671,65 @@ export function createController(io = {}) {
         });
     }
 
+    /*
+     * WHAT render() DOES NOT DRAW, AND WHY IT CANNOT.
+     *
+     * render() paints a page into a rect the CALLER owns. Nothing in
+     * src/shared/param_pages/ clears the screen -- grep it, there is not one
+     * clear_screen in the whole library -- and that is the contract `rect` and
+     * `bands` depend on: a consumer hosting a page inside its own chrome
+     * (movy's header, a tool's status row) must get the body alone. See the
+     * bands comment in render().
+     *
+     * The enum peek is the opposite kind of screen: FULL, over the top, on
+     * purpose, because while you are turning a knob you are not reading the
+     * rest of the grid. It therefore cannot live inside render() -- it would
+     * ignore the caller's rect and blank a frame the caller composed -- and it
+     * lived in the host binding instead, where the clear was available.
+     *
+     * That made it INVISIBLE TO EVERY OTHER CONSUMER. A module binding
+     * page_controller from its own ui_chain.js calls render() and stops, which
+     * is what every line of the library suggests is the whole draw; the
+     * controller then tracks a peek on every enum detent that is never
+     * painted, and applyInput dutifully routes Back to dismissPeek() to take
+     * down a panel nobody can see. Silent, with no error, and not discoverable
+     * from the API -- CW-78 and 6W6 both shipped that way, with a correct
+     * integration in every other respect.
+     *
+     * So the obligation is a FUNCTION rather than a paragraph in a doc. A
+     * caller that owns the frame calls render() then renderOverlays(), and a
+     * caller embedding a page in its own chrome passes no clearScreen and
+     * simply gets nothing -- a full-screen overlay is meaningless there.
+     *
+     * `ctx` is render()'s, plus `clearScreen`. Returns true when something was
+     * drawn, so a caller that flushes conditionally can tell.
+     */
+    function renderOverlays(ctx, { clearScreen } = {}) {
+        const peek = enumPeek();
+        if (!peek) return false;
+        /*
+         * No clear, no overlay. Drawing the list into a frame we may not blank
+         * would leave it interleaved with the grid underneath -- two screens at
+         * once, which is worse than the one we have.
+         */
+        if (typeof clearScreen !== "function") return false;
+        clearScreen();
+        drawEnumList(ctx, {
+            title: peek.title,
+            /* Not "SELECT". Nothing is being selected -- the value is already
+             * set -- and naming a gesture the screen does not have is how a
+             * user learns to press a button that does nothing. */
+            headerRight: "TURNING",
+            options: peek.options,
+            index: peek.index,
+            /* Cursor and live value are the SAME here, unlike the picker where
+             * the `*` marks what Back would return you to. */
+            markIndex: peek.index,
+            footer: [["TURN", "SET"]],
+        });
+        return true;
+    }
+
     let vizCache = null;
     function vizGroups() {
         const p = page();
@@ -3954,7 +4014,8 @@ export function createController(io = {}) {
         get pickerOpen() { return s.pickerOpen; },
         get pickerEntries() { return s.pickerEntries; },
         get pickerIndex() { return s.pickerIndex; },
-        setLayout, setReveal, setDecorations, render, announceContents,
+        setLayout, setReveal, setDecorations, render, renderOverlays,
+        announceContents,
         get state() { return s; },
         get page() { return page(); },
         get pages() { return s.pages; },

--- a/tests/host/test_enum_peek.sh
+++ b/tests/host/test_enum_peek.sh
@@ -31,10 +31,11 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 node --input-type=module -e '
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { createController, ENUM_PEEK_MS }
   from "./src/shared/param_pages/page_controller.mjs";
 import { applyInput } from "./src/shared/param_pages/page_input.mjs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
 
 let fail = 0;
 const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
@@ -239,35 +240,158 @@ const spin = (ctl, slot, n) => {
 }
 
 /* ===================================================================== 7 ==
- * THE WIRING, at the source. The pixels of this screen are already pinned by
- * test_enum_picker_chrome.sh, because the peek and the picker share
- * enum_list.mjs -- what is NOT covered there is that the grid reaches it with
- * the right arguments and, crucially, WITHOUT changing view.
+ * THE WIRING, at the source -- AND WHO OWNS THE DRAW.
+ *
+ * The pixels of this screen are pinned by test_enum_picker_chrome.sh, because
+ * the peek and the picker share enum_list.mjs. What is not covered there is
+ * that the peek is REACHED at all.
+ *
+ * It used to be drawn inside shadow_ui_param_pages.mjs, which is one consumer
+ * of page_controller and not the only one: a module supplying its own
+ * ui_chain.js binds the same controller and owns its own frame. Those modules
+ * called render() and stopped -- which is what the whole library suggests is
+ * the entire draw -- so the controller tracked a peek on every enum detent
+ * that was painted nowhere, and applyInput routed Back to dismissPeek() to
+ * take down a panel that did not exist. CW-78 and 6W6 both shipped that way.
+ *
+ * So the draw lives in the controller as renderOverlays() and the host
+ * delegates. The clear stays with the CALLER: nothing in
+ * src/shared/param_pages/ may clear the screen, or render()`s rect/bands
+ * contract -- a consumer hosting a page inside its own chrome -- is broken.
  */
 {
   const src = readFileSync("src/shadow/shadow_ui_param_pages.mjs", "utf8");
   const at = src.indexOf("export function drawParamPages(");
   const body = src.slice(at, src.indexOf("\nexport ", at + 10));
 
-  ok(/controller\.enumPeek\(\)/.test(body),
-     "drawParamPages asks the controller for the peek");
-  ok(/drawEnumList\(/.test(body),
-     "it draws through the SHARED enum screen, not a second list");
-  ok(/headerRight:\s*"TURNING"/.test(body),
-     "the header says TURNING, not SELECT -- nothing is being selected here");
+  ok(/controller\.renderOverlays\(/.test(body),
+     "drawParamPages delegates the overlay draw to the controller");
+  ok(/clearScreen:\s*clear_screen/.test(body),
+     "and hands it the clear -- clearing the frame is the callers job, which "
+     + "is why the library never does it");
+  ok(!/drawEnumList\(/.test(body),
+     "the host does NOT draw its own list -- a second copy is how the peek "
+     + "became invisible to every other consumer");
   ok(!/setView\(/.test(body),
      "the peek must not change view: the detent already wrote, so a Back that "
      + "cancelled it would be a lie");
 
+  /* The library half. */
+  const lib = readFileSync("src/shared/param_pages/page_controller.mjs", "utf8");
+  ok(/function renderOverlays\(/.test(lib),
+     "page_controller exports the overlay draw so every consumer can reach it");
+  /* THE CONTRACT THAT PUT THE PEEK OUTSIDE render() IN THE FIRST PLACE, and
+     the reason renderOverlays takes the clear as an argument rather than
+     calling one. Not one file in the shared library may clear the frame: a
+     consumer hosting a page inside its own chrome (see render()`s rect/bands)
+     gets the body alone, and a library that blanked the screen would paint
+     over the chrome it was handed. */
+  const libDir = "src/shared/param_pages";
+  const clearers = readdirSync(libDir)
+    .filter((f) => f.endsWith(".mjs"))
+    .filter((f) => /clear_screen|\bclearScreen\s*\(\s*\)/.test(
+      readFileSync(libDir + "/" + f, "utf8")
+        /* Comments discuss the rule; only CODE can break it. */
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/[^\n]*/g, "")
+        /* The clear the CALLER passed in is the sanctioned form. */
+        .replace(/typeof clearScreen[^\n]*\n/g, "")
+        .replace(/clearScreen\(\);/g, "CALLER_CLEAR")));
+  ok(clearers.length === 0,
+     "no file in " + libDir + " clears the frame itself, got " + JSON.stringify(clearers));
+
+  const ov = lib.slice(lib.indexOf("function renderOverlays("));
+  const ovBody = ov.slice(0, ov.indexOf("\n    }\n"));
+  ok(/drawEnumList\(/.test(ovBody),
+     "it draws through the SHARED enum screen, not a second list");
+  ok(/headerRight:\s*"TURNING"/.test(ovBody),
+     "the header says TURNING, not SELECT -- nothing is being selected here");
+
   /* Cursor and live value are the same thing on this screen. A markIndex that
      drifted from index would draw the `*` on a row that is not the value. */
-  const mk = body.match(/markIndex:\s*([^,\n]+)/);
-  const ix = body.match(/\n\s*index:\s*([^,\n]+)/);
-  ok(!!mk && !!ix && mk[1].trim() === ix[1].trim(),
+  const mkx = ovBody.match(/markIndex:\s*([^,\n]+)/);
+  const ix = ovBody.match(/\n\s*index:\s*([^,\n]+)/);
+  ok(!!mkx && !!ix && mkx[1].trim() === ix[1].trim(),
      "markIndex tracks index -- on a peek the cursor IS the live value (got "
-     + (mk && mk[1].trim()) + " vs " + (ix && ix[1].trim()) + ")");
+     + (mkx && mkx[1].trim()) + " vs " + (ix && ix[1].trim()) + ")");
 }
 
+/* ==================================================================== 7b ==
+ * AND IT ACTUALLY DRAWS. Grepping the call site proves a line exists; only
+ * calling it proves that a consumer owning its frame gets pixels. This is the
+ * assertion CW-78 would have failed.
+ *
+ * Into a real 128x64 framebuffer, because the two halves of this screen draw
+ * differently and only pixels see both: the rows go through menu_layout, which
+ * reaches for print / fill_rect / set_pixel BY NAME exactly as it does on the
+ * device, while the header is a PIXEL FONT (fontPrint4x5) that never calls
+ * print at all -- so a recording print() would report a headerless screen as
+ * complete.
+ */
+{
+  const GLOBAL_NAMES = ["print", "fill_rect", "set_pixel", "text_width",
+    "host_send_screenreader"];
+
+  function paint(ctl, opts) {
+    const fb = createFramebuffer();
+    const g = {
+      print: fb.print,
+      fill_rect: fb.fillRect,
+      set_pixel: fb.setPixel,
+      text_width: fb.textWidth,
+      host_send_screenreader: () => {},
+    };
+    for (const k of GLOBAL_NAMES) globalThis[k] = g[k];
+    let did;
+    try {
+      did = ctl.renderOverlays(drawContext(fb), opts);
+    } finally {
+      for (const k of GLOBAL_NAMES) delete globalThis[k];
+    }
+    return { did, fb };
+  }
+  const inkIn = (fb, y0, y1) => {
+    let n = 0;
+    for (let y = y0; y <= y1; y++)
+      for (let x = 0; x < fb.width; x++) if (fb.pixels[y * fb.width + x]) n++;
+    return n;
+  };
+
+  {
+    const { ctl, slotOf } = mk();
+    spin(ctl, slotOf("shape"), 6);
+    const cleared = { n: 0 };
+    const { did, fb } = paint(ctl, { clearScreen: () => { cleared.n++; } });
+    ok(did === true, "renderOverlays reports that it drew");
+    ok(cleared.n === 1, "it cleared the frame exactly once, got " + cleared.n);
+    /* The header band (see HEADER_H) carries the param name and TURNING. */
+    ok(inkIn(fb, 0, 7) > 0, "the header band has ink -- title and TURNING");
+    /* The list body. ENUM_LIST_TOP_Y is 9; the footer rule is near the bottom. */
+    ok(inkIn(fb, 9, 50) > 0, "the option list has ink under it");
+    ok(fb.clipped() === 0,
+       "and nothing was drawn off the 128x64 panel, got " + fb.clipped());
+  }
+  {
+    /* No peek, no overlay, no clear -- a caller that flushes on the return
+       value must not blank a complete page every frame. */
+    const { ctl } = mk();
+    const cleared = { n: 0 };
+    const { did, fb } = paint(ctl, { clearScreen: () => { cleared.n++; } });
+    ok(did === false && cleared.n === 0 && inkIn(fb, 0, 63) === 0,
+       "with no peek it draws nothing and clears nothing");
+  }
+  {
+    /* An EMBEDDED consumer -- movy hosting a page inside its own chrome --
+       passes no clear, because a full-screen overlay is meaningless there.
+       Drawing the list into a frame we may not blank would interleave it with
+       the grid underneath: two screens at once. */
+    const { ctl, slotOf } = mk();
+    spin(ctl, slotOf("shape"), 6);
+    const { did, fb } = paint(ctl, {});
+    ok(did === false && inkIn(fb, 0, 63) === 0,
+       "without a clearScreen it declines to draw rather than interleaving");
+  }
+}
 
 /* ===================================================================== N ==
  * AN ENUM INSIDE A WIDE GRAPHIC DOES NOT PEEK.


### PR DESCRIPTION
## What

`controller.renderOverlays(ctx, { clearScreen })` — the enum peek's draw moves from `shadow_ui_param_pages.mjs` into `page_controller.mjs`, and the host delegates to it.

## Why

`render()` paints a page into a rect the **caller** owns, and nothing in `src/shared/param_pages/` clears the screen (grep it). That is the contract `rect`/`bands` depend on — a consumer hosting a page inside its own chrome must get the body alone — so the peek, which is full-screen on purpose, could not live inside `render()`. It lived in the host binding instead, where the clear was available.

That made it **invisible to every other consumer**. A module binding `page_controller` from its own `ui_chain.js` calls `render()` and stops — which is what every line of the library suggests is the whole draw — so the controller tracked a peek on each enum detent that was painted nowhere, and `applyInput` dutifully routed Back to `dismissPeek()` to take down a panel nobody could see. Silent, no error, not discoverable from the API.

CW-78 and 6W6 both shipped that way, correct integrations in every other respect. Reported from the device: on CW-78's Rhythm page, turning Mode or Style shows one word and never the list.

The clear stays with the caller. Pass no `clearScreen` — movy embedding a page in its own chrome — and it declines to draw rather than interleaving its list with the grid underneath.

## Tests

`tests/host/test_enum_peek.sh`: section 7 follows the wiring to its new home; **7b is new and calls `renderOverlays` into a real 128x64 framebuffer** — the assertion CW-78 would have failed. A framebuffer rather than a recording `print()`, because the rows go through `menu_layout` (global `print`) while the header is a pixel font that never calls `print` at all, so a print recorder reports a headerless screen as complete.

Mutations that fail it:
- `renderOverlays` returning early → 4 failures
- the host dropping the call → 2
- the host growing a second copy of the list → 1
- a double clear → 1
- any library file clearing the frame itself → 1

48 assertions green; full `tests/host/` shell suite and `make -C tests/host test` clean.

Not caught by a source grep: `if (false) controller.renderOverlays(...)`. `shadow_ui_param_pages.mjs` imports by device-absolute path so node cannot execute it — the call site is grep-only, as it was before.

## Follow-ups (separate PRs, different repos)

- CW-78 and 6W6 `ui_chain.js`: add the `renderOverlays` call.
- `drawEnumList` passes the injected `ctx` to its header/footer but **not** to `drawMenuList`, so list rows always draw through the device globals. Harmless on hardware (both are the same surface); it is why the test installs globals. Noted, not changed here — routing `ctx` through would alter what a partial-ctx caller draws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014XSY8TFjgijdH9EUN2uMCq