### PR TITLE
Add Maze and Maze Lite modules to catalog

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1388,6 +1388,28 @@
       "default_branch": "main",
       "asset_name": "wayward-module.tar.gz",
       "min_host_version": "1.0.0"
+    },
+    {
+      "id": "maze_seq",
+      "name": "Maze",
+      "description": "Dual generative sequencer (Moog Labyrinth style) with pad + step-button control. Overtake tool.",
+      "author": "Sam Di Domizio",
+      "component_type": "tool",
+      "github_repo": "sd88me/schwung-maze-sequencer",
+      "default_branch": "main",
+      "asset_name": "maze_seq-module.tar.gz",
+      "min_host_version": "1.0.0"
+    },
+    {
+      "id": "maze_seq_lite",
+      "name": "Maze Lite",
+      "description": "Dual generative clock-synced sequencer (Moog Labyrinth style). Slot MIDI FX.",
+      "author": "Sam Di Domizio",
+      "component_type": "midi_fx",
+      "github_repo": "sd88me/schwung-maze-sequencer",
+      "default_branch": "main",
+      "asset_name": "maze_seq_lite-module.tar.gz",
+      "min_host_version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
Adds two modules to the catalog: 
- **Maze** (`maze_seq`, tool) — dual generative sequencer with pad + step-button control and custom display. - 
- **Maze Lite** (`maze_seq_lite`, midi_fx) — the same engine as a chain MIDI-FX slot. 
-
- Repo: https://github.com/sd88me/schwung-maze-sequencer 
- 
- Release v1.0.0 is published with both tarballs attached; `release.json` on main uses the multi-module format keyed by catalog id.
-
- Both modules tested on hardware. Slot FX is realtime-clean; the tool does state saves on a background thread (no file I/O on the audio callback). 
- 
- AI assistance: developed with Microsoft Copilot. Not developed with Grok.