### PR TITLE
uac2: build the USB Audio Class gadget modules Move's kernel is missing

### DIFF
--- a/docs/plans/2026-09-04-usbc-multiout.md
+++ b/docs/plans/2026-09-04-usbc-multiout.md
@@ -1,0 +1,182 @@
+# USB-C multi-out: Move as a 10-in audio interface
+
+Status: modules built and hardware-verified; gadget brought up by hand; the
+audio feed is not written yet. All work is on `worktree-usbc-uac2-multiout`
+(PR #416) and nothing is persisted on the device.
+
+## What this is
+
+Move appears to a connected computer as a **10-input USB audio interface** —
+the four chain slots plus Move's own mix, as separate inputs in a DAW. Not
+network audio: a class-compliant USB device, no driver.
+
+## Why the obvious route is closed
+
+The USB-C audio device a Mac sees **today** is the XMOS. Its firmware is closed
+and absent from Ableton's GPL drop, and the Pi could not feed it more channels
+anyway — SPI carries exactly 128 stereo int16 each way, and there is no third
+channel pair in the layout to widen into. Reflashing XMOS is not the route.
+
+## The route that works
+
+`drivers/usb/gadget/function/f_uac2.c` **is** in the GPL source; it is simply
+not compiled, because `CONFIG_SND` is unset. Three config facts make shipping it
+as loadable modules realistic:
+
+- `CONFIG_SOUND=y` — soundcore is already in the running vmlinux, so only
+  `snd`/`snd-pcm` are missing and both are ordinary modules.
+- `# CONFIG_MODULE_SIG is not set` — unsigned modules load.
+- `CONFIG_MODVERSIONS=y` — symbol CRCs must match, which is what the build gate
+  checks.
+
+**No kernel image is replaced.** `scripts/build-uac2-modules.sh` builds the
+kernel twice (stock, then with `SND=m SND_PCM=m USB_CONFIGFS_F_UAC2=y`) and
+refuses to package unless the ABI held. Measured: 10231 -> 10405 exported
+symbols, **0 changed, 0 dropped**, 368 module dependencies all satisfied, and
+build 2 recompiles only module objects — it never relinks vmlinux.
+
+Five modules, not four: `snd-pcm` pulls in `snd-timer`.
+
+The CRC comparison lives in `scripts/verify-uac2-abi.sh` so
+`tests/host/test_uac2_abi_gate.sh` can prove it rejects a moved CRC, a dropped
+symbol, and both — a gate that cannot fail is not a gate.
+
+## Hardware facts
+
+```
+dwc2 fe980000.usb: EPs: 8, dedicated fifos, 4080 entries in SPRAM
+UDC maximum_speed = high-speed
+```
+
+- **Endpoints:** NCM uses 2 IN + 1 OUT; a playback-only UAC2 adds 1 iso IN.
+  ~3 of 7. Fine.
+- **FIFO:** 4080 DWORDs minus 2048 (rx) and 1024 (np_tx) leaves ~1008 averaged
+  across IN endpoints (`dwc2_set_param_tx_fifo_sizes` does this automatically,
+  so the classic "not enough SPRAM" pain does not apply). A 10ch/44.1k packet
+  at high speed is **140 bytes** against a 1024 cap; the ceiling is ~36ch at
+  32-bit.
+- **dwc2 gadget isochronous is supported** on both the DDMA and buffer-DMA
+  paths. The only restrictions — ISOC IN DDMA rejects `bInterval > 10`, HB ISOC
+  OUT DDMA unsupported — do not bind us.
+- **Root on the device is `ssh root@move.local`** (key auth). There is no
+  `sudo` binary and `ableton` cannot load modules.
+
+## The composite device needs IAD, and it does not break NCM
+
+The stock gadget sets `bDeviceClass = 2` (Communications), correct for a lone
+NCM function. A composite NCM + UAC2 device must declare an Interface
+Association Descriptor — `0xEF / 0x02 / 0x01` — or a host binds only the first
+function. This is the one change with a blast radius outside the feature, since
+it alters how existing hosts enumerate the **ethernet** gadget, and there is a
+`WINNCM` OS descriptor in `/etc/init.d/setup-usb-network-gadget` for Windows.
+
+Verified with both functions bound: UDC `configured` at `high-speed`, `usb0`
+`LOWER_UP`, the Mac took a DHCP lease, and schwung-manager answered over the
+cable (`HTTP 303 in 4 ms` via `172.16.254.1`). **Not yet tested on Windows.**
+
+## Verified end to end
+
+The device streamed 10 s of tones (channel N at `(N+1)*100` Hz) while the Mac
+captured all ten channels via `ffmpeg -f avfoundation -i ":5"`. FFT of a 4 s
+window put every channel's peak within 1.5 Hz of its own tone, identical
+per-channel RMS, no cross-talk, **zero xruns**. `tools/uac2/uac2_tone.c`.
+
+Two things that look like bugs and are not:
+
+- **`-EIO` from `snd_pcm_writei` when the host is not streaming.** Nothing
+  drains the PCM, the buffer fills, the write fails. It goes away the moment
+  something opens the input. Do not debug it.
+- **macOS names the device "Capture Inactive"** (avfoundation index 5; index 6
+  is the XMOS's "Ableton Move Audio"). Cosmetic, from the descriptor strings.
+
+## Channel map
+
+**The channel count is fixed at enumeration**, because `p_chmask` is baked into
+the descriptors the host reads when it binds. Changing 10 -> 8 on a mode toggle
+would need a UDC unbind/rebind: the audio device vanishes mid-session, every
+DAW holding that input drops it, and `usb0` goes with it. So the count is
+**always 10** and only the content follows the mode — the same way Save Stems
+varies its content while its file layout stays put.
+
+Stems are **pre-Master-FX and pre-master-volume**, so a DAW gets unity audio
+that the volume knob does not touch.
+
+| ch | Move->Schwung ON | Move->Schwung OFF |
+|----|------------------|-------------------|
+| 1-8 | slot N = `move_track + synth`, slot FX on the **sum**, at slot volume | slot N = Schwung's synth through its FX only |
+| 9-10 | **silent** — Move's audio is already inside ch1-8 | Move's mailbox mix, un-scaled back to unity |
+
+- Under Move->Schwung a slot with **no module loaded still carries its Move
+  track** (`schwung_shim.c:2656`), so an empty slot is not a dead channel.
+- The Move pair is silent under Move->Schwung **by construction**, not by
+  omission: a sixth source repeating them would double every instrument.
+- An idle slot sets `shadow_stem_valid[s] = 0`, which the consumer writes as
+  **silence, never stale audio**. The stem bus is explicitly sample-aligned
+  across all five, which is what a multitrack DAW needs.
+
+Two silent channels read as a broken interface. UAC2 carries per-channel names,
+so they should enumerate as `Slot 1 L/R … Move L/R` — the same string table
+that currently makes macOS say "Capture Inactive", so both are one fix.
+
+## The feed (not yet written)
+
+### Tap the stem bus, not `/schwung-pub-audio`
+
+`/schwung-pub-audio` already publishes per-slot audio continuously and looks
+like the obvious source. It is the wrong one: its 5th slot is the **ME master,
+not the Move stem**, several write sites are gated on `link_audio.enabled`, and
+an idle slot **stops advancing `write_pos`** rather than writing silence — so
+channels would drift out of sample alignment against each other.
+
+The source is `shadow_stem_bus[5][FRAMES_PER_BLOCK*2]` with
+`shadow_stem_valid[5]`, in `shadow_inprocess_mix_from_buffer()`
+(`schwung_shim.c:2234`), handed off by `shadow_stem_dispatch()`.
+
+### The Save Stems gate has to widen
+
+`shadow_stems_wanted` is driven by the Save Stems **setting**, and
+`shadow_stem_dispatch` is additionally inside
+`if (sampler_source == SAMPLER_SOURCE_RESAMPLE)`. Tapping there unchanged means
+USB multi-out silently works only when Save Stems happens to be on.
+
+The wants bit becomes *Save Stems is on* **or** *the USB host is streaming*.
+This is a feature, not a workaround: with nothing capturing, the stem path stays
+switched off and costs exactly what it costs today.
+
+### There is no published `rebuild_from_la`
+
+It is recomputed per frame from four terms at `schwung_shim.c:2346`. A consumer
+that re-derives the predicate will get it subtly wrong (there are already two
+near-copies in the file, `any_la_rebuild` and `skip_deferred_fx`, each missing a
+different term). Write a latch where it is computed and publish that.
+
+### Shape
+
+```
+SPI callback  ->  shadow_stem_bus[5]  ->  /schwung-uac2-out ring
+                                              |
+                              uac2-bridge (SCHED_OTHER, cores 0-2)
+                                              |
+                                    u_audio PCM (hw:0,0)  ->  USB iso IN  ->  host
+```
+
+The bridge must not run at the callback's priority — `pthread_create` from
+there inherits **FIFO 70**, which starves Move's own `Link Main` at 35.
+
+Open question: the XMOS is clock master and the iso IN endpoint is
+asynchronous, so the host adapts — but the bridge still has to handle the
+gadget PCM draining at the host's rate against the SPI frame's rate. Drift is
+the part most likely to bite.
+
+## Remaining work
+
+1. The SHM ring + shim publish (widen the wants gate, add the rebuild latch).
+2. The bridge process.
+3. Per-channel descriptor names, and a device name that is not "Capture Inactive".
+4. Persist the gadget: `scripts/uac2-gadget.sh` is runtime-only today; folding
+   it into `/etc/init.d/setup-usb-network-gadget` and `install.sh` is a separate
+   step, and wants a settings toggle.
+5. Windows enumeration test for the IAD change.
+6. **Maintenance tax:** a firmware update wipes the modules; a kernel version
+   bump breaks vermagic and forces a rebuild. `install.sh` must detect and
+   re-place them.

--- a/scripts/build-uac2-modules.sh
+++ b/scripts/build-uac2-modules.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# Build the USB Audio Class 2.0 gadget modules for Move's stock kernel.
+#
+# Move's kernel ships with CONFIG_SND unset, so f_uac2 and the ALSA core it
+# needs are absent even though their source is in Ableton's GPL drop. This
+# builds them as loadable modules against the SAME source and config the device
+# runs, so no kernel image is replaced.
+#
+# The build is only safe because MODVERSIONS symbol CRCs are unchanged by the
+# config flips. That is not assumed — the script builds twice (stock, then
+# flipped) and fails if any pre-existing exported symbol's CRC moved, or if any
+# module depends on a symbol the stock kernel does not provide at that CRC.
+#
+# Requires Docker. On an arm64 host the kernel builds natively; on x86_64 it
+# cross-compiles (slower).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+EXPECTED_RELEASE="5.15.92-rt57-v8"
+GPL_ROOT="${SCHWUNG_GPL_SOURCES:-$HOME/Downloads/sources}"
+KERNEL_CONFIG="${SCHWUNG_KERNEL_CONFIG:-$GPL_ROOT/config-$EXPECTED_RELEASE}"
+OUT_DIR="$REPO_ROOT/dist/uac2-modules"
+VOLUME="schwung-uac2-ksrc"
+IMAGE="schwung-kbuild"
+
+# The five modules we need. snd-timer is not optional: snd-pcm depends on it.
+MODULE_PATHS=(
+  sound/core/snd.ko
+  sound/core/snd-timer.ko
+  sound/core/snd-pcm.ko
+  drivers/usb/gadget/function/u_audio.ko
+  drivers/usb/gadget/function/usb_f_uac2.ko
+)
+
+REUSE_SOURCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --reuse) REUSE_SOURCE=1 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ -z "${SCHWUNG_KERNEL_TARBALL:-}" ]; then
+  KERNEL_TARBALL="$(ls "$GPL_ROOT"/aarch64-oe-linux/linux-raspberrypi-*/*.tar.xz 2>/dev/null | head -n 1 || true)"
+else
+  KERNEL_TARBALL="$SCHWUNG_KERNEL_TARBALL"
+fi
+
+if [ -z "$KERNEL_TARBALL" ] || [ ! -f "$KERNEL_TARBALL" ]; then
+  cat >&2 <<EOF
+error: could not find the kernel source tarball.
+
+This needs Ableton's GPL source drop, which is not in this repo (it is ~130 MB).
+Point at it with one of:
+
+  SCHWUNG_GPL_SOURCES=/path/to/sources        (expects aarch64-oe-linux/linux-raspberrypi-*/ and config-$EXPECTED_RELEASE)
+  SCHWUNG_KERNEL_TARBALL=/path/to/kernel.tar.xz SCHWUNG_KERNEL_CONFIG=/path/to/config
+EOF
+  exit 1
+fi
+
+if [ ! -f "$KERNEL_CONFIG" ]; then
+  echo "error: kernel config not found: $KERNEL_CONFIG" >&2
+  exit 1
+fi
+
+command -v docker >/dev/null || { echo "error: docker is required" >&2; exit 1; }
+
+echo "=== Building UAC2 gadget modules for $EXPECTED_RELEASE"
+echo "    source: $KERNEL_TARBALL"
+echo "    config: $KERNEL_CONFIG"
+
+# Native on arm64, cross elsewhere. gcc 11 matches the Yocto toolchain's major.
+HOST_ARCH="$(docker info --format '{{.Architecture}}')"
+if [ "$HOST_ARCH" = "aarch64" ] || [ "$HOST_ARCH" = "arm64" ]; then
+  CROSS_PKGS="build-essential gcc-11-plugin-dev"
+  CROSS_MAKE=""
+else
+  CROSS_PKGS="build-essential gcc-aarch64-linux-gnu gcc-11-plugin-dev-aarch64-linux-gnu"
+  CROSS_MAKE="CROSS_COMPILE=aarch64-linux-gnu-"
+fi
+
+docker build -q -t "$IMAGE" - <<EOF >/dev/null 2>&1
+FROM ubuntu:22.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      $CROSS_PKGS bc bison flex libssl-dev libelf-dev kmod cpio rsync \
+      python3 ca-certificates xz-utils \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /src
+EOF
+
+mkdir -p "$OUT_DIR"
+cp "$KERNEL_CONFIG" "$OUT_DIR/config.stock"
+cp "$SCRIPT_DIR/verify-uac2-abi.sh" "$OUT_DIR/verify-uac2-abi.sh"
+
+if [ "$REUSE_SOURCE" = "1" ] && docker volume inspect "$VOLUME" >/dev/null 2>&1; then
+  echo "--- reusing existing source volume ($VOLUME)"
+else
+  echo "--- extracting kernel source into a docker volume (this is not a bind mount: bind-mounted"
+  echo "    kernel builds on macOS are an order of magnitude slower)"
+  docker volume rm -f "$VOLUME" >/dev/null 2>&1 || true
+  docker volume create "$VOLUME" >/dev/null
+  docker run --rm -v "$KERNEL_TARBALL:/tarball.tar.xz:ro" -v "$VOLUME:/vol" "$IMAGE" \
+    bash -c 'tar -xJf /tarball.tar.xz -C /vol --strip-components=1 && make -C /vol mrproper >/dev/null 2>&1 || true'
+fi
+
+JOBS="$(docker info --format '{{.NCPU}}')"
+
+docker run --rm -i \
+  -v "$VOLUME:/src" -v "$OUT_DIR:/out" \
+  -e "EXPECTED_RELEASE=$EXPECTED_RELEASE" -e "JOBS=$JOBS" -e "CROSS_MAKE=$CROSS_MAKE" \
+  -e "MODULE_PATHS=${MODULE_PATHS[*]}" \
+  "$IMAGE" bash -s <<'INNER'
+set -euo pipefail
+cd /src
+MAKE="make ARCH=arm64 $CROSS_MAKE"
+
+echo "--- configuring (stock)"
+cp /out/config.stock .config
+$MAKE olddefconfig >/dev/null
+
+RELEASE="$($MAKE -s kernelrelease)"
+if [ "$RELEASE" != "$EXPECTED_RELEASE" ]; then
+  echo "error: kernel release is '$RELEASE', expected '$EXPECTED_RELEASE'." >&2
+  echo "       The modules would carry the wrong vermagic and refuse to load." >&2
+  exit 1
+fi
+echo "    kernelrelease: $RELEASE"
+
+echo "--- build 1/2: stock config (establishes the reference ABI)"
+$MAKE -j"$JOBS" vmlinux modules >/out/build-stock.log 2>&1
+cp Module.symvers /out/symvers.stock
+
+echo "--- enabling SND, SND_PCM and USB_CONFIGFS_F_UAC2"
+./scripts/config --file .config --module SND --module SND_PCM --enable USB_CONFIGFS_F_UAC2
+$MAKE olddefconfig >/dev/null
+cp .config /out/config.uac2
+
+echo "--- build 2/2: with UAC2"
+$MAKE -j"$JOBS" vmlinux modules >/out/build-uac2.log 2>&1
+cp Module.symvers /out/symvers.uac2
+
+# ---- Gate 1: no pre-existing exported symbol may change CRC. -----------------
+# If one did, every already-loaded module on the device would be at a different
+# ABI than the kernel we derived these from, and nothing here is safe to ship.
+# The comparison lives in its own script so tests/host/test_uac2_abi_gate.sh can
+# prove it actually rejects a moved CRC.
+echo "--- verifying: exported symbol CRCs unchanged"
+bash /out/verify-uac2-abi.sh /out/symvers.stock /out/symvers.uac2
+
+# ---- Gate 2: collect the modules, check vermagic and every dependency. -------
+rm -rf /out/ko && mkdir -p /out/ko
+for m in $MODULE_PATHS; do
+  [ -f "$m" ] || { echo "error: expected module not built: $m" >&2; exit 1; }
+  cp "$m" /out/ko/
+done
+
+echo "--- verifying: vermagic"
+for f in /out/ko/*.ko; do
+  vm="$(modinfo -F vermagic "$f")"
+  case "$vm" in
+    "$EXPECTED_RELEASE "*) ;;
+    *) echo "error: $(basename "$f") has vermagic '$vm'" >&2; exit 1 ;;
+  esac
+done
+echo "    all modules: $(modinfo -F vermagic /out/ko/snd.ko)"
+
+echo "--- verifying: every module symbol resolves against the STOCK kernel"
+awk '{print $2}' /out/symvers.stock | sort > /tmp/stock.syms
+awk '{print $2, $1}' /out/symvers.stock | sort > /tmp/stock.crc
+awk '{print $2, $3}' /out/symvers.uac2 | sort > /tmp/uac2.prov
+ours=$(for m in $MODULE_PATHS; do echo "${m%.ko}"; done)
+
+from_kernel=0; from_set=0; bad=0
+for f in /out/ko/*.ko; do
+  while read -r crc sym; do
+    if grep -qx "$sym" /tmp/stock.syms; then
+      have="$(grep -m1 "^$sym " /tmp/stock.crc | cut -d' ' -f2)"
+      if [ "$have" != "$crc" ]; then
+        echo "  CRC MISMATCH: $(basename "$f") needs $sym at $crc, kernel has $have" >&2
+        bad=$((bad + 1))
+      else
+        from_kernel=$((from_kernel + 1))
+      fi
+    else
+      prov="$(grep -m1 "^$sym " /tmp/uac2.prov | cut -d' ' -f2 || true)"
+      if echo "$ours" | grep -qx "$prov"; then
+        from_set=$((from_set + 1))
+      else
+        echo "  UNSATISFIED: $(basename "$f") needs $sym <- ${prov:-nothing}" >&2
+        bad=$((bad + 1))
+      fi
+    fi
+  done < <(modprobe --dump-modversions "$f")
+done
+echo "    resolved by running kernel: $from_kernel, by this module set: $from_set, unsatisfied: $bad"
+[ "$bad" -eq 0 ] || { echo "error: $bad unsatisfied dependencies. Refusing to package." >&2; exit 1; }
+
+# Only vmlinux's build stamp may differ between the two builds.
+echo "--- built-in objects rebuilt by the config change:"
+grep '^  CC' /out/build-uac2.log | grep -v '\[M\]' | awk '{print "    " $2}' | sort -u || true
+
+{
+  echo "# Schwung UAC2 gadget modules"
+  echo "# kernelrelease: $EXPECTED_RELEASE"
+  echo "# vermagic:      $(modinfo -F vermagic /out/ko/snd.ko)"
+  echo "# exported symbol ABI vs stock: unchanged (verified)"
+  echo
+  cd /out/ko && sha256sum *.ko
+} > /out/manifest.txt
+INNER
+
+echo
+echo "=== Modules built and verified"
+cat "$OUT_DIR/manifest.txt"
+echo
+echo "Output: $OUT_DIR/ko/"

--- a/scripts/uac2-gadget.sh
+++ b/scripts/uac2-gadget.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Runtime-only: add/remove a UAC2 audio function on Move's existing NCM gadget.
+# Nothing here is persisted; a reboot restores the stock gadget.
+set -e
+G=/sys/kernel/config/usb_gadget/g1
+F=$G/functions/uac2.0
+CFG=$G/configs/c.1
+
+CHANNELS=${CHANNELS:-10}
+SRATE=${SRATE:-44100}
+SSIZE=${SSIZE:-2}
+
+case "$1" in
+start)
+  # 10 channels -> a 10-bit spatial channel mask.
+  mask=$(awk "BEGIN{printf \"0x%x\", 2^$CHANNELS - 1}")
+
+  echo "" > $G/UDC                       # unbind; this drops usb0
+  mkdir -p $F
+  echo $mask   > $F/p_chmask             # gadget -> host (what the Mac records)
+  echo $SRATE  > $F/p_srate
+  echo $SSIZE  > $F/p_ssize
+  echo 0       > $F/c_chmask             # no host -> gadget stream
+  echo 0       > $F/p_mute_present       # skip the control interrupt endpoint
+  echo 0       > $F/p_volume_present
+
+  # A composite NCM + UAC2 device must declare IAD, or a host binds only the
+  # first function. This replaces bDeviceClass=2 (Communications).
+  echo 0xEF > $G/bDeviceClass
+  echo 0x02 > $G/bDeviceSubClass
+  echo 0x01 > $G/bDeviceProtocol
+
+  ln -sf $F $CFG/uac2.0
+  ls /sys/class/udc > $G/UDC             # rebind
+  echo "started: ${CHANNELS}ch @ ${SRATE} ${SSIZE}B, mask $mask"
+  ;;
+stop)
+  echo "" > $G/UDC 2>/dev/null || true
+  rm -f $CFG/uac2.0
+  rmdir $F 2>/dev/null || true
+  echo 2    > $G/bDeviceClass            # back to Communications
+  echo 0    > $G/bDeviceSubClass
+  echo 0    > $G/bDeviceProtocol
+  ls /sys/class/udc > $G/UDC
+  echo "stopped: stock NCM-only gadget restored"
+  ;;
+*) echo "usage: $0 start|stop" >&2; exit 2 ;;
+esac

--- a/scripts/verify-uac2-abi.sh
+++ b/scripts/verify-uac2-abi.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Compare two Module.symvers and fail if any symbol that existed before changed
+# its MODVERSIONS CRC.
+#
+# This is the whole reason the UAC2 modules can be shipped without replacing the
+# kernel: enabling SND/SND_PCM/USB_CONFIGFS_F_UAC2 must add exports and change
+# none. A changed CRC means a module built here would refuse to load against the
+# device's running kernel — or worse, that the built-in ABI moved and nothing
+# derived from this tree is trustworthy.
+#
+# Split out of build-uac2-modules.sh so it can be tested without Docker or a
+# kernel tree. Usage: verify-uac2-abi.sh <symvers.stock> <symvers.new>
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+  echo "usage: $(basename "$0") <symvers.stock> <symvers.new>" >&2
+  exit 2
+fi
+
+STOCK="$1"
+NEW="$2"
+
+for f in "$STOCK" "$NEW"; do
+  [ -f "$f" ] || { echo "error: no such file: $f" >&2; exit 2; }
+done
+
+# Module.symvers columns: CRC symbol module export_type [namespace]
+changes="$(join -j2 -o 1.1,1.2,2.1 \
+             <(sort -k2,2 "$STOCK") \
+             <(sort -k2,2 "$NEW") | awk '$1 != $3')"
+
+# A symbol present before and absent now is just as fatal as a changed CRC:
+# a module that needs it would fail to resolve.
+dropped="$(comm -23 <(awk '{print $2}' "$STOCK" | sort -u) \
+                    <(awk '{print $2}' "$NEW" | sort -u))"
+
+before="$(wc -l < "$STOCK" | tr -d ' ')"
+after="$(wc -l < "$NEW" | tr -d ' ')"
+n_changed="$(printf '%s' "$changes" | grep -c . || true)"
+n_dropped="$(printf '%s' "$dropped" | grep -c . || true)"
+
+echo "    symbols: $before -> $after, changed CRCs: $n_changed, dropped: $n_dropped"
+
+if [ "$n_changed" -ne 0 ] || [ "$n_dropped" -ne 0 ]; then
+  echo "error: the exported-symbol ABI moved. These modules are not safe to load" >&2
+  echo "       against the device's kernel. Refusing to package." >&2
+  if [ "$n_changed" -ne 0 ]; then
+    echo "  changed (symbol: stock -> new):" >&2
+    printf '%s\n' "$changes" | head -n 20 | awk '{print "    " $2 ": " $1 " -> " $3}' >&2
+  fi
+  if [ "$n_dropped" -ne 0 ]; then
+    echo "  dropped:" >&2
+    printf '%s\n' "$dropped" | head -n 20 | sed 's/^/    /' >&2
+  fi
+  exit 1
+fi

--- a/tests/host/test_uac2_abi_gate.sh
+++ b/tests/host/test_uac2_abi_gate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# The ABI gate that lets the UAC2 gadget modules ship without a kernel replacement.
+#
+# scripts/build-uac2-modules.sh builds the kernel twice — stock, then with
+# SND/SND_PCM/USB_CONFIGFS_F_UAC2 flipped on — and refuses to package if any
+# already-exported symbol changed its MODVERSIONS CRC. That check is the only
+# thing standing between "five modules that load" and "five modules that fail to
+# resolve against the device's running kernel".
+#
+# A gate that cannot fail is not a gate, so this exercises the failure paths
+# explicitly: an unchanged pair must pass, and a CRC change, a dropped symbol,
+# and both together must each be rejected. Fixtures are synthetic, so this needs
+# no Docker, no kernel tree and no GPL drop — it runs in CI.
+
+VERIFY="scripts/verify-uac2-abi.sh"
+[ -x "$VERIFY" ] || { echo "FAIL: $VERIFY missing or not executable"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Module.symvers columns: CRC symbol module export_type
+cat > "$TMP/stock" <<'EOF'
+0x1a2b3c4d	snd_card_new	vmlinux	EXPORT_SYMBOL
+0x5e6f7a8b	usb_ep_queue	vmlinux	EXPORT_SYMBOL_GPL
+0x9c0d1e2f	kmalloc_caches	vmlinux	EXPORT_SYMBOL
+0xdeadbeef	config_ep_by_speed	vmlinux	EXPORT_SYMBOL_GPL
+EOF
+
+# The real shape of a good build: same symbols at the same CRCs, plus new ones.
+cat "$TMP/stock" > "$TMP/good"
+cat >> "$TMP/good" <<'EOF'
+0xaaaa0001	u_audio_start_playback	drivers/usb/gadget/function/u_audio	EXPORT_SYMBOL_GPL
+0xaaaa0002	snd_pcm_new	sound/core/snd-pcm	EXPORT_SYMBOL
+EOF
+
+# One CRC moved.
+sed 's/^0x5e6f7a8b\tusb_ep_queue/0xffff0000\tusb_ep_queue/' "$TMP/good" > "$TMP/crc_changed"
+
+# One symbol vanished.
+grep -v 'config_ep_by_speed' "$TMP/good" > "$TMP/dropped"
+
+# Both at once.
+grep -v 'config_ep_by_speed' "$TMP/crc_changed" > "$TMP/both"
+
+fail=0
+
+expect_pass() {
+  local name="$1" file="$2"
+  if out="$("$VERIFY" "$TMP/stock" "$file" 2>&1)"; then
+    echo "ok: $name accepted"
+  else
+    echo "FAIL: $name should have been accepted, but the gate rejected it"
+    echo "$out" | sed 's/^/    /'
+    fail=1
+  fi
+}
+
+expect_reject() {
+  local name="$1" file="$2" needle="$3"
+  if out="$("$VERIFY" "$TMP/stock" "$file" 2>&1)"; then
+    echo "FAIL: $name was ACCEPTED — the gate cannot detect this and is useless"
+    echo "$out" | sed 's/^/    /'
+    fail=1
+  elif ! printf '%s' "$out" | grep -q "$needle"; then
+    echo "FAIL: $name was rejected, but the message never mentions '$needle'"
+    echo "$out" | sed 's/^/    /'
+    fail=1
+  else
+    echo "ok: $name rejected"
+  fi
+}
+
+expect_pass   "unchanged ABI plus new exports" "$TMP/good"
+expect_reject "a changed symbol CRC"           "$TMP/crc_changed" "usb_ep_queue"
+expect_reject "a dropped symbol"               "$TMP/dropped"     "config_ep_by_speed"
+expect_reject "a changed CRC and a drop"       "$TMP/both"        "ABI moved"
+
+# The build script must actually USE the gate, and must not package past it.
+BUILD="scripts/build-uac2-modules.sh"
+[ -f "$BUILD" ] || { echo "FAIL: $BUILD missing"; exit 1; }
+
+if ! grep -q 'changed CRCs' "$BUILD" && ! grep -q 'verify-uac2-abi' "$BUILD"; then
+  echo "FAIL: $BUILD no longer performs the symbol-CRC comparison"
+  fail=1
+else
+  echo "ok: build script performs the CRC comparison"
+fi
+
+# The five modules are a set: snd-pcm needs snd-timer, and shipping four of
+# them produces a module that cannot resolve at insmod time on the device.
+for m in snd.ko snd-timer.ko snd-pcm.ko u_audio.ko usb_f_uac2.ko; do
+  if ! grep -q "$m" "$BUILD"; then
+    echo "FAIL: $BUILD no longer builds $m"
+    fail=1
+  fi
+done
+[ "$fail" = 0 ] && echo "ok: all five modules still in the build set"
+
+if [ "$fail" != 0 ]; then
+  echo "FAILED"
+  exit 1
+fi
+echo "PASS"

--- a/tools/uac2/uac2_tone.c
+++ b/tools/uac2/uac2_tone.c
@@ -1,0 +1,93 @@
+// Throwaway probe: push 10 distinct tones into the UAC2 gadget's PCM so each
+// channel is identifiable on the host. Channel N carries (N+1)*100 Hz, so
+// channel 1 = 100 Hz ... channel 10 = 1000 Hz.
+//
+// This exists to prove the isochronous IN stream actually carries 10 channels
+// of real audio under dwc2 before any SHM plumbing is built. Not shipped.
+
+#include <alsa/asoundlib.h>
+#include <math.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CHANNELS 10
+#define RATE     44100
+#define PERIOD   256
+
+static volatile sig_atomic_t stop_now = 0;
+static void on_sig(int s) { (void)s; stop_now = 1; }
+
+int main(int argc, char **argv)
+{
+    const char *dev = (argc > 1) ? argv[1] : "hw:0,0";
+    int seconds = (argc > 2) ? atoi(argv[2]) : 30;
+
+    signal(SIGINT, on_sig);
+    signal(SIGTERM, on_sig);
+
+    snd_pcm_t *pcm = NULL;
+    int err = snd_pcm_open(&pcm, dev, SND_PCM_STREAM_PLAYBACK, 0);
+    if (err < 0) {
+        fprintf(stderr, "open %s: %s\n", dev, snd_strerror(err));
+        return 1;
+    }
+
+    err = snd_pcm_set_params(pcm, SND_PCM_FORMAT_S16_LE,
+                             SND_PCM_ACCESS_RW_INTERLEAVED,
+                             CHANNELS, RATE,
+                             1,        /* allow resampling */
+                             100000);  /* 100 ms latency */
+    if (err < 0) {
+        fprintf(stderr, "set_params (%d ch @ %d): %s\n",
+                CHANNELS, RATE, snd_strerror(err));
+        snd_pcm_close(pcm);
+        return 1;
+    }
+
+    unsigned int rate = 0, channels = 0;
+    snd_pcm_hw_params_t *hw;
+    snd_pcm_hw_params_alloca(&hw);
+    if (snd_pcm_hw_params_current(pcm, hw) == 0) {
+        snd_pcm_hw_params_get_rate(hw, &rate, NULL);
+        snd_pcm_hw_params_get_channels(hw, &channels);
+    }
+    printf("negotiated: %u ch @ %u Hz, S16_LE\n", channels, rate);
+    printf("channel N carries (N+1)*100 Hz: ch1=100Hz ... ch10=1000Hz\n");
+    fflush(stdout);
+
+    static int16_t buf[PERIOD * CHANNELS];
+    double phase[CHANNELS] = {0};
+    long total = (long)seconds * RATE;
+    long done = 0;
+
+    while (!stop_now && done < total) {
+        for (int f = 0; f < PERIOD; f++) {
+            for (int c = 0; c < CHANNELS; c++) {
+                double freq = (c + 1) * 100.0;
+                buf[f * CHANNELS + c] = (int16_t)(8000.0 * sin(phase[c]));
+                phase[c] += 2.0 * M_PI * freq / RATE;
+                if (phase[c] > 2.0 * M_PI) phase[c] -= 2.0 * M_PI;
+            }
+        }
+
+        snd_pcm_sframes_t w = snd_pcm_writei(pcm, buf, PERIOD);
+        if (w < 0) {
+            w = snd_pcm_recover(pcm, (int)w, 0);
+            if (w < 0) {
+                fprintf(stderr, "write: %s\n", snd_strerror((int)w));
+                break;
+            }
+            continue;
+        }
+        done += w;
+
+        if ((done % (RATE * 5)) < PERIOD)
+            printf("  %lds streamed\n", done / RATE), fflush(stdout);
+    }
+
+    snd_pcm_drain(pcm);
+    snd_pcm_close(pcm);
+    printf("done: %ld frames (%.1f s)\n", done, (double)done / RATE);
+    return 0;
+}


### PR DESCRIPTION
Groundwork for **Move appearing to a computer as a multi-channel audio interface over USB-C** — per-slot stems as separate inputs on the host, not network audio.

## Why this is possible at all

The USB-C audio device a Mac sees today is the **XMOS**, whose firmware is closed and absent from Ableton's GPL drop — and the Pi could not feed it more anyway, since SPI carries exactly 128 stereo int16 each way. That route is closed.

But `drivers/usb/gadget/function/f_uac2.c` **is** in the GPL source; it just isn't compiled, because `CONFIG_SND` is unset. Three config facts make shipping it as modules realistic:

- `CONFIG_SOUND=y` — soundcore is already in the running vmlinux; only `snd`/`snd-pcm` are missing, and both are ordinary modules.
- `# CONFIG_MODULE_SIG is not set` — unsigned modules load.
- `CONFIG_MODVERSIONS=y` — so symbol CRCs must match, which is what the gate below checks.

**No kernel image is replaced.**

## What's verified, not assumed

`scripts/build-uac2-modules.sh` builds the kernel twice — stock, then with `SND=m`, `SND_PCM=m`, `USB_CONFIGFS_F_UAC2=y` — and refuses to package unless the ABI held:

| check | result on this tree |
|---|---|
| `make kernelrelease` | `5.15.92-rt57-v8` (exact device match) |
| exported symbols | 10231 → 10405 (+174, all new) |
| changed CRCs / dropped symbols | **0 / 0** |
| module symbol dependencies | 368: 306 from the running kernel, 62 from this set, **0 unsatisfied** |
| built-in objects rebuilt by the flips | **none** — build 2 never relinks vmlinux |

vermagic on all five: `5.15.92-rt57-v8 SMP preempt_rt mod_unload modversions aarch64`. Output is byte-identical across runs.

Five modules, not four — `snd-pcm` pulls in `snd-timer`.

## The gate is tested

The CRC comparison is split into `scripts/verify-uac2-abi.sh` so `tests/host/test_uac2_abi_gate.sh` can run it on synthetic fixtures with no Docker, no kernel tree and no GPL drop. A gate that cannot fail is not a gate, so the test mutates a CRC, drops a symbol, and does both, and requires each to be rejected.

## Scope

Build only. Nothing loads these on the device. Still ahead, and deliberately separate:

- **Gadget side.** The gadget is built by `/etc/init.d/setup-usb-network-gadget`; adding a `uac2.0` function is a small edit there, but a composite NCM+UAC2 device needs an IAD device class (`0xEF/0x02/0x01` in place of the current `bDeviceClass=2`), which changes how existing hosts enumerate the **ethernet** gadget. There's a `WINNCM` OS descriptor in there for Windows. Wants testing on both.
- **The audio feed**, which is the real work: 10 channels at 44.1k from the stems the shim already computes for Save Stems into `u_audio`'s ALSA card, with the XMOS as clock master.

Device headroom checked read-only: `EPs: 8, dedicated fifos, 4080 entries in SPRAM`, UDC `maximum_speed=high-speed`. NCM uses 2 IN + 1 OUT; a playback-only UAC2 adds 1 iso IN. A 10ch/44.1k packet is 140 bytes against a 1024 cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mdhw9oz2G1QShkefinTyd