### PR TITLE
shadow: a Track long-press toggles between Move and Schwung

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -596,7 +596,12 @@ is on screen):
 - **Shift+Delete** — put the snapshot back
 
 **Long-press** (modes Both / Long Press):
-- Hold Track 1–4 (500ms) → slot editor
+- **Hold Track 1–4 (500ms) → TOGGLE between the two worlds.** From Move it opens
+  that slot's editor; from the shadow UI it dismisses and leaves you on that
+  Move track. Its own inverse, so you long-press back and forth. The Move-track
+  tap is injected on BOTH directions — it is what made Move's selected track
+  follow the slot, and it is why the dismiss lands somewhere useful rather than
+  on whatever track Move was on.
 - Hold Menu (500ms) → Master FX
 - Shift + hold Step 2 (500ms) → Global Settings
 - Shift + Step 13 (immediate) → Tools menu

--- a/docs/SHADOW_UI.md
+++ b/docs/SHADOW_UI.md
@@ -140,6 +140,44 @@ Three things about the behaviour are easy to get wrong, and each fails silently:
   (solo) and a volume touch during the press are excluded for the same reason
   the dismiss excludes them.
 
+### A Track LONG-PRESS is a toggle, and it is its own inverse
+
+From Move, holding a Track for 500 ms opens that slot's editor. From the shadow
+UI, holding it **dismisses and leaves you on that Move track** — so the same
+gesture takes you back and forth and there is no second key to learn for the
+return trip. Requested from the device: *"long pressing a track should dismiss
+shadow ui and take you to that move track. This way you can long press between
+both."*
+
+**The dismiss direction is not a new mechanism**, and that is the whole reason
+it is one branch. The fire block already injected a synthetic Track TAP on every
+long-press — a release to close the real 500 ms hold, then a crisp press/release
+pair Move reads as a tap, with the user's eventual real release swallowed — to
+make Move's selected track follow the slot (the field report behind it: *"it
+does change to slot 2 on schwung, but still shows me the [old] pads"*). That
+injection stays OUTSIDE the branch and runs both ways, which is exactly what
+makes the dismiss land on the track the editor was about instead of wherever
+Move happened to be.
+
+Two things to keep straight:
+
+- **Only the OPEN direction sets `SHADOW_UI_FLAG_JUMP_TO_SLOT`.** Raising it on
+  the way out is a flag set while leaving. It is not needed for the round trip
+  either: long-pressing that track again re-opens through the open arm, which
+  sets it.
+- **Overtake needs no guard here and must not grow one.** The overtake early-out
+  above the Track CC block `continue`s before any long-press timer starts, so
+  the fire block cannot run at all. A second check there would be dead code that
+  reads as load-bearing.
+
+With Keep Schwung on, the PRESS also switches to that slot before the hold
+completes — so a long-press shows you the slot for half a second and then hands
+the screen back. That is confirmation of the target, not a race: both writes
+agree about which track you are going to.
+
+`tests/host/test_track_longpress_toggle.sh` pins the branch, the shared
+injection and the surviving escape hatches.
+
 The byte rides in `shadow_control_t.stay_in_shadow`, appended at the end of the
 struct and read live so the toggle takes effect on the next tap. Appending is
 free only because `CONTROL_BUFFER_SIZE` is 256 for a struct that uses ~86 —

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -6469,9 +6469,35 @@ pre_done:
                 long_press_elapsed(&track_press_time[i])) {
                 track_longpress_fired[i] = 1;
                 track_longpress_pending[i] = 0;
-                shadow_control->ui_slot = (uint8_t)i;
-                shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_SLOT;
-                if (!shadow_display_mode) {
+                /*
+                 * A TRACK LONG-PRESS IS A TOGGLE BETWEEN THE TWO WORLDS.
+                 *
+                 * From Move it opens the shadow UI on that slot; from the
+                 * shadow UI it hands the screen back to Move on that track.
+                 * One gesture, and it is its own inverse, so you can long-press
+                 * between the two without learning a second key for the way
+                 * back.
+                 *
+                 * The dismiss direction is not a new mechanism: the Move-track
+                 * tap below is injected on BOTH paths and always was — it is
+                 * what makes Move's selected track follow the slot — so
+                 * dismissing here lands on exactly the track the editor was
+                 * about. The only difference between the two directions is
+                 * which way display_mode goes.
+                 *
+                 * A tap keeps meaning what it meant (Keep Schwung: switch
+                 * slot; off: dismiss), and Shift+Track still dismisses, so the
+                 * escape hatch is untouched in both modes.
+                 */
+                if (shadow_display_mode) {
+                    shadow_display_mode = 0;
+                    shadow_control->display_mode = 0;
+                    /* No JUMP_TO_SLOT: we are leaving. Reopening on this track
+                     * lands on the matching slot anyway, because the open
+                     * direction below sets it. */
+                } else {
+                    shadow_control->ui_slot = (uint8_t)i;
+                    shadow_control->ui_flags |= SHADOW_UI_FLAG_JUMP_TO_SLOT;
                     shadow_display_mode = 1;
                     shadow_control->display_mode = 1;
                     launch_shadow_ui_reset_backoff();
@@ -6504,7 +6530,9 @@ pre_done:
                     shadow_midi_inject_push(shadow_midi_inject_shm, rel);
                     track_swallow_release[i] = 1;
                 }
-                shadow_log("Track long-press: opening slot settings (Move track follows)");
+                shadow_log(shadow_display_mode
+                           ? "Track long-press: opening slot settings (Move track follows)"
+                           : "Track long-press: dismissing shadow UI (Move track follows)");
             }
         }
         /* Menu button */

--- a/tests/host/test_track_longpress_toggle.sh
+++ b/tests/host/test_track_longpress_toggle.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Source pin: a Track LONG-PRESS is a toggle between the two worlds.
+#
+# From Move it opens the shadow UI on that slot. From the shadow UI it hands the
+# screen back to Move ON THAT TRACK. One gesture, its own inverse, so you can
+# long-press between the two without learning a second key for the way back.
+#
+# Three things hold it together and each is silent when it breaks:
+#
+#   1. The fire block must BRANCH on shadow_display_mode. It used to set
+#      JUMP_TO_SLOT unconditionally and only open when hidden, so a long-press
+#      with the UI already up was indistinguishable from a tap.
+#
+#   2. The Move-track tap must be injected on BOTH directions. It is the same
+#      injection that has always made Move's selected track follow the slot, and
+#      it is the entire reason the dismiss lands somewhere useful — dismissing
+#      without it drops you back on whatever track Move happened to be on. So it
+#      must stay OUTSIDE the branch, and track_swallow_release with it, or the
+#      user's real release is handed to Move as a release for a press it never
+#      saw open.
+#
+#   3. The escape hatches must survive. Shift+Track still dismisses (the one
+#      gesture that works whatever Keep Schwung says), and a plain TAP still
+#      means what it meant — switch slot with Keep Schwung on, dismiss with it
+#      off. Both live in the press/release handler, not here.
+#
+# Overtake needs no guard and must not grow one: the overtake early-out above
+# the track block `continue`s before any timer starts, so the fire block cannot
+# run at all. Pinned so a future reader does not "fix" that with a second check.
+set -u
+
+ROOT="$(dirname "$0")/../.."
+SHIM="$ROOT/src/schwung_shim.c"
+
+fails=0
+fail() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
+
+[ -f "$SHIM" ] || { echo "FAIL: cannot find $SHIM" >&2; exit 1; }
+
+# The fire block: from `track_longpress_fired[i] = 1;` to the shadow_log that
+# closes it. Extracted so every assertion below is about THAT block and cannot
+# be satisfied by a lookalike somewhere else in a 9000-line file.
+block=$(awk '
+    /track_longpress_fired\[i\] = 1;/ { inb = 1 }
+    inb { print }
+    inb && /Track long-press: dismissing shadow UI/ { exit }
+' "$SHIM")
+
+[ -n "$block" ] || { echo "FAIL: could not locate the track long-press fire block" >&2; exit 1; }
+
+# --- 1. it branches on display mode, both ways ------------------------------
+echo "$block" | grep -q 'if (shadow_display_mode) {' ||
+    fail "the fire block does not branch on shadow_display_mode — a long-press with the UI
+      already up cannot dismiss, which is the whole gesture"
+
+echo "$block" | grep -q 'shadow_control->display_mode = 0;' ||
+    fail "the fire block never clears display_mode — nothing hands the screen back to Move"
+
+echo "$block" | grep -q 'shadow_control->display_mode = 1;' ||
+    fail "the fire block never sets display_mode — the open direction is gone"
+
+# The open direction is the one that jumps, and it must be the ONLY one: a
+# JUMP_TO_SLOT written while dismissing is a flag set on the way out.
+jumps=$(echo "$block" | grep -c 'SHADOW_UI_FLAG_JUMP_TO_SLOT')
+[ "$jumps" = "1" ] ||
+    fail "SHADOW_UI_FLAG_JUMP_TO_SLOT appears $jumps times in the fire block, expected 1 — it
+      belongs to the OPEN direction only"
+
+# ...and it must sit on the open side of the branch, i.e. after the `} else {`.
+echo "$block" | awk '/} else {/ { seen = 1 } seen && /SHADOW_UI_FLAG_JUMP_TO_SLOT/ { found = 1 }
+                     END { exit !found }' ||
+    fail "JUMP_TO_SLOT is not in the else (open) arm — it is being set while dismissing"
+
+# --- 2. the Move-track tap is injected on BOTH directions -------------------
+# i.e. outside the branch entirely. The injection closes the real hold with a
+# synthetic release, taps, and swallows the user's eventual release.
+echo "$block" | grep -q 'shadow_midi_inject_push' ||
+    fail "the Move-track tap injection is gone from the fire block — a dismiss would drop you
+      on whatever track Move happened to be on, and an open would show one module while the
+      pads play another"
+
+echo "$block" | grep -q 'track_swallow_release\[i\] = 1;' ||
+    fail "the fire block does not swallow the real release — Move is handed a release for a
+      press it never saw open"
+
+# The injection must not have been pulled inside either arm. Everything from the
+# closing brace of the if/else to the end of the block is the shared tail.
+tail_txt=$(echo "$block" | awk '/^ *} else {/ { arm = 1 } arm && /^ *}$/ { tail = 1; next }
+                                tail { print }')
+echo "$tail_txt" | grep -q 'shadow_midi_inject_push' ||
+    fail "the Move-track tap injection moved INSIDE one arm of the branch — it must run on
+      both, or one direction of the toggle stops following the track"
+
+# --- 3. overtake is handled by the early-out, not by a second guard ---------
+echo "$block" | grep -q 'overtake' &&
+    fail "the fire block grew an overtake guard — the early-out above the track block already
+      \`continue\`s before any timer starts, so this one is dead code that reads as load-bearing"
+
+# --- 4. the escape hatches still exist --------------------------------------
+grep -q 'Shift+Track: dismissing shadow UI' "$SHIM" ||
+    fail "Shift+Track no longer dismisses — that is the escape hatch that works whatever
+      Keep Schwung says"
+
+grep -q 'Track tap: dismissing shadow UI' "$SHIM" ||
+    fail "the plain-tap dismiss (Keep Schwung off) is gone"
+
+grep -q 'STAY_IN_SHADOW() && shadow_display_mode' "$SHIM" ||
+    fail "the Keep Schwung tap-switches-slot branch is gone"
+
+if [ "$fails" -ne 0 ]; then
+    echo "FAIL: $fails assertion(s) failed" >&2
+    exit 1
+fi
+echo "PASS: a track long-press toggles between Move and the shadow UI, the Move-track tap runs
+      on both directions, and the tap/Shift escape hatches are intact"


### PR DESCRIPTION
> "When shadow ui is up long pressing a track should dismiss shadow ui and take you to that move track. This way you can long press between both."

From Move, holding a Track for 500 ms opens that slot's editor. It now does the reverse from the shadow UI: dismiss, and leave you on **that Move track**. One gesture, its own inverse, so there's no second key to learn for the way back.

**The dismiss direction is not a new mechanism**, which is why it's one branch. The fire block already injected a synthetic Track *tap* on every long-press — a release to close the real 500 ms hold, then a crisp press/release pair Move reads as a tap, with the user's real release swallowed — to make Move's selected track follow the slot (the field report behind it: *"it does change to slot 2 on schwung, but still shows me the [old] pads"*). That injection stays **outside** the branch and runs both ways, which is exactly what makes the dismiss land on the track the editor was about instead of wherever Move happened to be.

- Only the **open** direction sets `SHADOW_UI_FLAG_JUMP_TO_SLOT` — raising it on the way out is a flag set while leaving, and the round trip doesn't need it (long-pressing that track again re-opens through the open arm, which sets it).
- **Overtake needs no guard and must not grow one**: the overtake early-out above the Track CC block `continue`s before any timer starts, so the fire block can't run there at all. Pinned so nobody adds dead code that reads as load-bearing.
- Escape hatches untouched: Shift+Track still dismisses whatever Keep Schwung says, and a plain tap still means what it meant (switch slot on, dismiss off).

With Keep Schwung on, the press also switches to that slot before the hold completes — so a long-press shows you the slot for half a second and then hands the screen back. That's confirmation of the target, not a race; both writes agree on which track you're going to.

**Tests.** New `tests/host/test_track_longpress_toggle.sh` pins the branch, that `JUMP_TO_SLOT` appears exactly once and in the open arm, that the injection and `track_swallow_release` stay in the shared tail, that no overtake guard appears, and that the three escape hatches survive. Mutation-checked: reverting to the old unconditional form fails four assertions. Full `tests/host/` suite green; ARM64 cross-compile clean.

Docs: `CLAUDE.md` shortcuts, a new section in `docs/SHADOW_UI.md`, and the catalog-site manual.

**Not verified on hardware** — this is a shim change, so it wants a real long-press in both directions before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5TedGpFNRQznNTfAB5MAg