### PR TITLE
widget-test: a real card, so all three module surfaces have one example

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2064,9 +2064,15 @@ eight knob boxes: per-pixel blitting would cost ~1 ms of the 1.68 ms page render
 
 ##### The reference module
 
-`src/modules/audio_fx/widget-test/` is a working example: one `canvas.js`
-supplying both a `drawCell` segmented meter and the fullscreen `draw`, plus a
-passthrough DSP so it is a real, loadable chain FX.
+`src/modules/audio_fx/widget-test/` is a working example of **all three**
+module-supplied surfaces on one parameter: `canvas.js` supplies the `drawCell`
+segmented meter and the fullscreen `draw`, `cards.js` supplies the card that
+floats while the knob turns, and a passthrough DSP makes it a real, loadable
+chain FX.
+
+Its card is also the reference for the null contract: `raw` may be null, and the
+drawer prints `--` with **no bar** rather than a bar at zero, because a bar at
+zero is indistinguishable from a genuine zero.
 
 **It does not ship.** Like `gesture-test` and `sysex-test` it is a hardware
 fixture, built and packaged only on request:

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -596,6 +596,7 @@ if [ -n "${SCHWUNG_BUILD_TEST_MODULES:-}" ]; then
         -lm
     cp src/modules/audio_fx/widget-test/module.json \
        src/modules/audio_fx/widget-test/canvas.js \
+       src/modules/audio_fx/widget-test/cards.js \
        src/modules/audio_fx/widget-test/help.json \
        build/modules/audio_fx/widget-test/
 fi

--- a/src/modules/audio_fx/widget-test/cards.js
+++ b/src/modules/audio_fx/widget-test/cards.js
@@ -1,0 +1,70 @@
+/*
+ * widget-test/cards.js — the card that floats over the page while Level turns.
+ *
+ * The THIRD module-supplied surface, and the last one this fixture was missing:
+ *
+ *   drawCell (canvas.js)  one knob box, always, while the page is up
+ *   drawCard (here)       over the page, only while the knob is being turned
+ *   draw    (canvas.js)   the whole screen, when you dive into Detail
+ *
+ * A card answers a different question from a cell. The cell says "this knob is
+ * at 0.6"; the card says what 0.6 MEANS -- here, a bar with its numeric reading
+ * and the name, which is the smallest thing that justifies the surface at all.
+ *
+ * SAME COORDINATE CONTRACT AS A CELL WIDGET. The drawer is handed a frameCtx
+ * scoped to the INSIDE of the card, so (0,0) is the content area's top-left and
+ * ctx.width/ctx.height are its size. There is no accessor that reaches a screen
+ * pixel, and the card is centred in the page's frame -- which is the whole panel
+ * for the shadow UI and the embedded region for a tool that supplies a rect. So
+ * size everything against ctx.width/ctx.height; an absolute coordinate is wrong
+ * somewhere by construction.
+ *
+ * NO READS. `raw` and `value` are handed in. `raw` MAY BE NULL -- a key the
+ * module does not serve reads as "no answer" -- and the contract is that a
+ * drawer draws nothing interpretive then, rather than drawing zero. A read that
+ * did not answer must never become a picture.
+ *
+ * ONE STRIKE. If this throws it is retired for the session and the card is left
+ * empty; the page keeps working.
+ *
+ * Declared in the DSP's chain_params as:
+ *     "card_script": "cards.js#blend_card", "card_w": 96, "card_h": 34
+ */
+
+globalThis.blend_card = function (ctx, { name, value, raw }) {
+    const w = ctx.width, h = ctx.height;
+    if (w < 8 || h < 8) return;
+
+    /* The name, top-left. print truncates to the frame, so a long name cannot
+     * push the layout around. */
+    ctx.print(0, 0, String(name || ""), 1);
+
+    /*
+     * NOTHING INTERPRETIVE WITHOUT AN ANSWER.
+     *
+     * raw === null means the read did not answer. Drawing a bar at zero would
+     * be indistinguishable from a genuine zero, which is the picture this rule
+     * exists to prevent. The name and the frame still draw: the card is present
+     * and honest about knowing nothing yet.
+     */
+    const n = raw === null || raw === undefined ? NaN : Number(raw);
+    if (!Number.isFinite(n)) {
+        ctx.print(0, h - 7, "--", 1);
+        return;
+    }
+
+    const v = Math.max(0, Math.min(1, n));
+
+    /* The formatted reading, right-aligned against the frame's own width. */
+    const s = String(value || "");
+    const tw = ctx.textWidth(s);
+    if (tw <= w) ctx.print(w - tw, 0, s, 1);
+
+    /* A bar, sized from the frame rather than from a constant. */
+    const barY = Math.max(9, h - 10);
+    const barH = Math.max(3, h - barY - 1);
+    ctx.fillRect(0, barY, w, barH, 1);                       /* outline */
+    ctx.fillRect(1, barY + 1, w - 2, barH - 2, 0);           /* hollow */
+    const fill = Math.round((w - 4) * v);
+    if (fill > 0) ctx.fillRect(2, barY + 2, fill, barH - 4, 1);
+};

--- a/src/modules/audio_fx/widget-test/help.json
+++ b/src/modules/audio_fx/widget-test/help.json
@@ -1,18 +1,22 @@
 {
   "title": "Widget Test",
-  "summary": "Reference module showing a custom in-grid widget and its fullscreen canvas view, both from one canvas.js.",
+  "summary": "Reference module for the three module-supplied draw surfaces: an in-grid widget, a card that floats while the knob turns, and a fullscreen canvas view.",
   "sections": [
     {
       "heading": "What it shows",
-      "body": "The Level knob draws as a segmented meter supplied by the module itself rather than a built-in dial. Clicking Detail opens the module's own fullscreen view. Both come from the same canvas.js."
+      "body": "The Level knob draws as a segmented meter supplied by the module rather than a built-in dial. Turn it and a card floats over the page with the reading and a bar. Click Detail for the module's own fullscreen view. All three come from files beside the module."
     },
     {
       "heading": "For module authors",
-      "body": "Declare viz: { kind: \"custom:<name>\" } on a chain_params entry, then export widgetKind and drawCell from canvas.js. Coordinates are frame-local: (0,0) is the knob box, and ctx.width/ctx.height are its size. Values are handed to drawCell; it cannot read params. Schwung keeps drawing the label."
+      "body": "In grid: viz: { kind: \"custom:<name>\" } plus widgetKind and drawCell in canvas.js. On a turn: card_script: \"cards.js#export\" plus card_w and card_h. Fullscreen: type \"canvas\". Coordinates are frame-local everywhere: (0,0) is your own box and ctx.width/ctx.height are its size."
     },
     {
-      "heading": "If it does not appear",
-      "body": "An unknown or broken widget falls back to the built-in graphic rather than leaving a hole, so the page always looks correct. Check debug.log: a widget that threw is disabled for the session and names itself there."
+      "heading": "No reads on any of them",
+      "body": "Values are handed in; there is no getParam. A card's raw value may be null, meaning the read did not answer, and the contract is to draw nothing interpretive rather than to draw zero. Watch the card at null: it shows -- and no bar."
+    },
+    {
+      "heading": "If something does not appear",
+      "body": "An unknown or broken drawer falls back to the built-in rather than leaving a hole, so the page always looks correct. Check debug.log: a drawer that threw is retired for the session and names itself there."
     }
   ]
 }

--- a/src/modules/audio_fx/widget-test/module.json
+++ b/src/modules/audio_fx/widget-test/module.json
@@ -2,7 +2,7 @@
   "id": "widget-test",
   "name": "Widget Test",
   "version": "0.1.0",
-  "description": "Reference module for a custom in-grid widget (drawCell) plus its fullscreen canvas view.",
+  "description": "Reference module for the three module-supplied draw surfaces: an in-grid widget (drawCell), a card that floats while the knob turns (card_script), and a fullscreen canvas view.",
   "author": "Schwung",
   "component_type": "audio_fx",
   "capabilities": {
@@ -19,7 +19,10 @@
         "default": 0.5,
         "viz": {
           "kind": "custom:wtmeter"
-        }
+        },
+        "card_script": "cards.js#blend_card",
+        "card_w": 96,
+        "card_h": 34
       },
       {
         "key": "detail",

--- a/src/modules/audio_fx/widget-test/widget_test.c
+++ b/src/modules/audio_fx/widget-test/widget_test.c
@@ -93,6 +93,11 @@ static int v2_get_param(void *inst, const char *key, char *buf, int len) {
         "["
           "{\"key\":\"level\",\"name\":\"Level\",\"short_name\":\"Lvl\","
            "\"type\":\"float\",\"min\":0,\"max\":1,\"step\":0.01,\"default\":0.5,"
+           /* THE SAME PARAM CARRIES BOTH SURFACES: the in-grid cell widget and
+            * the card that floats while it is turned. They answer different
+            * questions and do not compete -- the cell is always there, the card
+            * only during the gesture. */
+           "\"card_script\":\"cards.js#blend_card\",\"card_w\":96,\"card_h\":34,"
            "\"viz\":{\"kind\":\"custom:wtmeter\"}},"
           "{\"key\":\"detail\",\"name\":\"Detail\",\"short_name\":\"Dtl\","
            "\"type\":\"canvas\",\"canvas_script\":\"canvas.js\",\"show_value\":false}"

--- a/tests/host/test_voice_follow_no_leds.sh
+++ b/tests/host/test_voice_follow_no_leds.sh
@@ -70,13 +70,21 @@ fi
 # Comments are stripped BEFORE the extraction, so a brace inside a comment
 # cannot end the body early -- and so the body being searched carries none of
 # the prose that describes this very rule.
+# STOP PRINTING, DO NOT `exit`.
+#
+# `exit` closes the pipe while strip_comments is still writing, so its `sed`
+# takes SIGPIPE -- and under `set -o pipefail` that is the pipeline's status.
+# BSD sed dies quietly so this passed on a Mac for as long as anyone looked;
+# GNU sed reports "couldn't write N items to stdout: Broken pipe" and the test
+# fails on CI with exit 4, naming a test that is not the one that changed.
+# Draining the rest of the input costs microseconds and cannot SIGPIPE anyone.
 BODY=$(strip_comments "$PC" | awk '
     /function syncVoiceFromModule\(/ { on = 1 }
-    on {
+    on && !done {
         print
         d += gsub(/\{/, "{")
         d -= gsub(/\}/, "}")
-        if (d <= 0) exit
+        if (d <= 0) done = 1
     }')
 
 [ -n "$BODY" ] || fail "syncVoiceFromModule not found in page_controller.mjs -- the extraction matched nothing, so this test was asserting on an empty string"

--- a/tests/host/test_widget_module_poc.sh
+++ b/tests/host/test_widget_module_poc.sh
@@ -38,6 +38,7 @@ import { buildMetaIndex } from "./src/shared/param_pages/param_meta.mjs";
 import { validateContract } from "./src/shared/param_pages/validate_contract.mjs";
 import { registerWidget, clearWidgets, isWidgetAvailable }
   from "./src/shared/param_pages/widget_registry.mjs";
+import { drawParamCard, paramCardRect } from "./src/shared/param_pages/param_card.mjs";
 
 let fail = 0;
 const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
@@ -53,6 +54,7 @@ const declared = CP.filter((p) => p.viz && typeof p.viz.kind === "string" &&
                                   p.viz.kind.startsWith("custom:"));
 ok(declared.length === 1, "exactly one param declares a custom viz kind");
 const KIND = declared[0].viz.kind;
+const declaredCard = CP.find((p) => typeof p.card_script === "string") || null;
 
 /* The validator is happy with it -- no errors, and no missing-script warning. */
 const findings = validateContract({ id: mod.id, hierarchy: mod.ui_hierarchy,
@@ -141,6 +143,78 @@ for (const k of CP.map((p) => p.key)) {
 }
 ok(/move_audio_fx_init_v2/.test(csrc), "the DSP exports the v2 audio FX entry point");
 ok(/process_block/.test(csrc), "and a process_block, so it is a loadable chain component");
+
+/* ---- THE CARD: the modules real cards.js, through the real drawParamCard ----
+ *
+ * test_param_card.sh injects its own loadCard stub and a fixture drawer, so no
+ * real file is ever loaded on any path there. This starts from the shipped
+ * cards.js. The equivalent gap on drawCell is what let a call-ordering defect
+ * survive nine green tasks, so the card gets a real consumer from the start. */
+const cardSpec = declaredCard && declaredCard.card_script;
+ok(typeof cardSpec === "string" && cardSpec.indexOf("#") > 0,
+   "the level param declares a card_script with an export fragment");
+const [cardFile, cardExport] = String(cardSpec).split("#");
+
+const cardSrc = readFileSync(`${DIR}/${cardFile}`, "utf8");
+const cg = {};
+new Function("globalThis", cardSrc)(cg);
+const drawer = cg[cardExport];
+ok(typeof drawer === "function",
+   `cards.js exports ${cardExport} as a FUNCTION (a card is not an overlay factory)`);
+
+const cardPx = (raw, frame) => {
+  const px = new Set();
+  const cctx = {
+    fillRect(x, y, w, h, c) {
+      for (let j = 0; j < h; j++) for (let i = 0; i < w; i++) {
+        const k = (x + i) + "," + (y + j);
+        if (c) px.add(k); else px.delete(k);
+      }
+    },
+    print() {}, textWidth: (t) => String(t).length * 4,
+  };
+  let threw = 0;
+  drawParamCard(cctx, {
+    meta: declaredCard, draw: drawer, frame,
+    name: "Level", value: raw === null ? "" : String(raw), raw,
+    onError: () => { threw++; },
+  });
+  return { px, threw };
+};
+
+const c50 = cardPx("0.5", null);
+ok(c50.threw === 0, "the shipped card drawer does not throw");
+ok(c50.px.size > 0, "and it lights pixels");
+ok(cardPx("1", null).px.size > cardPx("0", null).px.size,
+   "a full value lights more of the card than an empty one");
+
+/* THE NULL CONTRACT, on the real drawer. */
+const cNull = cardPx(null, null);
+ok(cNull.threw === 0, "a null raw does not throw");
+ok(cNull.px.size < c50.px.size,
+   "a null raw draws LESS than a real value -- no bar invented from no answer");
+
+/* Contained in the card, and in an EMBEDDED frame. */
+const outer = paramCardRect(declaredCard);
+ok([...c50.px].every((k) => {
+     const a = k.split(","), x = Number(a[0]), y = Number(a[1]);
+     return x >= outer.x && x < outer.x + outer.w &&
+            y >= outer.y + 0 && y < outer.y + outer.h;
+   }), "everything the card draws stays inside the card");
+
+const EMB = { x: 0, y: 20, w: 64, h: 44 };
+const embOuter = paramCardRect(declaredCard, EMB);
+ok([...cardPx("0.5", EMB).px].every((k) => {
+     const a = k.split(","), x = Number(a[0]), y = Number(a[1]);
+     return x >= EMB.x && x < EMB.x + EMB.w && y >= EMB.y && y < EMB.y + EMB.h;
+   }), "and inside an EMBEDDED page frame, not across the panel");
+
+/* The DSP must declare the card too -- the chain host reads the DSP, not
+ * module.json, so a card declared only in module.json would never appear. */
+ok(csrc.includes("card_script"),
+   "the DSP declares card_script, which is what the chain host actually serves");
+ok(csrc.includes(cardFile),
+   `the DSP names ${cardFile}, matching module.json`);
 
 /* ---- and the fallback story, from the shipped declaration ---- */
 clearWidgets();


### PR DESCRIPTION
**#410 shipped no module that declares `card_script`.** `cards.js#blend_card`
exists only in a doc comment and as a test fixture, and `test_param_card.sh`
injects its own `loadCard` stub — so no real card file has been loaded on any
path, by anything.

That is the gap `drawCell` had, and it was not academic there: nine tasks and
~100 green assertions sat on a feature that did not function, because every test
constructed the subject by hand and a fixture cannot see **call ordering**. It
took six deploys and on-device logging to find. The card gets a real consumer
before that repeats.

## What this adds

`widget-test` declares the card on the **same parameter** that carries the cell
widget, so one fixture demonstrates all three surfaces and shows they compose:

| surface | when it is on screen |
|---|---|
| `drawCell` (`canvas.js`) | always, while the page is up |
| `card_script` (`cards.js`) | only while that knob is being turned |
| `draw` (`canvas.js`) | when you dive into `Detail` |

Declared in the **DSP** as well as `module.json`, because the chain host serves
`chain_params` from the DSP's `get_param` — a card declared only in `module.json`
would never appear. The test pins both.

## The null contract, in a real drawer

`raw` may be null. The drawer prints `--` with **no bar**, rather than a bar at
zero, because a bar at zero is indistinguishable from a genuine zero. Rendered
and inspected at 0, 0.5, 1 and null rather than trusting assertions.

## Verification

`test_widget_module_poc.sh` drives the shipped `cards.js` through the real
`drawParamCard`: it does not throw, a full value lights more than an empty one,
**a null draws less than a real value**, everything stays inside the card — and
inside an embedded page frame, not across the panel.

253 host tests green. Still gated on `SCHWUNG_BUILD_TEST_MODULES`, so nothing
here ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LjRrjvkLSr7FqyZZpzBb8