### PR TITLE
chain: relative CC decoded only ±1, so accelerated encoders lost every fast turn

### DIFF
--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -804,14 +804,29 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
                     /* Relative encoder: apply acceleration to base step */
                     float base_step = (pinfo->step > 0) ? pinfo->step
                         : (is_int ? (float)KNOB_STEP_INT : KNOB_STEP_FLOAT);
-                    float delta = 0.0f;
-                    if (msg[2] == 1) {
-                        delta = base_step * accel;
-                    } else if (msg[2] == 127) {
-                        delta = -base_step * accel;
-                    } else {
-                        return;  /* Ignore other values */
-                    }
+
+                    /* Relative, two's complement 7-bit: 1..63 is +1..+63
+                     * detents, 127..65 is -1..-63. Move's own knobs only ever
+                     * send +/-1, so decoding only those was sufficient for Move
+                     * and silently wrong for everything else: an accelerated
+                     * encoder (OXI E16, and most endless controllers) reports
+                     * how many detents passed since the last message, so every
+                     * fast turn fell into the else and was dropped. The control
+                     * worked when crept and died when played. 0 is not a
+                     * movement, and 64 is the unusable midpoint. */
+                    if (msg[2] == 0 || msg[2] == 64) return;
+                    int ticks = (msg[2] < 64) ? (int)msg[2] : (int)msg[2] - 128;
+                    int mag = (ticks < 0) ? -ticks : ticks;
+
+                    /* An encoder reporting more than one detent has already
+                     * done the accelerating; applying the time-based multiplier
+                     * on top would compound them. Enums never accelerate (see
+                     * the cap above), so they advance one option per message. */
+                    if (pinfo->type == KNOB_TYPE_ENUM) mag = 1;
+                    else if (mag > 1) accel = KNOB_ACCEL_MIN_MULT;
+
+                    float delta = base_step * (float)accel * (float)mag;
+                    if (ticks < 0) delta = -delta;
 
                     float new_val = inst->knob_mappings[i].current_value + delta;
                     if (new_val < pinfo->min_val) new_val = pinfo->min_val;


### PR DESCRIPTION
Relative CC (71-78) decoded exactly two values, `1` and `127`, and returned on anything else:

```c
if (msg[2] == 1)        delta =  base_step * accel;
else if (msg[2] == 127) delta = -base_step * accel;
else return;   /* Ignore other values */
```

Move's own knobs only ever send ±1, so that was sufficient for Move and silently wrong for everything else. An accelerated encoder — an OXI E16, and most endless controllers — reports **how many detents passed since the last message**, so `2` and above fell into the `else` and vanished.

The symptom is a control that works when you creep it and dies when you play it, which reads as flaky hardware rather than a decoder ignoring the message. Found while mapping an E16 to a slot: slow turns moved the parameter, fast turns did nothing at all.

## The change

Decode the full two's-complement range and scale by detent count:

- `1..63` → +1..+63 detents, `127..65` → −1..−63
- `0` is not a movement and `64` is the unusable midpoint, so both return

The time-based multiplier is suppressed when the encoder already reported more than one detent, or the two compound — the encoder has done the accelerating, and applying `accel` on top of a magnitude of 8 makes a small turn jump the whole range. Enums still advance one option per message, per the existing cap.

## Move's own knobs are unaffected

They send ±1, which takes `mag == 1` and the unchanged `accel`, so the result is bit-identical to before. That is also why this survived: nothing on the device could show it.

Verified on hardware with an OXI E16 on Move's USB-A — fast turns now track, and Move's own knobs behave exactly as they did.
