### PR TITLE
catalog: refresh Tablor's description

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1292,7 +1292,7 @@
     {
       "id": "tablor",
       "name": "Tablor",
-      "description": "2-osc wavetable synth. Position morphing, bend, formant shift and 4-voice unison; sub and noise; multimode filter with its own ADSR; 2 envelopes, 2 LFOs, 4-slot mod matrix and 8 assignable macros. 8 voices poly or mono with glide. Unlimited shareable .tblr presets, 115 seeded wavetables, and Serum/Vital/Ableton tables via Move Manager. Web panel with a live display of the loaded wavetable.",
+      "description": "2-osc wavetable synth. Position morphing, bend, formant shift and 4-voice unison; sub and noise; multimode filter with its own ADSR. Four envelopes: amp, filter, and two spare ones you can point at wavetable position, level, tune, bend, formant, pan, cutoff, resonance, sub, noise or amp with a bipolar amount. 8 voices poly or mono with glide. 115 seeded wavetables and Serum/Vital/Ableton tables of any frame size via Move Manager. Web panel with a live display of the loaded wavetable.",
       "author": "athousanddetails; after Wavetable by Roland Rabien (FigBug)",
       "component_type": "sound_generator",
       "github_repo": "athousanddetails/schwung-tablor",


### PR DESCRIPTION
Tablor's catalog blurb had gone stale — it advertised a modulation layout the module no longer ships and missed the feature people are most likely to want.

**One line changed**, the description:

- **Four envelopes**, two of them routable at any of seventeen destinations with a bipolar amount. A decaying envelope on wavetable position is the thing users were asking for — it makes a table sound struck rather than held, which no LFO can do, since an LFO repeats.
- **Wavetables of any frame size.** Frame size is read from the file's own harmonics now, so 2048/1024/512/256/128 and single-cycle tables all load and play at pitch — including `WAVE_FORMAT_EXTENSIBLE` files, which used to be rejected outright.
- Dropped the claim about its own preset file format: presets live in Schwung's user-preset browser now, seeded on install and migrated on update.

`min_host_version` stays **0.12.0**. I checked rather than assumed: the param pages, the viz groups and `shadow_ui_presets.mjs` are all present in that tag, and the one newer field the module declares (`access` on three data-only keys, which sit on no page) is simply ignored by a host that predates it.

Nothing else in the file is touched — the entry is edited in place so the diff is one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
