### PR TITLE
catalog: JE-8086 lives at schwung-je8086

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1417,7 +1417,7 @@
       "description": "Roland JP-8000 SuperSaw emulator (Gearmulator JE-8086) with patch and performance banks",
       "author": "dsp56300/gearmulator (port: charlesvestal)",
       "component_type": "sound_generator",
-      "github_repo": "charlesvestal/schwung-jp8000",
+      "github_repo": "charlesvestal/schwung-je8086",
       "default_branch": "main",
       "asset_name": "jp8000-module.tar.gz",
       "min_host_version": "1.1.1",


### PR DESCRIPTION
Follow-up to #408. Installing JE-8086 returned **404**, for two reasons:

1. `charlesvestal/schwung-jp8000` was **private** — the Store fetches anonymously, so both `release.json` and the release asset 404'd. Now public.
2. The repo has been **renamed** to `schwung-je8086`. GitHub redirects web and API routes after a rename, so a stale name mostly looks fine — but **release asset downloads do not redirect**, they 404 with or without `-L`. Verified:

```
old asset URL, no redirect-follow:  HTTP 404
old asset URL, following:           HTTP 404
new asset URL:                      HTTP 302 → 810159 bytes
```

`release.json` on the module repo has been corrected by hand for the existing v0.5.1; future releases fix themselves, since the workflow writes it from `GITHUB_REPOSITORY`.

**`asset_name` stays `jp8000-module.tar.gz`** — it derives from the module `id`, which is still `jp8000`. Renaming that would change the on-device module directory and strand existing installs, which isn't worth the tidiness.

One-line change; catalog still parses at 127 modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5UnTs96Fq4bGd5TJ7yUSe