### PR TITLE
param_pages: the enum list drew its body through the device globals

### DIFF
--- a/src/shared/param_pages/enum_list.mjs
+++ b/src/shared/param_pages/enum_list.mjs
@@ -71,6 +71,16 @@ export function drawEnumList(ctx, o) {
     /* The same list every other picker on this device uses. A second list
      * widget is how Master FX and the chain editor drifted apart. */
     drawMenuList({
+        /* FORWARD THE CTX. Without it drawMenuList falls back to DEVICE_CTX and
+         * draws the list body through the `fill_rect` / `print` globals, while
+         * the header and footer either side of it go to the injected ctx — two
+         * surfaces for one screen. In the shadow UI both are the device, so it
+         * looked right and stayed wrong; an embedding host that injects a ctx
+         * (movy) gets a header and footer with no list between them, or a
+         * ReferenceError where the globals do not exist at all. The other
+         * drawMenuList call in this engine, page_controller's menu page, has
+         * always passed it. */
+        ctx,
         items: o.options,
         selectedIndex: o.index,
         listArea: { topY: ENUM_LIST_TOP_Y, bottomY: ENUM_LIST_BOTTOM_Y },


### PR DESCRIPTION
`drawEnumList` takes a `ctx` and uses it for the header and the footer, then
calls `drawMenuList` **without** it — so the list between them falls back to
`DEVICE_CTX` and draws through the `fill_rect` / `print` globals.

In the shadow UI both surfaces are the device, so it looks correct and has
stayed wrong for as long as it has existed. A host that injects a ctx gets a
header and a footer with no list between them, or a `ReferenceError` where those
globals do not exist at all.

Found from movy, which embeds `page_controller` and renders through an injected
ctx: turning a divable enum crashed on `print is not defined` the first time the
peek overlay was drawn.

`page_controller`'s own `drawMenuList` call has always passed `ctx`; this is the
only other one in the engine.

254 host suites pass.