### PR TITLE
chain: the two relative-CC multipliers are a MAX, and an enum counts detents

### DIFF
--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -7,6 +7,7 @@
 #include "chain_internal.h"
 #include "chain_pre_inject.h"
 #include "chain_midi_chain.h"
+#include "relative_cc.h"
 
 /* Clock availability state for sync-aware MIDI FX (arp, etc.). */
 static int g_clock_output_enabled = 1;              /* midiClockMode == "output" */
@@ -805,27 +806,25 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
                     float base_step = (pinfo->step > 0) ? pinfo->step
                         : (is_int ? (float)KNOB_STEP_INT : KNOB_STEP_FLOAT);
 
-                    /* Relative, two's complement 7-bit: 1..63 is +1..+63
-                     * detents, 127..65 is -1..-63. Move's own knobs only ever
-                     * send +/-1, so decoding only those was sufficient for Move
-                     * and silently wrong for everything else: an accelerated
-                     * encoder (OXI E16, and most endless controllers) reports
-                     * how many detents passed since the last message, so every
-                     * fast turn fell into the else and was dropped. The control
-                     * worked when crept and died when played. 0 is not a
-                     * movement, and 64 is the unusable midpoint. */
-                    if (msg[2] == 0 || msg[2] == 64) return;
-                    int ticks = (msg[2] < 64) ? (int)msg[2] : (int)msg[2] - 128;
+                    /* Two's complement 7-bit, decoded in relative_cc.h so
+                     * tests/host can run it — chain_midi.c itself cannot be
+                     * compiled natively, so a source-level pin here could not
+                     * tell 4 base steps from 8. 0 and the unused midpoint 64
+                     * both come back as no movement. */
+                    int ticks = relative_cc_ticks((int)msg[2]);
+                    if (ticks == 0) return;
                     int mag = (ticks < 0) ? -ticks : ticks;
 
-                    /* An encoder reporting more than one detent has already
-                     * done the accelerating; applying the time-based multiplier
-                     * on top would compound them. Enums never accelerate (see
-                     * the cap above), so they advance one option per message. */
-                    if (pinfo->type == KNOB_TYPE_ENUM) mag = 1;
-                    else if (mag > 1) accel = KNOB_ACCEL_MIN_MULT;
+                    /* The LARGER of the detent count and the time-based
+                     * multiplier, never the product: a plain encoder always
+                     * says one detent so `accel` is its only speed signal,
+                     * while an accelerated encoder batches detents so `mag`
+                     * already IS the acceleration. Enums fall out of this
+                     * without a special case, because `accel` was pinned to
+                     * KNOB_ACCEL_ENUM_MULT above. See relative_cc.h. */
+                    int mult = relative_cc_multiplier(mag, accel);
 
-                    float delta = base_step * (float)accel * (float)mag;
+                    float delta = base_step * (float)mult;
                     if (ticks < 0) delta = -delta;
 
                     float new_val = inst->knob_mappings[i].current_value + delta;

--- a/src/modules/chain/dsp/relative_cc.h
+++ b/src/modules/chain/dsp/relative_cc.h
@@ -1,0 +1,83 @@
+#ifndef RELATIVE_CC_H
+#define RELATIVE_CC_H
+
+/*
+ * Relative (endless) encoder CC arithmetic, as two pure functions.
+ *
+ * WHY IT IS A HEADER. The call site is v2_on_midi in chain_midi.c, which
+ * dlopens plugins and owns the get_param/set_param surface, so it cannot be
+ * compiled natively — test_chain_knob_cc_out.c says exactly that in its own
+ * preamble, and pins chain_midi.c at the SOURCE level in its companion .sh
+ * instead. Source-level pinning cannot tell 4 from 8. So the arithmetic moves
+ * here, the way recall_quantize.h, transport_grid.h, fx_midi_filter.h and
+ * master_fx_key.h did before it, and tests/host/test_relative_cc.c runs it.
+ *
+ * THE ENCODING. Two's complement, 7-bit: 1..63 is +1..+63 detents, 127..65 is
+ * -1..-63, and 0 and 64 are not movements. `127 == -1` is what makes this two's
+ * complement rather than the signed-bit convention, and it is the reading the
+ * rest of the tree already uses — schwung_shim.c (two sites), schwung_host.c,
+ * and decodeDelta() in shared/input_filter.mjs. chain_midi.c was the last
+ * decoder that read only +/-1 (#402).
+ */
+
+/*
+ * Signed detent count for a relative CC value. 0 means "no movement", which
+ * covers both the literal 0 and the midpoint 64 — a caller that treats the
+ * return as a delta needs no separate guard, and one that wants to skip the
+ * message entirely can test for zero.
+ *
+ * 64 is excluded rather than read as -64 because no endless encoder emits it:
+ * the convention is 1..63 / 65..127 either side of an unused centre, which is
+ * how every sibling decoder in the tree spells it (`d2 >= 65 && d2 <= 127`).
+ */
+static inline int relative_cc_ticks(int value) {
+    if (value <= 0 || value > 127) return 0;
+    if (value < 64) return value;
+    if (value == 64) return 0;
+    return value - 128;
+}
+
+/*
+ * How many base steps one message is worth, given the detents it reported and
+ * the time-based acceleration multiplier the caller computed.
+ *
+ * THE LARGER OF THE TWO, never the product, and never one replacing the other.
+ * They measure the same thing by different means and only one of them is ever
+ * real for a given controller:
+ *
+ *   - a plain encoder always says 1 detent, so `accel` is the only signal that
+ *     the user is turning fast, and it must survive;
+ *   - an accelerated encoder (OXI E16 and most endless controllers) batches
+ *     detents into the magnitude, so `mag` already IS the acceleration.
+ *
+ * Multiplying them compounds two accelerations and makes a small turn cross the
+ * whole range. But suppressing `accel` whenever `mag > 1` — the first shape
+ * this took — puts a CLIFF on the fast side: with KNOB_ACCEL_MAX_MULT at 4, a
+ * one-detent message turned fast was worth 4 base steps and a two-detent one
+ * only 2, so the parameter moved LESS the harder it was driven. That is the
+ * same symptom as the bug the decode fixed, one octave quieter.
+ *
+ * `max` is monotone in both inputs, has no crossover, and is the identity on
+ * Move's own knobs, which only ever report one detent: max(1, accel) == accel,
+ * bit-identical to the arithmetic that shipped before any of this.
+ *
+ * ENUMS NEED NO SPECIAL CASE, and that is load-bearing rather than lucky. The
+ * caller pins `accel` to KNOB_ACCEL_ENUM_MULT (1) for an enum, which is what
+ * "enums never accelerate" has always meant: no TIME-based multiplier, because
+ * a deliberate slow turn must not overshoot a list of options. A detent count
+ * is not acceleration — it is how far the user physically turned — so
+ * max(mag, 1) == mag hands an enum exactly the options the user asked for.
+ * Forcing mag to 1 instead made enums advance one option per MESSAGE, and an
+ * accelerated encoder scans at a fixed rate and answers a faster spin with a
+ * BIGGER message rather than more of them: options-per-second then stops
+ * depending on how hard you turn, and a long enum cannot be crossed at all.
+ * On Move that distinction never existed, because there messages and detents
+ * are the same thing.
+ */
+static inline int relative_cc_multiplier(int mag, int accel) {
+    if (mag < 1) mag = 1;
+    if (accel < 1) accel = 1;
+    return (mag > accel) ? mag : accel;
+}
+
+#endif /* RELATIVE_CC_H */

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -51,7 +51,8 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_metronome_announce \
 	$(BUILD_DIR)/test_shadow_metronome \
 	$(BUILD_DIR)/test_sampler_stem_path \
-	$(BUILD_DIR)/test_perf_snapshot_size
+	$(BUILD_DIR)/test_perf_snapshot_size \
+	$(BUILD_DIR)/test_relative_cc
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
 # the routing test covers whatever range Master FX actually runs with. Raising
@@ -123,6 +124,12 @@ $(BUILD_DIR)/test_sampler_stem_path: test_sampler_stem_path.c ../../src/host/sam
 
 $(BUILD_DIR)/test_shadow_metronome: test_shadow_metronome.c ../../src/host/shadow_metronome.c ../../src/host/metronome_click.h | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $(filter %.c,$^) -o $@ $(LDFLAGS) -lm
+
+# relative_cc.h lives with the chain DSP rather than in src/host, so this one
+# rule adds that include path. The header is standalone by construction (no
+# chain_internal.h, which would drag in the whole plugin surface).
+$(BUILD_DIR)/test_relative_cc: test_relative_cc.c ../../src/modules/chain/dsp/relative_cc.h | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(DEPFLAGS) -I../../src/modules/chain/dsp $< -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_master_fx_slot_routing: test_master_fx_slot_routing.c ../../src/host/master_fx_key.h ../../src/host/shadow_chain_mgmt.h | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) -DTEST_MASTER_FX_SLOTS=$(MASTER_FX_SLOTS) $< -o $@ $(LDFLAGS)

--- a/tests/host/test_relative_cc.c
+++ b/tests/host/test_relative_cc.c
@@ -1,0 +1,166 @@
+/*
+ * Relative (endless) encoder CC arithmetic — relative_cc.h.
+ *
+ * The call site is v2_on_midi in chain_midi.c, which cannot be compiled
+ * natively (it dlopens plugins and owns the get_param/set_param surface), so
+ * its companion .sh pins it at the SOURCE level. That is enough to catch a
+ * deleted call and useless for everything below: source-level pinning cannot
+ * tell 4 base steps from 8, which is precisely where both bugs lived.
+ *
+ * Four properties, and each of them shipped wrong at some point:
+ *
+ *   1. THE FULL RANGE DECODES. Before #402 only 1 and 127 did, so every fast
+ *      turn of an accelerated encoder was dropped. The control worked when
+ *      crept and died when played.
+ *   2. MOVE IS BIT-IDENTICAL. Move's own knobs only ever report one detent,
+ *      so max(1, accel) == accel must hold for every accel — this is the whole
+ *      reason the change is safe to ship.
+ *   3. NO CLIFF ON THE FAST SIDE. #402's first shape suppressed accel whenever
+ *      mag > 1, so a one-detent fast message was worth 4 and a two-detent one
+ *      only 2: the parameter moved LESS the harder it was driven.
+ *   4. ENUMS TAKE THE DETENT COUNT. Pinning mag to 1 made them advance one
+ *      option per MESSAGE, and an accelerated encoder answers a faster spin
+ *      with a bigger message rather than more of them — so a long enum could
+ *      not be crossed at any speed.
+ *
+ * Properties 3 and 4 are monotonicity claims, so they are asserted as
+ * monotonicity over the whole input space rather than at a couple of points: a
+ * cliff is exactly what a spot check steps over.
+ */
+#include <stdio.h>
+
+#include "relative_cc.h"
+
+/* Mirrors of the chain's constants. Restated rather than included because
+ * chain_internal.h pulls in the whole plugin surface; the .sh companion fails
+ * if these drift from the header that ships. */
+#define KNOB_ACCEL_MIN_MULT      1
+#define KNOB_ACCEL_MAX_MULT      4
+#define KNOB_ACCEL_MAX_MULT_INT  2
+#define KNOB_ACCEL_ENUM_MULT     1
+
+static int failures = 0;
+
+static void check(int cond, const char *what) {
+    if (!cond) { printf("  FAIL: %s\n", what); failures++; }
+}
+
+static void check_eq(int got, int want, const char *what) {
+    if (got != want) {
+        printf("  FAIL: %s — got %d, want %d\n", what, got, want);
+        failures++;
+    }
+}
+
+/* 1. The full two's-complement range, and the two non-movements. */
+static void test_decode_range(void) {
+    printf("== decode: the full range, not just +/-1 ==\n");
+
+    check_eq(relative_cc_ticks(1), 1, "value 1 is +1 detent");
+    check_eq(relative_cc_ticks(63), 63, "value 63 is +63 detents");
+    check_eq(relative_cc_ticks(127), -1, "value 127 is -1 detent (two's complement, not signed-bit)");
+    check_eq(relative_cc_ticks(65), -63, "value 65 is -63 detents");
+
+    check_eq(relative_cc_ticks(0), 0, "value 0 is not a movement");
+    check_eq(relative_cc_ticks(64), 0, "value 64 is the unused midpoint");
+
+    /* Out of range for a MIDI data byte; answer 0 rather than sign-extending
+     * whatever a caller happened to pass. */
+    check_eq(relative_cc_ticks(128), 0, "128 is not a data byte");
+    check_eq(relative_cc_ticks(-1), 0, "negative is not a data byte");
+
+    /* THE BUG: everything except 1 and 127 used to return nothing. Asserted
+     * over the whole range so a decoder that handles only a few extra values
+     * cannot pass. */
+    int moved = 0;
+    for (int v = 1; v <= 127; v++) if (relative_cc_ticks(v) != 0) moved++;
+    check_eq(moved, 126, "every value but 0 and 64 is a movement");
+
+    /* Symmetric: +n and its negative counterpart are the same magnitude. */
+    for (int n = 1; n <= 63; n++) {
+        check_eq(relative_cc_ticks(n), -relative_cc_ticks(128 - n),
+                 "positive and negative counterparts are symmetric");
+    }
+}
+
+/* 2. Move's own knobs. One detent, every accel value, unchanged. */
+static void test_move_is_bit_identical(void) {
+    printf("== Move's knobs: max(1, accel) == accel ==\n");
+    for (int accel = KNOB_ACCEL_MIN_MULT; accel <= KNOB_ACCEL_MAX_MULT; accel++) {
+        check_eq(relative_cc_multiplier(1, accel), accel,
+                 "a one-detent message is worth exactly the time-based multiplier");
+    }
+}
+
+/* 3. No cliff: the multiplier never DROPS as the encoder reports more detents. */
+static void test_no_cliff_on_the_fast_side(void) {
+    printf("== no cliff: more detents never means less movement ==\n");
+
+    /* The exact case that regressed: one detent turned fast beat two detents. */
+    check(relative_cc_multiplier(2, KNOB_ACCEL_MAX_MULT) >=
+          relative_cc_multiplier(1, KNOB_ACCEL_MAX_MULT),
+          "two detents is not worth less than one at max acceleration");
+
+    /* And the general claim, over every magnitude and every accel the caller
+     * can produce (floats reach MAX_MULT, ints are capped at MAX_MULT_INT,
+     * enums are pinned to ENUM_MULT — all covered by the accel loop). */
+    for (int accel = KNOB_ACCEL_MIN_MULT; accel <= KNOB_ACCEL_MAX_MULT; accel++) {
+        int prev = relative_cc_multiplier(1, accel);
+        for (int mag = 2; mag <= 63; mag++) {
+            int cur = relative_cc_multiplier(mag, accel);
+            check(cur >= prev, "multiplier is monotone in the detent count");
+            prev = cur;
+        }
+    }
+
+    /* Monotone in the other input too, so a faster turn of a plain encoder
+     * never moves the parameter less. */
+    for (int mag = 1; mag <= 63; mag++) {
+        int prev = relative_cc_multiplier(mag, KNOB_ACCEL_MIN_MULT);
+        for (int accel = KNOB_ACCEL_MIN_MULT + 1; accel <= KNOB_ACCEL_MAX_MULT; accel++) {
+            int cur = relative_cc_multiplier(mag, accel);
+            check(cur >= prev, "multiplier is monotone in the acceleration");
+            prev = cur;
+        }
+    }
+
+    /* Never the product: that is what makes a small turn cross the range. */
+    check(relative_cc_multiplier(8, KNOB_ACCEL_MAX_MULT) < 8 * KNOB_ACCEL_MAX_MULT,
+          "the two multipliers do not compound");
+}
+
+/* 4. An enum crosses at the speed the user turns, not at the message rate. */
+static void test_enum_takes_the_detent_count(void) {
+    printf("== enums: options follow detents, not messages ==\n");
+
+    /* The caller pins accel to ENUM_MULT, which is what "enums never
+     * accelerate" means — no TIME-based multiplier. The detent count is not
+     * acceleration, so it survives. */
+    check_eq(relative_cc_multiplier(1, KNOB_ACCEL_ENUM_MULT), 1,
+             "one detent still advances exactly one option (Move, unchanged)");
+    check_eq(relative_cc_multiplier(5, KNOB_ACCEL_ENUM_MULT), 5,
+             "five detents advance five options");
+    check_eq(relative_cc_multiplier(63, KNOB_ACCEL_ENUM_MULT), 63,
+             "a full-magnitude message is not clamped to one option");
+
+    /* THE BUG, as the property it broke: with mag pinned to 1, a spin that
+     * batches detents delivers the same number of options however hard it is
+     * turned. Assert that options-per-message actually tracks the spin. */
+    check(relative_cc_multiplier(8, KNOB_ACCEL_ENUM_MULT) >
+          relative_cc_multiplier(2, KNOB_ACCEL_ENUM_MULT),
+          "a harder spin crosses more of a long enum");
+}
+
+int main(void) {
+    test_decode_range();
+    test_move_is_bit_identical();
+    test_no_cliff_on_the_fast_side();
+    test_enum_takes_the_detent_count();
+
+    if (failures) {
+        printf("FAILED (%d)\n", failures);
+        return 1;
+    }
+    printf("PASS: relative CC decode + multiplier\n");
+    return 0;
+}

--- a/tests/host/test_relative_cc.sh
+++ b/tests/host/test_relative_cc.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The ARITHMETIC is run by tests/host/test_relative_cc.c against relative_cc.h.
+# This is the other half: chain_midi.c cannot be compiled natively (it dlopens
+# plugins and owns the get_param/set_param surface), so the two things the C
+# test cannot see are pinned at the source level here —
+#
+#   1. that the relative CC path still CALLS the header rather than carrying a
+#      second copy of the decode, and
+#   2. that the constants the C test mirrors still match the ones that ship.
+#
+# Without (2) the C test goes on asserting "no cliff at accel 4" long after
+# KNOB_ACCEL_MAX_MULT has moved, which is a green test measuring a range the
+# code no longer has.
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+midi="src/modules/chain/dsp/chain_midi.c"
+hdr="src/modules/chain/dsp/relative_cc.h"
+internal="src/modules/chain/dsp/chain_internal.h"
+ctest="tests/host/test_relative_cc.c"
+
+[ -f "$hdr" ] || fail "$hdr is missing"
+
+# ------------------------------------------------------- 1. the call site
+grep -q '#include "relative_cc.h"' "$midi" \
+  || fail "chain_midi.c no longer includes relative_cc.h"
+grep -q 'relative_cc_ticks(' "$midi" \
+  || fail "the relative CC path no longer decodes through relative_cc_ticks()"
+grep -q 'relative_cc_multiplier(' "$midi" \
+  || fail "the relative CC path no longer scales through relative_cc_multiplier()"
+
+# A SECOND decode is the failure mode worth naming: the original bug was a
+# hand-rolled two-branch decode inline here, and the fix is only a fix while
+# there is exactly one of them. `msg[2] == 127` was its signature.
+if grep -q 'msg\[2\] == 127' "$midi"; then
+    fail "chain_midi.c decodes a relative CC value inline again (msg[2] == 127) — \
+the decode belongs to relative_cc.h, and two copies is how the first one drifted"
+fi
+
+# The magnitude must not be pinned before it reaches the multiplier: that was
+# the enum regression (one option per MESSAGE rather than per detent).
+if grep -qE 'KNOB_TYPE_ENUM\)[[:space:]]*mag = 1' "$midi"; then
+    fail "the enum path pins the detent count to 1 again — an accelerated \
+encoder answers a faster spin with a bigger message, not more of them, so this \
+makes a long enum uncrossable at any speed"
+fi
+
+# ------------------------------------------------------- 2. the constants
+# Read each one out of the shipped header and require the C test's mirror to
+# agree, so a change to either side fails here rather than going quiet.
+for name in KNOB_ACCEL_MIN_MULT KNOB_ACCEL_MAX_MULT KNOB_ACCEL_MAX_MULT_INT KNOB_ACCEL_ENUM_MULT; do
+    shipped="$(awk -v n="$name" '$1 == "#define" && $2 == n { print $3; exit }' "$internal")"
+    mirror="$(awk -v n="$name" '$1 == "#define" && $2 == n { print $3; exit }' "$ctest")"
+    [ -n "$shipped" ] || fail "$name is gone from chain_internal.h"
+    [ -n "$mirror" ]  || fail "$name is no longer mirrored in test_relative_cc.c"
+    [ "$shipped" = "$mirror" ] \
+      || fail "$name drifted: chain_internal.h says $shipped, test_relative_cc.c mirrors $mirror"
+done
+
+echo "PASS: relative CC wiring + constant mirrors"


### PR DESCRIPTION
Follow-up to #402, which fixed the relative-CC decode and then scaled it two ways that each undo part of the fix. Both are invisible on Move, which is why they went in green.

## The cliff

`KNOB_ACCEL_MAX_MULT` is 4, and #402 suppressed `accel` whenever the encoder reported more than one detent:

```
mag == 1, turned fast   ->  base * 4
mag == 2                ->  base * 1 * 2 = base * 2
```

Crossing from one detent per message to two **halves** the per-message throughput, at the moment the user turned harder. Same symptom as the bug the decode fixed, one octave quieter. (Ints escape it: `MAX_MULT_INT` is 2, so both sides land on 2. Floats do not.)

## The enum regression

`mag = 1` for enums means one option per **message**. An accelerated encoder scans at a roughly fixed rate and answers a faster spin with a *bigger* message rather than more of them — so options-per-second stopped depending on how hard you turn, and a long enum could not be crossed at any speed.

On Move this could not happen, because there a message *is* a detent, and "one per message" and "one per detent" were the same sentence. The existing `KNOB_ACCEL_ENUM_MULT` cap was written under that assumption.

## Both go away with `max`

The two multipliers measure the same thing by different means, and only one is ever real for a given controller: a plain encoder always says one detent, so `accel` is its only speed signal; an accelerated one batches detents, so `mag` already *is* the acceleration. The product compounds them; replacing one with the other is the cliff. `max` is monotone in both, has no crossover, and is the identity on Move — `max(1, accel) == accel`, bit-identical to what shipped before any of this.

**Enums then need no special case**, which is load-bearing rather than tidy. The caller already pins `accel` to `KNOB_ACCEL_ENUM_MULT`, and that is what "enums never accelerate" has always meant: no *time-based* multiplier, so a deliberate slow turn cannot overshoot a list of options. A detent count is not acceleration — it is how far the user physically turned — so `max(mag, 1) == mag` hands an enum exactly the options asked for.

Net effect on the call site is three lines shorter than #402 left it.

## Why a header

`chain_midi.c` cannot be compiled natively — `test_chain_knob_cc_out.c` says so in its own preamble and pins it at the source level instead — and source-level pinning cannot tell 4 base steps from 8, which is exactly where both of these lived. So the arithmetic moves to `relative_cc.h`, the same move as `recall_quantize.h`, `transport_grid.h`, `fx_midi_filter.h` and `master_fx_key.h`.

## Tests

`tests/host/test_relative_cc.c` asserts the cliff and the enum claim as **monotonicity over the whole input space** rather than at a couple of points, because a cliff is precisely what a spot check steps over. It also pins that Move is bit-identical (`max(1, accel) == accel` for every accel).

Mutation-checked against all four wrong implementations — each one fails it:

| mutation | what fails |
|---|---|
| pre-#402 decode (only ±1) | `value 63 is +63 detents`, `every value but 0 and 64 is a movement — got 2, want 126` |
| #402's suppression | `two detents is not worth less than one at max acceleration`, `multiplier is monotone in the detent count` |
| magnitude ignored | `five detents advance five options — got 1, want 5`, `a harder spin crosses more of a long enum` |
| product instead of max | `the two multipliers do not compound` |

`test_relative_cc.sh` pins the call site — including "no second inline decode" (`msg[2] == 127` was the original bug's signature) and "the enum path does not pin `mag` again" — and pins the constants the C test mirrors against `chain_internal.h`, so a green test cannot go on measuring a range the code no longer has. Those pins are mutation-checked too.

Full local suite: `make -C tests/host test` green, 236/236 `tests/host/*.sh` green, and `chain_midi.c` syntax-checks clean with `-Wall -Wextra`.

## Not fixed here

An absolute controller mapped to CC 71-78 was near-inert before #402 and will now slam parameters — CC 102-109 is the absolute range. Worth a release-note line rather than a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMP4RNq2H8cy55LBDYbiMZ