### PR TITLE
catalog: add JE-8086, the JP-8000 emulator

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1410,6 +1410,18 @@
       "default_branch": "main",
       "asset_name": "maze_seq_lite-module.tar.gz",
       "min_host_version": "1.0.0"
+    },
+    {
+      "id": "jp8000",
+      "name": "JE-8086",
+      "description": "Roland JP-8000 SuperSaw emulator (Gearmulator JE-8086) with patch and performance banks",
+      "author": "dsp56300/gearmulator (port: charlesvestal)",
+      "component_type": "sound_generator",
+      "github_repo": "charlesvestal/schwung-jp8000",
+      "default_branch": "main",
+      "asset_name": "jp8000-module.tar.gz",
+      "min_host_version": "1.1.1",
+      "requires": "JP-8000 v1.5 firmware ROMs: all 8 .mid files in the module's roms/ folder"
     }
   ]
 }


### PR DESCRIPTION
Adds the JP-8000 emulator (Gearmulator JE-8086) to the module catalog, released as [v0.5.1](https://github.com/charlesvestal/schwung-jp8000/releases/tag/v0.5.1).

```json
{
  "id": "jp8000",
  "name": "JE-8086",
  "description": "Roland JP-8000 SuperSaw emulator (Gearmulator JE-8086) with patch and performance banks",
  "author": "dsp56300/gearmulator (port: charlesvestal)",
  "component_type": "sound_generator",
  "github_repo": "charlesvestal/schwung-jp8000",
  "default_branch": "main",
  "asset_name": "jp8000-module.tar.gz",
  "min_host_version": "1.1.1",
  "requires": "JP-8000 v1.5 firmware ROMs: all 8 .mid files in the module's roms/ folder"
}
```

**`requires` names all eight files deliberately.** The module cannot boot without them, and someone who supplies three of the eight gets a module that installs cleanly and then does nothing — which is the failure that field exists to prevent.

**Gated on 1.1.1** rather than the 1.0.0 the newest entries carry: it has only ever been built and verified against the current host, so a lower gate would be a guess.

Verified: `module-catalog.json` still parses, 127 modules, and the diff is 12 added lines with nothing else reformatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5UnTs96Fq4bGd5TJ7yUSe