### PR TITLE
param_card: centre in the page's frame, and leave nothing behind on a throw

### DIFF
--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1349,6 +1349,14 @@ grid's business is eight values at once. A card answers a different question —
 *what does THIS value mean* — for the one knob under a finger. The two do not
 compete: a page may have both, and the card only exists during the gesture.
 
+**A card is centred in the page's FRAME, not on the panel.** `render()` takes a
+`rect` so a tool can embed the grid in its own chrome, and `paramCardRect` is
+given that rect (defaulting to the whole panel, so the full-screen host is
+unchanged). It centred on `SCREEN_WIDTH`/`SCREEN_HEIGHT` unconditionally at
+first, which put the card across the whole display while the page it belongs to
+sat in a corner — not floating over that page but painting over the host's
+screen. Needing no clear is not the same as knowing where to draw.
+
 **It FLOATS, and that is why it needs no `clearScreen`.** The enum peek beside it
 is full-screen on purpose and therefore cannot draw without the frame owner's
 clear. A card blanks its own rect with `fillRect`, keeps the page visible around

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -3482,6 +3482,12 @@ export function createController(io = {}) {
     }
 
     function render(ctx, { title, rect, footer, bands } = {}) {
+        /* The frame this page was drawn into, remembered for renderOverlays.
+         * A floating card is centred in it -- on the panel for the full-screen
+         * host, and inside the embedded region for a tool that supplies a rect.
+         * Kept here rather than passed to renderOverlays so an existing caller
+         * needs no change. */
+        s.frameRect = rect || null;
         /* LAYOUT_LIST is LAYOUT_MOVY with one page kind arranged differently, so
          * it takes the same branch: the header, bank bar, footer, section
          * picker, menu, items and preset pages are all literally the same draws.
@@ -3859,6 +3865,9 @@ export function createController(io = {}) {
         return drawParamCard(ctx, {
             meta,
             draw,
+            /* Where the page actually is. Null for the full-screen host, which
+             * param_card reads as the whole panel. */
+            frame: s.frameRect || null,
             name: meta && (meta.name || meta.label) ? (meta.name || meta.label) : key,
             /* The SAME reading the header would show, through the one
              * formatter -- a card that spelled a value differently from the

--- a/src/shared/param_pages/param_card.mjs
+++ b/src/shared/param_pages/param_card.mjs
@@ -21,7 +21,8 @@
  * visible around it, so it blanks its OWN rect with fillRect and never asks for
  * the frame. That makes it drawable by an embedded consumer that owns no frame
  * at all, and keeps the library's "no file here clears the screen" contract
- * without an exception.
+ * without an exception. Such a consumer passes its own rect (see
+ * paramCardRect); needing no clear is not the same as knowing where to draw.
  *
  * ⭑ A DRAWER CANNOT EXPRESS A SCREEN COORDINATE, exactly as a cell widget
  * cannot. The drawer is handed a frameCtx scoped to the inside of the card, so
@@ -84,21 +85,38 @@ function clampSide(v, dflt, max) {
 }
 
 /**
- * Where a card of this declared size sits: centred, clamped to the panel.
+ * Where a card of this declared size sits: centred, clamped to its frame.
  *
  * Centred rather than anchored to the touched cell. The cell is 30px wide and a
  * card is not, so anchoring would put most cards off the edge and the rest in a
  * different place per knob — a picture that moves while you read it.
  *
- * @param {object} meta  the param's metadata; card_w / card_h are optional
+ * ⚠ CENTRED IN THE CALLER'S FRAME, NOT THE SCREEN.
+ *
+ * This took SCREEN_WIDTH/SCREEN_HEIGHT unconditionally, which is right for the
+ * full-screen host and wrong for the one case this file claims to support: a
+ * tool that embeds the grid in its own chrome (render() takes a `rect` for
+ * exactly that). A card centred on the panel while the page it belongs to sits
+ * in a corner is not floating over that page, it is painting over the host's
+ * screen — and "drawable by an embedded consumer" was the claim being made two
+ * paragraphs up. A frame is now passed in, defaulting to the whole panel so the
+ * full-screen caller is unchanged.
+ *
+ * @param {object} meta   the param's metadata; card_w / card_h are optional
+ * @param {object} [frame] {x,y,w,h} to centre within; defaults to the panel
  * @returns {{x:number,y:number,w:number,h:number}} the OUTER rect
  */
-export function paramCardRect(meta) {
-    const w = clampSide(meta && meta.card_w, DEFAULT_CARD_W, SCREEN_WIDTH - GUTTER * 2);
-    const h = clampSide(meta && meta.card_h, DEFAULT_CARD_H, SCREEN_HEIGHT - GUTTER * 2);
+export function paramCardRect(meta, frame) {
+    const fx = frame && Number.isFinite(frame.x) ? frame.x : 0;
+    const fy = frame && Number.isFinite(frame.y) ? frame.y : 0;
+    const fw = frame && frame.w > 0 ? frame.w : SCREEN_WIDTH;
+    const fh = frame && frame.h > 0 ? frame.h : SCREEN_HEIGHT;
+
+    const w = clampSide(meta && meta.card_w, DEFAULT_CARD_W, Math.max(MIN_SIDE, fw - GUTTER * 2));
+    const h = clampSide(meta && meta.card_h, DEFAULT_CARD_H, Math.max(MIN_SIDE, fh - GUTTER * 2));
     return {
-        x: Math.floor((SCREEN_WIDTH - w) / 2),
-        y: Math.floor((SCREEN_HEIGHT - h) / 2),
+        x: fx + Math.floor((fw - w) / 2),
+        y: fy + Math.floor((fh - h) / 2),
         w,
         h,
     };
@@ -136,7 +154,7 @@ export function paramCardContentRect(outer) {
 export function drawParamCard(ctx, o) {
     if (!ctx || !o || typeof o.draw !== "function") return false;
 
-    const r = paramCardRect(o.meta);
+    const r = paramCardRect(o.meta, o.frame);
 
     /* Lift it off the page: clear the gutter, then the border, then the inside.
      * Clipped at the panel edge by the caller`s own fillRect, which is why the
@@ -177,6 +195,16 @@ export function drawParamCard(ctx, o) {
             raw: o.raw === undefined ? null : o.raw,
         });
     } catch (e) {
+        /*
+         * RE-CLEAR WHAT IT MANAGED TO PAINT.
+         *
+         * The comment above promised "a plain empty card rather than a hole",
+         * and without this it was not one: a drawer that paints and THEN throws
+         * leaves its half-finished output sitting inside the frame, which is a
+         * picture built from an answer that did not arrive. Measured at 400 lit
+         * pixels for a drawer that filled a rect before throwing.
+         */
+        ctx.fillRect(content.x, content.y, content.w, content.h, 0);
         if (typeof o.onError === "function") o.onError(e);
         return true;
     }

--- a/tests/host/test_param_card.sh
+++ b/tests/host/test_param_card.sh
@@ -437,6 +437,77 @@ const ink = (fb) => fb.pixels.reduce((n, v) => n + (v ? 1 : 0), 0);
      + "— if this ever stops being true, the section above is obsolete, not wrong");
 }
 
+/* -------------------------------------------------------------------------
+ * A CARD IS CENTRED IN THE PAGES FRAME, NOT ON THE PANEL.
+ *
+ * paramCardRect took SCREEN_WIDTH/SCREEN_HEIGHT unconditionally. That is right
+ * for the full-screen host and wrong for the case this file claims to support:
+ * render() takes a rect so a tool can embed the grid in its own chrome, and a
+ * card centred on the panel while the page sits in a corner is not floating
+ * over that page -- it is painting over the hosts screen.
+ * ------------------------------------------------------------------------- */
+{
+  const full = paramCardRect({ card_w: 96, card_h: 44 });
+  ok(full.x === 16 && full.y === 10,
+     "with no frame the card centres on the panel, exactly as before");
+
+  const FRAME = { x: 0, y: 20, w: 64, h: 44 };
+  const r = paramCardRect({ card_w: 96, card_h: 44 }, FRAME);
+  ok(r.x >= FRAME.x && r.y >= FRAME.y &&
+     r.x + r.w <= FRAME.x + FRAME.w && r.y + r.h <= FRAME.y + FRAME.h,
+     "a card is CONTAINED by the frame it was given");
+  ok(r.w <= FRAME.w - 4, "and its width is clamped to that frame, not the panel");
+
+  const off = paramCardRect({ card_w: 40, card_h: 20 },
+                            { x: 60, y: 30, w: 60, h: 30 });
+  ok(off.x >= 60 && off.y >= 30, "a card follows a frame that is not at the origin");
+
+  for (const f of [{ x: 0, y: 0, w: 1, h: 1 }, { x: 0, y: 0, w: 0, h: 0 }]) {
+    const d = paramCardRect({ card_w: 96, card_h: 44 }, f);
+    ok(d.w > 0 && d.h > 0,
+       "a " + f.w + "x" + f.h + " frame still yields a positive rect");
+  }
+}
+
+/* -------------------------------------------------------------------------
+ * A DRAWER THAT PAINTS AND THEN THROWS LEAVES NOTHING BEHIND.
+ *
+ * The frame was documented as "a plain empty card rather than a hole" and was
+ * not one: the partial output stayed inside it -- a picture built from an
+ * answer that never arrived. Measured at 400 lit pixels before the fix.
+ * ------------------------------------------------------------------------- */
+{
+  const px = new Set();
+  const ctx = {
+    fillRect(x, y, w, h, c) {
+      for (let j = 0; j < h; j++) for (let i = 0; i < w; i++) {
+        const k = (x + i) + "," + (y + j);
+        if (c) px.add(k); else px.delete(k);
+      }
+    },
+    print() {}, textWidth: (t) => String(t).length * 4,
+  };
+  let errs = 0;
+  drawParamCard(ctx, {
+    meta: { card_w: 96, card_h: 44 },
+    draw: (c) => { c.fillRect(0, 0, 40, 10, 1); throw new Error("halfway"); },
+    name: "X", value: "1", raw: "1",
+    onError: () => { errs++; },
+  });
+  ok(errs === 1, "the throw is reported exactly once");
+
+  const outer = paramCardRect({ card_w: 96, card_h: 44 });
+  const c0 = paramCardContentRect(outer);
+  let inside = 0;
+  for (const k of px) {
+    const xy = k.split(",");
+    const x = Number(xy[0]), y = Number(xy[1]);
+    if (x >= c0.x && x < c0.x + c0.w && y >= c0.y && y < c0.y + c0.h) inside++;
+  }
+  ok(inside === 0,
+     "no partial output survives the throw -- the card really is empty, got " + inside);
+}
+
 console.log(fail === 0 ? "ALL PARAM CARD CHECKS PASSED" : (fail + " FAILED"));
 process.exit(fail === 0 ? 0 : 1);
 '


### PR DESCRIPTION
Two review findings from #410, fixed in house. Both narrow, and both places where
the file's own comment claimed more than the code did.

## Centred in the frame, not on the panel

`paramCardRect` took `SCREEN_WIDTH`/`SCREEN_HEIGHT` unconditionally. Right for the
full-screen host, wrong for the one case the file says it supports: `render()`
takes a `rect` so a tool can embed the grid in its own chrome (#373), and the
controller was not keeping it.

A page embedded at `{x:0,y:20,w:64,h:44}` still got its card at `x=16 w=96` —
across the whole display, painting over the host's chrome rather than floating
over the page it belongs to. The file claimed to be *"drawable by an embedded
consumer that owns no frame at all"*; it was drawable there and did not know
where to draw. **Needing no clear is not the same as knowing where.**

The frame now comes in, defaulting to the whole panel, so the full-screen caller
is byte-identical — pinned by an assertion that the default rect is still
`x=16 y=10`.

## Nothing survives a throw

The `catch` reported the error and returned without re-clearing, so a drawer that
painted and *then* threw left its half-finished output inside the frame —
measured at **400 lit pixels**. The comment promised *"a plain empty card rather
than a hole"*, and a partial picture built from an answer that never arrived is
the thing this tree keeps writing rules against.

## Verification

Both new assertions verified to fail with the fixes reverted — 3 of 3 on the
frame, and the throw case reporting 400 rather than 0. 248 host tests green,
C suite clean.

## Not included, deliberately

`frameCtx` still exposes only `fillRect` / `print` / `textWidth`, while the host's
grid context also carries `line`, `setPixel`, `fillCircle`, `drawCircle` and
`drawArc`. #410 flagged that and correctly left it out; it is a generic
`frame_ctx.mjs` change benefiting cell widgets equally, and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LjRrjvkLSr7FqyZZpzBb8