### PR TITLE
param_pages: a switch is clockwise-on, because a switch has a track

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,9 +475,13 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   the peek was tracked on each detent, `applyInput` swallowed the Back that
   dismissed it, and it was painted nowhere. CW-78 and 6W6 both shipped that
   way.
-- **Two-option enums: the GRID flips on click, a LIST focuses instead** — and a
-  detent TOGGLES, latched to one flick. `flipsOnClick` defines "is a two-way",
-  not "flip".
+- **Two-option enums: the GRID flips on click, a LIST focuses instead** — and on
+  the KNOB they split BY WIDGET, not by semantics: a **switch** has a track, so
+  its form names a direction and it is direction-absolute (clockwise on,
+  idempotent, no latch); the **boxed** enum square shows a state and no
+  direction, so it TOGGLES either way, latched to one flick. The turn partition
+  must EQUAL the draw partition or a shape promises what the knob won't do.
+  `flipsOnClick` defines "is a two-way", not "flip".
 - **Corner brackets and the chevron box do NOT both mean divable.** 967 divable
   cells on knob pages, 953 of them wearing no mark. Divability is a FOOTER fact.
 - **`access: "read"` is a STROKE, not a widget** — dotted, ONCE per cell,

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2156,11 +2156,23 @@ Every enum with a non-empty `options` array is **divable**: on the knob grid,
 holding its knob and clicking opens a scrolling option list. You get this for
 free — there is nothing to declare, and nothing to declare it away.
 
-**A two-option enum is turned differently, too.** With two values there is
-nowhere to go but the other one, so a detent TOGGLES it whichever way you
-turned — and one flick of the encoder is one flip, not a dozen. Three or more
-options keep the four-detent gate and clamp at the ends. A trigger
-(`access: "write"`) is never toggled; it fires.
+**A two-option param is turned differently, too, and how it is DRAWN decides
+how it turns.**
+
+- A param drawn as a **switch** — `Off`/`On`, or an `int` 0..1 — is
+  **direction-absolute**: clockwise is on, anticlockwise is off. The switch has
+  a track with its knob at one end, so the picture already tells you which way
+  is which. Turning an already-on switch clockwise is a no-op, not a flip, and
+  there is no gesture latch because the write is idempotent.
+- A param drawn as the **enum square** — `Mix`/`Reverb`, `Saw`/`Square` — is a
+  boxed value: both options sit in the same place, so it shows a state and names
+  no direction. A detent **toggles** it whichever way you turned, and one flick
+  of the encoder is one flip, not a dozen.
+
+You do not choose between these; the widget rule does, and it follows your
+`options`. Three or more options keep the four-detent gate and clamp at the
+ends. A trigger (`access: "write"`) is never toggled and never draws as a
+switch; it fires.
 
 **Except at exactly two options, where there is no list to open.** On the knob
 grid the click FLIPS it — the picker would show the value already in the cell

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -117,25 +117,47 @@ list-editor probe was anchored on the first `type === "enum"` in
 `shadow_ui.js` first, which landed on `isTriggerEnumMeta` 1500 lines earlier
 and stayed GREEN with the branch deleted.
 
-### Two values means the DETENT TOGGLES, once per flick
+### Two values: the BOXED one toggles, the SWITCH is clockwise-on
 
-There were three spellings of one control and two of them had a dead
-direction: an Off/On (or int 0..1) boolean was direction-ABSOLUTE — right meant
-On, left meant Off, so at Off a left turn did nothing forever — while a two-way
-CHOICE like Mix/Reverb fell to the enum branch and CLAMPED behind the
-four-detent gate, so at Mix a left turn did nothing forever and a right turn
-took four detents to do anything.
+**The split is the WIDGET, not the semantics**, and that is the whole of the
+rule. Both spellings are one control under the click and the dive; they part
+company in `knobStep`, and nowhere else. `isTwoWayMeta` still answers true for
+both — the switch branch simply sits ahead of it.
 
-Reported from the device: *"if there are only two, why not let it wrap
+A **boxed** two-way — Mix/Reverb, Saw/Square, drawn as the enum SQUARE —
+**TOGGLES on a detent whichever way it went.** The two options sit in the same
+box in the same place, so the cell shows a STATE and names no direction. It
+used to fall to the enum branch and CLAMP behind the four-detent gate, so at Mix
+a left turn did nothing forever and a right turn took four detents to do
+anything. Reported from the device: *"if there are only two, why not let it wrap
 otherwise you have to know which way is off and which way is on, in which case
-you need some knowledge you dont have."* There is no way to acquire it — the
-cell shows a STATE, not a direction. Same argument that makes a trigger fire in
-either direction.
+you need some knowledge you dont have."* There is no way to acquire it from a
+box. Same argument that makes a trigger fire in either direction.
 
-**WRAPPING ALONE WOULD NOT DO, and that is the part worth keeping.** With two
-values, "wrap" and "toggle on every detent" are the same thing, and one flick
-of an encoder is a dozen detents — so a flick would land on whichever value the
-detent count happened to be even or odd about. `isTwoWayMeta` in
+A **switch** — Off/On, or an int 0..1 — is **direction-absolute: clockwise on,
+anticlockwise off.** A switch has a TRACK, and its knob sits at one end of it:
+the form names the direction, and it is the same direction every physical switch
+has ever had. So the picture makes a promise here that the boxed value never
+makes, and the toggle broke it. Reported from the device: *"if it's on it should
+stay on when turning it on."* The write is IDEMPOTENT, so there is no latch: a
+dozen detents of one flick all say the same thing, and a flick that lands where
+it already was is the intended no-op rather than a parity accident. An author
+who declares the options backwards (`["On","Off"]`) still gets clockwise-on —
+`switchOnValue` resolves the direction against the WORDS, not the position, the
+same way the graphic does.
+
+**So the TURN partition must equal the DRAW partition.** `detectSwitch` emits
+`VIZ_SWITCH` for exactly `isBooleanMeta && !isTrigger`, and `knobStep`'s switch
+branch guards on exactly that pair. `test_two_way_knob_toggle.sh` §6 asserts
+them equal over the whole fleet fixture, in BOTH directions, because a drift
+either way means a control makes a promise with its shape that the knob does
+not keep — a track that points somewhere the knob will not go, or a box that
+turns as though it had one.
+
+**WRAPPING ALONE WOULD NOT DO for the boxed one, and that is the part worth
+keeping.** With two values, "wrap" and "toggle on every detent" are the same
+thing, and one flick of an encoder is a dozen detents — so a flick would land on
+whichever value the detent count happened to be even or odd about.
 `knob_engine.mjs` therefore pairs the toggle with a LATCH at
 `TWO_WAY_GESTURE_GAP_MS`, the same number and the same rule as
 `TRIGGER_KNOB_GESTURE_GAP_MS`: **one flick is one gesture.** And it is a latch

--- a/docs/plans/2026-08-28-device-test-plan.md
+++ b/docs/plans/2026-08-28-device-test-plan.md
@@ -1,0 +1,116 @@
+# Device test plan — everything merged since v0.12.1
+
+Build: `schwung.tar.gz`, from `main` at `2ca9f871`. Deploy with
+`./scripts/install.sh local --skip-modules --skip-confirmation`.
+
+Covers the seven outside-contributor PRs (#210, #221, #281, #291, #292, #293,
+#307) and the in-house follow-ups (#308-#313, #318, #319). Ordered by
+consequence, not by convenience — stop after 3 if time is short.
+
+---
+
+## 1. Master FX survives a reboot — #221 + #311
+
+The actual user-reported bug (two Discord reports): a master chain vanished on
+the next boot. **Nothing here has run on hardware**, and #311 replaced the fix's
+read path with a brand-new shim param (`master_fx:modules`) that has never been
+served on a device.
+
+- [ ] **Baseline.** Shift+Vol+Menu → load a Master FX slot. Reboot. Slot is
+      still there after boot.
+- [ ] **The reported case.** Load a master module *through movy* (it writes
+      `master_fx:fxN:module` to the shim directly, which is what the mirror
+      never saw). Reboot. It comes back.
+- [ ] **The other drift direction.** Clear a master slot through movy, reboot —
+      it stays cleared, rather than the stale mirror writing the old module back.
+- [ ] **Watch for a hitch.** #311 exists because the first fix put 8+N IPC reads
+      on the autosave tick. Leave the shadow UI up, untouched, for a minute —
+      there should be no periodic stutter every ~5 s.
+
+**Fails how:** a slot empty after reboot, or a slot you cleared coming back.
+
+---
+
+## 2. Power button, TAP as well as hold — #292
+
+Settles the one question the review left genuinely open: whether the matched
+byte is the command or the varying id. A **hold** is already known to work — it
+is what the author verified.
+
+- [ ] Load any overtake module (movy, Chord Finder).
+- [ ] **Tap** the power button. Move's "Press wheel to shut down" prompt should
+      appear.
+- [ ] Back dismisses it without shutting down.
+- [ ] The module does **not** enter Loop mode on either a tap or a hold (that
+      was the cable-14 collision, CC value `0x3A` = 58 = Move's Loop CC).
+
+**If the tap does nothing but the hold works:** my reading of the offset is
+wrong and the author's comment was right — the match only catches holds. Tell
+me; it's a one-line widening, not a redesign.
+
+---
+
+## 3. Movy's track-volume gesture — #291 + #309
+
+Every line is gated behind a flag nothing in the shipped fleet sets, so this is
+inert unless movy is loaded. #309 is the fix for the bug #291 shipped with.
+
+- [ ] In movy, hold a track button + turn master volume. The per-track overlay
+      draws **with no Shift held**.
+- [ ] **Master volume does not jump** during or after the gesture. That jump is
+      the bug #309 fixed — the volume-bar scanner was parsing Schwung's own OLED
+      frame as if it were Move's volume overlay.
+- [ ] Exit movy. The master volume knob works normally again.
+
+---
+
+## 4. The known-unfixed latch — #291 finding 2a
+
+Deliberately not fixed; it needs a synthesised release. Confirming it is real on
+hardware is what decides whether it's worth doing.
+
+- [ ] Touch and hold the volume knob **first**, then press a track button
+      (raising the flag mid-touch), then release both.
+- [ ] Does the volume knob still respond afterwards?
+
+**Expected to FAIL.** A "yes it still works" is the interesting answer — it
+would mean the theory is wrong and nothing needs doing.
+
+---
+
+## 5. Chain knob CC out — #307 + #313
+
+Needs a controller that can receive CC 102-109. Skip if the Roto-Control isn't
+to hand; the author tested the happy path.
+
+- [ ] Slot Settings → Knobs → **Knob CC Out** on. Every mapped knob dumps once,
+      so the surface starts in sync.
+- [ ] Turn a chain knob from Move's own encoder — the surface follows.
+- [ ] Load a patch — all eight knobs report at once.
+- [ ] **Then exit an overtake module** and confirm the chain's packets still
+      flow. That is #313 specifically: an overtake unload must not eat them.
+
+---
+
+## 6. Cheap UI checks — #308, #317, #319
+
+- [ ] **#308:** on a knob page with a string cell (a preset name), open the
+      keyboard, type, confirm → you land back on **that page**. Repeat with
+      Back/cancel → same page.
+- [ ] **#319:** in an overtake module, LEDs paint fully with no dropped packets
+      at init (this was the `uint8_t write_idx` truncating a 512-byte buffer at
+      255).
+- [ ] **#317:** momentary-from-knob — still untested on hardware per the notes.
+
+---
+
+## Not testable on device
+
+**#210 / #310** is `tools/pytest-schwung` only. Nothing in the tree calls
+`wait_for_overtake_dsp`, and the suite is not a CI gate, so merging it changed
+no runtime behaviour. Verified by reading, not by running.
+
+## Not in this build
+
+`tests/host/Makefile` (PR #321) is a test-harness fix with no runtime effect —
+the tarball is identical with or without it.

--- a/src/shared/knob_engine.mjs
+++ b/src/shared/knob_engine.mjs
@@ -127,10 +127,34 @@ function wideStepCount(state, direction, nowMs) {
 /**
  * A two-state boolean, i.e. exactly what viz.mjs `detectSwitch` draws as a
  * switch. Kept on the same BOOL_OPTION test so a control cannot be drawn as a
- * switch but turned like a list (or the reverse).
+ * switch but turned like a list (or the reverse) — and since the PICTURE is
+ * what tells you which way is on (see knobStep), the two must be the same set
+ * or the promise the graphic makes is one the knob does not keep.
  */
 function isSwitchMeta(meta) {
     return isBooleanMeta(meta);
+}
+
+/** The words BOOL_OPTION accepts that mean ON. */
+const BOOL_ON_WORD = /^(on|yes|1|true|enabled)$/i;
+
+/**
+ * Which of a switch's two values is ON.
+ *
+ * Almost always index 1, but an author is free to declare `["On", "Off"]` and
+ * a few do. A direction-absolute switch that assumed 1 would then turn OFF
+ * clockwise, which is the exact complaint this rule exists to fix — so the
+ * direction is resolved against the WORDS, not the position. An int 0..1 has
+ * no words and 1 is on by construction.
+ *
+ * This also keeps the knob agreeing with the picture: the switch graphic draws
+ * its knob at the ON end, resolved the same way.
+ */
+function switchOnValue(meta) {
+    const opts = Array.isArray(meta.options) ? meta.options.map(String) : null;
+    if (!opts || opts.length !== 2) return 1;
+    const i = opts.findIndex((o) => BOOL_ON_WORD.test(o.trim()));
+    return i >= 0 ? i : 1;
 }
 
 /**
@@ -152,9 +176,15 @@ export const TWO_WAY_GESTURE_GAP_MS = 270;
  *
  * Both spellings count — an Off/On (or int 0..1) boolean, which is drawn as a
  * switch, and a two-way CHOICE like Mix/Reverb or Saw/Square, which is drawn
- * as an enum square. They behave identically under the hand even though they
- * are drawn differently, because the question a detent asks is the same one:
- * there is nowhere to go but the other value.
+ * as an enum square. They are the same control under the click and the dive.
+ *
+ * They part company on the KNOB, and only there, on the strength of how they
+ * are DRAWN: a switch has a track and its knob sits at one end of it, so the
+ * form names the direction and the turn is direction-absolute (clockwise on).
+ * An enum square is a boxed value that shows a state and no direction, so it
+ * TOGGLES on a detent whichever way it went. knobStep takes the switch first
+ * for that reason; this predicate still answers true for both, because every
+ * other caller wants the shared answer.
  *
  * A TRIGGER is excluded. It is a two-option enum on the wire (["—","Rnd!"])
  * and toggling it would write "do nothing" on every other flick — which for
@@ -237,22 +267,25 @@ export function knobStep(state, meta, delta, nowMs, fine = false) {
     }
 
     /*
-     * TWO VALUES: A DETENT TOGGLES, WHICHEVER WAY IT WENT.
+     * A BOXED TWO-WAY TOGGLES, WHICHEVER WAY THE DETENT WENT.
      *
-     * It used to be direction-ABSOLUTE — right meant option 1, left meant
-     * option 0 — and a two-way choice like Mix/Reverb instead fell through to
-     * the enum branch below and CLAMPED behind a four-detent gate. Three
-     * spellings of one control, two of them with a dead direction:
+     * This is the enum-square spelling only — Mix/Reverb, Saw/Square. Anything
+     * drawn as a SWITCH was taken by the branch above and is
+     * direction-absolute. A boxed two-way used to fall through to the enum
+     * branch below and CLAMP behind a four-detent gate, so it had a dead
+     * direction:
      *
-     *   Off/On at Off, turned left     nothing, forever
      *   Mix/Reverb at Mix, turned left nothing, forever
      *
      * Reported from the device: "if there are only two, why not let it wrap
      * otherwise you have to know which way is off and which way is on, in
      * which case you need some knowledge you dont have." There is no way to
-     * acquire that knowledge from the screen — the cell shows a state, not a
-     * direction — so half of every reach for the knob reads as a dead control.
-     * That is the same argument that makes a trigger fire in either direction.
+     * acquire that knowledge from a boxed value — it shows a state, and the two
+     * options sit in the same place whichever one is current — so half of every
+     * reach for the knob reads as a dead control. That is the same argument
+     * that makes a trigger fire in either direction. And it is exactly why it
+     * stops at the switch: a track with a knob on it is a picture of a
+     * direction, so there the knowledge IS on the screen.
      *
      * WRAPPING ALONE WOULD NOT DO, and this is the part worth keeping. With
      * two values, "wrap" and "toggle on every detent" are the same thing, and
@@ -263,8 +296,42 @@ export function knobStep(state, meta, delta, nowMs, fine = false) {
      * the last flip.
      *
      * Hoisted above the enum branch for the reason it always was: an int 0..1
-     * never enters that branch and would accumulate on the numeric path.
+     * never enters that branch and would accumulate on the numeric path (the
+     * switch branch above it exists for the same reason).
      */
+    /*
+     * A SWITCH IS DIRECTION-ABSOLUTE: clockwise is ON, anticlockwise is OFF.
+     *
+     * THE SPLIT IS THE WIDGET, NOT THE SEMANTICS. The toggle rule below exists
+     * because "the cell shows a STATE, not a direction" — true of the boxed
+     * value an enum square draws, where Mix and Reverb sit in the same box in
+     * the same place and nothing on screen says which way the knob reaches
+     * which. It is NOT true of a switch: a switch has a TRACK, and its knob
+     * sits at one end of it. The form itself names the direction, and it is the
+     * same direction every physical switch has ever had. So the picture makes a
+     * promise here that the boxed value never makes, and the toggle broke it —
+     * clockwise on an already-on switch turned it OFF. Reported from the
+     * device: "if it's on it should stay on when turning it on."
+     *
+     * Which is why the test is isSwitchMeta and not "is this a boolean":
+     * detectSwitch draws VIZ_SWITCH for exactly isBooleanMeta && !isTrigger,
+     * and this branch guards on exactly that pair. Whatever WEARS the track
+     * gets the direction; everything else keeps the toggle. If the two ever
+     * drift apart, a control will make a promise with its shape that the knob
+     * does not keep.
+     *
+     * There is no latch because it does not need one: the write is IDEMPOTENT,
+     * so a dozen detents of one flick all say the same thing, and a flick that
+     * lands where it already was is the intended no-op rather than a parity
+     * accident. That is also why this returns without stamping lastTwoWayMs.
+     */
+    if (isSwitchMeta(meta) && !(meta.writeOnly || meta.access === "write")) {
+        const on = switchOnValue(meta);
+        state.detentAccum = 0;
+        state.value = delta > 0 ? on : (on === 1 ? 0 : 1);
+        return state.value;
+    }
+
     if (isTwoWayMeta(meta)) {
         const t = typeof nowMs === "number" ? nowMs : 0;
         const last = state.lastTwoWayMs;

--- a/tests/host/test_list_layout_footer.sh
+++ b/tests/host/test_list_layout_footer.sh
@@ -172,33 +172,26 @@ Promise.all([
     fail("the jog did not move a focused two-option enum — focus without a working jog is " +
          "worse than the flip it replaced");
 
-  /* EITHER DIRECTION toggles: from the same starting value, a DOWN detent must
-   * reach the same place an UP detent did. The cell shows a state, not a
-   * direction, so a control where left does nothing is dead half the time.
-   * Driven from a fresh gesture at the same start value rather than by
-   * reversing, which the latch is entitled to swallow. */
-  clock += 2000;
-  ctl.onJog(-1);                                   /* back to the start */
-  clock += 2000;
-  if (ctl.state.values["flip2"] !== beforeFlip)
-    fail("a two-way did not come back on the opposite detent");
-  ctl.onJog(-1);                                   /* DOWN from the start */
-  if (ctl.state.values["flip2"] !== afterUp)
-    fail("a DOWN detent left a two-way at " + ctl.state.values["flip2"] + " but UP reached " +
-         afterUp + " — the direction still has to be known, which is the whole complaint");
+  /* flip2 is Off/On, which is what DRAWS AS A SWITCH, and a switch turns
+   * direction-absolute: up is on and down is off, from wherever it already was.
+   * The either-way toggle belongs to the BOXED two-way (Mix/Reverb) and is
+   * pinned in tests/host/test_two_way_knob_toggle.sh along with the rule that
+   * the two partitions must stay equal. What is checked HERE is only that a
+   * focused list row reaches the same engine the grid does. */
+  if (afterUp !== "On")
+    fail("an UP detent on a focused Off/On row gave " + afterUp + " — clockwise is ON");
+  ctl.onJog(-1);
+  if (ctl.state.values["flip2"] !== "Off")
+    fail("a DOWN detent on a focused Off/On row gave " + ctl.state.values["flip2"] +
+         " — anticlockwise is OFF");
 
-  /* ONE FLICK IS ONE FLIP. Wrapping alone would toggle on every detent, so a
-   * spin would land wherever the count happened to be even or odd about. */
-  const settled = ctl.state.values["flip2"];
-  for (let i = 0; i < 20; i++) { clock += 30; ctl.onJog(1); }
-  if (ctl.state.values["flip2"] !== settled)
-    fail("a 20-detent spin flipped a two-way again — this is a wrap, not a gesture latch");
-  /* ...and stillness ends the gesture, so the next reach works. */
+  /* And it is IDEMPOTENT: a whole spin one way says the same thing every
+   * detent, so an already-on switch stays on. */
   clock += 2000;
-  ctl.onJog(1);
-  if (ctl.state.values["flip2"] === settled)
-    fail("the two-way stayed latched after the knob went still — the stamp must be the last " +
-         "DETENT, so the clock runs on stillness rather than on elapsed time");
+  for (let i = 0; i < 20; i++) { clock += 30; ctl.onJog(1); }
+  if (ctl.state.values["flip2"] !== "On")
+    fail("a 20-detent clockwise spin left a switch at " + ctl.state.values["flip2"] +
+         " — a switch write is idempotent, so it must land on ON however many detents it took");
 
   /* ---- 5. A HELD KNOB MUST NOT CLAIM THIS FOOTER ------------------------ */
   ctl.exitMenu();                 /* back to the row cursor */

--- a/tests/host/test_two_way_knob_toggle.sh
+++ b/tests/host/test_two_way_knob_toggle.sh
@@ -3,22 +3,32 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
-# A control with exactly TWO values TOGGLES on a detent, whichever way it went,
-# once per flick.
+# A BOXED two-way toggles on a detent whichever way it went, once per flick.
+# A SWITCH does not: clockwise is on, anticlockwise is off.
 #
-# There were three spellings of one control and two of them had a dead
-# direction:
+# THE SPLIT IS THE WIDGET, NOT THE SEMANTICS, and that is the whole of it:
 #
-#   Off/On (or int 0..1)  direction-ABSOLUTE: right meant On, left meant Off,
-#                         so at Off a left turn did nothing, forever
-#   Mix/Reverb            fell to the enum branch and CLAMPED behind a
-#                         four-detent gate, so at Mix a left turn did nothing,
-#                         forever, and a right turn took four detents
+#   Mix/Reverb   drawn as an enum SQUARE — a boxed value. Mix and Reverb sit in
+#                the same box in the same place, so the cell shows a STATE and
+#                names no direction. A direction-absolute knob there is dead
+#                half the time and there is nothing on screen to learn it from.
+#                Reported from the device: "if there are only two, why not let
+#                it wrap otherwise you have to know which way is off and which
+#                way is on, in which case you need some knowledge you dont
+#                have."
 #
-# Reported from the device: "if there are only two, why not let it wrap
-# otherwise you have to know which way is off and which way is on, in which
-# case you need some knowledge you dont have." There is no way to acquire it —
-# the cell shows a STATE, not a direction.
+#   Off/On       drawn as a SWITCH — a track with a knob at one end of it. The
+#                form itself names the direction, the same one every physical
+#                switch has. Toggling it breaks that promise: a clockwise turn
+#                on an already-on switch turned it OFF. Also reported from the
+#                device: "if it's on it should stay on when turning it on."
+#
+# So the turn partition must equal the DRAW partition — detectSwitch emits
+# VIZ_SWITCH for exactly isBooleanMeta && !isTrigger, and knobStep's switch
+# branch guards on exactly that pair. Section 6 pins them equal, because a
+# drift means a control makes a promise with its shape that the knob does not
+# keep. The split is in knobStep alone: both are still clicked and dived the
+# same, and isTwoWayMeta still answers true for both.
 #
 # WRAPPING ALONE IS NOT THE ANSWER, which is what most of this file is about.
 # With two values, "wrap" and "toggle on every detent" are identical, and one
@@ -39,12 +49,14 @@ fi
 node -e '
 Promise.all([
   import("./src/shared/knob_engine.mjs"),
-]).then(([K]) => {
+  import("./src/shared/param_pages/viz.mjs"),
+]).then(([K, V]) => {
   let failures = 0;
   const fail = (m) => { console.error("FAIL: " + m); failures++; };
 
   const OFF_ON  = { type: "enum", options: ["Off", "On"] };
   const CHOICE  = { type: "enum", options: ["Mix", "Reverb"] };
+  const ON_OFF  = { type: "enum", options: ["On", "Off"] };   /* declared backwards */
   const INTBOOL = { type: "int", min: 0, max: 1 };
   const THREE   = { type: "enum", options: ["A", "B", "C"] };
   const TRIGGER = { type: "enum", options: ["—", "Rnd!"], access: "write" };
@@ -56,22 +68,50 @@ Promise.all([
     return st.value;
   };
 
-  /* ---- 1. either direction reaches the other value --------------------- */
-  for (const [name, meta] of [["Off/On", OFF_ON], ["Mix/Reverb", CHOICE], ["int 0..1", INTBOOL]]) {
+  /* ---- 1a. a CHOICE: either direction reaches the other value ---------- */
+  for (const [name, meta] of [["Mix/Reverb", CHOICE]]) {
     for (const from of [0, 1]) {
       const want = from === 0 ? 1 : 0;
       for (const dir of [1, -1]) {
         const got = tap(meta, from, dir, 1000);
         if (got !== want)
           fail(name + " at " + from + " turned " + (dir > 0 ? "up" : "down") + " gave " + got +
-               ", expected " + want + " — a two-way with a dead direction is dead half the " +
-               "time, and the cell shows a state, not a direction");
+               ", expected " + want + " — a two-way choice with a dead direction is dead half " +
+               "the time, and the cell shows a state, not a direction");
       }
     }
   }
 
-  /* ---- 2. ONE FLICK IS ONE FLIP ---------------------------------------- */
-  for (const [name, meta] of [["Off/On", OFF_ON], ["Mix/Reverb", CHOICE], ["int 0..1", INTBOOL]]) {
+  /* ---- 1b. a BOOLEAN: clockwise is ON, and STAYS on -------------------- */
+  for (const [name, meta] of [["Off/On", OFF_ON], ["int 0..1", INTBOOL], ["On/Off", ON_OFF]]) {
+    const on = name === "On/Off" ? 0 : 1;   /* the ON value, by its WORD */
+    const off = 1 - on;
+    for (const from of [0, 1]) {
+      const up = tap(meta, from, 1, 1000);
+      if (up !== on)
+        fail(name + " at " + from + " turned clockwise gave " + up + ", expected " + on +
+             " — clockwise means ON, and on an already-on switch that is a no-op, not a flip");
+      const down = tap(meta, from, -1, 1000);
+      if (down !== off)
+        fail(name + " at " + from + " turned anticlockwise gave " + down + ", expected " + off +
+             " — anticlockwise means OFF");
+    }
+  }
+
+  /* ...and it is IDEMPOTENT across a whole flick, with no latch to rely on:
+   * a dozen clockwise detents all say the same thing. */
+  {
+    const st = K.knobInit(1);
+    for (let t = 1000; t <= 3000; t += 30) K.knobStep(st, OFF_ON, 1, t);
+    if (st.value !== 1)
+      fail("a 2-second clockwise spin on an ON switch left it at " + st.value +
+           " — a switch write is idempotent and must not depend on a gesture latch");
+    for (let t = 4000; t <= 6000; t += 30) K.knobStep(st, OFF_ON, -1, t);
+    if (st.value !== 0) fail("a 2-second anticlockwise spin did not leave the switch OFF");
+  }
+
+  /* ---- 2. ONE FLICK IS ONE FLIP (a choice only — a switch has no flip) -- */
+  for (const [name, meta] of [["Mix/Reverb", CHOICE]]) {
     const st = K.knobInit(0);
     let t = 1000;
     K.knobStep(st, meta, 1, t);
@@ -89,16 +129,16 @@ Promise.all([
   {
     const st = K.knobInit(0);
     let t = 1000;
-    K.knobStep(st, OFF_ON, 1, t);                       /* flip */
-    for (t = 1030; t <= 3000; t += 30) K.knobStep(st, OFF_ON, 1, t);
+    K.knobStep(st, CHOICE, 1, t);                       /* flip */
+    for (t = 1030; t <= 3000; t += 30) K.knobStep(st, CHOICE, 1, t);
     /* Still latched at t=3000 even though 2s have passed since the FLIP —
      * because the knob never stopped. Now let it stop. */
-    K.knobStep(st, OFF_ON, 1, 5000);
+    K.knobStep(st, CHOICE, 1, 5000);
     if (st.value !== 0)
       fail("the knob went still for 2s and the next detent did not flip it — the stamp must be " +
            "the last DETENT, written before the early return");
     /* And a detent clearly INSIDE the window is still swallowed. */
-    K.knobStep(st, OFF_ON, 1, 5100);
+    K.knobStep(st, CHOICE, 1, 5100);
     if (st.value !== 0) fail("a detent 100ms after a flip was not swallowed");
   }
 
@@ -138,8 +178,43 @@ Promise.all([
            "learn two different flick lengths for two controls that look alike");
   }
 
+  /* ---- 6. the TURN partition equals the DRAW partition ------------------ */
+  {
+    /* This is the load-bearing claim. A control that wears a track must be the
+     * control the knob treats as having a direction, and nothing else may be.
+     * Asserted over the whole fleet rather than a handful of literals. */
+    const fs = require("fs");
+    const fx = JSON.parse(fs.readFileSync("tests/fixtures/module-contracts.json", "utf8"));
+    /* Turning a meta twice from the SAME start, one detent each way, at times
+     * far enough apart that no latch is in play. Direction-absolute lands on
+     * two different values; a toggle lands on the same one both times. */
+    const isDirectional = (meta) => {
+      const up = tap(meta, 0, 1, 1000);
+      const dn = tap(meta, 0, -1, 1000);
+      return up !== dn;
+    };
+    let checked = 0, drawn = 0;
+    for (const m of fx.modules) {
+      for (const p of (m.chain_params || [])) {
+        const meta = { ...p, kind: p.kind || p.type };
+        const draws = V.isBooleanMeta(meta) && !(meta.writeOnly || meta.access === "write");
+        if (!draws && !(Array.isArray(meta.options) && meta.options.length === 2)) continue;
+        checked++;
+        if (draws) drawn++;
+        const turns = isDirectional(meta);
+        if (draws !== turns)
+          fail(m.id + "." + p.key + (draws
+            ? " is DRAWN as a switch but TOGGLES — the track points a direction the knob ignores"
+            : " is drawn as a boxed value but turns direction-absolute — nothing on screen says which way"));
+      }
+    }
+    if (drawn < 40)
+      fail("only " + drawn + " switch-drawn params found across " + checked +
+           " two-value params — the fixture is not exercising this");
+  }
+
   if (failures) process.exit(1);
-  console.log("PASS: a two-value control toggles either way, once per flick, and neither a " +
-              "longer enum nor a trigger is touched");
+  console.log("PASS: what is DRAWN as a switch is clockwise-on, a boxed two-way toggles either " +
+              "way once per flick, and neither a longer enum nor a trigger is touched");
 }).catch((e) => { console.error("FAIL: " + (e && e.stack || e)); process.exit(1); });
 '


### PR DESCRIPTION
Turning an already-on switch clockwise turned it **off**. Reported from the device: *"if it's on it should stay on when turning it on. clockwise is on ccw is off."*

**The split is the widget, not the semantics.** `knobStep` had one rule for everything with exactly two values: a detent toggles, whichever way it went. That rule is right for what it was written for — a boxed value shows a *state*, not a direction. Mix and Reverb sit in the same enum square in the same place, so nothing on screen says which way the knob reaches which, and a direction-absolute knob there is dead half the time. That was itself a device report.

A switch is not that. A switch has a **track**, and its knob sits at one end of it. The form names the direction, and it's the same direction every physical switch has ever had. The picture makes a promise the boxed value never makes, and the toggle broke it.

So the branch guards on `isSwitchMeta`, not on "is this a boolean" — `detectSwitch` emits `VIZ_SWITCH` for exactly `isBooleanMeta && !isTrigger`, and whatever *wears the track* is what gets the direction.

- **§6 of `test_two_way_knob_toggle.sh` pins the turn partition equal to the draw partition** over the whole fleet fixture, in both directions. A drift either way means a control makes a promise with its shape that the knob doesn't keep — a track pointing somewhere the knob won't go, or a box that turns as though it had one. Both mutations verified to fail it (disable the branch → 157 failures incl. every switch; widen it to all two-ways → `forge.save_kit`, `slicer.mode` and friends flagged as boxed-but-directional).
- **No gesture latch on the switch branch**: the write is idempotent, so a whole flick's detents all say the same thing, and a flick landing where it already was is the intended no-op rather than a parity accident.
- `switchOnValue` resolves the direction against the option **words**, not the position — the same way the graphic does — so a module declaring `["On","Off"]` backwards still gets clockwise-on. An int 0..1 has no words and 1 is on. A trigger can't reach it.

`test_list_layout_footer.sh` was driving its either-way assertion through an `Off/On` row, which draws as a switch — it asserts the switch rule there now, and the boxed toggle stays pinned where it belongs. Full `tests/host/` suite green (shell + C units).

Docs: `docs/PARAM_PAGES.md`, `docs/MODULES.md`, the `CLAUDE.md` hook, and the catalog-site manual — all reframed on the widget argument.

Not yet verified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5TedGpFNRQznNTfAB5MAg