### PR TITLE
A module may draw a card that floats over the knob page while a knob is turned

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1831,6 +1831,66 @@ the gate is off. A `module.json` shipped without its `.so` still appears in the
 FX picker, and a chain slot pointing at a module that cannot load is restored on
 every boot. `tests/host/test_test_fixtures_not_shipped.sh` pins both halves.
 
+#### The parameter card (`card_script`)
+
+A `drawCell` widget replaces one cell's graphic. A **card** is the other surface:
+a picture that floats over the whole page while a knob is held or has just been
+turned, and is gone the moment you let go. Use it when a value needs more room
+than a 17×15 box — a crossfade sitting between two named anchors, a feedback
+amount that computes to a repeat count, a mode whose meaning is a diagram.
+
+Declare it on the parameter, in the same `chain_params` entry the rest of the
+knob comes from:
+
+```json
+{ "key": "blend", "name": "Blend", "type": "float", "min": 0, "max": 1,
+  "card_script": "cards.js#blend_card", "card_w": 96, "card_h": 44 }
+```
+
+- `card_script` (required to get a card): `file.js#exportName`, spelled exactly
+  like `canvas_script`. The file is resolved from the module root, and the
+  export is looked up on `globalThis`.
+- `card_w` / `card_h` (optional): the size you want, in pixels. Defaults are
+  96×34; anything nonsense (zero, negative, NaN, a string) falls back to the
+  default, and anything larger than the panel is clamped to it.
+
+Then export the drawer:
+
+```javascript
+globalThis.blend_card = function (ctx, o) {
+    ctx.print(1, 0, o.name, 1);
+    ctx.print(o.w - 1 - ctx.textWidth(o.value), 0, o.value, 1);
+    const v = Number(o.raw);
+    if (isFinite(v)) ctx.fillRect(0, 12, Math.round(o.w * v), 6, 1);
+};
+```
+
+**The card is not the screen, exactly as a widget's cell is not.** `(0,0)` is the
+inside of the card — the host has already cleared it and drawn its border — and
+`ctx.width` / `ctx.height` (also `o.w` / `o.h`) are that inside, not the display.
+There is no accessor that reaches absolute space and nothing you draw outside
+the card can land, which matters twice here: the size is per parameter, so
+coordinates authored against one card are wrong on the next, and a card that
+could paint past its own border would eat the page it exists to float over.
+**Size everything against `o.w` / `o.h`; never write a fixed screen offset.**
+
+**You get the value; you cannot read it.** `o.name` is the parameter's name,
+`o.value` is the same formatted reading the header would show, and `o.raw` is
+the wire value — **and `o.raw` may be `null`**, meaning the module did not answer
+that read. Draw a word and stop when it does; a read that did not answer must
+never become a picture. There is no `getParam` on this path (~2.8 ms, against a
+1.68 ms whole-page render).
+
+**One strike.** A drawer that throws is retired for the session, the card is
+left as an empty frame rather than a hole, and the parameter goes back to
+drawing like any other — which is also what a host too old to know `card_script`
+shows, so the degraded state is one you already ship.
+
+**Keep the card file small and separate from `canvas.js`.** The host evaluates
+the script on the first touch of a declaring knob. If your bank editor lives in
+the same file, that whole file is evaluated on a gesture to reach one drawing
+function.
+
 #### Dynamic Target Pickers
 
 Use `module_picker` and `parameter_picker` for chain-aware target routing without custom UI code.

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1337,3 +1337,63 @@ is covered by `tests/host/test_widget_module_poc.sh`, which starts from the
 shipped `src/modules/audio_fx/widget-test/{module.json,canvas.js}` rather than
 calling `registerWidget()` directly. Every other widget test registers directly,
 and that is exactly why none of them saw this.
+
+### A module's OTHER draw surface is a CARD, and it floats
+
+`drawCell` gives a module one cell. `card_script` gives it the page: a bordered
+picture, centred, raised while a knob is held or has just been turned, and gone
+on release. `param_card.mjs` owns the frame and the module owns the inside.
+
+**Why a second surface rather than a bigger cell.** A cell is 17×15 and the
+grid's business is eight values at once. A card answers a different question —
+*what does THIS value mean* — for the one knob under a finger. The two do not
+compete: a page may have both, and the card only exists during the gesture.
+
+**It FLOATS, and that is why it needs no `clearScreen`.** The enum peek beside it
+is full-screen on purpose and therefore cannot draw without the frame owner's
+clear. A card blanks its own rect with `fillRect`, keeps the page visible around
+it, and so stays drawable by an embedded consumer that owns no frame at all —
+which keeps the library's "no file here clears the screen" contract without an
+exception. The peek wins when both could show: a card is an aid to reading one
+value; the peek is the list of values you are moving between.
+
+**Same coordinate contract as a cell widget, through the same file.** The drawer
+is handed a `frameCtx` scoped to the inside of the card, so `(0,0)` is its own
+top-left and there is no way to name a screen pixel. The instability argument
+that made `frame_ctx.mjs` necessary for widgets applies here for a different
+reason: a card's size is declared **per parameter** (`card_w` / `card_h`, clamped
+to the panel), so absolute coordinates authored against one card are wrong on
+the next — and a floating card that could paint outside its border would eat the
+page it exists to float over. Two module draw hooks, one rule.
+`tests/host/test_param_card.sh` pins it by drawing `(-5, -5, 200, 200)` and
+asserting nothing outside the card is lit and the frame *counted* the overflow.
+
+**Centred, not anchored to the touched cell.** A cell is 30px wide and a card is
+not, so anchoring would put most cards off the edge and the rest in a different
+place per knob — a picture that moves while you read it.
+
+**No timer of its own.** `s.touched` is already "the knob being held, or the one
+just turned": a hold sets `turnClaimMs` to 0 so it never expires, a release
+clears it at once, and a turn no finger registered on expires through
+`TURN_CLAIM_MS`. Every other follow-the-knob surface here obeys that law and a
+second one would drift from it.
+
+**The load is off the draw path, and a null answer is cached.** Nothing
+module-side is resident while the grid is up and the host loader has no cache, so
+loading from `renderOverlays` would evaluate a module script on every frame of a
+turn. `warmCard` runs from touch and from a turn, once per spec per session,
+caching the failures too — a missing file or a bad export costs one attempt, not
+one per touch.
+
+**Default-off, and old-host-safe by construction.** A host with no `loadCard` in
+its io draws no card for a declaring parameter, and a parameter that declares
+nothing is untouched. So a module may ship `card_script` for years and change
+nothing anywhere it is not supported.
+
+⚠ **`frameCtx` exposes `fillRect` / `print` / `textWidth` only.** The context the
+host hands the grid also carries `line`, `setPixel`, `fillCircle`, `drawCircle`
+and `drawArc` (`shadow_ui.js`'s `movy` object), and the widget design spec names
+`setPixel` and `drawLine` as part of a frame context — so a drawer that wants
+them today must fall back to `fillRect` (a Bresenham built on it still clips
+correctly). Passing the optional primitives through, clipped, is a separate and
+generic change to `frame_ctx.mjs`; it is not part of the card.

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16736,6 +16736,55 @@ function resolveCanvasScriptPath(meta) {
  * it did not ship, which the caller reads as "no card" — a missing file is a
  * module bug, not a reason to fail a page.
  */
+/*
+ * Evaluate a card script and return its named export.
+ *
+ * ⚠ NOT loadCanvasOverlayScript, and the difference is not cosmetic. That
+ * resolves a canvas OVERLAY OBJECT, and resolveOverlayObject treats a function
+ * as a FACTORY — it CALLS the candidate and keeps the object it returns. A card
+ * export is a plain drawer, so routing it through there invoked it with no
+ * arguments, it threw on the rect it was not given, and the loader reported
+ * "overlay factory returned invalid value" and answered null. The controller
+ * cached that null exactly as designed and the knob had no picture, with no
+ * error anywhere. It only showed up on one of the two consumers, because the
+ * other supplies its own loader.
+ *
+ * A card is a FUNCTION. Take it as one.
+ *
+ * The saved/restored names are the module globals a UI script may assign, plus
+ * the card's own export — which is arbitrary, so it has to be saved by name.
+ * shadow_load_ui_module evaluates into the shared globalThis, and clobbering
+ * init/tick there is how the host stops ticking.
+ */
+function loadCardDrawer(scriptPath, exportRef) {
+    if (!scriptPath || !exportRef) return null;
+    if (typeof shadow_load_ui_module !== "function") return null;
+
+    const NAMES = ["init", "tick", "onMidiMessageInternal", "onMidiMessageExternal",
+                   exportRef];
+    const had = {}, saved = {};
+    for (const n of NAMES) {
+        had[n] = Object.prototype.hasOwnProperty.call(globalThis, n);
+        saved[n] = globalThis[n];
+    }
+
+    let out = null;
+    try {
+        if (shadow_load_ui_module(scriptPath)) {
+            const fn = globalThis[exportRef];
+            if (typeof fn === "function") out = fn;
+        }
+    } catch (e) {
+        out = null;
+    } finally {
+        for (const n of NAMES) {
+            if (had[n]) globalThis[n] = saved[n];
+            else { try { delete globalThis[n]; } catch (e) {} }
+        }
+    }
+    return out;
+}
+
 function resolveCardScriptPath(slot, component, scriptRef) {
     if (!scriptRef) return "";
     if (scriptRef.startsWith("/")) {
@@ -20378,10 +20427,8 @@ function drawHelpDetail() {
      */
     _ctx.loadCardScript = (slot, component, scriptPath, exportRef) => {
         if (!scriptPath || !exportRef) return null;
-        const loaded = loadCanvasOverlayScript(
+        return loadCardDrawer(
             resolveCardScriptPath(slot, component, scriptPath), exportRef);
-        const fn = loaded && loaded.overlay;
-        return typeof fn === 'function' ? fn : null;
     };
     _ctx.isMuteHeld = () => hostMuteHeld;
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16736,12 +16736,27 @@ function resolveCanvasScriptPath(meta) {
  * it did not ship, which the caller reads as "no card" — a missing file is a
  * module bug, not a reason to fail a page.
  */
-function resolveCardScriptPath(scriptRef) {
+function resolveCardScriptPath(slot, component, scriptRef) {
     if (!scriptRef) return "";
     if (scriptRef.startsWith("/")) {
         return moduleFileExists(scriptRef) ? scriptRef : "";
     }
-    const moduleDir = getModuleBasePath(getHierarchyActiveModuleId());
+    /*
+     * ⚠ RESOLVED FROM THE SLOT AND COMPONENT THE GRID IS ON, never from
+     * getHierarchyActiveModuleId().
+     *
+     * That reads hierEditorSlot / hierEditorComponent — the LIST editor's
+     * state, which is stale or empty while the knob grid is up, the same
+     * hazard the binding documents for `visible`. Using it resolved to "" on a
+     * grid entered without the list editor, so the card silently never loaded:
+     * no error, a cached null, and a knob that simply had no picture. It
+     * worked in one consumer and not the other for exactly this reason, which
+     * is what a single-host test would have missed.
+     */
+    const prefix = getComponentParamPrefix(component);
+    if (!prefix || slot < 0) return "";
+    const moduleId = getSlotParam(slot, `${prefix}_module`) || "";
+    const moduleDir = getModuleBasePath(moduleId);
     if (!moduleDir) return "";
     const scriptPath = `${moduleDir}/${scriptRef}`;
     return moduleFileExists(scriptPath) ? scriptPath : "";
@@ -20364,7 +20379,7 @@ function drawHelpDetail() {
     _ctx.loadCardScript = (slot, component, scriptPath, exportRef) => {
         if (!scriptPath || !exportRef) return null;
         const loaded = loadCanvasOverlayScript(
-            resolveCardScriptPath(scriptPath), exportRef);
+            resolveCardScriptPath(slot, component, scriptPath), exportRef);
         const fn = loaded && loaded.overlay;
         return typeof fn === 'function' ? fn : null;
     };

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16727,6 +16727,26 @@ function resolveCanvasScriptPath(meta) {
     };
 }
 
+/*
+ * A CARD script's path, resolved against the loaded module.
+ *
+ * The same join resolveCanvasScriptPath makes, without the canvas's spelling
+ * variants: a card names one file and one export, and the fragment has already
+ * been split off by the controller. Returns "" when the module declares a file
+ * it did not ship, which the caller reads as "no card" — a missing file is a
+ * module bug, not a reason to fail a page.
+ */
+function resolveCardScriptPath(scriptRef) {
+    if (!scriptRef) return "";
+    if (scriptRef.startsWith("/")) {
+        return moduleFileExists(scriptRef) ? scriptRef : "";
+    }
+    const moduleDir = getModuleBasePath(getHierarchyActiveModuleId());
+    if (!moduleDir) return "";
+    const scriptPath = `${moduleDir}/${scriptRef}`;
+    return moduleFileExists(scriptPath) ? scriptPath : "";
+}
+
 function loadCanvasOverlayScript(scriptPath, overlayRef) {
     if (!scriptPath || typeof shadow_load_ui_module !== "function") {
         return { overlay: null, error: "canvas script unavailable" };
@@ -20327,6 +20347,27 @@ function drawHelpDetail() {
         return (c && c.key) ? c.key : null;
     };
     _ctx.isParamModulated = (slot, fullKey) => isHierarchyParamModulated(slot, fullKey);
+    /*
+     * Load a module-supplied CARD DRAWER, for a parameter that declared one.
+     *
+     * The library cannot read a file and must not try, so this is injected the
+     * same way isParamModulated is. It resolves the script against the module
+     * that is actually loaded — the same base path the fullscreen canvas uses —
+     * and returns the named export, or null.
+     *
+     * ⚠ CALLED FROM THE GESTURE, NEVER FROM THE DRAW. page_controller warms it
+     * on touch and on turn and caches the answer, including a null. No module
+     * script is resident while the grid is up and shadow_load_ui_module has no
+     * cache of its own, so a load from the draw path would evaluate the script
+     * on every frame of a knob turn.
+     */
+    _ctx.loadCardScript = (slot, component, scriptPath, exportRef) => {
+        if (!scriptPath || !exportRef) return null;
+        const loaded = loadCanvasOverlayScript(
+            resolveCardScriptPath(scriptPath), exportRef);
+        const fn = loaded && loaded.overlay;
+        return typeof fn === 'function' ? fn : null;
+    };
     _ctx.isMuteHeld = () => hostMuteHeld;
 
     /* Overtake session state (for tools menu "Resume" indicator) */

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -292,7 +292,12 @@ export function enterParamPages(slot, component, prefix, restorePageName, io, ch
              */
             loadCard: (scriptPath, exportRef) => (
                 typeof ctx.loadCardScript === 'function'
-                    ? ctx.loadCardScript(currentSlot, component, scriptPath, exportRef)
+                    /* currentComponent, not the closed-over `component`: the
+                     * controller closes over these accessors, so a controller
+                     * built for one component would keep resolving against it
+                     * after a switch — the hazard the comment above already
+                     * states for the other accessors. */
+                    ? ctx.loadCardScript(currentSlot, currentComponent, scriptPath, exportRef)
                     : null),
         }, io || {}));
     }

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -283,6 +283,17 @@ export function enterParamPages(slot, component, prefix, restorePageName, io, ch
              * keys and cost three IPC round trips per tick to do so. */
             isModulated: (key) => (typeof ctx.isParamModulated === 'function'
                 ? !!ctx.isParamModulated(currentSlot, key) : false),
+            /*
+             * A parameter may declare a card its MODULE draws while the knob is
+             * turned. Resolving and evaluating that script needs the module's
+             * directory and the host loader, neither of which the library has —
+             * so it comes from the consumer, exactly as isModulated does, and a
+             * consumer that offers none simply has no cards.
+             */
+            loadCard: (scriptPath, exportRef) => (
+                typeof ctx.loadCardScript === 'function'
+                    ? ctx.loadCardScript(currentSlot, component, scriptPath, exportRef)
+                    : null),
         }, io || {}));
     }
     /* Entering the view is the only way the module behind it can have changed,

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -43,6 +43,7 @@ import { widgetsGeneration } from "./widget_registry.mjs";
 import { createAnimState } from "./anim_state.mjs";
 import { drawMenuList } from "../menu_layout.mjs";
 import { drawEnumList } from "./enum_list.mjs";
+import { drawParamCard } from "./param_card.mjs";
 
 export { LAYOUT_MOVY };
 
@@ -519,6 +520,24 @@ export function createController(io = {}) {
      * invitation to handle one of them wrong.
      */
     const formatValue = io.formatValue || null;
+    /*
+     * Optional: load a module-supplied card drawer.
+     *
+     *   loadCard(scriptPath, overlayRef) -> function | null
+     *
+     * Same shape and same reason as isModulated and formatValue above — the
+     * library cannot read a file and must not try, so the host injects the
+     * loader and a caller that has none simply gets no cards. That is the whole
+     * default-off story: a module may declare card_script for years and nothing
+     * changes until a host offers to load it.
+     *
+     * ⚠ THE LOAD IS NOT ON THE DRAW PATH. It is called from onKnobTouch, on the
+     * first touch of a declaring parameter, and the answer is cached for the
+     * session — including a null, which is never retried. Nothing module-side
+     * is resident while the grid is up and the host loader has no cache of its
+     * own, so a load from the draw would evaluate a script every frame.
+     */
+    const loadCard = io.loadCard || null;
     const now = io.now || (() => Date.now());
     /* Graphics default on; a caller can pass `enableViz: false` to keep the
      * plain grid (a tool that wants every cell individually addressable), and
@@ -680,6 +699,10 @@ export function createController(io = {}) {
          * Holds no value of its own — `index` is the knob engine's, which is
          * why the whole overlay costs no IPC read. */
         peek: null,
+        /* Module-supplied card drawers, keyed by the declared script spec.
+         * A cached `null` means "asked and got nothing", and is never retried —
+         * a missing file must not be re-evaluated on every touch. See loadCard. */
+        cardFns: {},
         /* Name of the menu page currently ENTERED, or null. */
         menuEntered: null,
         /*
@@ -2767,6 +2790,10 @@ export function createController(io = {}) {
             s.touched = slot;
             s.turnClaimMs = 0;
         }
+        /* A knob can be turned without the capacitive touch ever registering,
+         * so the turn warms too -- otherwise the one gesture that reaches this
+         * screen without a finger is the one that never gets a card. */
+        warmCard(slot);
 
         /* ONE knob model, whatever the layout. There used to be two, and this
          * branch picked between them by layout -- a knob that behaves
@@ -3081,6 +3108,8 @@ export function createController(io = {}) {
         if (s.touchOrder.indexOf(slot) < 0) s.touchOrder.push(slot);
         s.touched = slot;
         s.turnClaimMs = 0;
+        /* The load lives on the gesture, never on the draw. See warmCard. */
+        warmCard(slot);
         const key = keyAt(slot);
         const meta = metaAt(slot);
         const dec = s.decorations ? s.decorations[slot] : null;
@@ -3692,6 +3721,55 @@ export function createController(io = {}) {
     }
 
     /*
+     * A parameter's declared card drawer, or null.
+     *
+     * `card_script` is spelled like `canvas_script` — "file.js#exportName" —
+     * because a module author already knows that spelling and a second grammar
+     * for the same idea is a second thing to get wrong.
+     */
+    function cardSpec(meta) {
+        if (!meta) return null;
+        const spec = typeof meta.card_script === "string" ? meta.card_script.trim() : "";
+        if (!spec) return null;
+        const hash = spec.indexOf("#");
+        return hash < 0
+            ? { spec, path: spec, ref: "" }
+            : { spec, path: spec.slice(0, hash), ref: spec.slice(hash + 1) };
+    }
+
+    /*
+     * Load a declaring parameter's drawer, ONCE, off the draw path.
+     *
+     * Called from touch and from a turn -- the two events that can raise a card
+     * -- and never from renderOverlays. Nothing module-side is resident while
+     * the grid is up and the host loader has no cache of its own, so a load on
+     * the draw path would evaluate the script on every frame of a knob turn.
+     *
+     * A null answer is CACHED. A missing file, a bad export or a host with no
+     * loader must cost one attempt for the session, not one per touch.
+     */
+    function warmCard(slot) {
+        if (!loadCard) return;
+        const spec = cardSpec(metaAt(slot));
+        if (!spec || Object.prototype.hasOwnProperty.call(s.cardFns, spec.spec)) return;
+        let fn = null;
+        try {
+            fn = loadCard(spec.path, spec.ref);
+        } catch (e) {
+            fn = null;
+        }
+        s.cardFns[spec.spec] = typeof fn === "function" ? fn : null;
+    }
+
+    /** The loaded drawer for a param, or null. Never loads -- see warmCard. */
+    function cardFnFor(meta) {
+        const spec = cardSpec(meta);
+        if (!spec) return null;
+        const fn = s.cardFns[spec.spec];
+        return typeof fn === "function" ? fn : null;
+    }
+
+    /*
      * WHAT render() DOES NOT DRAW, AND WHY IT CANNOT.
      *
      * render() paints a page into a rect the CALLER owns. Nothing in
@@ -3726,7 +3804,7 @@ export function createController(io = {}) {
      */
     function renderOverlays(ctx, { clearScreen } = {}) {
         const peek = enumPeek();
-        if (!peek) return false;
+        if (!peek) return drawDeclaredCard(ctx);
         /*
          * No clear, no overlay. Drawing the list into a frame we may not blank
          * would leave it interleaved with the grid underneath -- two screens at
@@ -3748,6 +3826,57 @@ export function createController(io = {}) {
             footer: [["TURN", "SET"]],
         });
         return true;
+    }
+
+    /*
+     * THE CARD A MODULE DRAWS WHILE ITS KNOB IS TURNED.
+     *
+     * Same overlay slot as the peek and the opposite kind of screen: it FLOATS,
+     * so the page stays readable around it. That is why it is not gated on
+     * `clearScreen` the way the peek is -- it blanks only its own rect (see
+     * param_card.mjs) and therefore draws correctly for an embedded consumer
+     * that owns no frame at all.
+     *
+     * The peek wins when both could show. A card is an aid to reading one
+     * value; the peek is the list of values you are moving between, and the
+     * detent that raised it has already written.
+     *
+     * NO TIMER OF ITS OWN. `s.touched` is already "the knob being held, or the
+     * one just turned": held sets turnClaimMs to 0 so it never expires, a
+     * release clears it at once, and a turn no finger registered on expires
+     * through TURN_CLAIM_MS. That is the law every other follow-the-knob
+     * surface here obeys, and a second one would drift from it.
+     */
+    function drawDeclaredCard(ctx) {
+        if (!ctx) return false;
+        const slot = s.touched;
+        if (slot === undefined || slot === null || slot < 0) return false;
+        const meta = metaAt(slot);
+        const draw = cardFnFor(meta);
+        if (!draw) return false;
+        const key = keyAt(slot);
+        if (!key) return false;
+        return drawParamCard(ctx, {
+            meta,
+            draw,
+            name: meta && (meta.name || meta.label) ? (meta.name || meta.label) : key,
+            /* The SAME reading the header would show, through the one
+             * formatter -- a card that spelled a value differently from the
+             * strip above it would be a second formatter by another name. */
+            value: knobRowValue(key),
+            raw: s.values[key] === undefined ? null : s.values[key],
+            /*
+             * ONE STRIKE. A drawer that threw is retired for the session rather
+             * than re-entered up to sixty times a second, and the parameter
+             * falls back to the ordinary page -- which is what a host too old
+             * to know the field shows anyway, so the degraded state is one we
+             * already ship.
+             */
+            onError: () => {
+                const spec = cardSpec(meta);
+                if (spec) s.cardFns[spec.spec] = null;
+            },
+        });
     }
 
     let vizCache = null;

--- a/src/shared/param_pages/param_card.mjs
+++ b/src/shared/param_pages/param_card.mjs
@@ -23,6 +23,16 @@
  * at all, and keeps the library's "no file here clears the screen" contract
  * without an exception.
  *
+ * ⭑ A DRAWER CANNOT EXPRESS A SCREEN COORDINATE, exactly as a cell widget
+ * cannot. The drawer is handed a frameCtx scoped to the inside of the card, so
+ * (0,0) is its own top-left, ctx.width/height are the card's, and there is no
+ * accessor that reaches absolute space. The reasoning is frame_ctx.mjs's and
+ * applies here for the same reason it applies there: the rect is not stable.
+ * A card's size is per PARAMETER and the panel clamps it, so coordinates
+ * authored against one card are wrong on the next one -- and a floating card
+ * that could paint outside its own border would eat the page it is meant to
+ * float over. Two module draw hooks, one coordinate contract.
+ *
  * THE SPLIT: THE MODULE DECLARES THE SIZE, THIS FILE OWNS THE FRAME.
  * The card is positioned, clamped, cleared and bordered here; the drawer is
  * handed the content rect and paints inside it. A module that positioned itself
@@ -36,6 +46,7 @@
  */
 
 import { SCREEN_WIDTH, SCREEN_HEIGHT } from "../list_geometry.mjs";
+import { frameCtx } from "./frame_ctx.mjs";
 
 /** Border thickness. 2px reads as a frame where 1px reads as a hairline. */
 export const BORDER_W = 2;
@@ -119,6 +130,7 @@ export function paramCardContentRect(outer) {
  *
  * @param {object} ctx    fillRect / print / textWidth, as render() takes
  * @param {object} o      { meta, draw, name, value, raw, onError }
+ *                        draw is called as draw(frameCtx, { w, h, name, value, raw })
  * @returns {boolean}     true when a card was drawn
  */
 export function drawParamCard(ctx, o) {
@@ -138,9 +150,16 @@ export function drawParamCard(ctx, o) {
                  r.w - BORDER_W * 2, r.h - BORDER_W * 2, 0);
 
     const content = paramCardContentRect(r);
+    /*
+     * THE DRAWER GETS THE INSIDE OF THE CARD AND NOTHING ELSE. No x/y is passed
+     * because there is nothing for one to mean: the context's origin already IS
+     * the content rect's top-left, and a drawer that received both would be
+     * invited to add them.
+     */
+    const inner = frameCtx(ctx, content);
     try {
-        o.draw(ctx, {
-            x: content.x, y: content.y, w: content.w, h: content.h,
+        o.draw(inner, {
+            w: content.w, h: content.h,
             name: o.name === undefined ? "" : o.name,
             /* The FORMATTED reading, the same string the header would show. */
             value: o.value === undefined ? "" : o.value,

--- a/src/shared/param_pages/param_card.mjs
+++ b/src/shared/param_pages/param_card.mjs
@@ -1,0 +1,165 @@
+/**
+ * param_card.mjs — the floating card a MODULE draws while its knob is turned.
+ *
+ * Some values only mean something as a picture. A crossfade sitting between two
+ * named waveform anchors is a position, not a number; a delay feedback that
+ * computes to eleven audible repeats and then to HI CUT ONLY is a reading no
+ * unit can spell. The grid can draw an envelope, a filter and six other named
+ * graphics, but those are a fixed vocabulary — a module whose value falls
+ * outside it has had nowhere to put the picture, and has had to ship its own
+ * whole-screen editor to get one.
+ *
+ * So a parameter may name a drawer, and while its knob is held or has just been
+ * turned the drawer paints a card over the page:
+ *
+ *   { "key": "blend", "type": "float", "min": 0, "max": 1, "step": 0.01,
+ *     "card_script": "cards.js#blend_card", "card_w": 96, "card_h": 44 }
+ *
+ * ⭑ IT FLOATS, AND THAT IS WHY IT NEEDS NO CLEAR. The enum peek beside it is
+ * full-screen on purpose and therefore cannot draw without the frame owner's
+ * clearScreen — see renderOverlays. A card is the opposite: the page must stay
+ * visible around it, so it blanks its OWN rect with fillRect and never asks for
+ * the frame. That makes it drawable by an embedded consumer that owns no frame
+ * at all, and keeps the library's "no file here clears the screen" contract
+ * without an exception.
+ *
+ * THE SPLIT: THE MODULE DECLARES THE SIZE, THIS FILE OWNS THE FRAME.
+ * The card is positioned, clamped, cleared and bordered here; the drawer is
+ * handed the content rect and paints inside it. A module that positioned itself
+ * would eventually leave debris — the size is per parameter, so it changes as
+ * the focus moves between knobs, and a shrinking card must not leave the last
+ * one's edges behind.
+ *
+ * Frame grammar is the knob card's, deliberately: 2px border, one black row
+ * inside it, a cleared gutter outside. Two cards that differ only in who filled
+ * them should not read as two different objects.
+ */
+
+import { SCREEN_WIDTH, SCREEN_HEIGHT } from "../list_geometry.mjs";
+
+/** Border thickness. 2px reads as a frame where 1px reads as a hairline. */
+export const BORDER_W = 2;
+/** The black row inside the border. See knob_card.mjs — the gap is load-bearing. */
+export const GAP_W = 1;
+/** Cleared outside the border, so the card lifts off the page under it. */
+export const GUTTER = 2;
+
+const INSET = BORDER_W + GAP_W;
+
+/** What a card costs before the drawer gets any room. */
+export const CARD_CHROME = INSET * 2;
+
+/**
+ * The default when a module declares a drawer but no size. Wide enough for a
+ * short label and a bar, short enough to leave the page readable around it.
+ */
+export const DEFAULT_CARD_W = 96;
+export const DEFAULT_CARD_H = 34;
+
+/** Smallest card that can hold a border, its gap and one pixel of content. */
+const MIN_SIDE = CARD_CHROME + 1;
+
+function clampSide(v, dflt, max) {
+    const n = Math.round(Number(v));
+    /*
+     * A NONSENSE SIZE FALLS BACK, IT DOES NOT BREAK THE FRAME.
+     *
+     * Zero, negative, NaN and a string all arrive here from a hand-written
+     * module.json, and every one of them would otherwise draw a border with no
+     * inside — or, negative, a fillRect walking backwards across the page.
+     */
+    if (!isFinite(n) || n < MIN_SIDE) return Math.min(dflt, max);
+    return Math.min(n, max);
+}
+
+/**
+ * Where a card of this declared size sits: centred, clamped to the panel.
+ *
+ * Centred rather than anchored to the touched cell. The cell is 30px wide and a
+ * card is not, so anchoring would put most cards off the edge and the rest in a
+ * different place per knob — a picture that moves while you read it.
+ *
+ * @param {object} meta  the param's metadata; card_w / card_h are optional
+ * @returns {{x:number,y:number,w:number,h:number}} the OUTER rect
+ */
+export function paramCardRect(meta) {
+    const w = clampSide(meta && meta.card_w, DEFAULT_CARD_W, SCREEN_WIDTH - GUTTER * 2);
+    const h = clampSide(meta && meta.card_h, DEFAULT_CARD_H, SCREEN_HEIGHT - GUTTER * 2);
+    return {
+        x: Math.floor((SCREEN_WIDTH - w) / 2),
+        y: Math.floor((SCREEN_HEIGHT - h) / 2),
+        w,
+        h,
+    };
+}
+
+/** The rect the DRAWER gets: inside the border and its gap. */
+export function paramCardContentRect(outer) {
+    return {
+        x: outer.x + INSET,
+        y: outer.y + INSET,
+        w: outer.w - INSET * 2,
+        h: outer.h - INSET * 2,
+    };
+}
+
+/**
+ * Draw the frame and hand the inside to the module.
+ *
+ * ⚠ A DRAWER THAT THROWS MUST COST NOTHING AND SAY SO ONCE.
+ *
+ * This runs on the draw path, up to every frame while a knob is held, and the
+ * module's code is not ours. An exception escaping here would take the whole
+ * page down with it — and the failure this tree has already shipped once is
+ * worse than a crash: a hook whose thrower was caught but whose caller reported
+ * success, leaving whatever drew before the throw, then nothing, with no error
+ * anywhere. So the throw is caught HERE, `onError` is called once so the caller
+ * can retire the drawer for the session rather than re-entering it 60 times a
+ * second, and the frame is left as a plain empty card rather than a hole.
+ *
+ * @param {object} ctx    fillRect / print / textWidth, as render() takes
+ * @param {object} o      { meta, draw, name, value, raw, onError }
+ * @returns {boolean}     true when a card was drawn
+ */
+export function drawParamCard(ctx, o) {
+    if (!ctx || !o || typeof o.draw !== "function") return false;
+
+    const r = paramCardRect(o.meta);
+
+    /* Lift it off the page: clear the gutter, then the border, then the inside.
+     * Clipped at the panel edge by the caller`s own fillRect, which is why the
+     * gutter may safely be asked for outside it. */
+    ctx.fillRect(r.x - GUTTER, r.y - GUTTER, r.w + GUTTER * 2, r.h + GUTTER * 2, 0);
+    ctx.fillRect(r.x, r.y, r.w, BORDER_W, 1);
+    ctx.fillRect(r.x, r.y + r.h - BORDER_W, r.w, BORDER_W, 1);
+    ctx.fillRect(r.x, r.y, BORDER_W, r.h, 1);
+    ctx.fillRect(r.x + r.w - BORDER_W, r.y, BORDER_W, r.h, 1);
+    ctx.fillRect(r.x + BORDER_W, r.y + BORDER_W,
+                 r.w - BORDER_W * 2, r.h - BORDER_W * 2, 0);
+
+    const content = paramCardContentRect(r);
+    try {
+        o.draw(ctx, {
+            x: content.x, y: content.y, w: content.w, h: content.h,
+            name: o.name === undefined ? "" : o.name,
+            /* The FORMATTED reading, the same string the header would show. */
+            value: o.value === undefined ? "" : o.value,
+            /*
+             * The RAW wire value, for a drawer that has to compute rather than
+             * print — a repeat count, a position between anchors.
+             *
+             * ⚠ May be null: a key the module does not serve reads as "no
+             * answer", and the contract is that a drawer draws NOTHING
+             * interpretive then. A read that did not answer must never become a
+             * picture; that rule is why the grid reads on touch and turn and
+             * never on the draw path, and it does not stop applying because the
+             * pixels are somebody else`s.
+             */
+            raw: o.raw === undefined ? null : o.raw,
+        });
+    } catch (e) {
+        if (typeof o.onError === "function") o.onError(e);
+        return true;
+    }
+    return true;
+}

--- a/tests/host/test_param_card.sh
+++ b/tests/host/test_param_card.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A MODULE MAY DRAW THE CARD THAT FLOATS OVER THE PAGE WHILE ITS KNOB IS TURNED.
+#
+# Some values only mean something as a picture: a crossfade sitting between two
+# named anchors is a position, and a delay feedback that computes to eleven
+# repeats and then to silence is a reading no unit can spell. The grid draws
+# eight named graphics and a parameter outside that vocabulary has had nowhere
+# to put a picture at all.
+#
+# THREE THINGS HERE ARE EASY TO GET WRONG, AND EACH HAS ITS OWN SECTION.
+#
+# It must be OFF unless a host offers a loader and a module names a script --
+# every existing page has to render exactly as before. It must never LOAD on the
+# draw path, because nothing module-side is resident while the grid is up and
+# the host loader has no cache, so a load from the draw evaluates a script on
+# every frame of a turn. And a drawer that THROWS must leave the ordinary page
+# rather than a hole -- this tree has already shipped a hook whose thrower was
+# caught but whose caller reported success, which draws whatever came before the
+# throw and then nothing, with no error anywhere.
+#
+# NO APOSTROPHES BELOW THIS LINE inside the node script: it is a single-quoted
+# bash string, and one apostrophe ends it early with an error pointing nowhere
+# near the real line.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the param card tests" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { createController } from "./src/shared/param_pages/page_controller.mjs";
+import { paramCardRect, paramCardContentRect, drawParamCard,
+         DEFAULT_CARD_W, DEFAULT_CARD_H, BORDER_W, GAP_W }
+  from "./src/shared/param_pages/param_card.mjs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
+
+let fail = 0;
+const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
+
+const INSET = BORDER_W + GAP_W;
+
+/* `blend` declares a drawer and a size; `plain` declares nothing and is the
+   control for every default-off assertion below. */
+const CHAIN_PARAMS = [
+  { key: "blend", name: "Blend", type: "float", min: 0, max: 1, step: 0.01,
+    card_script: "cards.js#blend_card", card_w: 96, card_h: 44 },
+  { key: "plain", name: "Plain", type: "float", min: 0, max: 1, step: 0.01 },
+  { key: "shape", name: "Shape", type: "enum",
+    options: ["Sine", "Tri", "Saw", "Square", "Noise"],
+    card_script: "cards.js#shape_card" },
+];
+const HIER = { modes: null, levels: { root: { label: "T",
+  knobs: ["blend", "plain", "shape"],
+  params: CHAIN_PARAMS.map((p) => ({ key: p.key })) } } };
+
+let clock = 1000;
+function mk(io = {}) {
+  clock = 1000;
+  const store = { blend: "0.5", plain: "0.25", shape: "0" };
+  const ctl = createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return JSON.stringify(HIER);
+      if (b === "chain_params") return JSON.stringify(CHAIN_PARAMS);
+      return b in store ? store[b] : "";
+    },
+    setParam: (k, v) => { store[String(k).replace(/^[^:]+:/, "")] = String(v); },
+    announce: () => {},
+    now: () => clock,
+    ...io,
+  });
+  ctl.load({ prefix: "synth" });
+  for (let i = 0; i < 12; i++) ctl.tick();
+  const slotOf = (key) => (ctl.page.keys || []).indexOf(key);
+  return { ctl, store, slotOf };
+}
+
+/* A loader that records what it was asked for, so "loaded once, off the draw
+   path" is a count rather than an argument. */
+function recordingLoader(drawer) {
+  const calls = [];
+  return {
+    calls,
+    loadCard: (path, ref) => { calls.push(path + "#" + ref); return drawer; },
+  };
+}
+
+/* menu_layout reaches for print / fill_rect / set_pixel BY NAME, exactly as it
+   does on the device, so the peek half of renderOverlays needs them installed.
+   The card half does not -- it draws through the ctx it is handed -- and that
+   asymmetry is real rather than test scaffolding. */
+const GLOBAL_NAMES = ["print", "fill_rect", "set_pixel", "text_width",
+  "host_send_screenreader"];
+function paint(ctl, opts) {
+  const fb = createFramebuffer();
+  const g = {
+    print: fb.print, fill_rect: fb.fillRect, set_pixel: fb.setPixel,
+    text_width: fb.textWidth, host_send_screenreader: () => {},
+  };
+  for (const k of GLOBAL_NAMES) globalThis[k] = g[k];
+  let did;
+  try {
+    did = ctl.renderOverlays(drawContext(fb), opts || {});
+  } finally {
+    for (const k of GLOBAL_NAMES) delete globalThis[k];
+  }
+  return { did, fb };
+}
+const ink = (fb) => fb.pixels.reduce((n, v) => n + (v ? 1 : 0), 0);
+
+/* ===================================================================== 1 ==
+ * GEOMETRY: the module declares the size, and a nonsense size falls back
+ * rather than drawing a frame with no inside.
+ */
+{
+  const declared = paramCardRect({ card_w: 96, card_h: 44 });
+  ok(declared.w === 96 && declared.h === 44, "a declared size is honoured");
+  ok(declared.x === 16 && declared.y === 10,
+     "and it is centred on the 128x64 panel, got " + declared.x + "," + declared.y);
+
+  const dflt = paramCardRect({});
+  ok(dflt.w === DEFAULT_CARD_W && dflt.h === DEFAULT_CARD_H,
+     "no declaration gets the default size");
+
+  const huge = paramCardRect({ card_w: 400, card_h: 400 });
+  ok(huge.w <= 128 && huge.h <= 64 && huge.x >= 0 && huge.y >= 0,
+     "an oversize card is clamped to the panel, got " + huge.w + "x" + huge.h);
+
+  for (const bad of [0, -5, "wide", null, NaN, 3]) {
+    const r = paramCardRect({ card_w: bad, card_h: bad });
+    ok(r.w === DEFAULT_CARD_W && r.h === DEFAULT_CARD_H,
+       "a nonsense size (" + String(bad) + ") falls back to the default");
+  }
+
+  const content = paramCardContentRect(declared);
+  ok(content.x === declared.x + INSET && content.y === declared.y + INSET
+     && content.w === declared.w - INSET * 2 && content.h === declared.h - INSET * 2,
+     "the drawer gets the rect INSIDE the border and its gap");
+}
+
+/* ===================================================================== 2 ==
+ * THE FRAME IS OURS, THE INSIDE IS THEIRS.
+ */
+{
+  const fb = createFramebuffer();
+  let got = null;
+  const drew = drawParamCard(drawContext(fb), {
+    meta: { card_w: 96, card_h: 44 }, name: "Blend", value: "0.50", raw: "0.5",
+    draw: (ctx, o) => { got = o; },
+  });
+  ok(drew === true, "drawParamCard reports that it drew");
+  ok(!!got, "the module drawer was called");
+  const r = paramCardRect({ card_w: 96, card_h: 44 });
+  ok(got && got.x === r.x + INSET && got.w === r.w - INSET * 2,
+     "it is handed the CONTENT rect, not the outer one");
+  ok(got && got.name === "Blend" && got.value === "0.50" && got.raw === "0.5",
+     "and the name, the formatted reading and the raw wire value");
+  ok(ink(fb) > 0, "the frame is drawn even though the drawer painted nothing");
+  ok(fb.clipped() === 0, "and nothing landed off the panel, got " + fb.clipped());
+}
+
+/* ===================================================================== 3 ==
+ * A READ THAT DID NOT ANSWER MUST NOT BECOME A PICTURE. The rule does not
+ * stop applying because the pixels belong to a module: raw arrives as null so
+ * a drawer can tell "no answer" from a real zero.
+ */
+{
+  const fb = createFramebuffer();
+  let got = null;
+  drawParamCard(drawContext(fb), {
+    meta: {}, name: "X", value: "--",
+    draw: (ctx, o) => { got = o; },
+  });
+  ok(got && got.raw === null, "an unanswered read is handed through as null, not as 0");
+}
+
+/* ===================================================================== 4 ==
+ * A DRAWER THAT THROWS COSTS ONE FRAME AND IS RETIRED.
+ *
+ * The failure this guards is not the crash. It is the shape already shipped
+ * once here: a hook that threw, was caught, and reported success -- leaving
+ * whatever drew before the throw and then nothing, with no error.
+ */
+{
+  const fb = createFramebuffer();
+  let errs = 0;
+  let drew;
+  try {
+    drew = drawParamCard(drawContext(fb), {
+      meta: { card_w: 96, card_h: 44 }, name: "B", value: "1",
+      draw: () => { throw new Error("module bug"); },
+      onError: () => { errs++; },
+    });
+  } catch (e) {
+    ok(false, "the throw escaped drawParamCard: " + e.message);
+  }
+  ok(drew === true, "it still reports the frame it drew");
+  ok(errs === 1, "onError fires once so the caller can retire the drawer, got " + errs);
+  ok(ink(fb) > 0, "and an empty card is left, never a hole");
+}
+
+/* ===================================================================== 5 ==
+ * OFF BY DEFAULT, TWICE OVER: no loader, or no declaration.
+ */
+{
+  const { ctl, slotOf } = mk();                       /* no io.loadCard */
+  ctl.onKnobTouch(slotOf("blend"), true);
+  const { did, fb } = paint(ctl);
+  ok(did === false && ink(fb) === 0,
+     "a host with no loader draws no card, even for a declaring param");
+}
+{
+  const rec = recordingLoader(() => {});
+  const { ctl, slotOf } = mk({ loadCard: rec.loadCard });
+  ctl.onKnobTouch(slotOf("plain"), true);
+  const { did, fb } = paint(ctl);
+  ok(did === false && ink(fb) === 0, "a param declaring nothing draws no card");
+  ok(rec.calls.length === 0, "and nothing was loaded for it");
+}
+
+/* ===================================================================== 6 ==
+ * IT DRAWS, from a touch, into a real framebuffer.
+ */
+{
+  let seen = null;
+  const rec = recordingLoader((ctx, o) => {
+    seen = o;
+    ctx.fillRect(o.x, o.y, o.w, o.h, 1);
+  });
+  const { ctl, slotOf } = mk({ loadCard: rec.loadCard });
+  ctl.onKnobTouch(slotOf("blend"), true);
+  const { did, fb } = paint(ctl);
+  ok(did === true, "touching a declaring knob draws its card");
+  ok(rec.calls[0] === "cards.js#blend_card",
+     "the declared script and export are what got loaded, got " + rec.calls[0]);
+  ok(seen && seen.name === "Blend", "the drawer is told which param it is drawing");
+  ok(ink(fb) > 0 && fb.clipped() === 0, "pixels landed, and none off the panel");
+}
+
+/* ===================================================================== 7 ==
+ * IT FLOATS, SO IT NEEDS NO CLEAR -- the difference from the enum peek beside
+ * it, and the reason an embedded consumer that owns no frame still gets one.
+ */
+{
+  const rec = recordingLoader((ctx, o) => ctx.fillRect(o.x, o.y, o.w, o.h, 1));
+  const { ctl, slotOf } = mk({ loadCard: rec.loadCard });
+  ctl.onKnobTouch(slotOf("blend"), true);
+  let cleared = 0;
+  const { did, fb } = paint(ctl, { clearScreen: () => { cleared++; } });
+  ok(did === true && cleared === 0,
+     "it draws WITHOUT clearing the frame -- the page stays readable around it");
+  ok(ink(fb) < fb.pixels.length,
+     "and it does not cover the whole panel, which is what full-screen would mean");
+}
+
+/* ===================================================================== 8 ==
+ * THE LOAD IS ON THE GESTURE, NEVER ON THE DRAW.
+ *
+ * A load from the draw path evaluates the module script on every frame of a
+ * turn. Counting the loader is the only way to see that, because the pixels
+ * are identical either way.
+ */
+{
+  const rec = recordingLoader((ctx, o) => ctx.fillRect(o.x, o.y, o.w, o.h, 1));
+  const { ctl, slotOf } = mk({ loadCard: rec.loadCard });
+  const slot = slotOf("blend");
+  ctl.onKnobTouch(slot, true);
+  for (let i = 0; i < 30; i++) paint(ctl);
+  ok(rec.calls.length === 1,
+     "30 frames later it has still been loaded exactly once, got " + rec.calls.length);
+  ctl.onKnobTouch(slot, false);
+  ctl.onKnobTouch(slot, true);
+  ok(rec.calls.length === 1,
+     "and a second touch reuses the cached drawer, got " + rec.calls.length);
+}
+{
+  /* A loader that answers null is asked ONCE. A missing file must not be
+     re-evaluated on every touch for the rest of the session. */
+  let calls = 0;
+  const { ctl, slotOf } = mk({ loadCard: () => { calls++; return null; } });
+  const slot = slotOf("blend");
+  for (let i = 0; i < 5; i++) { ctl.onKnobTouch(slot, true); ctl.onKnobTouch(slot, false); }
+  const { did } = paint(ctl);
+  ok(calls === 1, "a null answer is cached, not retried, got " + calls);
+  ok(did === false, "and no card is drawn");
+}
+
+/* ===================================================================== 9 ==
+ * RELEASE TAKES IT DOWN, and it rides the SAME law as every other
+ * follow-the-knob surface here rather than a timer of its own.
+ */
+{
+  const rec = recordingLoader((ctx, o) => ctx.fillRect(o.x, o.y, o.w, o.h, 1));
+  const { ctl, slotOf } = mk({ loadCard: rec.loadCard });
+  const slot = slotOf("blend");
+  ctl.onKnobTouch(slot, true);
+  ok(paint(ctl).did === true, "up while held");
+  ctl.onKnobTouch(slot, false);
+  ok(paint(ctl).did === false, "and gone the moment the finger leaves");
+}
+
+/* ==================================================================== 10 ==
+ * THE PEEK WINS. A card is an aid to reading ONE value; the peek is the list
+ * of values you are moving between, and it is full-screen on purpose.
+ */
+{
+  const rec = recordingLoader((ctx, o) => ctx.fillRect(o.x, o.y, o.w, o.h, 1));
+  const { ctl, slotOf } = mk({ loadCard: rec.loadCard });
+  const s = slotOf("shape");
+  for (let i = 0; i < 6; i++) { clock += 20; ctl.onKnobTurn(s, 1, clock); }
+  ok(!!ctl.enumPeek(), "the fixture really does raise a peek");
+  let cleared = 0;
+  const { did } = paint(ctl, { clearScreen: () => { cleared++; } });
+  ok(did === true && cleared === 1,
+     "the peek is what draws, and it still takes the frame clear");
+}
+
+/* ==================================================================== 11 ==
+ * NO EXISTING PAGE MOVES. The whole default-off claim, stated as pixels: the
+ * same fixture with no loader must render byte-identically to one whose params
+ * carry no declaration at all.
+ */
+{
+  const render = (io) => {
+    const { ctl } = mk(io);
+    const fb = createFramebuffer();
+    ctl.render(drawContext(fb), {});
+    return fb.pixels.join(",");
+  };
+  ok(render({}) === render({ loadCard: () => () => {} }),
+     "the PAGE renders identically whether or not a loader is present");
+}
+
+console.log(fail === 0 ? "ALL PARAM CARD CHECKS PASSED" : (fail + " FAILED"));
+process.exit(fail === 0 ? 0 : 1);
+'

--- a/tests/host/test_param_card.sh
+++ b/tests/host/test_param_card.sh
@@ -32,6 +32,7 @@ if ! command -v node >/dev/null 2>&1; then
 fi
 
 node --input-type=module -e '
+import { readFileSync } from "node:fs";
 import { createController } from "./src/shared/param_pages/page_controller.mjs";
 import { paramCardRect, paramCardContentRect, drawParamCard,
          DEFAULT_CARD_W, DEFAULT_CARD_H, BORDER_W, GAP_W }
@@ -333,6 +334,50 @@ const ink = (fb) => fb.pixels.reduce((n, v) => n + (v ? 1 : 0), 0);
   };
   ok(render({}) === render({ loadCard: () => () => {} }),
      "the PAGE renders identically whether or not a loader is present");
+}
+
+/* ==================================================================== 12 ==
+ * THE HOST TAKES A CARD EXPORT AS A FUNCTION, NOT AS AN OVERLAY FACTORY.
+ *
+ * A source pin, because the failure it guards is host-side and silent. The card
+ * loader first reused loadCanvasOverlayScript, which resolves a canvas OVERLAY
+ * OBJECT — and resolveOverlayObject treats a function candidate as a FACTORY:
+ * it CALLS it and keeps whatever object comes back. So the drawer was invoked
+ * with no arguments, threw on the rect it was never given, and was discarded as
+ * "overlay factory returned invalid value". The loader answered null, the
+ * controller cached that null exactly as designed, and the knob had no picture
+ * — no error anywhere, and only on the consumer that used this loader.
+ */
+{
+  const host = readFileSync("src/shadow/shadow_ui.js", "utf8");
+
+  ok(/function loadCardDrawer\(/.test(host),
+     "the host has a loader dedicated to card drawers");
+
+  const at = host.indexOf("function loadCardDrawer(");
+  const body = host.slice(at, host.indexOf("\nfunction ", at + 10));
+
+  ok(/typeof fn === "function"/.test(body),
+     "it accepts the export as a FUNCTION");
+  ok(!/loadCanvasOverlayScript|resolveOverlayFromGlobals|resolveOverlayObject/.test(body),
+     "and does NOT route a card through the canvas-overlay resolver, which "
+     + "would CALL it as a factory");
+
+  /* The call site must use it. A loader nothing calls is the same bug back. */
+  const ctxAt = host.indexOf("_ctx.loadCardScript");
+  const ctxBody = host.slice(ctxAt, ctxAt + 600);
+  ok(/loadCardDrawer\(/.test(ctxBody),
+     "and the ctx hook goes through it");
+  ok(!/loadCanvasOverlayScript\(/.test(ctxBody),
+     "not through the canvas one");
+
+  /* The premise, so this section cannot quietly stop meaning anything: the
+     overlay resolver really does call a function candidate. */
+  const roAt = host.indexOf("function resolveOverlayObject(");
+  const roBody = host.slice(roAt, host.indexOf("\nfunction ", roAt + 10));
+  ok(/typeof candidate === "function"/.test(roBody) && /candidate\(\)/.test(roBody),
+     "PREMISE: resolveOverlayObject still calls a function candidate as a factory "
+     + "— if this ever stops being true, the section above is obsolete, not wrong");
 }
 
 console.log(fail === 0 ? "ALL PARAM CARD CHECKS PASSED" : (fail + " FAILED"));

--- a/tests/host/test_param_card.sh
+++ b/tests/host/test_param_card.sh
@@ -148,20 +148,77 @@ const ink = (fb) => fb.pixels.reduce((n, v) => n + (v ? 1 : 0), 0);
  */
 {
   const fb = createFramebuffer();
-  let got = null;
+  let got = null, gotCtx = null;
   const drew = drawParamCard(drawContext(fb), {
     meta: { card_w: 96, card_h: 44 }, name: "Blend", value: "0.50", raw: "0.5",
-    draw: (ctx, o) => { got = o; },
+    draw: (ctx, o) => { gotCtx = ctx; got = o; },
   });
   ok(drew === true, "drawParamCard reports that it drew");
   ok(!!got, "the module drawer was called");
   const r = paramCardRect({ card_w: 96, card_h: 44 });
-  ok(got && got.x === r.x + INSET && got.w === r.w - INSET * 2,
-     "it is handed the CONTENT rect, not the outer one");
+  ok(got && got.w === r.w - INSET * 2 && got.h === r.h - INSET * 2,
+     "it is handed the size of the space INSIDE the border and its gap");
+  ok(got && got.x === undefined && got.y === undefined,
+     "and NO x/y -- there is no absolute position for a drawer to be given");
+  ok(gotCtx && gotCtx.width === got.w && gotCtx.height === got.h,
+     "the context it draws through is the cards own, not the panels");
   ok(got && got.name === "Blend" && got.value === "0.50" && got.raw === "0.5",
      "and the name, the formatted reading and the raw wire value");
   ok(ink(fb) > 0, "the frame is drawn even though the drawer painted nothing");
   ok(fb.clipped() === 0, "and nothing landed off the panel, got " + fb.clipped());
+}
+
+/* ==================================================================== 2b ==
+ * A DRAWER CANNOT EXPRESS A COORDINATE OUTSIDE ITS CARD.
+ *
+ * The same rule #405 made for a cell widget, for the same reason and through
+ * the same file: the cards rect is per PARAMETER and clamped to the panel, so
+ * absolute coordinates authored against one card are wrong on the next. Here
+ * it matters twice over -- a floating card that could paint outside its border
+ * would eat the page it exists to float over.
+ *
+ * (0,0) IS THE INSIDE OF THE CARD. This test pins that by drawing a rect that
+ * starts before the origin and runs far past the far corner: what lands must
+ * be exactly the content rect, no more, and the frame must SAY it clipped
+ * rather than absorbing it silently.
+ */
+{
+  const fb = createFramebuffer();
+  const outer = paramCardRect({ card_w: 96, card_h: 44 });
+  const inside = { x: outer.x + INSET, y: outer.y + INSET,
+                   w: outer.w - INSET * 2, h: outer.h - INSET * 2 };
+  let clipped = -1;
+  drawParamCard(drawContext(fb), {
+    meta: { card_w: 96, card_h: 44 }, name: "B", value: "1", raw: "1",
+    draw: (ctx) => {
+      ctx.fillRect(-5, -5, 200, 200, 1);
+      ctx.print(-9, -9, "SPILL", 1);
+      clipped = ctx.clipped();
+    },
+  });
+  ok(clipped > 0, "the frame COUNTS the overflow rather than hiding it, got " + clipped);
+
+  /* Every lit pixel outside the cards inside is a leak -- except the border
+   * itself, which is ours and was drawn before the drawer ran. */
+  let outsideContent = 0, outsideCard = 0;
+  for (let y = 0; y < fb.height; y++) {
+    for (let x = 0; x < fb.width; x++) {
+      if (!fb.pixels[y * fb.width + x]) continue;
+      const inContent = x >= inside.x && x < inside.x + inside.w
+                     && y >= inside.y && y < inside.y + inside.h;
+      const inCard = x >= outer.x && x < outer.x + outer.w
+                  && y >= outer.y && y < outer.y + outer.h;
+      if (!inContent) outsideContent++;
+      if (!inCard) outsideCard++;
+    }
+  }
+  ok(outsideCard === 0,
+     "nothing the drawer asked for landed outside the CARD, got " + outsideCard);
+  /* What is left outside the content rect can only be our own border. */
+  const borderInk = 2 * (outer.w * BORDER_W) + 2 * ((outer.h - BORDER_W * 2) * BORDER_W);
+  ok(outsideContent === borderInk,
+     "and outside the content rect there is only OUR border, got "
+     + outsideContent + " want " + borderInk);
 }
 
 /* ===================================================================== 3 ==


### PR DESCRIPTION
### The gap

Some values only mean something as a picture, and the grid's eight named graphics are a fixed vocabulary. A crossfade sitting between two named waveform anchors is a *position*, not a number; a delay feedback that computes to eleven audible repeats and then to HI CUT ONLY is a reading no unit can spell. A module whose value falls outside the built-in vocabulary has had nowhere to put the picture, and has had to ship a whole-screen editor to get one.

Between the two surfaces that exist there is a third that does not:

| surface | scale | already exists |
|---|---|---|
| `type: "canvas"` | the whole screen | yes |
| `drawCell` (#405) | one knob's box | yes, as of last week |
| **a card over the page, during a turn** | the value under your finger | **this PR** |

### What it is

A parameter names a drawer and a size:

```json
{ "key": "blend", "name": "Blend", "type": "float", "min": 0, "max": 1,
  "card_script": "cards.js#blend_card", "card_w": 96, "card_h": 44 }
```

While that knob is held or has just been turned, `param_card.mjs` clears a centred rect, draws the frame, and hands the inside to the module. Release and it is gone.

### How it relates to #405

**Same coordinate contract, through the same file.** The drawer receives a `frameCtx` scoped to the inside of the card, so `(0,0)` is its own top-left and there is no accessor that reaches absolute space. Your reasoning for that rule applies here for a second reason as well: a card's size is declared *per parameter* and clamped to the panel, so coordinates authored against one card are wrong on the next — and a floating card that could paint outside its border would eat the page it exists to float over. Two module draw hooks, one rule.

`tests/host/test_param_card.sh` pins it the way it has to be pinned: a drawer painting `(-5, -5, 200, 200)` lands nothing outside the card, and the frame *counts* the overflow rather than absorbing it. (Checked by reverting the change — the assertion fails 4 of 4, so it is not a guard that cries wolf.)

### The parts that are easy to get wrong, each with its own test section

- **Off unless both sides opt in.** A host with no loader draws no card even for a declaring parameter, and a parameter declaring nothing is untouched. A module may ship `card_script` for years and change nothing on a host that has never heard of it.
- **It floats, so it needs no `clearScreen`.** The enum peek beside it is full-screen on purpose and cannot draw without the frame owner's clear. A card blanks only its own rect, which keeps the library's "no file here clears the screen" contract without an exception and leaves it drawable by an embedded consumer that owns no frame.
- **Never loaded on the draw path.** Nothing module-side is resident while the grid is up and the host loader has no cache, so a load from `renderOverlays` would evaluate a module script every frame of a turn. `warmCard` runs from touch and turn, once per spec per session — and caches the *failures* too, so a missing file or bad export costs one attempt, not one per touch.
- **One strike.** A drawer that throws is retired for the session and the card is left as an empty frame rather than a hole. (The failure this guards is not the crash: it is the shape where a hook throws, is caught, and the caller reports success — leaving whatever drew before the throw, then nothing, with no error anywhere.)
- **No reads.** `getParam` is absent; the formatted reading and the raw wire value arrive as arguments. `raw` **may be null** — a key the module does not serve reads as "no answer", and a read that did not answer must never become a picture.

### Docs

`docs/MODULES.md` gains the author contract next to the `drawCell` section; `docs/PARAM_PAGES.md` gains the design note next to yours.

One thing recorded there rather than changed: `frameCtx` exposes `fillRect` / `print` / `textWidth`, while the context the host hands the grid also carries `line`, `setPixel`, `fillCircle`, `drawCircle` and `drawArc` — and your own design spec names `setPixel` and `drawLine` as part of a frame context. Passing them through, clipped, looks like a separate generic change to `frame_ctx.mjs` and would benefit cell widgets equally, so it is not folded in here. Happy to follow up with it if you want it.

### Verification

Rebased onto `c8cb169e`. `test_param_card.sh` green, `make -C tests/host test` green, every `tests/host/*.sh` green, and `tests/fixtures/movy-geom-baseline.txt` byte-unchanged.

(One unrelated pre-existing failure on `main`: `test_knob_engine_single.sh` reports `MIN_STEP_RANGE_FRAC is referenced outside the engine: src//shared/knob_engine.mjs` — the file it names *is* the engine; the path is built with a double slash so its own exclusion never matches. Not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fqirYjqdLfXoFQJN5C9zL