### PR TITLE
chain: forward channel Auto asks the module, instead of being overwritten by it

### DIFF
--- a/src/host/forward_channel.h
+++ b/src/host/forward_channel.h
@@ -1,0 +1,45 @@
+#ifndef FORWARD_CHANNEL_H
+#define FORWARD_CHANNEL_H
+
+/*
+ * Resolving a slot's forward channel.
+ *
+ * Lives in a header so tests/host can run it: the decision is three-way and it
+ * was previously spread across shadow_chain_remap_channel (which knew only
+ * "auto = receive channel") and four load call sites in shadow_chain_mgmt.c
+ * (which applied a module's declared default by OVERWRITING forward_channel).
+ * That made Auto a one-shot conversion rather than a live answer -- a slot
+ * seeded from an older module.json kept that channel forever, and a module
+ * whose default mattered only on some load paths silently got the receive
+ * channel. The JP-8000 is the case that surfaced it: its arpeggiator is
+ * reachable only on the Remote Control Channel, so an Auto slot with receive=1
+ * forwarded on ch1 and never arpeggiated.
+ *
+ * Precedence for AUTO: the module's declared default, then the receive
+ * channel, then passthrough (receive=All).
+ */
+
+#include "shadow_chain_types.h"
+
+/* Effective forward channel for a slot.
+ *   fwd     -2 THRU, -1 AUTO, 0-15 explicit  (the user's setting)
+ *   mod_def -2 THRU, 0-15, anything else = "the module said nothing"
+ *   recv    0-15 receive channel, < 0 = All
+ * Returns 0-15 to remap onto, or SHADOW_FORWARD_THRU to preserve the channel.
+ */
+static inline int forward_channel_resolve(int fwd, int mod_def, int recv)
+{
+    if (fwd == SHADOW_FORWARD_AUTO) {
+        if (mod_def == SHADOW_FORWARD_THRU || (mod_def >= 0 && mod_def <= 15))
+            fwd = mod_def;
+    }
+    if (fwd == SHADOW_FORWARD_THRU)
+        return SHADOW_FORWARD_THRU;
+    if (fwd >= 0 && fwd <= 15)
+        return fwd;
+    if (recv < 0)
+        return SHADOW_FORWARD_THRU;   /* recv=All + auto, no module default */
+    return recv;
+}
+
+#endif /* FORWARD_CHANNEL_H */

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -523,6 +523,7 @@ void shadow_chain_defaults(void) {
         shadow_chain_slots[i].muted = 0;
         shadow_chain_slots[i].soloed = 0;
         shadow_chain_slots[i].forward_channel = -1;
+        shadow_chain_slots[i].default_forward_channel = -1;
         shadow_chain_slots[i].transpose = 0;
         capture_clear(&shadow_chain_slots[i].capture);
         shadow_chain_slots[i].fade.gain = 0.0f;
@@ -1487,7 +1488,7 @@ int shadow_inprocess_load_chain(void) {
                 shadow_chain_slots[i].fade.target = 1.0f;
                 shadow_chain_slots[i].patch_index = -1;
                 /* Query channel settings from loaded autosave */
-                if (shadow_chain_slots[i].forward_channel == -1 && shadow_plugin_v2->get_param) {
+                if (shadow_plugin_v2->get_param) {
                     char fwd_buf[16];
                     int len = shadow_plugin_v2->get_param(shadow_chain_slots[i].instance,
                         "synth:default_forward_channel", fwd_buf, sizeof(fwd_buf));
@@ -1495,7 +1496,7 @@ int shadow_inprocess_load_chain(void) {
                         fwd_buf[len < (int)sizeof(fwd_buf) ? len : (int)sizeof(fwd_buf) - 1] = '\0';
                         int default_fwd = atoi(fwd_buf);
                         if (default_fwd == -2 || (default_fwd >= 0 && default_fwd <= 15)) {
-                            shadow_chain_slots[i].forward_channel = default_fwd;
+                            shadow_chain_slots[i].default_forward_channel = default_fwd;
                         }
                     }
                 }
@@ -1526,15 +1527,15 @@ int shadow_inprocess_load_chain(void) {
             shadow_plugin_v2->set_param(shadow_chain_slots[i].instance, "load_patch", idx_str);
             shadow_chain_slots[i].active = 1;
             shadow_slot_load_capture(i, idx);
-            if (shadow_chain_slots[i].forward_channel == -1 && shadow_plugin_v2->get_param) {
+            if (shadow_plugin_v2->get_param) {
                 char fwd_buf[16];
                 int len = shadow_plugin_v2->get_param(shadow_chain_slots[i].instance,
                     "synth:default_forward_channel", fwd_buf, sizeof(fwd_buf));
                 if (len > 0) {
                     fwd_buf[len < (int)sizeof(fwd_buf) ? len : (int)sizeof(fwd_buf) - 1] = '\0';
                     int default_fwd = atoi(fwd_buf);
-                    if (default_fwd >= 0 && default_fwd <= 15) {
-                        shadow_chain_slots[i].forward_channel = default_fwd;
+                    if (default_fwd == -2 || (default_fwd >= 0 && default_fwd <= 15)) {
+                        shadow_chain_slots[i].default_forward_channel = default_fwd;
                     }
                 }
             }
@@ -3443,7 +3444,7 @@ void shadow_inprocess_handle_param_request(void) {
                 if (value_copy[0] != '\0') {
                     shadow_chain_slots[slot].active = 1;
     shadow_chain_slots[slot].fade.target = 1.0f;
-                    if (shadow_chain_slots[slot].forward_channel == -1 && shadow_plugin_v2->get_param) {
+                    if (shadow_plugin_v2->get_param) {
                         char fwd_buf[16];
                         int len = shadow_plugin_v2->get_param(shadow_chain_slots[slot].instance,
                             "synth:default_forward_channel", fwd_buf, sizeof(fwd_buf));
@@ -3451,7 +3452,7 @@ void shadow_inprocess_handle_param_request(void) {
                             fwd_buf[len < (int)sizeof(fwd_buf) ? len : (int)sizeof(fwd_buf) - 1] = '\0';
                             int default_fwd = atoi(fwd_buf);
                             if (default_fwd == -2 || (default_fwd >= 0 && default_fwd <= 15)) {
-                                shadow_chain_slots[slot].forward_channel = default_fwd;
+                                shadow_chain_slots[slot].default_forward_channel = default_fwd;
                                 shadow_ui_state_update_slot(slot);
                             }
                         }
@@ -3510,7 +3511,7 @@ void shadow_inprocess_handle_param_request(void) {
                     shadow_chain_slots[slot].patch_index = idx;
                     shadow_slot_load_capture(slot, idx);
 
-                    if (shadow_chain_slots[slot].forward_channel == -1 && shadow_plugin_v2->get_param) {
+                    if (shadow_plugin_v2->get_param) {
                         char fwd_buf[16];
                         int len = shadow_plugin_v2->get_param(shadow_chain_slots[slot].instance,
                             "synth:default_forward_channel", fwd_buf, sizeof(fwd_buf));
@@ -3518,7 +3519,7 @@ void shadow_inprocess_handle_param_request(void) {
                             fwd_buf[len < (int)sizeof(fwd_buf) ? len : (int)sizeof(fwd_buf) - 1] = '\0';
                             int default_fwd = atoi(fwd_buf);
                             if (default_fwd == -2 || (default_fwd >= 0 && default_fwd <= 15)) {
-                                shadow_chain_slots[slot].forward_channel = default_fwd;
+                                shadow_chain_slots[slot].default_forward_channel = default_fwd;
                             }
                         }
                     }

--- a/src/host/shadow_chain_types.h
+++ b/src/host/shadow_chain_types.h
@@ -27,7 +27,7 @@ typedef struct slot_fade_t {
 
 /* forward_channel sentinel values */
 #define SHADOW_FORWARD_THRU (-2)  /* passthrough: preserve original MIDI channel */
-#define SHADOW_FORWARD_AUTO (-1)  /* auto: remap to slot's receive channel */
+#define SHADOW_FORWARD_AUTO (-1)  /* auto: ask the module, else the receive channel */
 
 typedef struct shadow_chain_slot_t {
     void *instance;
@@ -39,6 +39,13 @@ typedef struct shadow_chain_slot_t {
     int soloed;             /* 1 = soloed (Shift+Mute+Track or Move solo-cue sync) */
     int feedback_hold;      /* 1 = booted muted as a line-input feedback guard; JS clears once jack state is safe */
     int forward_channel;    /* -2 = passthrough, -1 = auto, 0-15 = forward MIDI to this channel */
+    /* What the loaded synth declared as capabilities.default_forward_channel,
+     * cached at load: -2 = THRU, 0-15 = channel, -1 = the module said nothing.
+     * AUTO consults this before falling back to the receive channel, so "Auto"
+     * keeps meaning Auto instead of being silently rewritten to a fixed channel
+     * the first time a load path happens to run. Cached, never queried from
+     * shadow_chain_remap_channel -- that runs per MIDI event. */
+    int default_forward_channel;
     int transpose;          /* semitone offset applied to incoming note-on/off/poly-AT, range -12..+12 */
     /* 1 = some component in this slot declared capabilities.wants_sysex, so
      * cable-2 SysEx fragments are delivered to it. Read from the chain host at

--- a/src/host/shadow_midi.c
+++ b/src/host/shadow_midi.c
@@ -9,6 +9,7 @@
 #include "shadow_midi_inject_writer.h"
 #include "shadow_overtake_midi.h"
 #include "shadow_chain_mgmt.h"
+#include "forward_channel.h"   /* AUTO asks the module before the receive channel */
 #include "shadow_led_queue.h"
 #include "shadow_overlay.h"  /* MIDI channel indicator globals */
 #include "ui_midi_out_carry.h"  /* outbound packets that did not fit this frame */
@@ -212,23 +213,29 @@ void midi_routing_init(const midi_host_t *host)
 
 /* Apply forward channel remapping for a slot.
  * If forward_channel >= 0, remap to that specific channel.
- * If forward_channel == -1 (auto), use the slot's receive channel. */
+ * If forward_channel == -1 (auto), ASK THE MODULE first, then fall back to the
+ * slot's receive channel.
+ *
+ * Auto used to mean only "use the receive channel", and a module's declared
+ * capabilities.default_forward_channel was applied by *overwriting*
+ * forward_channel at four load call sites in shadow_chain_mgmt.c. That made
+ * Auto a one-shot conversion rather than a live answer, with two consequences:
+ * a slot seeded from an older module.json kept that channel forever, and a
+ * module whose default only mattered on some load paths silently got the
+ * receive channel instead. The JP-8000 is the case that surfaced it — its
+ * arpeggiator is reachable only on the Remote Control Channel, so an Auto slot
+ * with receive=1 forwarded on ch1 and never arpeggiated.
+ *
+ * default_forward_channel is CACHED on the slot at load. Never call get_param
+ * from here: this runs per MIDI event. */
 uint8_t shadow_chain_remap_channel(int slot, uint8_t status)
 {
-    int fwd_ch = host_chain_slots[slot].forward_channel;
-    if (fwd_ch == -2) {
-        /* Passthrough: preserve original MIDI channel */
-        return status;
-    }
-    if (fwd_ch >= 0 && fwd_ch <= 15) {
-        /* Specific forward channel */
-        return (status & 0xF0) | (uint8_t)fwd_ch;
-    }
-    /* Auto (-1): use the receive channel, but if recv=All (-1), passthrough */
-    if (host_chain_slots[slot].channel < 0) {
-        return status;  /* Recv=All + Fwd=Auto → passthrough */
-    }
-    return (status & 0xF0) | (uint8_t)host_chain_slots[slot].channel;
+    const int ch = forward_channel_resolve(host_chain_slots[slot].forward_channel,
+                                           host_chain_slots[slot].default_forward_channel,
+                                           host_chain_slots[slot].channel);
+    if (ch == SHADOW_FORWARD_THRU)
+        return status;                       /* preserve the original channel */
+    return (status & 0xF0) | (uint8_t)ch;
 }
 
 /* Per-slot active-note tracker: remembers the *transposed* note value that

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -46,6 +46,7 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_host_api_reserved_tail \
 	$(BUILD_DIR)/test_ui_flags_layout \
 	$(BUILD_DIR)/test_recall_quantize \
+	$(BUILD_DIR)/test_forward_channel \
 	$(BUILD_DIR)/test_metronome_click \
 	$(BUILD_DIR)/test_metronome_announce \
 	$(BUILD_DIR)/test_shadow_metronome
@@ -98,6 +99,9 @@ $(BUILD_DIR)/test_master_fx_snapshot: test_master_fx_snapshot.c ../../src/host/m
 # metronome_click.h calls sinf/expf. The generic pattern rule above does not
 # link libm, and on glibc the failure is a link error rather than anything
 # subtle.
+$(BUILD_DIR)/test_forward_channel: test_forward_channel.c ../../src/host/forward_channel.h ../../src/host/shadow_chain_types.h | $(BUILD_DIR)
+	$(CC) $(CFLAGS) -o $@ $<
+
 $(BUILD_DIR)/test_metronome_click: test_metronome_click.c ../../src/host/metronome_click.h | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS) -lm
 

--- a/tests/host/test_forward_channel.c
+++ b/tests/host/test_forward_channel.c
@@ -1,0 +1,39 @@
+/* forward_channel_resolve: AUTO asks the module before the receive channel. */
+#include <stdio.h>
+#include "../../src/host/forward_channel.h"
+
+static int fails;
+static void chk(const char *what, int got, int want)
+{
+    if (got != want) { printf("FAIL %s: got %d want %d\n", what, got, want); fails++; }
+}
+
+int main(void)
+{
+    const int AUTO = SHADOW_FORWARD_AUTO, THRU = SHADOW_FORWARD_THRU;
+    const int NONE = -1;   /* module declared nothing */
+
+    /* An explicit user channel always wins, module default or not. */
+    chk("explicit ch5 beats module default", forward_channel_resolve(4, 2, 0), 4);
+    chk("explicit ch1 beats module default", forward_channel_resolve(0, 2, 3), 0);
+    chk("explicit THRU beats module default", forward_channel_resolve(THRU, 2, 0), THRU);
+
+    /* AUTO consults the module. This is the JP-8000 case: receive=1 would have
+     * forwarded ch1 and never reached the arpeggiator's remote channel. */
+    chk("auto + module ch3", forward_channel_resolve(AUTO, 2, 0), 2);
+    chk("auto + module ch3, recv=All", forward_channel_resolve(AUTO, 2, -1), 2);
+    chk("auto + module THRU", forward_channel_resolve(AUTO, THRU, 0), THRU);
+
+    /* AUTO with no module preference keeps the old meaning exactly. */
+    chk("auto, no module, recv=1", forward_channel_resolve(AUTO, NONE, 0), 0);
+    chk("auto, no module, recv=4", forward_channel_resolve(AUTO, NONE, 3), 3);
+    chk("auto, no module, recv=All", forward_channel_resolve(AUTO, NONE, -1), THRU);
+
+    /* Out-of-range module values are "said nothing", not silently clamped. */
+    chk("auto, module 16 ignored", forward_channel_resolve(AUTO, 16, 2), 2);
+    chk("auto, module -7 ignored", forward_channel_resolve(AUTO, -7, 2), 2);
+
+    if (fails) { printf("test_forward_channel: %d FAILED\n", fails); return 1; }
+    printf("test_forward_channel: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
## What

`forward_channel = Auto` meant only *"use the slot's receive channel"*. A module's declared `capabilities.default_forward_channel` was applied somewhere else entirely — four load call sites in `shadow_chain_mgmt.c` that **overwrote** `forward_channel` from `-1` to the module's value.

So Auto was a one-shot conversion, not a live answer:

- a slot seeded from an older `module.json` kept that channel forever, even after the module changed its mind;
- a module whose default only mattered on a load path that didn't run silently got the receive channel instead.

## Why now

The JP-8000's arpeggiator is reachable **only** on the Remote Control Channel. An Auto slot with `receive=1` forwarded on ch1 and never arpeggiated — while the UI said "Auto", which reads as "whatever the module wants".

## How

- Load sites now **cache** the module's declared value on the slot (`default_forward_channel`) and no longer touch the user's setting.
- `AUTO` resolves live: **module default → receive channel → passthrough** (when receive=All). An explicit user channel still wins over everything.
- The decision moves into `src/host/forward_channel.h` so `tests/host` can run it — same shape as `recall_quantize.h` and `transport_grid.h`. `shadow_chain_remap_channel` runs per MIDI event, so the module value is read from the cached slot field, never via `get_param`.
- One of the four sites omitted the `THRU (-2)` case the other three accepted; all four now agree.

## Testing

- `tests/host/test_forward_channel.c` pins the precedence, including that an out-of-range module value means "said nothing" rather than being clamped.
- **Mutation-checked**: reverting to the old auto-ignores-the-module behaviour fails 3 cases, so the test can actually fail.
- `make -C tests/host test` 16/16, all `tests/host/*.sh` green, ARM cross-compile clean.

## Compatibility

Slots already seeded with an explicit channel keep it — nothing is rewritten. Users on older builds can still just set the forward channel to 3 by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)