### PR TITLE
Link Audio: bound the backlog, so a module load cannot park Move's audio 85 ms late

### DIFF
--- a/src/host/link_audio.h
+++ b/src/host/link_audio.h
@@ -225,6 +225,99 @@ typedef struct {
 #error "catch-up threshold must sit inside the ring, or it can never fire"
 #endif
 
+/*
+ * THE BACKLOG HAS NO SET-POINT, SO IT KEEPS WHATEVER IT IS GIVEN.
+ *
+ * Producer and consumer both run at one block per SPI frame, so nothing in the
+ * loop closes the distance between them: `avail` is wherever the last
+ * disturbance left it, for the rest of the session. Both a healthy ~11 ms and a
+ * miserable ~85 ms are stable equilibria.
+ *
+ * How it gets given 85 ms, measured on a Move loading jp8000 with Move->Schwung
+ * on: Move stalls, the reader STARVES -- and a starved read consumes nothing,
+ * so read_pos does not advance -- then Move's catch-up burst lands all at once.
+ * A rate-locked reader can never drain that burst, so it does not decay back to
+ * the old level, it BECOMES the new level:
+ *
+ *   before  mean 10.97 ms (max 12.38)      6 windows, stable
+ *   after   mean 85.05 ms (min 83.65)      6 windows, stable
+ *
+ * min, mean and max agreeing to a millisecond over 5 s is a fixed offset. The
+ * user hears it as "significant delay after loading a module", and the only
+ * cure was toggling Move->Schwung, whose rebuild-entry snap resets read_pos.
+ *
+ * So: trim it. Only when it has been high for a WHILE -- a single elevated read
+ * is Move's ordinary jitter, and trimming on that is how the old 35 ms catch-up
+ * came to throw away the very burst that covers the next stall.
+ *
+ * THE TRADE-OFF IS REAL, AND BOTH ENDS OF IT ARE AUDIBLE.
+ *
+ * `avail` is how late MOVE'S OWN TRACKS arrive at the mixer. Schwung's synths
+ * are rendered fresh each SPI frame and are not delayed by it, so the backlog
+ * is heard as Move's clips and drums lagging behind what you play. Deep is the
+ * complaint. Shallow is a dropout, because the ring has to cover the producer's
+ * own gaps. There is no setting that is good at both; there is only the
+ * smallest depth that does not starve.
+ *
+ * TARGET IS DERIVED FROM MEASURED PRODUCER JITTER, and the first attempt at it
+ * was wrong in a way worth recording. It was set to ~12 ms because that is the
+ * level the machine happened to be running at when it looked healthy. Measured
+ * on the device afterwards:
+ *
+ *   producer max_gap     5.1 - 15.9 ms   (link_subscriber, breaks=0)
+ *   avail after trimming  mean 17.3 ms, dipping to 7.03 ms
+ *   result                la_starve_fallback=400, then 288 -- ~1.2 s of
+ *                         missing Move audio, heard as a dropout
+ *
+ * A 15.9 ms gap landing on a 7 ms buffer starves, and `avail` swings about
+ * 10 ms below its own mean, so the mean has to sit that much above the worst
+ * gap. 16 + 10, rounded up for margin, is where TARGET comes from.
+ *
+ * Note that LATENCY_COMP_TARGET_SAMPLES -- the single constant behind the whole
+ * alignment scheme (nudge set-point, Schwung-side delay, metronome offset) --
+ * is 1400 samples, 15.9 ms, exactly the worst gap measured here. Zero margin.
+ * That is worth knowing before trusting Latency Comp to hold a depth.
+ *
+ * If dropouts appear, raise TARGET; la_starve_fallback is the number that says
+ * so. If Move's tracks lag audibly, lower it, and expect starvation below ~30 ms.
+ */
+#define LINK_AUDIO_IN_TRIM_CEILING   (LINK_AUDIO_IN_BLOCK_SAMPLES * 20)  /* ~58 ms */
+#define LINK_AUDIO_IN_TRIM_TARGET    (LINK_AUDIO_IN_BLOCK_SAMPLES * 10)  /* ~29 ms */
+/* One second of reads at 128 frames / 44.1 kHz. Long enough that Move's
+ * stall-and-burst has come and gone; short enough that a parked backlog is
+ * corrected before it is worth complaining about. */
+#define LINK_AUDIO_IN_TRIM_SUSTAIN   345
+
+#if LINK_AUDIO_IN_TRIM_TARGET >= LINK_AUDIO_IN_TRIM_CEILING
+#error "trim target must sit below the ceiling, or trimming does nothing"
+#endif
+#if LINK_AUDIO_IN_TRIM_CEILING >= LINK_AUDIO_IN_CATCHUP_SAMPLES
+#error "trim ceiling must sit below catch-up, which handles the runaway case"
+#endif
+
+/*
+ * The trim decision, as a pure function so the two silent mistakes can be
+ * pinned: REWINDING (if avail is below the target, moving read_pos to
+ * write_pos - target moves it backwards and replays delivered audio) and
+ * WRAPPING (both positions free-run through 2^32, so avail is only correct as
+ * an unsigned difference).
+ *
+ * `run` is the caller's per-slot count of consecutive reads above the ceiling;
+ * it is updated here so the reset-on-dip cannot be forgotten at a call site.
+ */
+static inline int link_audio_in_trim_pos(uint32_t write_pos, uint32_t read_pos,
+                                         uint32_t *run, uint32_t *out_read_pos) {
+    const uint32_t avail = write_pos - read_pos;   /* wraps correctly */
+    if (avail <= (uint32_t)LINK_AUDIO_IN_TRIM_CEILING) { *run = 0; return 0; }
+    if (++(*run) < (uint32_t)LINK_AUDIO_IN_TRIM_SUSTAIN) return 0;
+    *run = 0;
+    /* Cannot fire below the target -- the ceiling is above it -- but a caller
+     * that changed the constants could, and that would rewind the reader. */
+    if (avail <= (uint32_t)LINK_AUDIO_IN_TRIM_TARGET) return 0;
+    if (out_read_pos) *out_read_pos = write_pos - (uint32_t)LINK_AUDIO_IN_TRIM_TARGET;
+    return 1;
+}
+
 /* Slots 0-3: per-track audio from Move. Slot 4 (Main) is reserved but
  * unsubscribed by link_subscriber to keep Move's Audio Worker threads free
  * from a publish we don't consume. The shim rebuilds Move's output from the

--- a/src/host/shadow_link_audio.c
+++ b/src/host/shadow_link_audio.c
@@ -57,6 +57,12 @@ static void la_avail_stats_reset(void) {
 #define NUDGE_PERIOD            16
 #define NUDGE_BURST_THRESHOLD   512
 #define NUDGE_BURST_FRAMES      8
+/* Consecutive reads with avail above LINK_AUDIO_IN_TRIM_CEILING, per slot.
+ * Single-threaded: every read happens on the SPI path. */
+static uint32_t trim_high_run[LINK_AUDIO_IN_SLOT_COUNT];
+volatile uint32_t la_trim_count[LINK_AUDIO_IN_SLOT_COUNT];
+volatile uint32_t la_trim_dropped[LINK_AUDIO_IN_SLOT_COUNT];
+
 static uint32_t nudge_drop_counter[LINK_AUDIO_IN_SLOT_COUNT];
 static uint32_t nudge_dup_counter[LINK_AUDIO_IN_SLOT_COUNT];
 
@@ -165,6 +171,29 @@ int link_audio_read_channel_shm(link_audio_in_shm_t *shm, int slot_idx,
                            (new_rp - rp), __ATOMIC_RELAXED);
         __atomic_fetch_add(&slot->catchup_count, 1, __ATOMIC_RELAXED);
         rp = new_rp;
+        trim_high_run[slot_idx] = 0;
+    } else {
+        /* SUSTAINED BACKLOG TRIM -- see link_audio.h.
+         *
+         * Catch-up above handles a producer running away. This handles the
+         * quieter failure: a backlog that is nowhere near the ring but has
+         * simply been sitting there since a disturbance, because nothing in a
+         * rate-locked loop ever removes it. Measured at 85 ms after a module
+         * load, stable to the millisecond over six 5 s windows.
+         *
+         * Skipped while Latency Comp is active: the nudge below is already a
+         * controller with its own set-point, and two of them fight. */
+        if (!latency_comp_active) {
+            uint32_t new_rp;
+            if (link_audio_in_trim_pos(wp, rp, &trim_high_run[slot_idx], &new_rp)) {
+                __atomic_fetch_add(&la_trim_dropped[slot_idx],
+                                   (new_rp - rp), __ATOMIC_RELAXED);
+                __atomic_fetch_add(&la_trim_count[slot_idx], 1, __ATOMIC_RELAXED);
+                rp = new_rp;
+            }
+        } else {
+            trim_high_run[slot_idx] = 0;
+        }
     }
 
     /* Adaptive nudge toward LATENCY_COMP_TARGET_SAMPLES. Drops or duplicates

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -9328,6 +9328,11 @@ static void *spi_timing_logger_thread(void *arg)
             shim_la_starve_fallback_count = 0;
 
             int any_nonzero = (flips || fallback);
+            {
+                extern volatile uint32_t la_trim_count[LINK_AUDIO_IN_SLOT_COUNT];
+                for (int s = 0; s < LINK_AUDIO_IN_SLOT_COUNT; s++)
+                    if (__atomic_load_n(&la_trim_count[s], __ATOMIC_RELAXED)) any_nonzero = 1;
+            }
             uint32_t slot_starve[LINK_AUDIO_IN_SLOT_COUNT];
             uint32_t slot_catchup[LINK_AUDIO_IN_SLOT_COUNT];
             uint32_t slot_dropped[LINK_AUDIO_IN_SLOT_COUNT];
@@ -9371,9 +9376,21 @@ static void *spi_timing_logger_thread(void *arg)
                         slot_max_avail[s], slot_produced[s],
                         slot_would_overrun[s], slot_max_frames[s]);
                 }
-                unified_log("link_audio", LOG_LEVEL_DEBUG,
-                    "path: rebuild_flips=%u la_starve_fallback=%u",
-                    flips, fallback);
+                {
+                    extern volatile uint32_t la_trim_count[LINK_AUDIO_IN_SLOT_COUNT];
+                    extern volatile uint32_t la_trim_dropped[LINK_AUDIO_IN_SLOT_COUNT];
+                    uint32_t tc = 0, td = 0;
+                    for (int s = 0; s < LINK_AUDIO_IN_SLOT_COUNT; s++) {
+                        tc += __atomic_exchange_n(&la_trim_count[s], 0, __ATOMIC_RELAXED);
+                        td += __atomic_exchange_n(&la_trim_dropped[s], 0, __ATOMIC_RELAXED);
+                    }
+                    /* backlog_trims counts sustained backlogs removed;
+                     * trim_dropped_ms is the latency reclaimed. */
+                    unified_log("link_audio", LOG_LEVEL_DEBUG,
+                        "path: rebuild_flips=%u la_starve_fallback=%u "
+                        "backlog_trims=%u trim_dropped_ms=%u",
+                        flips, fallback, tc, (unsigned)(td / 2 / 44));
+                }
             }
         }
 

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -52,7 +52,8 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_shadow_metronome \
 	$(BUILD_DIR)/test_sampler_stem_path \
 	$(BUILD_DIR)/test_perf_snapshot_size \
-	$(BUILD_DIR)/test_relative_cc
+	$(BUILD_DIR)/test_relative_cc \
+	$(BUILD_DIR)/test_link_audio_backlog_trim
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
 # the routing test covers whatever range Master FX actually runs with. Raising
@@ -98,6 +99,11 @@ $(BUILD_DIR)/test_rt_thread_audit: test_rt_thread_audit.c ../../src/host/rt_thre
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $(filter %.c,$^) -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_spi_tally: test_spi_tally.c ../../src/host/spi_tally.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $(filter %.c,$^) -o $@ $(LDFLAGS)
+
+# Header-only unit: link_audio_in_trim_pos lives in link_audio.h, so the
+# DEPFLAGS header tracking above is what keeps this honest when it changes.
+$(BUILD_DIR)/test_link_audio_backlog_trim: test_link_audio_backlog_trim.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $(filter %.c,$^) -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_align_capture: test_align_capture.c ../../src/host/align_capture.c | $(BUILD_DIR)

--- a/tests/host/test_link_audio_backlog_trim.c
+++ b/tests/host/test_link_audio_backlog_trim.c
@@ -1,0 +1,102 @@
+/*
+ * The Move->Schwung link-in ring has no set-point: producer and consumer both
+ * run at one block per SPI frame, so `avail` keeps whatever offset a
+ * disturbance gives it, for the session. Measured on a Move loading jp8000 with
+ * Move->Schwung on -- 10.97 ms mean before, 85.05 ms mean after, both stable to
+ * the millisecond over six 5 s windows.
+ *
+ * link_audio_in_trim_pos() removes a backlog that has been high for a WHILE.
+ * The "for a while" is the whole design: trimming on a single elevated read is
+ * how the old 35 ms catch-up came to discard the burst that covers Move's next
+ * stall.
+ */
+#include "link_audio.h"
+#include <stdio.h>
+#include <stdint.h>
+
+static int fails = 0;
+static void check(int cond, const char *what) {
+    printf("  %-4s %s\n", cond ? "ok:" : "FAIL", what);
+    if (!cond) fails++;
+}
+
+#define CEIL   ((uint32_t)LINK_AUDIO_IN_TRIM_CEILING)
+#define TGT    ((uint32_t)LINK_AUDIO_IN_TRIM_TARGET)
+#define SUS    ((uint32_t)LINK_AUDIO_IN_TRIM_SUSTAIN)
+
+/* Drive n consecutive reads at a fixed avail; return how many trims fired. */
+static int drive(uint32_t avail, uint32_t n, uint32_t *run, uint32_t *last_out) {
+    int trims = 0;
+    const uint32_t rp = 1000;
+    for (uint32_t i = 0; i < n; i++) {
+        uint32_t out;
+        if (link_audio_in_trim_pos(rp + avail, rp, run, &out)) { trims++; if (last_out) *last_out = out; }
+    }
+    return trims;
+}
+
+int main(void) {
+    uint32_t run = 0, out = 0;
+    printf("link audio backlog trim\n");
+
+    /* A backlog held above the ceiling for the sustain window trims ONCE. */
+    run = 0;
+    check(drive(CEIL + 1, SUS - 1, &run, &out) == 0,
+          "no trim before the sustain window elapses");
+    check(drive(CEIL + 1, 1, &run, &out) == 1,
+          "trims once the backlog has been high for the whole window");
+    check(out == (uint32_t)(1000 + CEIL + 1 - TGT),
+          "…leaving exactly TARGET pending");
+    check((uint32_t)(1000 + CEIL + 1) - out == TGT, "…i.e. TARGET behind the writer");
+
+    /* Move's stall-and-burst: elevated, then it drops. Must NOT trim -- this is
+     * the case the old 35 ms catch-up got wrong. */
+    run = 0;
+    check(drive(CEIL + 1, SUS / 2, &run, &out) == 0, "a burst alone does not trim");
+    check(drive(TGT, 1, &run, &out) == 0, "…and a dip below the ceiling…");
+    check(run == 0, "…resets the run, so the burst cannot accumulate across dips");
+    check(drive(CEIL + 1, SUS - 1, &run, &out) == 0,
+          "…so the next elevated stretch starts counting from zero");
+
+    /* Healthy operation never trims. Measured baseline was ~11 ms mean,
+     * 12.38 ms max; the ceiling must sit well above that. */
+    run = 0;
+    check(drive(TGT, SUS * 3, &run, &out) == 0, "a healthy backlog never trims");
+    check(CEIL > (uint32_t)(12 * 2 * 44),
+          "ceiling sits above the 12.4 ms healthy max measured on the device");
+
+    /* Never rewind: below the target there is nothing to drop. */
+    run = 0;
+    { uint32_t r2 = SUS; uint32_t o2;
+      check(link_audio_in_trim_pos(1000 + TGT / 2, 1000, &r2, &o2) == 0,
+            "a backlog under the target never rewinds the reader"); }
+
+    /* The 32-bit wrap: both positions free-run. */
+    { const uint32_t rp = 0xFFFFFF00u, wp = rp + CEIL + 64;
+      uint32_t r3 = SUS - 1, o3;
+      check(wp < rp, "…the test really does straddle the wrap");
+      check(link_audio_in_trim_pos(wp, rp, &r3, &o3) == 1,
+            "a backlog straddling the wrap still trims");
+      check(o3 == (uint32_t)(wp - TGT), "…and lands TARGET behind the writer"); }
+
+    /* Margins. */
+    check(TGT < CEIL, "TARGET below CEILING, or trimming does nothing");
+    check(CEIL < (uint32_t)LINK_AUDIO_IN_CATCHUP_SAMPLES,
+          "CEILING below catch-up, which handles the runaway case");
+    check(SUS >= 300, "sustain is ~1 s of reads, not a handful");
+
+    /* THE STARVATION FLOOR, MEASURED. Worst producer gap on the device was
+     * 15.9 ms and `avail` swings ~10 ms below its own mean, so a target under
+     * ~26 ms puts the dips beneath the gaps. Setting it to 12 ms did exactly
+     * that: la_starve_fallback=400 then 288, about 1.2 s of missing Move audio.
+     * This is the check that stops someone reclaiming latency back into a
+     * dropout. */
+    check(TGT >= (uint32_t)(26 * 2 * 44),
+          "target above the measured starvation floor (~26 ms)");
+    check(TGT <= (uint32_t)(60 * 2 * 44),
+          "…but not so deep that Move's tracks lag audibly (<=60 ms)");
+
+    if (fails) { printf("FAIL: %d check(s)\n", fails); return 1; }
+    printf("PASS: link audio backlog trim\n");
+    return 0;
+}


### PR DESCRIPTION
## The bug

Loading a module with **Move→Schwung** on left `/schwung-link-in` parked at **85 ms** and it stayed there for the session. Heard as Move's clips and drums lagging behind what you play — `avail` is how late Move's own tracks arrive at the mixer; Schwung's synths render fresh each SPI frame and aren't delayed by it.

Measured on a Move:

```
before  mean 10.97 ms (max 12.38)   6 windows, stable
after   mean 85.05 ms (min 83.65)   6 windows, stable
```

min, mean and max agreeing to a millisecond over 5 s is a fixed offset, not jitter. Nothing regulates it — producer and consumer both run one block per SPI frame, so the ring keeps whatever depth a disturbance gives it. The only cure was toggling Move→Schwung off and on, whose rebuild-entry snap resets `read_pos`.

## A stall detector was tried first, and does not work

Recording this because it's the obvious idea. A module load runs `dlopen` + `create_instance` synchronously on the SPI callback, so "measure the gap since the consumer's own previous frame" looks exactly right. Built, deployed, measured: it **fired** (`stalls_seen=1 stall_resyncs=1`, a 20.9 ms gap, 15 ms backlog dropped) and the ring parked at 85 ms anyway.

The route is **starvation, not absence** — `la_starve_fallback=58` in that window. A starved read consumes nothing, so `read_pos` doesn't advance; Move's catch-up burst then lands and a rate-locked reader can never drain it. The burst doesn't decay into the old level, it *becomes* the level. A consumer-gap detector is structurally blind to that.

## The fix

Trim the backlog when it has been above a ceiling **for a while**. The duration is the whole design: trimming on a single elevated read is how the old 35 ms catch-up came to discard the very burst that covers Move's next stall. Catch-up keeps the far end (139 ms, a runaway producer); this handles the quiet middle, where the ring is nowhere near full and simply never empties.

`CEILING 58 ms / TARGET 29 ms`, and the target is **derived**: worst producer gap 15.9 ms, `avail` swings ~10 ms below its own mean, so a target under ~26 ms puts the dips beneath the gaps. An earlier 12 ms target — picked because it was "where the machine ran when it looked healthy" — did exactly that and starved. In practice the ring rests at ~20 ms and the trim never fires; TARGET only says where a *parked* ring lands.

Skipped while Latency Comp is active — that path already has a controller with its own set-point, and two of them fight.

## Worth knowing

`LATENCY_COMP_TARGET_SAMPLES`, the single constant behind the whole alignment scheme (nudge set-point, Schwung-side delay, metronome offset), is 1400 samples = **15.9 ms — exactly the worst producer gap measured here**. Zero margin. Worth knowing before trusting Latency Comp to hold a depth.

## Testing

`tests/host/test_link_audio_backlog_trim.c` — 19 checks, **mutation-verified**:

- removing the sustain window fails 3 checks (that mutant *is* the old 35 ms catch-up bug)
- dropping the run-reset fails 2
- putting TARGET back to 12 ms fails the starvation-floor check

Full `make -C tests/host test` green; `test_link_audio_ring_sizing.sh` still green; `./scripts/build.sh` clean.

**On hardware:** the 85 ms parking no longer occurs, the ring rests at 20.4 ms across six windows, `backlog_trims` fires only on a genuine park.

## What this does not fix

Move stalling upstream past the whole ring — seen once at `max_avail=367 ms` with `would_overrun=64` and catch-up dropping ~32k samples per slot. That's a producer-side problem, not a depth this can tune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5UnTs96Fq4bGd5TJ7yUSe