### PR TITLE
frame_ctx: the drawing primitives, implemented rather than delegated

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2012,6 +2012,20 @@ globalThis.canvas_overlay = {
 };
 ```
 
+**What you can draw with.** The frame context carries `fillRect`, `print`,
+`textWidth`, `setPixel`, `line`, `fillCircle`, `drawCircle` and `drawArc`. All of
+them are always present — they are implemented on the frame's own clipped
+`fillRect` rather than delegated to the host, so there is nothing to feature-detect
+and nothing that can escape your frame. `drawArc(cx, cy, r, startDeg, sweepDeg,
+color)` reads angles the way a knob does: **0 at twelve o'clock, increasing
+clockwise**, so a track from 210 to 510 puts its gap at the bottom. The circle and
+arc are pixel-identical to the host's, so yours sits beside a built-in arc knob
+without looking like a different object.
+
+They cost more bindings than the host's single call — a filled circle is one
+`fillRect` per row — which is the price of clipping being structural. Fine at cell
+and card sizes; reach for a rect if you are filling something large every frame.
+
 **The frame is not the screen.** `(0,0)` is your knob box's top-left and
 `ctx.width` / `ctx.height` are the box's, not the display's. There is no accessor
 that reaches absolute coordinates, and anything you draw outside the frame is

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1365,6 +1365,18 @@ sizes** — 32×14 through 32×26, plus 16×15, 24×15 and 25×15 from clamped s
 than listing them, because `computeGeom`'s thresholds are module-private and a
 written-down table would go stale silently and green.
 
+**The primitives are implemented, not delegated.** The frame context offers
+`setPixel`, `line`, `fillCircle`, `drawCircle` and `drawArc` alongside
+`fillRect` / `print` / `textWidth`, built on its own clipped `fillRect`. Passing
+them through to the host was the obvious alternative and is wrong twice: a
+delegated call draws in the parent's coordinates with the parent's implementation,
+so nothing here could clip it — one `line` and the guarantee is gone — and the
+host builds several of them as `typeof draw_line === "function" ? … : undefined`,
+which would make availability depend on the caller and force every drawer to
+feature-detect. The algorithms are ports of `js_display.c`, asserted
+**pixel-identical** rather than merely plausible, because a widget's circle sits
+beside the grid's own arc knobs.
+
 **The frame ctx carries no `getParam`,** so the "nothing reads on the draw path"
 rule holds by construction. `clipped()` counts attempted overflow rather than
 absorbing it — the same bargain as `test_master_fx_diagram_fit.sh`, which exists

--- a/src/shared/param_pages/frame_ctx.mjs
+++ b/src/shared/param_pages/frame_ctx.mjs
@@ -29,6 +29,36 @@
  * a 1.68ms whole-page render); here that is enforced by construction rather
  * than by review, because values arrive as an argument.
  *
+ * THE PRIMITIVES ARE IMPLEMENTED HERE, NOT DELEGATED. The context the host
+ * hands the grid carries setPixel / line / fillCircle / drawCircle / drawArc
+ * alongside fillRect, and for a while this file offered only the three that
+ * render() documents -- so a module drawer that wanted a line had to build
+ * Bresenham on fillRect, while the built-in widget beside it called the host.
+ *
+ * They are NOT passed through to the parent, for two reasons that both matter:
+ *
+ *   - a delegated call draws in the PARENT's coordinates with the parent's own
+ *     implementation, so nothing here could clip it. One `line` and the central
+ *     guarantee of this file is gone. Built on the clipped fillRect below,
+ *     clipping is not a rule they follow, it is a thing they cannot avoid.
+ *   - the host builds several of them as `typeof draw_line === "function" ?
+ *     draw_line : undefined`, so delegating would make availability depend on
+ *     the caller and force every drawer to feature-detect. Implemented here,
+ *     they are always present -- including for a node test, which has no host.
+ *
+ * The algorithms are ported from js_display.c deliberately rather than
+ * reinvented: a widget's arc sits beside the grid's own arc knobs, and two
+ * circles drawn by different maths on a 1-bit display do not look like the same
+ * object. The row/column union in drawArc is the one that avoids stranded
+ * pixels at the compass points -- see that file for the three constructions
+ * that are wrong.
+ *
+ * THE COST IS BINDINGS. Each is a run of fillRect calls where the host would
+ * make one crossing, so a filled circle of r=8 is ~17 calls rather than 1. That
+ * is the price of clipping being structural, and it is the right trade at cell
+ * and card sizes; a drawer filling a large disc every frame should reach for a
+ * rect.
+ *
  * clipped() COUNTS ATTEMPTED OVERFLOW rather than hiding it. A fixed-width row
  * cannot report that it overflowed, which is exactly how nine Master FX boxes
  * came to be drawn 86px off-screen with no error at all
@@ -57,7 +87,7 @@ export function frameCtx(ctx, frame) {
     const w = Math.max(0, Math.round(frame.w)), h = Math.max(0, Math.round(frame.h));
     let clipCount = 0;
 
-    return {
+    const self = {
         width: w,
         height: h,
 
@@ -87,10 +117,93 @@ export function frameCtx(ctx, frame) {
             ctx.print(ox + fx, oy + fy, s, color);
         },
 
+        /* ---------------------------------------------------------------
+         * Primitives, all routed through this object's own fillRect, so every
+         * one of them is translated and clipped by construction. `self` is the
+         * context being built; the methods call each other through it rather
+         * than through a captured local so a caller that wraps or spies on
+         * fillRect sees every write.
+         * --------------------------------------------------------------- */
+
+        setPixel(x, y, color) { self.fillRect(x, y, 1, 1, color); },
+
+        /* Bresenham, matching render_page.mjs's `line`. */
+        line(x0, y0, x1, y1, color) {
+            let ax = Math.round(x0), ay = Math.round(y0);
+            const bx = Math.round(x1), by = Math.round(y1);
+            let dx = Math.abs(bx - ax), sx = ax < bx ? 1 : -1;
+            let dy = -Math.abs(by - ay), sy = ay < by ? 1 : -1;
+            let err = dx + dy;
+            /* A run this long cannot be a real drawing on a 128x64 panel; it is
+             * a NaN or a runaway, and without the bound it would spin. */
+            for (let guard = 0; guard < 4096; guard++) {
+                self.fillRect(ax, ay, 1, 1, color);
+                if (ax === bx && ay === by) break;
+                const e2 = 2 * err;
+                if (e2 >= dy) { err += dy; ax += sx; }
+                if (e2 <= dx) { err += dx; ay += sy; }
+            }
+        },
+
+        /* js_display.c fill_circle: every pixel inside the radius. Emitted as
+         * one fillRect per ROW rather than per pixel -- same pixels, ~2r calls
+         * instead of ~pi*r*r. */
+        fillCircle(cx, cy, r, color) {
+            const x = Math.round(cx), y = Math.round(cy), rr = Math.round(r);
+            if (!(rr >= 0)) return;
+            for (let dy = -rr; dy <= rr; dy++) {
+                const half = Math.floor(Math.sqrt(rr * rr - dy * dy));
+                self.fillRect(x - half, y + dy, half * 2 + 1, 1, color);
+            }
+        },
+
+        drawCircle(cx, cy, r, color) { self.drawArc(cx, cy, r, 0, 360, color); },
+
+        /*
+         * js_display.c draw_arc, ported exactly.
+         *
+         * Angles are read the way a knob is: 0 at twelve o`clock, increasing
+         * CLOCKWISE. One pixel per row and one per column, unioned -- rows
+         * alone strand a lone pixel at twelve and six, columns alone at three
+         * and nine.
+         */
+        drawArc(cx, cy, r, startDeg, sweepDeg, color) {
+            const x = Math.round(cx), y = Math.round(cy), rr = Math.round(r);
+            if (!(rr >= 0)) return;
+            if (rr === 0) { self.fillRect(x, y, 1, 1, color); return; }
+            let sweep = Number(sweepDeg);
+            if (!(sweep > 0)) return;
+            if (sweep >= 360) sweep = 360;
+            const start = ((Math.round(Number(startDeg) || 0) % 360) + 360) % 360;
+
+            const plot = (dx, dy) => {
+                if (sweep < 360) {
+                    let a = Math.atan2(dx, -dy) * 180 / Math.PI;
+                    if (a < 0) a += 360;
+                    let delta = a - start;
+                    if (delta < 0) delta += 360;
+                    if (delta > sweep) return;
+                }
+                self.fillRect(x + dx, y + dy, 1, 1, color);
+            };
+
+            for (let dy = -rr; dy <= rr; dy++) {
+                const dx = Math.round(Math.sqrt(rr * rr - dy * dy));
+                plot(dx, dy);
+                if (dx !== 0) plot(-dx, dy);
+            }
+            for (let dx = -rr; dx <= rr; dx++) {
+                const dy = Math.round(Math.sqrt(rr * rr - dx * dx));
+                plot(dx, dy);
+                if (dy !== 0) plot(dx, -dy);
+            }
+        },
+
         /* Measurement, not drawing -- no translation to do. */
         textWidth(text) { return ctx.textWidth(text); },
 
         /** How many draw calls were clipped, truncated or dropped. */
         clipped() { return clipCount; },
     };
+    return self;
 }

--- a/tests/host/test_frame_ctx_primitives.sh
+++ b/tests/host/test_frame_ctx_primitives.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# THE PRIMITIVES ARE CLIPPED BECAUSE THEY ARE BUILT ON THE CLIPPED fillRect.
+#
+# frame_ctx offered only fillRect / print / textWidth, so a module drawer that
+# wanted a line built Bresenham on rects while the built-in widget beside it
+# called the host. The gap was real for BOTH module hooks -- a cell widget and a
+# card drawer see the same context.
+#
+# They are NOT delegated to the parent, and that is the whole design: a
+# delegated call draws in the parent's coordinates with the parent's own
+# implementation, so nothing could clip it, and one `line` would end the
+# guarantee this file exists for. Built on the frame's own fillRect, clipping is
+# not a rule they follow -- it is a thing they cannot avoid. So the assertions
+# below drive every primitive far outside the frame and demand zero escapes.
+#
+# The algorithms are ports of js_display.c, not reinventions: a widget's arc
+# sits beside the grid's own arc knobs, and two circles drawn by different maths
+# on a 1-bit display do not read as the same object.
+#
+# NO APOSTROPHES inside the node script: single-quoted bash string.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the frame ctx primitive tests" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { frameCtx } from "./src/shared/param_pages/frame_ctx.mjs";
+
+let fail = 0;
+const ok = (c, m) => { console.log((c ? "PASS" : "FAIL") + ": " + m); if (!c) fail++; };
+
+const FRAME = { x: 10, y: 20, w: 17, h: 15 };
+const mk = () => {
+  const calls = [];
+  const parent = {
+    fillRect: (...a) => calls.push(a),
+    print() {}, textWidth: (t) => String(t).length * 4,
+  };
+  return { calls, ctx: frameCtx(parent, FRAME) };
+};
+const contained = (calls) => calls.every(([x, y, w, h]) =>
+  x >= FRAME.x && y >= FRAME.y &&
+  x + w <= FRAME.x + FRAME.w && y + h <= FRAME.y + FRAME.h);
+
+/* All five exist, on every frame ctx, with no host and no feature detection. */
+{
+  const { ctx } = mk();
+  for (const n of ["setPixel", "line", "fillCircle", "drawCircle", "drawArc"]) {
+    ok(typeof ctx[n] === "function", `${n} is present without a host`);
+  }
+}
+
+/* setPixel translates, and is clipped. */
+{
+  const a = mk();
+  a.ctx.setPixel(2, 3, 1);
+  ok(JSON.stringify(a.calls[0]) === JSON.stringify([12, 23, 1, 1, 1]),
+     "setPixel is translated by the frame origin");
+  const b = mk();
+  b.ctx.setPixel(-5, -5, 1);
+  b.ctx.setPixel(500, 500, 1);
+  ok(b.calls.length === 0, "an out-of-frame setPixel draws nothing");
+  ok(b.ctx.clipped() === 2, "and both attempts are counted");
+}
+
+/* Every primitive, driven far outside, lands nothing outside. */
+{
+  const cases = {
+    line: (c) => c.line(-40, -40, 400, 400, 1),
+    "line (vertical)": (c) => c.line(8, -100, 8, 100, 1),
+    fillCircle: (c) => c.fillCircle(8, 7, 60, 1),
+    drawCircle: (c) => c.drawCircle(8, 7, 60, 1),
+    drawArc: (c) => c.drawArc(8, 7, 60, 210, 300, 1),
+    "drawArc (full)": (c) => c.drawArc(-20, -20, 90, 0, 360, 1),
+  };
+  for (const [name, fn] of Object.entries(cases)) {
+    const { calls, ctx } = mk();
+    fn(ctx);
+    ok(contained(calls), `${name} cannot draw outside the frame`);
+    ok(ctx.clipped() > 0, `${name} COUNTS the overflow rather than hiding it`);
+  }
+}
+
+/* A primitive that fits draws, and clips nothing. */
+{
+  const { calls, ctx } = mk();
+  ctx.line(1, 1, 5, 5, 1);
+  ok(calls.length > 0 && contained(calls), "an in-frame line draws and stays in");
+  ok(ctx.clipped() === 0, "and clips nothing");
+}
+
+/* fillCircle is emitted per ROW, not per pixel -- the budget is bindings. */
+{
+  const { calls, ctx } = mk();
+  ctx.fillCircle(8, 7, 6, 1);
+  ok(calls.length <= 13 + 2,
+     "fillCircle costs about one call per row, not one per pixel, got " + calls.length);
+}
+
+/* A degenerate or hostile argument must not hang or throw. */
+{
+  const { ctx } = mk();
+  let threw = false;
+  try {
+    ctx.line(NaN, NaN, NaN, NaN, 1);
+    ctx.fillCircle(8, 7, -3, 1);
+    ctx.drawArc(8, 7, 5, 0, 0, 1);
+    ctx.drawArc(8, 7, 5, NaN, NaN, 1);
+    ctx.drawCircle(8, 7, 0, 1);
+  } catch (e) { threw = true; }
+  ok(!threw, "NaN, a negative radius and a zero sweep neither throw nor hang");
+}
+
+/* drawArc reads like a knob: 0 at twelve oclock, increasing CLOCKWISE. */
+{
+  const { calls, ctx } = mk();
+  ctx.drawArc(8, 7, 5, 45, 90, 1);
+  const pts = calls.map(([x, y]) => [x - FRAME.x - 8, y - FRAME.y - 7]);
+  ok(pts.length > 0, "a quarter arc draws something");
+  ok(pts.every(([dx, dy]) => dx >= -1),
+     "a 45..135 sweep stays on the RIGHT of centre -- clockwise from twelve");
+}
+
+/* A CIRCLE MUST BE A CIRCLE, NOT MERELY CONTAINED.
+ *
+ * Containment and a quadrant check are not a shape: deleting the mirrored plot
+ * from drawArc row pass wipes the entire LEFT half of every circle, and the
+ * first version of this file went green on it. Symmetry and no-gaps are what
+ * actually pin the port. */
+{
+  const R = 9, C = 40;
+  const lit = new Set();
+  const c = frameCtx({
+    fillRect(x, y, w, h, col) {
+      for (let i = 0; i < w; i++) if (col) lit.add((x + i - C) + "," + (y - C));
+    },
+    print() {}, textWidth: (t) => String(t).length * 4,
+  }, { x: 0, y: 0, w: 200, h: 200 });
+  c.drawCircle(C, C, R, 1);
+
+  ok(lit.size > 0, "a full circle draws pixels");
+  const mirroredX = [...lit].every((k) => {
+    const a = k.split(","); return lit.has((-Number(a[0])) + "," + a[1]);
+  });
+  const mirroredY = [...lit].every((k) => {
+    const a = k.split(","); return lit.has(a[0] + "," + (-Number(a[1])));
+  });
+  ok(mirroredX, "a full circle is symmetric left-to-right");
+  ok(mirroredY, "and top-to-bottom");
+
+  let gaps = 0;
+  for (let dy = -R; dy <= R; dy++) {
+    if (![...lit].some((k) => Number(k.split(",")[1]) === dy)) gaps++;
+  }
+  ok(gaps === 0, "every row of the circle has at least one pixel -- no gaps");
+}
+
+/* PORTED, NOT REINVENTED.
+ *
+ * A widget circle sits beside the grid own arc knobs, and two circles drawn by
+ * different maths on a 1-bit display do not read as the same object. So this
+ * asserts pixel identity against js_display.c fill_circle predicate rather than
+ * against a picture someone liked -- including the single-pixel poles, which
+ * are the host shape and not a bug in the port. */
+{
+  const cRef = (r) => {
+    const set = new Set();
+    for (let dy = -r; dy <= r; dy++)
+      for (let dx = -r; dx <= r; dx++)
+        if (dx * dx + dy * dy <= r * r) set.add(dx + "," + dy);
+    return set;
+  };
+  let bad = 0;
+  for (const r of [0, 1, 2, 3, 5, 7, 8, 12]) {
+    const got = new Set();
+    const c = frameCtx({
+      fillRect(x, y, w, h, col) {
+        for (let i = 0; i < w; i++) if (col) got.add((x + i - 40) + "," + (y - 40));
+      },
+      print() {}, textWidth: (t) => String(t).length * 4,
+    }, { x: 0, y: 0, w: 200, h: 200 });
+    c.fillCircle(40, 40, r, 1);
+    const want = cRef(r);
+    if (!(got.size === want.size && [...want].every((k) => got.has(k)))) bad++;
+  }
+  ok(bad === 0, "fillCircle is pixel-identical to js_display.c at every radius tested");
+}
+
+process.exit(fail ? 1 : 0);
+'


### PR DESCRIPTION
The frame context offered `fillRect` / `print` / `textWidth` — what `render()`
documents — while the context the host hands the grid also carries `setPixel`,
`line`, `fillCircle`, `drawCircle` and `drawArc`. So a module drawer wanting a
line built Bresenham on rects while the built-in widget beside it called the
host. That applies to **both** module hooks now, a cell widget and a card
drawer. #410 flagged it and correctly kept it out of the card.

## Implemented here, not delegated

Passing them through to the parent is the obvious alternative and is wrong twice:

- a delegated call draws in the **parent's** coordinates with the parent's own
  implementation, so nothing here could clip it. One `line` and the central
  guarantee of this file is gone. Built on the frame's own clipped `fillRect`,
  clipping is not a rule they follow — it is a thing they cannot avoid.
- the host builds several as `typeof draw_line === "function" ? … : undefined`,
  so delegating would make availability depend on the caller and force every
  drawer to feature-detect. Implemented here they are always present, including
  under node.

## Ported, and asserted pixel-identical

The algorithms come from `js_display.c` rather than being reinvented, and
`fillCircle` is asserted **pixel-identical at eight radii**. A widget's circle
sits beside the grid's own arc knobs, and two circles drawn by different maths
on a 1-bit display do not read as the same object.

`drawArc(cx, cy, r, startDeg, sweepDeg, color)` keeps the host's convention: 0 at
twelve o'clock, increasing clockwise, so a 210→510 track puts its gap at the
bottom. The single-pixel poles of `fillCircle` are the **host's** shape, not a
defect in the port — the sort of thing an identity assertion settles and a
picture someone liked would not.

## My first test was too weak, and mutation found it

Deleting the mirrored plot from `drawArc`'s row pass **wipes the entire left half
of every circle** — and containment plus a quadrant check went green on it.
Containment is not a shape. Symmetry in both axes and a no-gaps row scan now fail
on that mutation.

Also bounded the Bresenham loop: a NaN endpoint would otherwise spin.

## Cost

Each primitive is a run of `fillRect` calls where the host makes one crossing —
a filled circle is one call per row. That is the price of clipping being
structural, and it is the right trade at cell and card sizes; the docs say to
reach for a rect when filling something large every frame.

254 host tests green, C suite clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LjRrjvkLSr7FqyZZpzBb8