### PR TITLE
One knob, several destinations — each through its own window

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,6 +481,12 @@ layout, and the shape-edit verbs. Read it before touching `modules/chain/dsp/`.
 - **Use `key`, not `param`**, for editable `params` entries — metadata comes from
   `chain_params`, and a module missing it gets an invented `float 0..1 step 0.01`
   knob writing `0.058750` into an enum.
+- **A knob drives up to four destinations, each through its own window** (a
+  slice of that parameter's range, stored as fractions so it survives
+  re-pointing). ⚠ **One destination keeps its parameter's own step and enum
+  feel; only SEVERAL are driven by the knob's 0..1 position** — driving a lone
+  enum from a position needs ~95 detents per option instead of one. The line is
+  "several destinations", not "has a range".
 - **A plain read of a modulated key answers the BASE**, never the plugin's value
   — the plugin holds the effective value the overlay keeps writing into it. The
   driven value is asked for as `<key>:effective` (#276).

--- a/docs/API.md
+++ b/docs/API.md
@@ -363,7 +363,7 @@ console.log(msg)              // Routed to the unified logger when enabled
 | 63  | Right arrow       |                                |
 | 71-78 | Knobs 1-8       | Relative encoder (1-63 CW, 65-127 CCW) |
 | 79  | Master volume     | Relative encoder (1-63 CW, 65-127 CCW) |
-| 102-109 | Knobs 1-8 (absolute) | Absolute value (0-127 scaled to assigned param range); targets the same user-assigned knob mappings as CC 71-78 |
+| 102-109 | Knobs 1-8 (absolute) | Absolute POSITION (0-127) across the knob's own travel; targets the same user-assigned knob mappings as CC 71-78. See Chain Knob CC Out below |
 | 85  | Play              |                                |
 | 86  | Record            |                                |
 | 88  | Mute              |                                |
@@ -377,6 +377,23 @@ console.log(msg)              // Routed to the unified logger when enabled
 CC 102-109 above are the *inbound* half: they drive a chain slot's eight knob
 mappings. A slot can also send them, so a motorised controller follows values
 changed anywhere else — Move's own encoder, or a patch load.
+
+**What 0-127 means, in one sentence: where the knob sits across its own travel.**
+A knob driving several parameters sends its own position, which is the only
+thing they have in common; a knob driving one sends that parameter's value as a
+fraction of its own window. With a single whole-range destination — every knob
+that existed before destinations did — the second reduces to the parameter
+scaled across its full range, exactly as it always was, so nothing about an
+existing rig changes.
+
+Measuring a *ranged* single destination against its window rather than the full
+range is what keeps in and out symmetric. Against the full range, an external
+fader would map outside the window at both ends and clamp there, so a third of
+its throw would do nothing.
+
+Inbound is the same rule read backwards, so a controller that echoes what it was
+told lands where it started. See **Knob destinations** in `docs/CHAIN.md` for
+the destination model itself.
 
 Off by default. Enable it per slot on the device at **Slot Settings > Knobs >
 Knob CC Out**, at the bottom of the knob list. Turning it on immediately sends

--- a/docs/CHAIN.md
+++ b/docs/CHAIN.md
@@ -43,6 +43,92 @@ Modules expose `ui_hierarchy` (menu structure + knob mappings) via get_param:
 
 Types: `float` (min/max/step), `int` (min/max), `enum` (options). Optional: `default`, `unit`, `display_format`.
 
+### Knob destinations — one knob, several parameters
+
+Each of a slot's eight knobs drives up to **four** parameters (`MAX_KNOB_DESTS`),
+and each destination can be limited to a **window**: a slice of that parameter's
+own range.
+
+```
+knob 1  ->  synth: cutoff     0 .. 100%
+            fx1: mix         20 ..  80%
+            fx2: drive      100 ..   0%     (inverted)
+```
+
+`lo`/`hi` are **fractions of the destination parameter's own range**, never
+values in its units. That is what makes a window portable: re-point a
+destination at a parameter measured in Hz, dB or list positions and the window
+still means the same thing. `lo > hi` is an inverted destination — turn the knob
+up, that parameter goes down — and needs no extra machinery, because the
+interpolation simply runs backwards. An `enum` destination takes a **sub-range**
+of its option list, and its last option is reachable rather than one short.
+
+#### One destination keeps its parameter's feel
+
+> **The line is "several destinations", not "has a range".**
+
+- **One destination**, ranged or not, is the path that has always shipped plus a
+  clamp into its window. It keeps that parameter's own step size, its own
+  acceleration and its own enum behaviour.
+- **Several destinations** have no single parameter to be, so the knob's own
+  0..1 **position** becomes the thing being turned, and each destination follows
+  it through its own window.
+
+This asymmetry is arithmetic rather than taste, and it is worth stating because
+it looks like an inconsistency worth "simplifying" away. An 8-option enum spans
+7 units. A position moving by `KNOB_STEP_FLOAT` (0.0015) shifts that enum by
+0.0105 per detent — `4 -> 4.0105 -> (int) 4`, the same value — so it needs about
+95 detents per option instead of one. A parameter that shares a knob with others
+pays that by necessity. A parameter that does not must never be made to, which
+is why giving a single destination a window does **not** move it onto the
+position path. `tests/host/test_chain_knob_turn.c` measures both cases
+side by side.
+
+A knob's position is seeded from its first destination the moment it gains a
+second, so nothing jumps at that moment. It is never re-derived from a
+destination afterwards: doing so between detents would snap the position back to
+that destination's own quantisation grid, and a slow turn on a coarse
+destination would never advance.
+
+#### Editing
+
+Set-param keys, all per slot. `N` is the knob 1-8 and `M` the destination 1-4:
+
+| Key | Value | Meaning |
+| --- | --- | --- |
+| `knob_N_set` | `"target:param"` | Collapse this knob to **one whole-range** destination. Unchanged meaning. |
+| `knob_N_clear` | `"1"` | Remove the mapping. |
+| `knob_N_adjust` | `"+N"` / `"-N"` | Turn by an accumulated detent count. |
+| `knob_N_dest_M_set` | `"target:param"` | Point destination M, **keeping its window**. `M` one past the end appends. |
+| `knob_N_dest_M_range` | `"lo:hi"` | Its window, as fractions. **Applies immediately.** |
+| `knob_N_dest_M_clear` | `"1"` | Remove destination M. Removing the last clears the knob. |
+| `knob_N_position` | `"0.0".."1.0"` | Put the knob at a position; every destination follows. |
+
+⚠ `knob_N_set` **collapses** the knob, which is right for assigning an empty one
+and wrong for re-pointing the first destination of one that drives several — that
+is what `knob_N_dest_1_set` is for.
+
+A window **applies as it is set**, rather than on the next turn of the knob. A
+window is adjusted by ear, and one you cannot hear until you turn the knob again
+is one you are setting blind. On a multi-destination knob that re-derives the
+destination from the current position; on a single one it clamps the parameter
+into the new window, which can move it — deliberately, for the same reason.
+
+Readbacks: `knob_N_dests` answers the whole list as JSON in one read,
+`knob_N_dest_count` and `knob_N_position` the scalars. `knob_N_target` and
+`knob_N_param` keep answering the **first** destination, so anything that knew
+about knobs before destinations existed still gets a sensible answer.
+`knob_N_name` answers `cutoff +2` for a multi-destination knob and
+`knob_N_value` its position as a percentage.
+
+#### A knob write is a base, not a fight with an LFO
+
+`knob_forward_value` routes a modulated parameter through the modulation bus
+rather than writing past it — a knob turn is an edit of the **resting** value,
+exactly as an edit from the parameter's own page is (see the four forms above).
+Without that the next LFO tick recomputes from the stale base and erases the
+turn within milliseconds, and the knob reads as dead.
+
 ### Reading a modulated parameter — four forms, one rule
 
 While a chain-mod source (slot LFO, etc.) drives `<prefix>:<key>`, the overlay

--- a/docs/CHAIN.md
+++ b/docs/CHAIN.md
@@ -98,7 +98,7 @@ Set-param keys, all per slot. `N` is the knob 1-8 and `M` the destination 1-4:
 | --- | --- | --- |
 | `knob_N_set` | `"target:param"` | Collapse this knob to **one whole-range** destination. Unchanged meaning. |
 | `knob_N_clear` | `"1"` | Remove the mapping. |
-| `knob_N_adjust` | `"+N"` / `"-N"` | Turn by an accumulated detent count. |
+| `knob_N_adjust` | `"+N"` / `"-N"` | Turn by one detent in that direction. ⚠ The value is an accumulated COUNT, and only its sign is used — honouring the count would change the feel of every existing chain knob. |
 | `knob_N_dest_M_set` | `"target:param"` | Point destination M, **keeping its window**. `M` one past the end appends. |
 | `knob_N_dest_M_range` | `"lo:hi"` | Its window, as fractions. **Applies immediately.** |
 | `knob_N_dest_M_clear` | `"1"` | Remove destination M. Removing the last clears the knob. |

--- a/docs/CHAIN.md
+++ b/docs/CHAIN.md
@@ -121,6 +121,26 @@ about knobs before destinations existed still gets a sensible answer.
 `knob_N_name` answers `cutoff +2` for a multi-destination knob and
 `knob_N_value` its position as a percentage.
 
+#### Older hosts and a patch that uses destinations
+
+The rows are flat — several ordinary objects sharing one `cc` — so a host that
+predates destinations still *parses* the array correctly: nothing is nested, and
+the first `]` is still the end of it. A knob with one whole-range destination is
+written exactly as it always was, so an ordinary patch is unchanged in every
+respect.
+
+⚠ **But a patch that actually uses destinations is not safe to round-trip
+through an older host.** That parser stops after `MAX_KNOB_MAPPINGS` (8)
+*mappings*, and each row is one mapping to it. One four-destination knob plus
+seven ordinary ones is eleven rows, so it loads eight and silently drops the
+last three knobs — and saving from there writes back what it loaded, deleting
+them and stripping every window. `knob_N_set` and `knob_N_clear` on such a host
+also touch only the first row for that CC, so a knob "cleared" there comes back
+to a newer host still carrying its other destinations.
+
+Downgrading is therefore lossy in a way that opening is not. It is worth knowing
+before assuming a patch library is portable in both directions.
+
 #### A knob write is a base, not a fight with an LFO
 
 `knob_forward_value` routes a modulated parameter through the modulation bus

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1287,29 +1287,14 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                         chain_param_info_t *pinfo = knob_find_param(inst, target, param);
                         if (!pinfo) continue;
 
-                        /* Calculate acceleration based on time between events */
-                        uint64_t now = get_time_ms();
-                        uint64_t last = inst->knob_last_time_ms[i];
-                        inst->knob_last_time_ms[i] = now;
-                        int accel = KNOB_ACCEL_MIN_MULT;
-                        if (last > 0) {
-                            uint64_t elapsed = now - last;
-                            if (elapsed <= KNOB_ACCEL_FAST_MS) {
-                                accel = KNOB_ACCEL_MAX_MULT;
-                            } else if (elapsed < KNOB_ACCEL_SLOW_MS) {
-                                float ratio = (float)(KNOB_ACCEL_SLOW_MS - elapsed) /
-                                              (float)(KNOB_ACCEL_SLOW_MS - KNOB_ACCEL_FAST_MS);
-                                accel = KNOB_ACCEL_MIN_MULT + (int)(ratio * (KNOB_ACCEL_MAX_MULT - KNOB_ACCEL_MIN_MULT));
-                            }
-                        }
-
-                        /* Cap acceleration: enums never accelerate, ints limited */
+                        /* Acceleration from the time between events, then the
+                         * cap this parameter's type asks for. The two spellings
+                         * this replaces nested their bounds differently and
+                         * computed the same answer; chain_knob_accel is the one
+                         * that remains. */
+                        int accel = chain_knob_accel(&inst->knob_last_time_ms[i]);
+                        accel = chain_knob_accel_cap(accel, pinfo->type);
                         int is_int = (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM);
-                        if (pinfo->type == KNOB_TYPE_ENUM) {
-                            accel = KNOB_ACCEL_ENUM_MULT;
-                        } else if (is_int && accel > KNOB_ACCEL_MAX_MULT_INT) {
-                            accel = KNOB_ACCEL_MAX_MULT_INT;
-                        }
                         /* Use step from param metadata, or 0.01 default for shadow adjust */
                         float base_step = (pinfo->step > 0) ? pinfo->step
                             : (is_int ? (float)KNOB_STEP_INT : 0.01f);

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1288,43 +1288,26 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                 /* Find mapping for this CC */
                 for (int i = 0; i < inst->knob_mapping_count; i++) {
                     if (inst->knob_mappings[i].cc == cc) {
-                        /* Look up parameter metadata */
-                        const char *target = inst->knob_mappings[i].dests[0].target;
-                        const char *param = inst->knob_mappings[i].dests[0].param;
-                        chain_param_info_t *pinfo = knob_find_param(inst, target, param);
-                        if (!pinfo) continue;
-
-                        /* Acceleration from the time between events, then the
-                         * cap this parameter's type asks for. The two spellings
-                         * this replaces nested their bounds differently and
-                         * computed the same answer; chain_knob_accel is the one
-                         * that remains. */
-                        int accel = chain_knob_accel(&inst->knob_last_time_ms[i]);
-                        accel = chain_knob_accel_cap(accel, pinfo->type);
-                        int is_int = (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM);
-                        /* Use step from param metadata, or 0.01 default for shadow adjust */
-                        float base_step = (pinfo->step > 0) ? pinfo->step
-                            : (is_int ? (float)KNOB_STEP_INT : 0.01f);
-                        float delta = base_step * accel * (delta_int > 0 ? 1 : -1);
-
-                        /* Apply delta with clamping */
-                        float new_val = inst->knob_mappings[i].dests[0].current_value + delta;
-                        if (new_val < pinfo->min_val) new_val = pinfo->min_val;
-                        if (new_val > pinfo->max_val) new_val = pinfo->max_val;
-                        if (is_int) new_val = (float)((int)new_val);  /* Round to int */
-                        inst->knob_mappings[i].dests[0].current_value = new_val;
-
-                        /* Format value as string */
-                        char val_str[16];
-                        if (is_int) {
-                            snprintf(val_str, sizeof(val_str), "%d", (int)new_val);
-                        } else {
-                            snprintf(val_str, sizeof(val_str), "%.3f", new_val);
-                        }
-
-                        knob_forward_value(inst, target, param, val_str);
-                        /* Move's own encoder moved this knob. Nothing else
-                         * tells an external control surface that happened. */
+                        /*
+                         * ONE detent per message, whatever `val` says.
+                         *
+                         * handleKnobTurn in shadow_ui.js sums every detent for
+                         * this knob between frames, so `val` is an accumulated
+                         * COUNT and reading only its sign discards a fast turn.
+                         * Honouring the count would make the device's own
+                         * encoders move further for the same gesture -- a
+                         * change every existing user would feel on every chain
+                         * knob, and not one to make in passing. The sign is
+                         * what has always shipped here; max(1, accel) == accel,
+                         * so this is bit-identical to it.
+                         *
+                         * 0.01f rather than KNOB_STEP_FLOAT is this path's
+                         * historical fallback for a parameter that declares no
+                         * step -- a 6.7x difference from the external-CC path
+                         * on the same parameter, preserved for the same reason.
+                         * See the note above chain_knob_accel.
+                         */
+                        knob_turn(inst, i, (delta_int > 0) ? 1 : -1, 0.01f);
                         knob_emit_cc_out(inst, i);
                         inst->dirty = 1;
                         break;

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1226,6 +1226,15 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                                 km->last_cc_out = -1;
                                 knob_emit_cc_out(inst, knob_mapping_index(inst, km));
                                 inst->dirty = 1;
+                            } else if (km && km->dest_count == 0) {
+                                /* The mapping had to exist before the point
+                                 * could be attempted, and the point was
+                                 * refused -- a destination index past the end.
+                                 * Leaving it would be a mapping with no
+                                 * destinations, which every readback answers
+                                 * for by reading dests[0]: ": " where the knob
+                                 * should read unassigned. */
+                                knob_mapping_drop(inst, km);
                             }
                         }
                     }
@@ -1665,27 +1674,43 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
                     value = dsp_value_to_float(val_buf, pinfo, value);
                 }
 
+                /*
+                 * Four writes, and the room is checked after each.
+                 *
+                 * `buf_len - off` is an int: once off passes buf_len it goes
+                 * NEGATIVE and converts to an enormous size_t, so a single
+                 * check after the last write would be checking a bound that
+                 * had already been blown past. Unreachable at today's sizes
+                 * (64 KB against ~4 KB of rows) and cheap to make impossible.
+                 *
+                 * Truncation answers an empty array rather than half an
+                 * object: JSON.parse in the shadow UI throws a half-written
+                 * one into a silent catch, and the knobs would vanish from the
+                 * saved patch with no error anywhere. Visibly nothing beats
+                 * invisibly broken.
+                 */
+                #define KNOB_ROW_ROOM() do { if (off >= buf_len - 2) \
+                    return snprintf(buf, buf_len, "[]"); } while (0)
+
                 off += snprintf(buf + off, buf_len - off,
                     "%s{\"cc\":%d,\"target\":\"%s\",\"param\":\"%s\",\"value\":%.3f",
                     rows ? "," : "", km->cc, target, param, value);
+                KNOB_ROW_ROOM();
 
                 if (km->dests[di].lo != 0.0f || km->dests[di].hi != 1.0f) {
                     off += snprintf(buf + off, buf_len - off,
                         ",\"lo\":%.4f,\"hi\":%.4f", km->dests[di].lo, km->dests[di].hi);
+                    KNOB_ROW_ROOM();
                 }
                 if (multi) {
                     off += snprintf(buf + off, buf_len - off,
                         ",\"dest\":%d,\"pos\":%.4f", di, km->position);
+                    KNOB_ROW_ROOM();
                 }
                 off += snprintf(buf + off, buf_len - off, "}");
                 rows++;
-
-                /* Truncation would emit half an object, and JSON.parse in the
-                 * shadow UI throws that into a silent catch -- the knob array
-                 * would vanish from the saved patch with no error anywhere.
-                 * Answer an empty array instead: visibly nothing, not
-                 * invisibly broken. */
-                if (off >= buf_len - 2) return snprintf(buf, buf_len, "[]");
+                KNOB_ROW_ROOM();
+                #undef KNOB_ROW_ROOM
             }
         }
         off += snprintf(buf + off, buf_len - off, "]");

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1539,48 +1539,87 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
 
     /* Knob mapping info */
     if (strcmp(key, "knob_mappings") == 0) {
-        /* Return full knob mappings array as JSON for patch saving.
-         * Read ACTUAL current values from DSP plugins, not the knob
-         * tracking value which may be stale if params were changed
-         * via module UI or state restore. */
+        /*
+         * The patch's knob array, as FLAT ROWS.
+         *
+         * A knob with several destinations writes one ordinary object per
+         * destination, all sharing its `cc`, distinguished by `dest`. Nothing
+         * is nested, which matters: the parser below walks objects with a plain
+         * scan for the next brace, and so does every build already in the
+         * field. An older host reading this file sees several mappings on one
+         * CC and uses the first, which is destination 0 -- it degrades to the
+         * knob it would have had rather than to nonsense.
+         *
+         * `lo`/`hi` are written only when the destination is not whole-range,
+         * and `dest`/`pos` only when there is more than one destination, so a
+         * patch full of ordinary knobs re-saves BYTE-IDENTICAL to what shipped
+         * before any of this. test_chain_patch_roundtrip asserts exactly that.
+         *
+         * Values are read back from the plugins rather than trusted from the
+         * tracking copy, which may be stale if a parameter was changed through
+         * the module's own UI or a state restore.
+         */
         int off = 0;
+        int rows = 0;
         off += snprintf(buf + off, buf_len - off, "[");
         for (int i = 0; i < inst->knob_mapping_count && i < MAX_KNOB_MAPPINGS; i++) {
-            const char *target = inst->knob_mappings[i].dests[0].target;
-            const char *param = inst->knob_mappings[i].dests[0].param;
-            float value = inst->knob_mappings[i].dests[0].current_value;
+            const knob_mapping_t *km = &inst->knob_mappings[i];
+            int multi = knob_is_multi(km);
 
-            /* Try to read actual value from DSP plugin */
-            char val_buf[64];
-            int got = -1;
-            /* Indexed, not enumerated: this ladder stopped at fx2/midi_fx1, so
-             * a knob on fx3+ saved the STALE tracking value into the patch
-             * instead of the plugin's live one. The per-position plugin/
-             * instance checks stay — fx_count is a high-water mark and an
-             * interior position can be empty. */
-            if (strcmp(target, "synth") == 0 && inst->synth_plugin_v2 && inst->synth_instance) {
-                got = inst->synth_plugin_v2->get_param(inst->synth_instance, param, val_buf, sizeof(val_buf));
-            } else {
-                int fxi = chain_fx_index_from_id(target, "fx", MAX_AUDIO_FX);
-                int mfi = chain_fx_index_from_id(target, "midi_fx", MAX_MIDI_FX);
-                if (fxi >= 0 && fxi < inst->fx_count &&
-                    inst->fx_is_v2[fxi] && inst->fx_plugins_v2[fxi] && inst->fx_instances[fxi]) {
-                    got = inst->fx_plugins_v2[fxi]->get_param(inst->fx_instances[fxi], param, val_buf, sizeof(val_buf));
-                } else if (mfi >= 0 && mfi < inst->midi_fx_count &&
-                           inst->midi_fx_plugins[mfi] && inst->midi_fx_instances[mfi]) {
-                    got = inst->midi_fx_plugins[mfi]->get_param(inst->midi_fx_instances[mfi], param, val_buf, sizeof(val_buf));
+            for (int di = 0; di < km->dest_count && di < MAX_KNOB_DESTS; di++) {
+                const char *target = km->dests[di].target;
+                const char *param = km->dests[di].param;
+                if (!param[0]) continue;
+                float value = km->dests[di].current_value;
+
+                /* Try to read actual value from DSP plugin.
+                 * Indexed, not enumerated: this ladder stopped at fx2/midi_fx1, so
+                 * a knob on fx3+ saved the STALE tracking value into the patch
+                 * instead of the plugin's live one. The per-position plugin/
+                 * instance checks stay -- fx_count is a high-water mark and an
+                 * interior position can be empty. */
+                char val_buf[64];
+                int got = -1;
+                if (strcmp(target, "synth") == 0 && inst->synth_plugin_v2 && inst->synth_instance) {
+                    got = inst->synth_plugin_v2->get_param(inst->synth_instance, param, val_buf, sizeof(val_buf));
+                } else {
+                    int fxi = chain_fx_index_from_id(target, "fx", MAX_AUDIO_FX);
+                    int mfi = chain_fx_index_from_id(target, "midi_fx", MAX_MIDI_FX);
+                    if (fxi >= 0 && fxi < inst->fx_count &&
+                        inst->fx_is_v2[fxi] && inst->fx_plugins_v2[fxi] && inst->fx_instances[fxi]) {
+                        got = inst->fx_plugins_v2[fxi]->get_param(inst->fx_instances[fxi], param, val_buf, sizeof(val_buf));
+                    } else if (mfi >= 0 && mfi < inst->midi_fx_count &&
+                               inst->midi_fx_plugins[mfi] && inst->midi_fx_instances[mfi]) {
+                        got = inst->midi_fx_plugins[mfi]->get_param(inst->midi_fx_instances[mfi], param, val_buf, sizeof(val_buf));
+                    }
                 }
-            }
-            if (got > 0) {
-                chain_param_info_t *pinfo = find_param_by_key(inst, target, param);
-                value = dsp_value_to_float(val_buf, pinfo, value);
-            }
+                if (got > 0) {
+                    chain_param_info_t *pinfo = find_param_by_key(inst, target, param);
+                    value = dsp_value_to_float(val_buf, pinfo, value);
+                }
 
-            off += snprintf(buf + off, buf_len - off,
-                "%s{\"cc\":%d,\"target\":\"%s\",\"param\":\"%s\",\"value\":%.3f}",
-                (i > 0) ? "," : "",
-                inst->knob_mappings[i].cc, target, param, value);
-            if (off >= buf_len - 1) break;
+                off += snprintf(buf + off, buf_len - off,
+                    "%s{\"cc\":%d,\"target\":\"%s\",\"param\":\"%s\",\"value\":%.3f",
+                    rows ? "," : "", km->cc, target, param, value);
+
+                if (km->dests[di].lo != 0.0f || km->dests[di].hi != 1.0f) {
+                    off += snprintf(buf + off, buf_len - off,
+                        ",\"lo\":%.4f,\"hi\":%.4f", km->dests[di].lo, km->dests[di].hi);
+                }
+                if (multi) {
+                    off += snprintf(buf + off, buf_len - off,
+                        ",\"dest\":%d,\"pos\":%.4f", di, km->position);
+                }
+                off += snprintf(buf + off, buf_len - off, "}");
+                rows++;
+
+                /* Truncation would emit half an object, and JSON.parse in the
+                 * shadow UI throws that into a silent catch -- the knob array
+                 * would vanish from the saved patch with no error anywhere.
+                 * Answer an empty array instead: visibly nothing, not
+                 * invisibly broken. */
+                if (off >= buf_len - 2) return snprintf(buf, buf_len, "[]");
+            }
         }
         off += snprintf(buf + off, buf_len - off, "]");
         return off;

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1198,6 +1198,73 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
         if (sscanf(key + 5, "%d_%31s", &knob_num, action) == 2 && knob_num >= 1 && knob_num <= 8) {
             int cc = 70 + knob_num;  /* CC 71-78 for knobs 1-8 */
 
+            /* Destination editing: knob_N_dest_M_set / _clear / _range, and
+             * knob_N_position. M is 1-based to match knob_N, fxN and lfoN.
+             *
+             * A key family rather than a JSON value: this set_param is reached
+             * from the SPI callback, and the existing dispatcher already
+             * sscanf's `knob_N_<action>`, so a second sscanf on the action
+             * finishes the job with no structural change and no parser on a
+             * realtime path. */
+            if (strncmp(action, "dest_", 5) == 0) {
+                int dest_num; char sub[16];
+                if (sscanf(action + 5, "%d_%15s", &dest_num, sub) == 2 &&
+                    dest_num >= 1 && dest_num <= MAX_KNOB_DESTS) {
+                    int di = dest_num - 1;
+
+                    if (strcmp(sub, "set") == 0 && val) {
+                        char target[32] = "", param[64] = "";
+                        const char *colon = strchr(val, ':');
+                        if (colon) {
+                            int tlen = colon - val;
+                            if (tlen > 0 && tlen < 32) { strncpy(target, val, tlen); target[tlen] = '\0'; }
+                            strncpy(param, colon + 1, 63); param[63] = '\0';
+                        }
+                        if (target[0] && param[0]) {
+                            knob_mapping_t *km = knob_mapping_for_cc(inst, cc, 1);
+                            if (km && knob_dest_point(inst, km, di, target, param) == 0) {
+                                km->last_cc_out = -1;
+                                knob_emit_cc_out(inst, knob_mapping_index(inst, km));
+                                inst->dirty = 1;
+                            }
+                        }
+                    }
+                    else if (strcmp(sub, "clear") == 0) {
+                        knob_mapping_t *km = knob_mapping_for_cc(inst, cc, 0);
+                        if (km) {
+                            /* Removing the last destination is the same thing
+                             * as clearing the knob, and must leave the table
+                             * in the same state either way. */
+                            if (knob_dest_remove(inst, km, di) == 0)
+                                knob_mapping_drop(inst, km);
+                            inst->dirty = 1;
+                        }
+                    }
+                    else if (strcmp(sub, "range") == 0 && val) {
+                        /* "lo:hi", fractions of the destination's own range. */
+                        const char *colon = strchr(val, ':');
+                        if (colon) {
+                            knob_mapping_t *km = knob_mapping_for_cc(inst, cc, 0);
+                            if (km) {
+                                knob_dest_set_window(inst, km, di,
+                                                     strtof(val, NULL), strtof(colon + 1, NULL));
+                                knob_emit_cc_out(inst, knob_mapping_index(inst, km));
+                                inst->dirty = 1;
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+            if (strcmp(action, "position") == 0 && val) {
+                knob_mapping_t *km = knob_mapping_for_cc(inst, cc, 0);
+                if (km) {
+                    knob_set_position(inst, knob_mapping_index(inst, km), strtof(val, NULL));
+                    inst->dirty = 1;
+                }
+                return;
+            }
+
             if (strcmp(action, "set") == 0 && val) {
                 /* Parse "target:param" format */
                 char target[32] = "";
@@ -1645,8 +1712,42 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
                     chain_param_info_t *pinfo = knob_find_param(inst, target, param);
 
                     if (strcmp(query_param, "name") == 0) {
+                        /* A multi-destination knob is not any one parameter, so
+                         * it says what it DRIVES: the first destination plus a
+                         * count of the others. This one string is what puts the
+                         * label on the touched-knob card -- refreshPendingKnobOverlay
+                         * passes knob_N_name and knob_N_value straight through --
+                         * so the card needs no change and, more to the point, no
+                         * extra read. */
+                        if (knob_is_multi(&inst->knob_mappings[i]))
+                            return snprintf(buf, buf_len, "%s +%d", param,
+                                            inst->knob_mappings[i].dest_count - 1);
                         /* Construct display name from target and param */
                         return snprintf(buf, buf_len, "%s: %s", target, param);
+                    }
+                    else if (strcmp(query_param, "dest_count") == 0) {
+                        return snprintf(buf, buf_len, "%d", inst->knob_mappings[i].dest_count);
+                    }
+                    else if (strcmp(query_param, "position") == 0) {
+                        return snprintf(buf, buf_len, "%.4f", inst->knob_mappings[i].position);
+                    }
+                    else if (strcmp(query_param, "dests") == 0) {
+                        /* The whole destination list in ONE read, for the
+                         * editor screen. Eight knobs times four destinations
+                         * times three reads each would be most of a second of
+                         * IPC on entry. */
+                        const knob_mapping_t *km = &inst->knob_mappings[i];
+                        int off = snprintf(buf, buf_len, "[");
+                        for (int di = 0; di < km->dest_count && di < MAX_KNOB_DESTS; di++) {
+                            off += snprintf(buf + off, buf_len - off,
+                                "%s{\"target\":\"%s\",\"param\":\"%s\",\"lo\":%.4f,\"hi\":%.4f}",
+                                di ? "," : "",
+                                km->dests[di].target, km->dests[di].param,
+                                km->dests[di].lo, km->dests[di].hi);
+                            if (off >= buf_len - 2) return snprintf(buf, buf_len, "[]");
+                        }
+                        off += snprintf(buf + off, buf_len - off, "]");
+                        return off;
                     }
                     else if (strcmp(query_param, "target") == 0) {
                         return snprintf(buf, buf_len, "%s", target);
@@ -1655,6 +1756,13 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
                         return snprintf(buf, buf_len, "%s", param);
                     }
                     else if (strcmp(query_param, "value") == 0) {
+                        /* A multi-destination knob has no single parameter
+                         * value to show, so it shows where it sits: the same
+                         * thing it sends on CC 102-109, in the same units the
+                         * user set it in. */
+                        if (knob_is_multi(&inst->knob_mappings[i]))
+                            return snprintf(buf, buf_len, "%d%%",
+                                            (int)(inst->knob_mappings[i].position * 100.0f + 0.5f));
                         /* Look up param metadata */
                         chain_param_info_t *param_info = find_param_by_key(inst, target, param);
                         if (param_info) {

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -1231,29 +1231,29 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                     chain_param_info_t *pinfo = knob_find_param(inst, target, param);
 
                     /* Set mapping */
+                    /* knob_N_set means "this knob has ONE whole-range
+                     * destination, here" -- it collapses whatever the knob had
+                     * before. That is what it has always meant for a knob with
+                     * a single destination, and it is the contract the shadow
+                     * UI and any external caller already rely on. */
                     if (found >= 0) {
                         /* Update existing (type/min/max looked up dynamically from pinfo) */
-                        strncpy(inst->knob_mappings[found].target, target, sizeof(inst->knob_mappings[found].target) - 1);
-                        inst->knob_mappings[found].target[sizeof(inst->knob_mappings[found].target) - 1] = '\0';
-                        strncpy(inst->knob_mappings[found].param, param, sizeof(inst->knob_mappings[found].param) - 1);
-                        inst->knob_mappings[found].param[sizeof(inst->knob_mappings[found].param) - 1] = '\0';
+                        knob_mapping_t *km = &inst->knob_mappings[found];
+                        knob_dest_assign(&km->dests[0], target, param);
+                        km->dest_count = 1;
                         /* Remapped: this knob now means something else. */
-                        inst->knob_mappings[found].last_cc_out = -1;
+                        km->last_cc_out = -1;
                         knob_emit_cc_out(inst, found);
                     } else if (inst->knob_mapping_count < MAX_KNOB_MAPPINGS) {
                         /* Add new */
                         int i = inst->knob_mapping_count++;
-                        inst->knob_mappings[i].cc = cc;
-                        strncpy(inst->knob_mappings[i].target, target, sizeof(inst->knob_mappings[i].target) - 1);
-                        inst->knob_mappings[i].target[sizeof(inst->knob_mappings[i].target) - 1] = '\0';
-                        strncpy(inst->knob_mappings[i].param, param, sizeof(inst->knob_mappings[i].param) - 1);
-                        inst->knob_mappings[i].param[sizeof(inst->knob_mappings[i].param) - 1] = '\0';
-                        if (pinfo) {
-                            inst->knob_mappings[i].current_value = pinfo->default_val;
-                        } else {
-                            inst->knob_mappings[i].current_value = 0.5f;
-                        }
-                        inst->knob_mappings[i].last_cc_out = -1;
+                        knob_mapping_t *km = &inst->knob_mappings[i];
+                        memset(km, 0, sizeof(*km));   /* no inherited destinations */
+                        km->cc = cc;
+                        knob_dest_assign(&km->dests[0], target, param);
+                        km->dest_count = 1;
+                        km->dests[0].current_value = pinfo ? pinfo->default_val : 0.5f;
+                        km->last_cc_out = -1;
                         knob_emit_cc_out(inst, i);
                     }
                 }
@@ -1268,6 +1268,13 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                             inst->knob_mappings[j] = inst->knob_mappings[j + 1];
                         }
                         inst->knob_mapping_count--;
+                        /* Blank the slot the shift vacated. It is past the
+                         * count and so unread today, but a mapping added later
+                         * lands on it, and only its first destination is
+                         * written on that path -- any others would be
+                         * inherited from whatever used to live here. */
+                        memset(&inst->knob_mappings[inst->knob_mapping_count], 0,
+                               sizeof(inst->knob_mappings[0]));
                         inst->dirty = 1;
                         break;
                     }
@@ -1282,8 +1289,8 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                 for (int i = 0; i < inst->knob_mapping_count; i++) {
                     if (inst->knob_mappings[i].cc == cc) {
                         /* Look up parameter metadata */
-                        const char *target = inst->knob_mappings[i].target;
-                        const char *param = inst->knob_mappings[i].param;
+                        const char *target = inst->knob_mappings[i].dests[0].target;
+                        const char *param = inst->knob_mappings[i].dests[0].param;
                         chain_param_info_t *pinfo = knob_find_param(inst, target, param);
                         if (!pinfo) continue;
 
@@ -1301,11 +1308,11 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
                         float delta = base_step * accel * (delta_int > 0 ? 1 : -1);
 
                         /* Apply delta with clamping */
-                        float new_val = inst->knob_mappings[i].current_value + delta;
+                        float new_val = inst->knob_mappings[i].dests[0].current_value + delta;
                         if (new_val < pinfo->min_val) new_val = pinfo->min_val;
                         if (new_val > pinfo->max_val) new_val = pinfo->max_val;
                         if (is_int) new_val = (float)((int)new_val);  /* Round to int */
-                        inst->knob_mappings[i].current_value = new_val;
+                        inst->knob_mappings[i].dests[0].current_value = new_val;
 
                         /* Format value as string */
                         char val_str[16];
@@ -1556,9 +1563,9 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
         int off = 0;
         off += snprintf(buf + off, buf_len - off, "[");
         for (int i = 0; i < inst->knob_mapping_count && i < MAX_KNOB_MAPPINGS; i++) {
-            const char *target = inst->knob_mappings[i].target;
-            const char *param = inst->knob_mappings[i].param;
-            float value = inst->knob_mappings[i].current_value;
+            const char *target = inst->knob_mappings[i].dests[0].target;
+            const char *param = inst->knob_mappings[i].dests[0].param;
+            float value = inst->knob_mappings[i].dests[0].current_value;
 
             /* Try to read actual value from DSP plugin */
             char val_buf[64];
@@ -1608,8 +1615,8 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
             for (int i = 0; i < inst->knob_mapping_count; i++) {
                 if (inst->knob_mappings[i].cc == cc) {
                     /* Look up param info for all queries */
-                    const char *target = inst->knob_mappings[i].target;
-                    const char *param = inst->knob_mappings[i].param;
+                    const char *target = inst->knob_mappings[i].dests[0].target;
+                    const char *param = inst->knob_mappings[i].dests[0].param;
                     /* Indexed, not enumerated — see the knob_N_set site. This
                      * pinfo feeds the min/max/step/options answers below, so
                      * an unresolved fx4+ target made the whole knob undrivable. */
@@ -1630,13 +1637,13 @@ static int v2_get_param(void *instance, const char *key, char *buf, int buf_len)
                         chain_param_info_t *param_info = find_param_by_key(inst, target, param);
                         if (param_info) {
                             /* Use centralized formatting */
-                            return format_param_value(param_info, inst->knob_mappings[i].current_value, buf, buf_len);
+                            return format_param_value(param_info, inst->knob_mappings[i].dests[0].current_value, buf, buf_len);
                         }
                         /* Fallback for params without metadata */
                         if (pinfo && pinfo->type == KNOB_TYPE_INT) {
-                            return snprintf(buf, buf_len, "%d", (int)inst->knob_mappings[i].current_value);
+                            return snprintf(buf, buf_len, "%d", (int)inst->knob_mappings[i].dests[0].current_value);
                         } else {
-                            return snprintf(buf, buf_len, "%.2f", inst->knob_mappings[i].current_value);
+                            return snprintf(buf, buf_len, "%.2f", inst->knob_mappings[i].dests[0].current_value);
                         }
                     }
                     else if (strcmp(query_param, "min") == 0) {

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -559,6 +559,10 @@ CHAIN_INTERNAL chain_param_info_t* find_param_by_key(chain_instance_t *inst, con
 CHAIN_INTERNAL chain_param_info_t *find_param_info(chain_param_info_t *params, int count, const char *key);
 CHAIN_INTERNAL int format_param_value(chain_param_info_t *param, float value, char *buf, int buf_len);
 CHAIN_INTERNAL int is_smoothable_float(const char *val, float *out_value);
+/* One knob-turn law, shared by the three paths that turn a chain knob. */
+CHAIN_INTERNAL int chain_knob_accel_for_gap(uint64_t elapsed_ms);
+CHAIN_INTERNAL int chain_knob_accel(uint64_t *last_ms);
+CHAIN_INTERNAL int chain_knob_accel_cap(int accel, int type);
 CHAIN_INTERNAL chain_param_info_t *knob_find_param(chain_instance_t *inst, const char *target, const char *param);
 CHAIN_INTERNAL void knob_forward_value(chain_instance_t *inst, const char *target, const char *param, const char *val_str);
 

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -611,6 +611,15 @@ CHAIN_INTERNAL chain_param_info_t *find_param_info(chain_param_info_t *params, i
 CHAIN_INTERNAL int format_param_value(chain_param_info_t *param, float value, char *buf, int buf_len);
 CHAIN_INTERNAL int is_smoothable_float(const char *val, float *out_value);
 /* One knob-turn law, shared by the three paths that turn a chain knob. */
+CHAIN_INTERNAL int knob_mapping_index(chain_instance_t *inst, const knob_mapping_t *km);
+CHAIN_INTERNAL void knob_mapping_drop(chain_instance_t *inst, knob_mapping_t *km);
+CHAIN_INTERNAL knob_mapping_t *knob_mapping_for_cc(chain_instance_t *inst, int cc, int create);
+CHAIN_INTERNAL void knob_seed_position(chain_instance_t *inst, knob_mapping_t *km);
+CHAIN_INTERNAL int knob_dest_point(chain_instance_t *inst, knob_mapping_t *km, int di,
+                                   const char *target, const char *param);
+CHAIN_INTERNAL int knob_dest_remove(chain_instance_t *inst, knob_mapping_t *km, int di);
+CHAIN_INTERNAL void knob_dest_set_window(chain_instance_t *inst, knob_mapping_t *km, int di,
+                                         float lo, float hi);
 CHAIN_INTERNAL int knob_position_cc(chain_instance_t *inst, const knob_mapping_t *km);
 CHAIN_INTERNAL void knob_set_position(chain_instance_t *inst, int idx, float position);
 CHAIN_INTERNAL void knob_turn(chain_instance_t *inst, int idx, int ticks, float float_fallback_step);

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -611,6 +611,8 @@ CHAIN_INTERNAL chain_param_info_t *find_param_info(chain_param_info_t *params, i
 CHAIN_INTERNAL int format_param_value(chain_param_info_t *param, float value, char *buf, int buf_len);
 CHAIN_INTERNAL int is_smoothable_float(const char *val, float *out_value);
 /* One knob-turn law, shared by the three paths that turn a chain knob. */
+CHAIN_INTERNAL int knob_read_live_value(chain_instance_t *inst, const char *target,
+                                        const char *param, char *buf, int buf_len);
 CHAIN_INTERNAL int knob_mapping_index(chain_instance_t *inst, const knob_mapping_t *km);
 CHAIN_INTERNAL void knob_mapping_drop(chain_instance_t *inst, knob_mapping_t *km);
 CHAIN_INTERNAL knob_mapping_t *knob_mapping_for_cc(chain_instance_t *inst, int cc, int create);

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -611,6 +611,8 @@ CHAIN_INTERNAL chain_param_info_t *find_param_info(chain_param_info_t *params, i
 CHAIN_INTERNAL int format_param_value(chain_param_info_t *param, float value, char *buf, int buf_len);
 CHAIN_INTERNAL int is_smoothable_float(const char *val, float *out_value);
 /* One knob-turn law, shared by the three paths that turn a chain knob. */
+CHAIN_INTERNAL int knob_position_cc(chain_instance_t *inst, const knob_mapping_t *km);
+CHAIN_INTERNAL void knob_set_position(chain_instance_t *inst, int idx, float position);
 CHAIN_INTERNAL void knob_turn(chain_instance_t *inst, int idx, int ticks, float float_fallback_step);
 CHAIN_INTERNAL float knob_frac_to_value(float frac, const chain_param_info_t *pinfo);
 CHAIN_INTERNAL float knob_value_to_frac(float value, const chain_param_info_t *pinfo);

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -96,17 +96,68 @@ typedef enum {
     KNOB_TYPE_ENUM = 2
 } knob_type_t;
 
-/* Knob mapping structure */
+/*
+ * How many parameters one knob may drive. The cap is set by the SCREEN, not by
+ * memory: four destinations is fourteen rows in the editor, which scrolls
+ * comfortably on 128x64; eight would be twenty-six and unusable.
+ */
+#define MAX_KNOB_DESTS 4
+
+/*
+ * One place a knob writes.
+ *
+ * `lo`/`hi` are FRACTIONS of this parameter's own range, not values in its
+ * units -- so a range survives re-pointing the destination at a parameter with
+ * completely different units, and `lo > hi` is an inverted destination (turn
+ * the knob up, this one goes down) with no extra machinery. The whole-range
+ * default is lo=0, hi=1.
+ */
 typedef struct {
-    int cc;              /* CC number (71-78 for knobs 1-8) */
     char target[16];     /* Component: "synth", "fx1", "fx2", "midi_fx" */
     char param[32];      /* Parameter key (lookup metadata in chain_params) */
-    float current_value; /* Current value only */
+    float lo;            /* Fraction of the parameter's range, 0..1 */
+    float hi;            /* lo > hi = inverted */
+    float current_value; /* This destination's value, in its OWN units */
+} knob_dest_t;
+
+/*
+ * Knob mapping structure.
+ *
+ * `dests[0]` is the knob's public face: every readback that answers "what is
+ * this knob assigned to" answers with it, which is what lets a knob with one
+ * destination behave, serialise and read back exactly as it always has.
+ *
+ * `position` is only consulted when there is MORE THAN ONE destination. That
+ * asymmetry is the design, not an optimisation: a single destination keeps the
+ * parameter's own step, acceleration and enum feel, and is merely clamped to
+ * its [lo,hi] window. Driving a lone stepped parameter from a 0..1 position
+ * instead makes it crawl -- an 8-option enum needs a 1/7 move of the position
+ * to advance one option, which is ~95 detents at the float step rather than 1.
+ */
+typedef struct {
+    int cc;              /* CC number (71-78 for knobs 1-8) */
+    knob_dest_t dests[MAX_KNOB_DESTS];
+    int dest_count;      /* 0 = unmapped; 1 = the ordinary case */
+    float position;      /* 0..1, authoritative iff dest_count > 1 */
     int last_cc_out;     /* Last 0-127 value emitted to the external port,
                           * -1 = nothing sent yet. Change detection happens at
                           * CC resolution, so a knob swept through a range that
                           * maps to one CC step emits once, not once per turn. */
 } knob_mapping_t;
+
+/* dests[0], or empty strings for an unmapped knob. The readbacks and the patch
+ * mirror answer with these, so a caller never has to remember the rule. */
+static inline const char *knob_lead_target(const knob_mapping_t *km) {
+    return (km && km->dest_count > 0) ? km->dests[0].target : "";
+}
+static inline const char *knob_lead_param(const knob_mapping_t *km) {
+    return (km && km->dest_count > 0) ? km->dests[0].param : "";
+}
+/* True when the knob's own position drives its destinations rather than each
+ * destination keeping its parameter's feel. THE line; see the struct comment. */
+static inline int knob_is_multi(const knob_mapping_t *km) {
+    return km && km->dest_count > 1;
+}
 
 /* Chain parameter info from module.json */
 #define MAX_CHAIN_PARAMS 256
@@ -560,6 +611,7 @@ CHAIN_INTERNAL chain_param_info_t *find_param_info(chain_param_info_t *params, i
 CHAIN_INTERNAL int format_param_value(chain_param_info_t *param, float value, char *buf, int buf_len);
 CHAIN_INTERNAL int is_smoothable_float(const char *val, float *out_value);
 /* One knob-turn law, shared by the three paths that turn a chain knob. */
+CHAIN_INTERNAL void knob_dest_assign(knob_dest_t *d, const char *target, const char *param);
 CHAIN_INTERNAL int chain_knob_accel_for_gap(uint64_t elapsed_ms);
 CHAIN_INTERNAL int chain_knob_accel(uint64_t *last_ms);
 CHAIN_INTERNAL int chain_knob_accel_cap(int accel, int type);

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -611,6 +611,14 @@ CHAIN_INTERNAL chain_param_info_t *find_param_info(chain_param_info_t *params, i
 CHAIN_INTERNAL int format_param_value(chain_param_info_t *param, float value, char *buf, int buf_len);
 CHAIN_INTERNAL int is_smoothable_float(const char *val, float *out_value);
 /* One knob-turn law, shared by the three paths that turn a chain knob. */
+CHAIN_INTERNAL void knob_turn(chain_instance_t *inst, int idx, int ticks, float float_fallback_step);
+CHAIN_INTERNAL float knob_frac_to_value(float frac, const chain_param_info_t *pinfo);
+CHAIN_INTERNAL float knob_value_to_frac(float value, const chain_param_info_t *pinfo);
+CHAIN_INTERNAL float knob_dest_value_at(const knob_dest_t *d, float position,
+                                        const chain_param_info_t *pinfo);
+CHAIN_INTERNAL float knob_dest_clamp(const knob_dest_t *d, float value,
+                                     const chain_param_info_t *pinfo);
+CHAIN_INTERNAL float knob_base_step(const chain_param_info_t *pinfo, float float_fallback);
 CHAIN_INTERNAL void knob_dest_assign(knob_dest_t *d, const char *target, const char *param);
 CHAIN_INTERNAL int chain_knob_accel_for_gap(uint64_t elapsed_ms);
 CHAIN_INTERNAL int chain_knob_accel(uint64_t *last_ms);

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -790,8 +790,8 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
         if (cc >= KNOB_CC_START && cc <= KNOB_CC_END) {
             for (int i = 0; i < inst->knob_mapping_count; i++) {
                 if (inst->knob_mappings[i].cc == cc) {
-                    const char *target = inst->knob_mappings[i].target;
-                    const char *param = inst->knob_mappings[i].param;
+                    const char *target = inst->knob_mappings[i].dests[0].target;
+                    const char *param = inst->knob_mappings[i].dests[0].param;
                     chain_param_info_t *pinfo = knob_find_param(inst, target, param);
                     if (!pinfo) continue;
 
@@ -826,11 +826,11 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
                     float delta = base_step * (float)mult;
                     if (ticks < 0) delta = -delta;
 
-                    float new_val = inst->knob_mappings[i].current_value + delta;
+                    float new_val = inst->knob_mappings[i].dests[0].current_value + delta;
                     if (new_val < pinfo->min_val) new_val = pinfo->min_val;
                     if (new_val > pinfo->max_val) new_val = pinfo->max_val;
                     if (is_int) new_val = (float)((int)new_val);  /* Round to int */
-                    inst->knob_mappings[i].current_value = new_val;
+                    inst->knob_mappings[i].dests[0].current_value = new_val;
 
                     /* Format as int or float */
                     char val_str[16];
@@ -856,8 +856,8 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
             int target_cc = KNOB_CC_START + (cc - KNOB_ABS_CC_START);
             for (int i = 0; i < inst->knob_mapping_count; i++) {
                 if (inst->knob_mappings[i].cc == target_cc) {
-                    const char *target = inst->knob_mappings[i].target;
-                    const char *param = inst->knob_mappings[i].param;
+                    const char *target = inst->knob_mappings[i].dests[0].target;
+                    const char *param = inst->knob_mappings[i].dests[0].param;
                     chain_param_info_t *pinfo = knob_find_param(inst, target, param);
                     if (!pinfo) return;
 
@@ -866,7 +866,7 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
                     if (is_int) abs_val = (float)((int)(abs_val + 0.5f));
                     if (abs_val < pinfo->min_val) abs_val = pinfo->min_val;
                     if (abs_val > pinfo->max_val) abs_val = pinfo->max_val;
-                    inst->knob_mappings[i].current_value = abs_val;
+                    inst->knob_mappings[i].dests[0].current_value = abs_val;
 
                     char val_str[16];
                     if (is_int) snprintf(val_str, sizeof(val_str), "%d", (int)abs_val);

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -795,31 +795,11 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
                     chain_param_info_t *pinfo = knob_find_param(inst, target, param);
                     if (!pinfo) continue;
 
-                    /* Calculate acceleration based on time between events */
-                    uint64_t now = get_time_ms();
-                    uint64_t last = inst->knob_last_time_ms[i];
-                    inst->knob_last_time_ms[i] = now;
-                    int accel = KNOB_ACCEL_MIN_MULT;
-                    if (last > 0) {
-                        uint64_t elapsed = now - last;
-                        if (elapsed < KNOB_ACCEL_SLOW_MS) {
-                            if (elapsed <= KNOB_ACCEL_FAST_MS) {
-                                accel = KNOB_ACCEL_MAX_MULT;
-                            } else {
-                                float ratio = (float)(KNOB_ACCEL_SLOW_MS - elapsed) /
-                                              (float)(KNOB_ACCEL_SLOW_MS - KNOB_ACCEL_FAST_MS);
-                                accel = KNOB_ACCEL_MIN_MULT + (int)(ratio * (KNOB_ACCEL_MAX_MULT - KNOB_ACCEL_MIN_MULT));
-                            }
-                        }
-                    }
-
-                    /* Cap acceleration: enums never accelerate, ints limited */
+                    /* Acceleration from the time between events, then the
+                     * cap this parameter's type asks for. */
+                    int accel = chain_knob_accel(&inst->knob_last_time_ms[i]);
+                    accel = chain_knob_accel_cap(accel, pinfo->type);
                     int is_int = (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM);
-                    if (pinfo->type == KNOB_TYPE_ENUM) {
-                        accel = KNOB_ACCEL_ENUM_MULT;
-                    } else if (is_int && accel > KNOB_ACCEL_MAX_MULT_INT) {
-                        accel = KNOB_ACCEL_MAX_MULT_INT;
-                    }
 
                     /* Relative encoder: apply acceleration to base step */
                     float base_step = (pinfo->step > 0) ? pinfo->step

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -818,29 +818,20 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
             int target_cc = KNOB_CC_START + (cc - KNOB_ABS_CC_START);
             for (int i = 0; i < inst->knob_mapping_count; i++) {
                 if (inst->knob_mappings[i].cc == target_cc) {
-                    const char *target = inst->knob_mappings[i].dests[0].target;
-                    const char *param = inst->knob_mappings[i].dests[0].param;
-                    chain_param_info_t *pinfo = knob_find_param(inst, target, param);
-                    if (!pinfo) return;
+                    /* 0-127 is a POSITION across the knob's own travel -- the
+                     * same thing knob_emit_cc_out sends, read backwards, so a
+                     * controller that echoes what it was told lands where it
+                     * started. With one whole-range destination this is the
+                     * value scaling that has always shipped. */
+                    knob_set_position(inst, i, (float)msg[2] / 127.0f);
 
-                    float abs_val = pinfo->min_val + ((float)msg[2] / 127.0f) * (pinfo->max_val - pinfo->min_val);
-                    int is_int = (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM);
-                    if (is_int) abs_val = (float)((int)(abs_val + 0.5f));
-                    if (abs_val < pinfo->min_val) abs_val = pinfo->min_val;
-                    if (abs_val > pinfo->max_val) abs_val = pinfo->max_val;
-                    inst->knob_mappings[i].dests[0].current_value = abs_val;
-
-                    char val_str[16];
-                    if (is_int) snprintf(val_str, sizeof(val_str), "%d", (int)abs_val);
-                    else        snprintf(val_str, sizeof(val_str), "%.3f", abs_val);
-
-                    knob_forward_value(inst, target, param, val_str);
                     /* Deliberately no knob_emit_cc_out() here. The sender set
                      * this value, so echoing it back is at best redundant and
                      * at worst a loop: a controller configured to echo its own
-                     * output (common — it is how a motorised unit hears itself)
-                     * would fight the user's fingers mid-turn. Record what the
-                     * sender already knows so later change detection is honest. */
+                     * output (common -- it is how a motorised unit hears
+                     * itself) would fight the user's fingers mid-turn. Record
+                     * what the sender already knows so later change detection
+                     * is honest. */
                     inst->knob_mappings[i].last_cc_out = msg[2];
                     return;
                 }

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -790,57 +790,19 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
         if (cc >= KNOB_CC_START && cc <= KNOB_CC_END) {
             for (int i = 0; i < inst->knob_mapping_count; i++) {
                 if (inst->knob_mappings[i].cc == cc) {
-                    const char *target = inst->knob_mappings[i].dests[0].target;
-                    const char *param = inst->knob_mappings[i].dests[0].param;
-                    chain_param_info_t *pinfo = knob_find_param(inst, target, param);
-                    if (!pinfo) continue;
-
-                    /* Acceleration from the time between events, then the
-                     * cap this parameter's type asks for. */
-                    int accel = chain_knob_accel(&inst->knob_last_time_ms[i]);
-                    accel = chain_knob_accel_cap(accel, pinfo->type);
-                    int is_int = (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM);
-
-                    /* Relative encoder: apply acceleration to base step */
-                    float base_step = (pinfo->step > 0) ? pinfo->step
-                        : (is_int ? (float)KNOB_STEP_INT : KNOB_STEP_FLOAT);
-
                     /* Two's complement 7-bit, decoded in relative_cc.h so
-                     * tests/host can run it — chain_midi.c itself cannot be
+                     * tests/host can run it -- chain_midi.c itself cannot be
                      * compiled natively, so a source-level pin here could not
                      * tell 4 base steps from 8. 0 and the unused midpoint 64
                      * both come back as no movement. */
                     int ticks = relative_cc_ticks((int)msg[2]);
                     if (ticks == 0) return;
-                    int mag = (ticks < 0) ? -ticks : ticks;
 
-                    /* The LARGER of the detent count and the time-based
-                     * multiplier, never the product: a plain encoder always
-                     * says one detent so `accel` is its only speed signal,
-                     * while an accelerated encoder batches detents so `mag`
-                     * already IS the acceleration. Enums fall out of this
-                     * without a special case, because `accel` was pinned to
-                     * KNOB_ACCEL_ENUM_MULT above. See relative_cc.h. */
-                    int mult = relative_cc_multiplier(mag, accel);
+                    /* Everything else -- acceleration, the detent count, the
+                     * step, the one-vs-several-destinations law -- is
+                     * knob_turn's, in a file tests/host can compile. */
+                    knob_turn(inst, i, ticks, KNOB_STEP_FLOAT);
 
-                    float delta = base_step * (float)mult;
-                    if (ticks < 0) delta = -delta;
-
-                    float new_val = inst->knob_mappings[i].dests[0].current_value + delta;
-                    if (new_val < pinfo->min_val) new_val = pinfo->min_val;
-                    if (new_val > pinfo->max_val) new_val = pinfo->max_val;
-                    if (is_int) new_val = (float)((int)new_val);  /* Round to int */
-                    inst->knob_mappings[i].dests[0].current_value = new_val;
-
-                    /* Format as int or float */
-                    char val_str[16];
-                    if (is_int) {
-                        snprintf(val_str, sizeof(val_str), "%d", (int)new_val);
-                    } else {
-                        snprintf(val_str, sizeof(val_str), "%.3f", new_val);
-                    }
-
-                    knob_forward_value(inst, target, param, val_str);
                     /* Relative: the sender moved by a delta and has no idea
                      * where that landed, so it needs the absolute answer. */
                     knob_emit_cc_out(inst, i);

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -1159,6 +1159,161 @@ static void knob_format_and_forward(chain_instance_t *inst, const knob_dest_t *d
     knob_forward_value(inst, d->target, d->param, val_str);
 }
 
+/* ---- Destination editing -------------------------------------------------
+ *
+ * One owner for every change to a knob's destination list, so the two things
+ * that must happen alongside a change cannot be forgotten at a call site:
+ * seeding the position when a knob first gains a second destination, and
+ * re-writing the destinations when a window moves.
+ */
+
+/*
+ * Find the knob mapping for a CC, creating one if there is room.
+ * Returns NULL when the table is full.
+ */
+knob_mapping_t *knob_mapping_for_cc(chain_instance_t *inst, int cc, int create) {
+    if (!inst) return NULL;
+    for (int i = 0; i < inst->knob_mapping_count; i++)
+        if (inst->knob_mappings[i].cc == cc) return &inst->knob_mappings[i];
+    if (!create || inst->knob_mapping_count >= MAX_KNOB_MAPPINGS) return NULL;
+
+    knob_mapping_t *km = &inst->knob_mappings[inst->knob_mapping_count++];
+    memset(km, 0, sizeof(*km));
+    km->cc = cc;
+    km->last_cc_out = -1;
+    return km;
+}
+
+/*
+ * Seed the knob's position from its FIRST destination's live value.
+ *
+ * Called at the moment a knob gains a second destination. Without it the
+ * position is wherever it was left -- 0 for a new mapping -- and the first
+ * turn would yank every destination to the bottom of its window. Seeding from
+ * destination 0 means nothing moves at the moment of adding.
+ *
+ * NOT called from a poll, and that is deliberate: re-deriving the position
+ * from a destination's own quantisation grid between detents would stall a
+ * slow turn on a coarse destination, which is the same arithmetic that keeps a
+ * single destination off this path in the first place.
+ */
+void knob_seed_position(chain_instance_t *inst, knob_mapping_t *km) {
+    if (!inst || !km || km->dest_count < 1) return;
+    const knob_dest_t *d = &km->dests[0];
+    chain_param_info_t *pinfo = knob_find_param(inst, d->target, d->param);
+    if (!pinfo) return;
+
+    float span = d->hi - d->lo;
+    if (span == 0.0f) { km->position = 0.0f; return; }
+
+    float pos = (knob_value_to_frac(d->current_value, pinfo) - d->lo) / span;
+    if (pos < 0.0f) pos = 0.0f;
+    if (pos > 1.0f) pos = 1.0f;
+    km->position = pos;
+}
+
+/* A mapping's index in the table, or -1. The knob helpers take a pointer, but
+ * the CC-out and position calls are indexed. */
+int knob_mapping_index(chain_instance_t *inst, const knob_mapping_t *km) {
+    if (!inst || !km) return -1;
+    for (int i = 0; i < inst->knob_mapping_count; i++)
+        if (&inst->knob_mappings[i] == km) return i;
+    return -1;
+}
+
+/* Remove a mapping from the table, blanking the slot the shift vacates -- a
+ * mapping added later lands on it and only writes its first destination. */
+void knob_mapping_drop(chain_instance_t *inst, knob_mapping_t *km) {
+    int i = knob_mapping_index(inst, km);
+    if (i < 0) return;
+    for (int j = i; j < inst->knob_mapping_count - 1; j++)
+        inst->knob_mappings[j] = inst->knob_mappings[j + 1];
+    inst->knob_mapping_count--;
+    memset(&inst->knob_mappings[inst->knob_mapping_count], 0, sizeof(inst->knob_mappings[0]));
+}
+
+/* Point destination `di` (0-based) at a parameter, keeping its window -- a
+ * window is a fraction of whatever parameter is there, so re-pointing is
+ * exactly the case it was designed to survive. `di == dest_count` appends.
+ * Returns 0 on success. */
+int knob_dest_point(chain_instance_t *inst, knob_mapping_t *km, int di,
+                    const char *target, const char *param) {
+    if (!inst || !km || di < 0 || di >= MAX_KNOB_DESTS) return -1;
+    if (di > km->dest_count) return -1;          /* no gaps */
+
+    int appending = (di == km->dest_count);
+    if (appending) {
+        memset(&km->dests[di], 0, sizeof(km->dests[di]));
+        km->dests[di].lo = 0.0f;
+        km->dests[di].hi = 1.0f;
+    }
+
+    float lo = km->dests[di].lo, hi = km->dests[di].hi;
+    knob_dest_assign(&km->dests[di], target, param);
+    km->dests[di].lo = lo;
+    km->dests[di].hi = hi;
+
+    chain_param_info_t *pinfo = knob_find_param(inst, target, param);
+    if (pinfo) {
+        char val_buf[64];
+        int got = -1;
+        if (strcmp(target, "synth") == 0 && inst->synth_plugin_v2 && inst->synth_instance)
+            got = inst->synth_plugin_v2->get_param(inst->synth_instance, param, val_buf, sizeof(val_buf));
+        km->dests[di].current_value = (got > 0)
+            ? dsp_value_to_float(val_buf, pinfo, pinfo->default_val)
+            : pinfo->default_val;
+    }
+
+    if (appending) km->dest_count = di + 1;
+
+    /* Crossing from one destination to two is where the position starts to
+     * mean something. */
+    if (km->dest_count == 2 && appending) knob_seed_position(inst, km);
+    return 0;
+}
+
+/* Remove destination `di`, closing the gap. Returns the remaining count. */
+int knob_dest_remove(chain_instance_t *inst, knob_mapping_t *km, int di) {
+    (void)inst;
+    if (!km || di < 0 || di >= km->dest_count) return km ? km->dest_count : 0;
+    for (int j = di; j < km->dest_count - 1; j++) km->dests[j] = km->dests[j + 1];
+    memset(&km->dests[km->dest_count - 1], 0, sizeof(km->dests[0]));
+    km->dest_count--;
+    return km->dest_count;
+}
+
+/*
+ * Set destination `di`'s window and APPLY IT NOW.
+ *
+ * Applying immediately is the point: the window is being adjusted by ear, and
+ * a range you cannot hear until the next turn is a range you are setting
+ * blind. For a multi-destination knob that means re-deriving this destination
+ * from the current position; for a single one it means clamping the value into
+ * the new window, which can move the parameter -- deliberately, for the same
+ * reason.
+ */
+void knob_dest_set_window(chain_instance_t *inst, knob_mapping_t *km, int di,
+                          float lo, float hi) {
+    if (!inst || !km || di < 0 || di >= km->dest_count) return;
+    if (lo < 0.0f) lo = 0.0f;
+    if (lo > 1.0f) lo = 1.0f;
+    if (hi < 0.0f) hi = 0.0f;
+    if (hi > 1.0f) hi = 1.0f;
+
+    knob_dest_t *d = &km->dests[di];
+    d->lo = lo;
+    d->hi = hi;
+
+    chain_param_info_t *pinfo = knob_find_param(inst, d->target, d->param);
+    if (!pinfo) return;
+
+    float nv = knob_is_multi(km) ? knob_dest_value_at(d, km->position, pinfo)
+                                 : knob_dest_clamp(d, d->current_value, pinfo);
+    if (nv == d->current_value) return;
+    d->current_value = nv;
+    knob_format_and_forward(inst, d, pinfo, nv);
+}
+
 /* ---- The turn -----------------------------------------------------------
  *
  * One place a chain knob becomes parameter writes, called by all three input

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -1018,6 +1018,25 @@ int chain_knob_accel_cap(int accel, int type) {
  * convert between the two, and they are the only place that arithmetic lives.
  */
 
+/*
+ * ceil and floor, without libm.
+ *
+ * `ceilf`/`floorf` live in libm on glibc and in libc on macOS, so using them
+ * here linked fine on a dev machine and broke CI with `undefined reference to
+ * ceilf` -- and it would have broken it again for the next person to compile
+ * chain_params.c into a test, of which there are thirteen. A cast truncates
+ * toward zero, which is all that is needed to build both: correct for negative
+ * inputs too, which signed parameter ranges make ordinary.
+ */
+static float knob_ceil_toward_pos(float v) {
+    float t = (float)(long)v;
+    return (t < v) ? t + 1.0f : t;
+}
+static float knob_floor_toward_neg(float v) {
+    float t = (float)(long)v;
+    return (t > v) ? t - 1.0f : t;
+}
+
 /* Fraction (0..1 of the parameter's range) -> a value in the parameter's own
  * units, WITHOUT quantisation. The bounds of a window come from here, so that
  * a whole-range window is exactly [min_val, max_val] and clamping to it cannot
@@ -1087,8 +1106,8 @@ float knob_dest_clamp(const knob_dest_t *d, float value,
     /* A stepped parameter's window is the whole steps INSIDE it: a window
      * ending at 4.3 offers 4, not a value the parameter cannot hold. */
     if (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM) {
-        lo = ceilf(lo);
-        hi = floorf(hi);
+        lo = knob_ceil_toward_pos(lo);
+        hi = knob_floor_toward_neg(hi);
         if (hi < lo) hi = lo;
     }
 

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -1019,17 +1019,34 @@ int chain_knob_accel_cap(int accel, int type) {
  */
 
 /* Fraction (0..1 of the parameter's range) -> a value in the parameter's own
- * units, quantised the way that parameter is quantised. */
-float knob_frac_to_value(float frac, const chain_param_info_t *pinfo) {
-    if (!pinfo) return frac;
+ * units, WITHOUT quantisation. The bounds of a window come from here, so that
+ * a whole-range window is exactly [min_val, max_val] and clamping to it cannot
+ * move a value the caller has already quantised. */
+static float knob_frac_to_raw(float frac, const chain_param_info_t *pinfo) {
     if (frac < 0.0f) frac = 0.0f;
     if (frac > 1.0f) frac = 1.0f;
+    return pinfo->min_val + frac * (pinfo->max_val - pinfo->min_val);
+}
 
-    float v = pinfo->min_val + frac * (pinfo->max_val - pinfo->min_val);
+/* ...and the same, quantised the way the parameter is quantised. */
+float knob_frac_to_value(float frac, const chain_param_info_t *pinfo) {
+    if (!pinfo) return frac;
+
+    float v = knob_frac_to_raw(frac, pinfo);
     if (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM) {
-        /* +0.5 before truncation: an enum sub-range must be able to REACH its
-         * top option, and plain truncation leaves the last one unreachable
-         * except at exactly 1.0. */
+        /*
+         * The half is what lets an enum sub-range REACH its top option; plain
+         * truncation leaves the last one unreachable except at exactly 1.0.
+         *
+         * ⚠ `(int)` truncates TOWARD ZERO, so on a parameter with a negative
+         * minimum this rounds the wrong way -- -64 + 0.5 = -63.5 becomes -63,
+         * and the bottom of a -64..63 parameter is a step out of reach. That
+         * is not new: it is exactly what the absolute-CC path (CC 102-109) has
+         * always done, and it is left alone deliberately. Correcting it here
+         * would shift every inbound CC value by one step on every signed
+         * parameter -- a behaviour change to existing rigs, which does not
+         * belong in a commit about destinations. Worth fixing on its own.
+         */
         v = (float)((int)(v + 0.5f));
     }
     if (v < pinfo->min_val) v = pinfo->min_val;
@@ -1066,10 +1083,26 @@ float knob_dest_value_at(const knob_dest_t *d, float position,
 float knob_dest_clamp(const knob_dest_t *d, float value,
                       const chain_param_info_t *pinfo) {
     if (!d || !pinfo) return value;
-    float a = knob_frac_to_value(d->lo, pinfo);
-    float b = knob_frac_to_value(d->hi, pinfo);
+
+    /* Bounds from the UNQUANTISED map, so a whole-range window is exactly the
+     * parameter's own [min, max] and this is a no-op on it -- which is what
+     * keeps an ordinary knob's behaviour bit-identical to what shipped. Taking
+     * them through the quantiser instead rounded the bounds themselves, and on
+     * a parameter with a negative minimum that made its bottom value
+     * unreachable through a knob that had always reached it. */
+    float a = knob_frac_to_raw(d->lo, pinfo);
+    float b = knob_frac_to_raw(d->hi, pinfo);
     float lo = (a < b) ? a : b;
     float hi = (a < b) ? b : a;
+
+    /* A stepped parameter's window is the whole steps INSIDE it: a window
+     * ending at 4.3 offers 4, not a value the parameter cannot hold. */
+    if (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM) {
+        lo = ceilf(lo);
+        hi = floorf(hi);
+        if (hi < lo) hi = lo;
+    }
+
     if (value < lo) return lo;
     if (value > hi) return hi;
     return value;

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -929,9 +929,37 @@ chain_param_info_t *knob_find_param(chain_instance_t *inst, const char *target, 
     return NULL;
 }
 
-/* Forward a formatted value string to the plugin identified by target. */
+/*
+ * Forward a formatted value string to the plugin identified by target.
+ *
+ * A knob turn is an EDIT of the parameter's RESTING value, exactly as an edit
+ * from the parameter's own page is -- so it has to reach the modulation bus by
+ * the same route. It did not, and the consequence was a knob that looked dead.
+ *
+ * A modulated parameter is not owned by whoever wrote it last. The bus holds a
+ * base and rewrites `base + modulation` to the plugin on every tick
+ * (chain_mod_apply_effective_value). The prefixed `synth:` / `fxN:` /
+ * `midi_fxN:` set_param routes therefore update the base FIRST, so the wobble
+ * follows the new setting. This function did not: it wrote straight through to
+ * the plugin and told the bus nothing, so the next tick recomputed from the
+ * stale base and erased the turn -- within milliseconds, every time. Assign a
+ * knob to a parameter an LFO is driving and the knob reads as dead, or moves
+ * and snaps back.
+ *
+ * REALTIME: the added call is the same one the prefixed routes already make
+ * from this same thread, and chain_mod_apply_effective_value allocates nothing.
+ */
 void knob_forward_value(chain_instance_t *inst, const char *target, const char *param, const char *val_str) {
-    if (!inst || !target) return;
+    if (!inst || !target || !param) return;
+
+    if (chain_mod_is_target_active(inst, target, param)) {
+        chain_mod_update_base_from_set_param(inst, target, param, val_str);
+        mod_target_state_t *entry = chain_mod_find_target_entry(inst, target, param);
+        if (entry) {
+            chain_mod_apply_effective_value(inst, entry, 0);
+            return;
+        }
+    }
 
     if (strcmp(target, "synth") == 0) {
         if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->set_param)

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -5,6 +5,7 @@
  */
 
 #include "chain_internal.h"
+#include "relative_cc.h"
 
 /*
  * Format a parameter value for display based on its metadata.
@@ -1011,6 +1012,83 @@ int chain_knob_accel_cap(int accel, int type) {
     return accel;
 }
 
+/* ---- Destination windows -------------------------------------------------
+ *
+ * A destination's lo/hi are fractions of its parameter's own range. These four
+ * convert between the two, and they are the only place that arithmetic lives.
+ */
+
+/* Fraction (0..1 of the parameter's range) -> a value in the parameter's own
+ * units, quantised the way that parameter is quantised. */
+float knob_frac_to_value(float frac, const chain_param_info_t *pinfo) {
+    if (!pinfo) return frac;
+    if (frac < 0.0f) frac = 0.0f;
+    if (frac > 1.0f) frac = 1.0f;
+
+    float v = pinfo->min_val + frac * (pinfo->max_val - pinfo->min_val);
+    if (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM) {
+        /* +0.5 before truncation: an enum sub-range must be able to REACH its
+         * top option, and plain truncation leaves the last one unreachable
+         * except at exactly 1.0. */
+        v = (float)((int)(v + 0.5f));
+    }
+    if (v < pinfo->min_val) v = pinfo->min_val;
+    if (v > pinfo->max_val) v = pinfo->max_val;
+    return v;
+}
+
+/* The inverse. A degenerate range answers 0 rather than dividing by it. */
+float knob_value_to_frac(float value, const chain_param_info_t *pinfo) {
+    if (!pinfo) return 0.0f;
+    float span = pinfo->max_val - pinfo->min_val;
+    if (span <= 0.0f) return 0.0f;
+    float f = (value - pinfo->min_val) / span;
+    if (f < 0.0f) f = 0.0f;
+    if (f > 1.0f) f = 1.0f;
+    return f;
+}
+
+/* Where a destination sits when the knob is at `position`. lo > hi is an
+ * inverted destination and needs no special case: the interpolation simply
+ * runs backwards. */
+float knob_dest_value_at(const knob_dest_t *d, float position,
+                         const chain_param_info_t *pinfo) {
+    if (!d) return 0.0f;
+    if (position < 0.0f) position = 0.0f;
+    if (position > 1.0f) position = 1.0f;
+    return knob_frac_to_value(d->lo + position * (d->hi - d->lo), pinfo);
+}
+
+/* Clamp a value into a destination's window, in the parameter's own units.
+ * This is the whole of what a range means for a SINGLE-destination knob: the
+ * parameter keeps its own step and feel and is simply bounded. `lo > hi` names
+ * the same window from the other end, so the bounds are ordered here. */
+float knob_dest_clamp(const knob_dest_t *d, float value,
+                      const chain_param_info_t *pinfo) {
+    if (!d || !pinfo) return value;
+    float a = knob_frac_to_value(d->lo, pinfo);
+    float b = knob_frac_to_value(d->hi, pinfo);
+    float lo = (a < b) ? a : b;
+    float hi = (a < b) ? b : a;
+    if (value < lo) return lo;
+    if (value > hi) return hi;
+    return value;
+}
+
+/* The base step for one detent: what the parameter declares, or a fallback.
+ * `float_fallback` is a PARAMETER because the two knob paths disagree about it
+ * -- chain_midi.c has always used KNOB_STEP_FLOAT and chain_host.c 0.01f, a
+ * 6.7x difference on the same parameter. Passing it in keeps that divergence
+ * visible at both call sites instead of quietly resolving it here; see the
+ * note above chain_knob_accel. */
+float knob_base_step(const chain_param_info_t *pinfo, float float_fallback) {
+    if (!pinfo) return float_fallback;
+    if (pinfo->step > 0) return pinfo->step;
+    if (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM)
+        return (float)KNOB_STEP_INT;
+    return float_fallback;
+}
+
 /*
  * Forward a formatted value string to the plugin identified by target.
  *
@@ -1068,6 +1146,101 @@ void knob_forward_value(chain_instance_t *inst, const char *target, const char *
     }
 }
 
+
+/* Format a value the way its parameter is spelled, and forward it. Kept
+ * separate so the two branches of knob_turn cannot format differently. */
+static void knob_format_and_forward(chain_instance_t *inst, const knob_dest_t *d,
+                                    const chain_param_info_t *pinfo, float value) {
+    char val_str[16];
+    if (pinfo && (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM))
+        snprintf(val_str, sizeof(val_str), "%d", (int)value);
+    else
+        snprintf(val_str, sizeof(val_str), "%.3f", value);
+    knob_forward_value(inst, d->target, d->param, val_str);
+}
+
+/* ---- The turn -----------------------------------------------------------
+ *
+ * One place a chain knob becomes parameter writes, called by all three input
+ * paths: the relative CC decode and the absolute CC in chain_midi.c, and
+ * knob_N_adjust in chain_host.c (the device's own encoders).
+ *
+ * THE LINE IS "SEVERAL DESTINATIONS", NOT "HAS A RANGE", and the two branches
+ * below are that line:
+ *
+ *   ONE destination, ranged or not -- the parameter's own step, its own
+ *   acceleration, its own enum feel, and a clamp into the destination's
+ *   window. The knob's `position` is not consulted and not stored.
+ *
+ *   SEVERAL destinations -- there is no single parameter to be, so the knob's
+ *   own 0..1 position becomes the thing being turned, and each destination
+ *   follows it through its own window.
+ *
+ * The asymmetry is not tidiness. Driving a LONE stepped parameter from a
+ * position makes it crawl: an 8-option enum spans 7 units, so one detent of
+ * KNOB_STEP_FLOAT moves it 0.0105 -- 4 -> 4.0105 -> (int) 4, the same value,
+ * for ~95 detents per option instead of one. A parameter that shares a knob
+ * with others pays that price by necessity; one that does not must never be
+ * made to.
+ *
+ * REALTIME: fixed arrays, a stack buffer per write, no allocation, no logging.
+ * A multi-destination turn issues up to MAX_KNOB_DESTS plugin writes instead of
+ * one -- bounded, and the same shape the LFO tick already runs every block.
+ */
+void knob_turn(chain_instance_t *inst, int idx, int ticks, float float_fallback_step) {
+    if (!inst || idx < 0 || idx >= MAX_KNOB_MAPPINGS) return;
+    if (ticks == 0) return;
+
+    knob_mapping_t *km = &inst->knob_mappings[idx];
+    if (km->dest_count < 1) return;
+
+    int mag = (ticks < 0) ? -ticks : ticks;
+    int dir = (ticks < 0) ? -1 : 1;
+
+    if (!knob_is_multi(km)) {
+        knob_dest_t *d = &km->dests[0];
+        chain_param_info_t *pinfo = knob_find_param(inst, d->target, d->param);
+        if (!pinfo) return;
+
+        int accel = chain_knob_accel_cap(chain_knob_accel(&inst->knob_last_time_ms[idx]),
+                                         pinfo->type);
+        int mult = relative_cc_multiplier(mag, accel);
+        float delta = knob_base_step(pinfo, float_fallback_step) * (float)mult * (float)dir;
+
+        float nv = d->current_value + delta;
+        if (nv < pinfo->min_val) nv = pinfo->min_val;
+        if (nv > pinfo->max_val) nv = pinfo->max_val;
+        if (pinfo->type == KNOB_TYPE_INT || pinfo->type == KNOB_TYPE_ENUM)
+            nv = (float)((int)nv);
+        nv = knob_dest_clamp(d, nv, pinfo);
+        d->current_value = nv;
+
+        knob_format_and_forward(inst, d, pinfo, nv);
+        return;
+    }
+
+    /* Several destinations: the position is what turns. The float ceiling
+     * applies whatever the destinations are -- a stepped destination does not
+     * get to slow down a knob it shares with a continuous one. */
+    int accel = chain_knob_accel(&inst->knob_last_time_ms[idx]);
+    int mult = relative_cc_multiplier(mag, accel);
+
+    float pos = km->position + KNOB_STEP_FLOAT * (float)mult * (float)dir;
+    if (pos < 0.0f) pos = 0.0f;
+    if (pos > 1.0f) pos = 1.0f;
+    km->position = pos;
+
+    for (int i = 0; i < km->dest_count && i < MAX_KNOB_DESTS; i++) {
+        knob_dest_t *d = &km->dests[i];
+        if (!d->param[0]) continue;
+        chain_param_info_t *pinfo = knob_find_param(inst, d->target, d->param);
+        if (!pinfo) continue;   /* a destination whose module is gone is skipped,
+                                 * not fatal to its siblings */
+        float nv = knob_dest_value_at(d, pos, pinfo);
+        d->current_value = nv;
+        knob_format_and_forward(inst, d, pinfo, nv);
+    }
+}
 
 /* ---- Chain-knob CC out ---------------------------------------------------
  *

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -929,6 +929,73 @@ chain_param_info_t *knob_find_param(chain_instance_t *inst, const char *target, 
     return NULL;
 }
 
+/* ---- One knob-turn law ---------------------------------------------------
+ *
+ * Three paths turn a chain knob and each had hand-rolled the same time-based
+ * acceleration curve: the relative CC decode and the absolute CC in
+ * chain_midi.c, and knob_N_adjust in chain_host.c -- which is the path the
+ * device's own encoders use, so it is the common case rather than an edge.
+ *
+ * Three copies of one curve is three places for it to drift, and it already
+ * had. The two spellings nested their bounds differently (`elapsed <
+ * KNOB_ACCEL_SLOW_MS` outside, vs `elapsed <= KNOB_ACCEL_FAST_MS` first) and
+ * happened to compute the same answer -- but they still disagree on the
+ * FALLBACK BASE STEP used when a parameter declares no step of its own:
+ * chain_midi.c uses KNOB_STEP_FLOAT (0.0015), chain_host.c uses 0.01f, a 6.7x
+ * difference between an external controller and the device's own encoder on
+ * the same parameter. That one is deliberately NOT resolved here: either value
+ * is a behaviour change for somebody, and picking one is a judgement call for
+ * review rather than a silent side effect of deduplication.
+ *
+ * Extracted here rather than into a header because chain_params.c IS compiled
+ * natively by tests/host (unlike chain_midi.c and chain_host.c, which dlopen
+ * plugins -- that asymmetry is why relative_cc.h exists at all). The curve is
+ * split from the clock read for the same reason relative_cc.h split the decode
+ * from its call site: a source-level pin cannot tell 4 from 8.
+ *
+ * Shape and name taken from #347, which reached the same extraction first.
+ */
+
+/*
+ * Time-based acceleration multiplier for one knob message, against the FLOAT
+ * ceiling. Callers that need the int or enum cap apply chain_knob_accel_cap
+ * afterwards, because only they know the parameter's type. `last_ms` is read
+ * and updated in place.
+ */
+int chain_knob_accel_for_gap(uint64_t elapsed_ms) {
+    if (elapsed_ms >= KNOB_ACCEL_SLOW_MS) return KNOB_ACCEL_MIN_MULT;
+    if (elapsed_ms <= KNOB_ACCEL_FAST_MS) return KNOB_ACCEL_MAX_MULT;
+
+    float ratio = (float)(KNOB_ACCEL_SLOW_MS - elapsed_ms) /
+                  (float)(KNOB_ACCEL_SLOW_MS - KNOB_ACCEL_FAST_MS);
+    return KNOB_ACCEL_MIN_MULT +
+           (int)(ratio * (KNOB_ACCEL_MAX_MULT - KNOB_ACCEL_MIN_MULT));
+}
+
+int chain_knob_accel(uint64_t *last_ms) {
+    uint64_t now = get_time_ms();
+    uint64_t last = *last_ms;
+    *last_ms = now;
+
+    /* No previous message: the first turn of a session is a slow one. */
+    if (last == 0) return KNOB_ACCEL_MIN_MULT;
+    return chain_knob_accel_for_gap(now - last);
+}
+
+/*
+ * Cap the multiplier for a stepped parameter. Enums never accelerate on TIME
+ * (a deliberate slow turn must not overshoot a list of options); ints are
+ * limited rather than pinned. Both rules predate this extraction and are
+ * unchanged -- see relative_cc_multiplier for why a DETENT count is still
+ * honoured for an enum even though the time multiplier is not.
+ */
+int chain_knob_accel_cap(int accel, int type) {
+    if (type == KNOB_TYPE_ENUM) return KNOB_ACCEL_ENUM_MULT;
+    if (type == KNOB_TYPE_INT && accel > KNOB_ACCEL_MAX_MULT_INT)
+        return KNOB_ACCEL_MAX_MULT_INT;
+    return accel;
+}
+
 /*
  * Forward a formatted value string to the plugin identified by target.
  *

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -1065,9 +1065,10 @@ float knob_value_to_frac(float value, const chain_param_info_t *pinfo) {
     return f;
 }
 
-/* Where a destination sits when the knob is at `position`. lo > hi is an
- * inverted destination and needs no special case: the interpolation simply
- * runs backwards. */
+/* Clamp a value into a destination's window, in the parameter's own units.
+ * This is the whole of what a range means for a SINGLE-destination knob: the
+ * parameter keeps its own step and feel and is simply bounded. `lo > hi` names
+ * the same window from the other end, so the bounds are ordered here. */
 float knob_dest_clamp(const knob_dest_t *d, float value,
                       const chain_param_info_t *pinfo) {
     if (!d || !pinfo) return value;
@@ -1096,6 +1097,9 @@ float knob_dest_clamp(const knob_dest_t *d, float value,
     return value;
 }
 
+/* Where a destination sits when the knob is at `position`. lo > hi is an
+ * inverted destination and needs no special case: the interpolation simply
+ * runs backwards. */
 float knob_dest_value_at(const knob_dest_t *d, float position,
                          const chain_param_info_t *pinfo) {
     if (!d) return 0.0f;
@@ -1408,11 +1412,12 @@ void knob_dest_set_window(chain_instance_t *inst, knob_mapping_t *km, int di,
  *   follows it through its own window.
  *
  * The asymmetry is not tidiness. Driving a LONE stepped parameter from a
- * position makes it crawl: an 8-option enum spans 7 units, so one detent of
- * KNOB_STEP_FLOAT moves it 0.0105 -- 4 -> 4.0105 -> (int) 4, the same value,
- * for ~95 detents per option instead of one. A parameter that shares a knob
- * with others pays that price by necessity; one that does not must never be
- * made to.
+ * position makes it crawl: an 8-option enum spans 7 units, so one detent moves
+ * it by the position step times 7 -- 4 -> 4.0105 -> (int) 4, the same value,
+ * for ~95 detents per option instead of one at the MIDI path's 0.0015 step.
+ * The device's own encoder passes a coarser fallback and so crawls less, but
+ * the shape is the same at any step: a shared parameter pays this by
+ * necessity, and one that is not shared must never be made to.
  *
  * REALTIME: fixed arrays, a stack buffer per write, no allocation, no logging.
  * A multi-destination turn issues up to MAX_KNOB_DESTS plugin writes instead of
@@ -1569,15 +1574,6 @@ void knob_set_position(chain_instance_t *inst, int idx, float position) {
     }
 }
 
-static int knob_value_to_cc(float val, const chain_param_info_t *pinfo) {
-    if (!pinfo) return -1;
-    float span = pinfo->max_val - pinfo->min_val;
-    if (!(span > 0.0f)) return -1;
-    int cc_val = (int)(((val - pinfo->min_val) / span) * 127.0f + 0.5f);
-    if (cc_val < 0) cc_val = 0;
-    if (cc_val > 127) cc_val = 127;
-    return cc_val;
-}
 
 void knob_emit_cc_out(chain_instance_t *inst, int idx) {
     if (!inst || !inst->knob_cc_out) return;

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -1068,18 +1068,6 @@ float knob_value_to_frac(float value, const chain_param_info_t *pinfo) {
 /* Where a destination sits when the knob is at `position`. lo > hi is an
  * inverted destination and needs no special case: the interpolation simply
  * runs backwards. */
-float knob_dest_value_at(const knob_dest_t *d, float position,
-                         const chain_param_info_t *pinfo) {
-    if (!d) return 0.0f;
-    if (position < 0.0f) position = 0.0f;
-    if (position > 1.0f) position = 1.0f;
-    return knob_frac_to_value(d->lo + position * (d->hi - d->lo), pinfo);
-}
-
-/* Clamp a value into a destination's window, in the parameter's own units.
- * This is the whole of what a range means for a SINGLE-destination knob: the
- * parameter keeps its own step and feel and is simply bounded. `lo > hi` names
- * the same window from the other end, so the bounds are ordered here. */
 float knob_dest_clamp(const knob_dest_t *d, float value,
                       const chain_param_info_t *pinfo) {
     if (!d || !pinfo) return value;
@@ -1107,6 +1095,27 @@ float knob_dest_clamp(const knob_dest_t *d, float value,
     if (value > hi) return hi;
     return value;
 }
+
+float knob_dest_value_at(const knob_dest_t *d, float position,
+                         const chain_param_info_t *pinfo) {
+    if (!d) return 0.0f;
+    if (position < 0.0f) position = 0.0f;
+    if (position > 1.0f) position = 1.0f;
+
+    /* Clamped through the SAME rule that bounds a single destination, so a
+     * window has the same edges however many destinations the knob has.
+     * Without it the two rounding rules disagree wherever a bound's fraction
+     * falls below a half: an 8-option enum windowed 30-90% bottomed at option
+     * 3 with one destination and option 2 with two, so adding a second
+     * destination moved the first one's floor. */
+    return knob_dest_clamp(d, knob_frac_to_value(d->lo + position * (d->hi - d->lo), pinfo),
+                           pinfo);
+}
+
+/* Clamp a value into a destination's window, in the parameter's own units.
+ * This is the whole of what a range means for a SINGLE-destination knob: the
+ * parameter keeps its own step and feel and is simply bounded. `lo > hi` names
+ * the same window from the other end, so the bounds are ordered here. */
 
 /* The base step for one detent: what the parameter declares, or a fallback.
  * `float_fallback` is a PARAMETER because the two knob paths disagree about it
@@ -1245,6 +1254,37 @@ void knob_seed_position(chain_instance_t *inst, knob_mapping_t *km) {
     km->position = pos;
 }
 
+/* Ask whatever is at `target` for a parameter's current value. The same
+ * indexed ladder the patch serializer walks -- enumerated versions of it have
+ * stopped at fx2/midi_fx1 twice, so the bound is the cap and not a list. */
+int knob_read_live_value(chain_instance_t *inst, const char *target, const char *param,
+                         char *buf, int buf_len) {
+    if (!inst || !target || !param) return -1;
+
+    if (strcmp(target, "synth") == 0) {
+        if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->get_param)
+            return inst->synth_plugin_v2->get_param(inst->synth_instance, param, buf, buf_len);
+        return -1;
+    }
+
+    int fx = chain_fx_index_from_id(target, "fx", MAX_AUDIO_FX);
+    if (fx >= 0) {
+        if (fx < inst->fx_count && inst->fx_is_v2[fx] && inst->fx_plugins_v2[fx] &&
+            inst->fx_instances[fx] && inst->fx_plugins_v2[fx]->get_param)
+            return inst->fx_plugins_v2[fx]->get_param(inst->fx_instances[fx], param, buf, buf_len);
+        return -1;
+    }
+
+    int mfx = chain_fx_index_from_id(target, "midi_fx", MAX_MIDI_FX);
+    if (mfx >= 0) {
+        if (mfx < inst->midi_fx_count && inst->midi_fx_plugins[mfx] &&
+            inst->midi_fx_instances[mfx] && inst->midi_fx_plugins[mfx]->get_param)
+            return inst->midi_fx_plugins[mfx]->get_param(inst->midi_fx_instances[mfx], param, buf, buf_len);
+        return -1;
+    }
+    return -1;
+}
+
 /* A mapping's index in the table, or -1. The knob helpers take a pointer, but
  * the CC-out and position calls are indexed. */
 int knob_mapping_index(chain_instance_t *inst, const knob_mapping_t *km) {
@@ -1289,9 +1329,12 @@ int knob_dest_point(chain_instance_t *inst, knob_mapping_t *km, int di,
     chain_param_info_t *pinfo = knob_find_param(inst, target, param);
     if (pinfo) {
         char val_buf[64];
-        int got = -1;
-        if (strcmp(target, "synth") == 0 && inst->synth_plugin_v2 && inst->synth_instance)
-            got = inst->synth_plugin_v2->get_param(inst->synth_instance, param, val_buf, sizeof(val_buf));
+        /* Every kind of position, not just the synth. Reading only synth here
+         * meant a destination on an FX started from the parameter's DEFAULT,
+         * so the first turn of the knob jumped it away from whatever the user
+         * had actually dialled in -- and the position seeded from it was wrong
+         * by the same amount. */
+        int got = knob_read_live_value(inst, target, param, val_buf, sizeof(val_buf));
         km->dests[di].current_value = (got > 0)
             ? dsp_value_to_float(val_buf, pinfo, pinfo->default_val)
             : pinfo->default_val;
@@ -1413,7 +1456,12 @@ void knob_turn(chain_instance_t *inst, int idx, int ticks, float float_fallback_
     int accel = chain_knob_accel(&inst->knob_last_time_ms[idx]);
     int mult = relative_cc_multiplier(mag, accel);
 
-    float pos = km->position + KNOB_STEP_FLOAT * (float)mult * (float)dir;
+    /* The position is a 0..1 quantity with no declared step of its own, so it
+     * takes the caller's fallback exactly as a stepless float parameter does.
+     * Pinning it to KNOB_STEP_FLOAT instead made a multi-destination knob
+     * ~6.7x slower than an ordinary one on the device's own encoder, which
+     * reads as a broken knob rather than as a design. */
+    float pos = km->position + float_fallback_step * (float)mult * (float)dir;
     if (pos < 0.0f) pos = 0.0f;
     if (pos > 1.0f) pos = 1.0f;
     km->position = pos;
@@ -1481,6 +1529,9 @@ int knob_position_cc(chain_instance_t *inst, const knob_mapping_t *km) {
     const knob_dest_t *d = &km->dests[0];
     chain_param_info_t *pinfo = knob_find_param(inst, d->target, d->param);
     if (!pinfo) return -1;
+    /* A parameter with no range has no position. knob_value_to_frac answers 0
+     * for one, which would emit CC 0 where nothing was ever emitted before. */
+    if (!(pinfo->max_val - pinfo->min_val > 0.0f)) return -1;
 
     float lo = d->lo, hi = d->hi;
     float span = hi - lo;

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -929,6 +929,21 @@ chain_param_info_t *knob_find_param(chain_instance_t *inst, const char *target, 
     return NULL;
 }
 
+/*
+ * Point a destination at a parameter, whole-range.
+ *
+ * One owner for the three fields that must move together: a truncated name and
+ * an unreset range are both silent, and the strncpy-then-terminate spelling
+ * this replaces was six lines per assignment and appeared twice.
+ */
+void knob_dest_assign(knob_dest_t *d, const char *target, const char *param) {
+    if (!d) return;
+    snprintf(d->target, sizeof(d->target), "%s", target ? target : "");
+    snprintf(d->param, sizeof(d->param), "%s", param ? param : "");
+    d->lo = 0.0f;
+    d->hi = 1.0f;
+}
+
 /* ---- One knob-turn law ---------------------------------------------------
  *
  * Three paths turn a chain knob and each had hand-rolled the same time-based
@@ -1099,8 +1114,8 @@ void knob_emit_cc_out(chain_instance_t *inst, int idx) {
     int recv_ch = inst->host->slot_recv_channel((void *)inst);
     if (recv_ch < 0 || recv_ch > 15) return;
 
-    chain_param_info_t *pinfo = knob_find_param(inst, km->target, km->param);
-    int cc_val = knob_value_to_cc(km->current_value, pinfo);
+    chain_param_info_t *pinfo = knob_find_param(inst, km->dests[0].target, km->dests[0].param);
+    int cc_val = knob_value_to_cc(km->dests[0].current_value, pinfo);
     if (cc_val < 0) return;
     if (cc_val == km->last_cc_out) return;          /* change detection at CC resolution */
 

--- a/src/modules/chain/dsp/chain_params.c
+++ b/src/modules/chain/dsp/chain_params.c
@@ -1261,6 +1261,75 @@ void knob_turn(chain_instance_t *inst, int idx, int ticks, float float_fallback_
 
 /* Inverse of the inbound scaling in chain_midi.c. Returns -1 when the range is
  * degenerate or dynamic (max_val < 0), where there is no meaningful 0-127. */
+/*
+ * WHERE THE KNOB SITS ACROSS ITS OWN TRAVEL, as 0-127. One sentence, and
+ * therefore one rule, for both kinds of knob:
+ *
+ *   several destinations -> the knob's own position, which is the only thing
+ *                           they have in common;
+ *   one destination      -> that parameter's value as a fraction of its own
+ *                           WINDOW (not of the parameter's full range).
+ *
+ * With one destination at the whole-range default the second reduces to
+ * (val - min) / (max - min), i.e. exactly knob_value_to_cc -- so nothing
+ * changes for any knob that exists today, and test_chain_knob_cc_out's
+ * inverse-scaling assertion passes untouched.
+ *
+ * Measuring a RANGED single destination against its window rather than the
+ * full range is what keeps in and out symmetric. The alternative gives an
+ * external fader dead zones at both ends, where its travel maps outside the
+ * window and clamps, so a third of the throw does nothing.
+ */
+int knob_position_cc(chain_instance_t *inst, const knob_mapping_t *km) {
+    if (!inst || !km || km->dest_count < 1) return -1;
+
+    if (knob_is_multi(km)) {
+        int cc_val = (int)(km->position * 127.0f + 0.5f);
+        if (cc_val < 0) cc_val = 0;
+        if (cc_val > 127) cc_val = 127;
+        return cc_val;
+    }
+
+    const knob_dest_t *d = &km->dests[0];
+    chain_param_info_t *pinfo = knob_find_param(inst, d->target, d->param);
+    if (!pinfo) return -1;
+
+    float lo = d->lo, hi = d->hi;
+    float span = hi - lo;
+    if (span == 0.0f) return -1;              /* a zero-width window has no position */
+
+    float frac = (knob_value_to_frac(d->current_value, pinfo) - lo) / span;
+    if (frac < 0.0f) frac = 0.0f;
+    if (frac > 1.0f) frac = 1.0f;
+    return (int)(frac * 127.0f + 0.5f);
+}
+
+/*
+ * The inbound half: put the knob AT a position, 0..1, and let every
+ * destination follow. The same rule read backwards, so a controller that sends
+ * back what it was told lands where it started.
+ */
+void knob_set_position(chain_instance_t *inst, int idx, float position) {
+    if (!inst || idx < 0 || idx >= MAX_KNOB_MAPPINGS) return;
+    knob_mapping_t *km = &inst->knob_mappings[idx];
+    if (km->dest_count < 1) return;
+
+    if (position < 0.0f) position = 0.0f;
+    if (position > 1.0f) position = 1.0f;
+
+    if (knob_is_multi(km)) km->position = position;
+
+    for (int i = 0; i < km->dest_count && i < MAX_KNOB_DESTS; i++) {
+        knob_dest_t *d = &km->dests[i];
+        if (!d->param[0]) continue;
+        chain_param_info_t *pinfo = knob_find_param(inst, d->target, d->param);
+        if (!pinfo) continue;
+        float nv = knob_dest_value_at(d, position, pinfo);
+        d->current_value = nv;
+        knob_format_and_forward(inst, d, pinfo, nv);
+    }
+}
+
 static int knob_value_to_cc(float val, const chain_param_info_t *pinfo) {
     if (!pinfo) return -1;
     float span = pinfo->max_val - pinfo->min_val;
@@ -1287,8 +1356,7 @@ void knob_emit_cc_out(chain_instance_t *inst, int idx) {
     int recv_ch = inst->host->slot_recv_channel((void *)inst);
     if (recv_ch < 0 || recv_ch > 15) return;
 
-    chain_param_info_t *pinfo = knob_find_param(inst, km->dests[0].target, km->dests[0].param);
-    int cc_val = knob_value_to_cc(km->dests[0].current_value, pinfo);
+    int cc_val = knob_position_cc(inst, km);
     if (cc_val < 0) return;
     if (cc_val == km->last_cc_out) return;          /* change detection at CC resolution */
 

--- a/src/modules/chain/dsp/chain_patch.c
+++ b/src/modules/chain/dsp/chain_patch.c
@@ -672,6 +672,11 @@ static const char *json_span_end(const char *start) {
 static void json_row_string(const char *obj_start, const char *obj_end,
                             const char *field, char *out, size_t out_len) {
     out[0] = '\0';
+    /* `field` carries its own colon ("\"param\":"), so a row whose VALUE is the
+     * word this looks for cannot be mistaken for the key. Without it,
+     * {"param":"lo","value":0.5} answers the search for "lo" at its own value
+     * and reads 0.5 as that field -- a module free to name a parameter `lo`,
+     * `hi`, `dest` or `pos` could silently rewrite the row around it. */
     const char *pos = strstr(obj_start, field);
     if (!pos || pos >= obj_end) return;
     const char *colon = strchr(pos, ':');
@@ -690,6 +695,7 @@ static void json_row_string(const char *obj_start, const char *obj_end,
  * so a caller's default survives a field the writer did not emit. */
 static void json_row_float(const char *obj_start, const char *obj_end,
                            const char *field, float *out) {
+    /* `field` carries its own colon -- see json_row_string. */
     const char *pos = strstr(obj_start, field);
     if (!pos || pos >= obj_end) return;
     const char *colon = strchr(pos, ':');
@@ -1269,21 +1275,21 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
                 float row_lo = 0.0f, row_hi = 1.0f, row_pos = -1.0f;
                 float row_value = -999999.0f;   /* Sentinel: no saved value */
 
-                const char *cc_pos = strstr(obj_start, "\"cc\"");
+                const char *cc_pos = strstr(obj_start, "\"cc\":");
                 if (cc_pos && cc_pos < obj_end) {
                     const char *colon = strchr(cc_pos, ':');
                     if (colon) row_cc = atoi(colon + 1);
                 }
 
-                json_row_string(obj_start, obj_end, "\"target\"", row_target, sizeof(row_target));
-                json_row_string(obj_start, obj_end, "\"param\"", row_param, sizeof(row_param));
+                json_row_string(obj_start, obj_end, "\"target\":", row_target, sizeof(row_target));
+                json_row_string(obj_start, obj_end, "\"param\":", row_param, sizeof(row_param));
 
-                json_row_float(obj_start, obj_end, "\"value\"", &row_value);
-                json_row_float(obj_start, obj_end, "\"lo\"", &row_lo);
-                json_row_float(obj_start, obj_end, "\"hi\"", &row_hi);
-                json_row_float(obj_start, obj_end, "\"pos\"", &row_pos);
+                json_row_float(obj_start, obj_end, "\"value\":", &row_value);
+                json_row_float(obj_start, obj_end, "\"lo\":", &row_lo);
+                json_row_float(obj_start, obj_end, "\"hi\":", &row_hi);
+                json_row_float(obj_start, obj_end, "\"pos\":", &row_pos);
 
-                const char *dest_pos = strstr(obj_start, "\"dest\"");
+                const char *dest_pos = strstr(obj_start, "\"dest\":");
                 if (dest_pos && dest_pos < obj_end) {
                     const char *colon = strchr(dest_pos, ':');
                     if (colon) row_dest = atoi(colon + 1);

--- a/src/modules/chain/dsp/chain_patch.c
+++ b/src/modules/chain/dsp/chain_patch.c
@@ -1255,7 +1255,7 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
                         if (q2 && q2 < obj_end) {
                             int len = q2 - q1 - 1;
                             if (len > 15) len = 15;
-                            strncpy(m->target, q1 + 1, len);
+                            strncpy(m->dests[0].target, q1 + 1, len);
                         }
                     }
                 }
@@ -1269,20 +1269,25 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
                         if (q2 && q2 < obj_end) {
                             int len = q2 - q1 - 1;
                             if (len > 31) len = 31;
-                            strncpy(m->param, q1 + 1, len);
+                            strncpy(m->dests[0].param, q1 + 1, len);
                         }
                     }
                 }
 
                 /* Parse saved value if present */
-                m->current_value = -999999.0f;  /* Sentinel: no saved value */
+                m->dests[0].current_value = -999999.0f;  /* Sentinel: no saved value */
                 const char *val_pos = strstr(obj_start, "\"value\"");
                 if (val_pos && val_pos < obj_end) {
                     const char *colon = strchr(val_pos, ':');
-                    if (colon) m->current_value = strtof(colon + 1, NULL);
+                    if (colon) m->dests[0].current_value = strtof(colon + 1, NULL);
                 }
 
-                if (m->cc >= KNOB_CC_START && m->cc <= KNOB_CC_END && m->param[0]) {
+                if (m->cc >= KNOB_CC_START && m->cc <= KNOB_CC_END && m->dests[0].param[0]) {
+                    /* Accepted: one whole-range destination. The memset above
+                     * left lo=hi=0, which would read as a zero-width window. */
+                    m->dests[0].lo = 0.0f;
+                    m->dests[0].hi = 1.0f;
+                    m->dest_count = 1;
                     patch->knob_mapping_count++;
                 }
 
@@ -1505,8 +1510,8 @@ int v2_load_from_patch_info(chain_instance_t *inst, patch_info_t *patch) {
      * The saved value may be stale if params were changed via module UI,
      * so always read the real value from the plugin after state restore. */
     for (int i = 0; i < inst->knob_mapping_count; i++) {
-        const char *target = inst->knob_mappings[i].target;
-        const char *param = inst->knob_mappings[i].param;
+        const char *target = inst->knob_mappings[i].dests[0].target;
+        const char *param = inst->knob_mappings[i].dests[0].param;
 
         /* "Nothing sent to the controller yet" is -1, but the rows we just
          * copied came from a patch_info_t whose parser clears each row with
@@ -1537,20 +1542,20 @@ int v2_load_from_patch_info(chain_instance_t *inst, patch_info_t *patch) {
 
         chain_param_info_t *pinfo = find_param_by_key(inst, target, param);
         if (got > 0) {
-            inst->knob_mappings[i].current_value = dsp_value_to_float(
+            inst->knob_mappings[i].dests[0].current_value = dsp_value_to_float(
                 val_buf, pinfo, pinfo ? (pinfo->min_val + pinfo->max_val) / 2.0f : 0.5f);
         } else if (pinfo) {
             /* No DSP read — use saved value or midpoint */
-            float saved = patch->knob_mappings[i].current_value;
+            float saved = patch->knob_mappings[i].dests[0].current_value;
             if (saved > -999998.0f) {
                 if (saved < pinfo->min_val) saved = pinfo->min_val;
                 if (saved > pinfo->max_val) saved = pinfo->max_val;
-                inst->knob_mappings[i].current_value = saved;
+                inst->knob_mappings[i].dests[0].current_value = saved;
             } else {
-                inst->knob_mappings[i].current_value = (pinfo->min_val + pinfo->max_val) / 2.0f;
+                inst->knob_mappings[i].dests[0].current_value = (pinfo->min_val + pinfo->max_val) / 2.0f;
             }
         } else {
-            inst->knob_mappings[i].current_value = 0.5f;
+            inst->knob_mappings[i].dests[0].current_value = 0.5f;
         }
     }
 

--- a/src/modules/chain/dsp/chain_patch.c
+++ b/src/modules/chain/dsp/chain_patch.c
@@ -667,6 +667,35 @@ static const char *json_span_end(const char *start) {
     return NULL;
 }
 
+/* Read a quoted string field out of one JSON object, bounded by that object.
+ * Replaces four copies of the same nested-strchr dance. */
+static void json_row_string(const char *obj_start, const char *obj_end,
+                            const char *field, char *out, size_t out_len) {
+    out[0] = '\0';
+    const char *pos = strstr(obj_start, field);
+    if (!pos || pos >= obj_end) return;
+    const char *colon = strchr(pos, ':');
+    if (!colon) return;
+    const char *q1 = strchr(colon, '"');
+    if (!q1 || q1 >= obj_end) return;
+    const char *q2 = strchr(q1 + 1, '"');
+    if (!q2 || q2 >= obj_end) return;
+    size_t len = (size_t)(q2 - q1 - 1);
+    if (len > out_len - 1) len = out_len - 1;
+    memcpy(out, q1 + 1, len);
+    out[len] = '\0';
+}
+
+/* Read a numeric field out of one JSON object, leaving *out alone if absent --
+ * so a caller's default survives a field the writer did not emit. */
+static void json_row_float(const char *obj_start, const char *obj_end,
+                           const char *field, float *out) {
+    const char *pos = strstr(obj_start, field);
+    if (!pos || pos >= obj_end) return;
+    const char *colon = strchr(pos, ':');
+    if (colon) *out = strtof(colon + 1, NULL);
+}
+
 /* Matching ']' for an array, or NULL (including when the span closed on '}'). */
 static const char *json_array_end(const char *arr_start) {
     const char *end = json_span_end(arr_start);
@@ -1205,90 +1234,100 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
         }
     }
 
-    /* Parse knob_mappings - simplified */
+    /* Parse knob_mappings.
+     *
+     * Bounded by ROWS, not by mappings: a knob with several destinations
+     * contributes one row each and they merge onto one mapping, so counting
+     * mappings would stop reading part-way through the last knob's
+     * destinations and drop them silently. */
     const char *mappings_pos = strstr(json, "\"knob_mappings\"");
     if (mappings_pos) {
         const char *arr_start = strchr(mappings_pos, '[');
-        const char *arr_end = arr_start ? strchr(arr_start, ']') : NULL;
+        /* Depth-aware, and required to be: these helpers already exist for the
+         * rest of the file, while this one scan still used the first ']' and
+         * the first '}' it could find. Nothing nested is written here today,
+         * but a first ']' is the wrong end of any array that ever gains one. */
+        const char *arr_end = arr_start ? json_array_end(arr_start) : NULL;
 
         if (arr_start && arr_end) {
             const char *obj_start = arr_start;
-            while (patch->knob_mapping_count < MAX_KNOB_MAPPINGS) {
+            int rows_seen = 0;
+            while (rows_seen++ < MAX_KNOB_MAPPINGS * MAX_KNOB_DESTS) {
                 obj_start = strchr(obj_start + 1, '{');
                 if (!obj_start || obj_start > arr_end) break;
 
-                const char *obj_end = strchr(obj_start, '}');
+                const char *obj_end = json_object_end(obj_start);
                 if (!obj_end || obj_end > arr_end) break;
 
-                knob_mapping_t *m = &patch->knob_mappings[patch->knob_mapping_count];
+                /* Parse the row into scratch first. A row may MERGE into a
+                 * mapping already built for this cc (a knob with several
+                 * destinations writes one row each, all sharing its cc), so
+                 * where it lands is not known until cc and dest are read. */
+                int row_cc = 0, row_dest = -1;
+                char row_target[16] = {0};
+                char row_param[32] = {0};
+                float row_lo = 0.0f, row_hi = 1.0f, row_pos = -1.0f;
+                float row_value = -999999.0f;   /* Sentinel: no saved value */
 
-                /*
-                 * Clear the row before parsing into it.
-                 *
-                 * `m` is only ADVANCED when a row is accepted, so a REJECTED
-                 * row leaves its cc/target/param sitting in the slot and the
-                 * next row inherits every field it happens to omit — a mapping
-                 * silently pointed at a module named by a row that was thrown
-                 * away. Rejected rows used to be a curiosity of hand-edited
-                 * patches; the permutation makes them routine, because vacating
-                 * a position blanks a mapping in place rather than removing it.
-                 *
-                 * It also terminates `target`: the strncpy below caps `len` at
-                 * exactly sizeof-1, and strncpy writes no NUL when it copies
-                 * the full count.
-                 */
-                memset(m, 0, sizeof(*m));
-
-                /* Parse cc */
                 const char *cc_pos = strstr(obj_start, "\"cc\"");
                 if (cc_pos && cc_pos < obj_end) {
                     const char *colon = strchr(cc_pos, ':');
-                    if (colon) m->cc = atoi(colon + 1);
+                    if (colon) row_cc = atoi(colon + 1);
                 }
 
-                /* Parse target */
-                const char *target_pos = strstr(obj_start, "\"target\"");
-                if (target_pos && target_pos < obj_end) {
-                    const char *q1 = strchr(strchr(target_pos, ':'), '"');
-                    if (q1 && q1 < obj_end) {
-                        const char *q2 = strchr(q1 + 1, '"');
-                        if (q2 && q2 < obj_end) {
-                            int len = q2 - q1 - 1;
-                            if (len > 15) len = 15;
-                            strncpy(m->dests[0].target, q1 + 1, len);
+                json_row_string(obj_start, obj_end, "\"target\"", row_target, sizeof(row_target));
+                json_row_string(obj_start, obj_end, "\"param\"", row_param, sizeof(row_param));
+
+                json_row_float(obj_start, obj_end, "\"value\"", &row_value);
+                json_row_float(obj_start, obj_end, "\"lo\"", &row_lo);
+                json_row_float(obj_start, obj_end, "\"hi\"", &row_hi);
+                json_row_float(obj_start, obj_end, "\"pos\"", &row_pos);
+
+                const char *dest_pos = strstr(obj_start, "\"dest\"");
+                if (dest_pos && dest_pos < obj_end) {
+                    const char *colon = strchr(dest_pos, ':');
+                    if (colon) row_dest = atoi(colon + 1);
+                }
+
+                if (row_cc >= KNOB_CC_START && row_cc <= KNOB_CC_END && row_param[0]) {
+                    /* Does a mapping for this cc already exist? */
+                    knob_mapping_t *m = NULL;
+                    for (int k = 0; k < patch->knob_mapping_count; k++) {
+                        if (patch->knob_mappings[k].cc == row_cc) {
+                            m = &patch->knob_mappings[k];
+                            break;
                         }
                     }
-                }
-
-                /* Parse param */
-                const char *param_pos = strstr(obj_start, "\"param\"");
-                if (param_pos && param_pos < obj_end) {
-                    const char *q1 = strchr(strchr(param_pos, ':'), '"');
-                    if (q1 && q1 < obj_end) {
-                        const char *q2 = strchr(q1 + 1, '"');
-                        if (q2 && q2 < obj_end) {
-                            int len = q2 - q1 - 1;
-                            if (len > 31) len = 31;
-                            strncpy(m->dests[0].param, q1 + 1, len);
+                    if (!m && patch->knob_mapping_count < MAX_KNOB_MAPPINGS) {
+                        m = &patch->knob_mappings[patch->knob_mapping_count++];
+                        /*
+                         * Clear the row before parsing into it.
+                         *
+                         * A REJECTED row used to leave its cc/target/param in
+                         * the slot for the next row to inherit every field it
+                         * happened to omit -- a mapping silently pointed at a
+                         * module named by a row that was thrown away. Rejected
+                         * rows became routine when vacating a chain position
+                         * started blanking a mapping in place rather than
+                         * removing it.
+                         */
+                        memset(m, 0, sizeof(*m));
+                        m->cc = row_cc;
+                    }
+                    if (m) {
+                        /* An explicit dest index, or append. A row naming a
+                         * slot past the cap is dropped rather than folded onto
+                         * another destination. */
+                        int di = (row_dest >= 0) ? row_dest : m->dest_count;
+                        if (di >= 0 && di < MAX_KNOB_DESTS) {
+                            knob_dest_assign(&m->dests[di], row_target, row_param);
+                            m->dests[di].lo = row_lo;
+                            m->dests[di].hi = row_hi;
+                            m->dests[di].current_value = row_value;
+                            if (di + 1 > m->dest_count) m->dest_count = di + 1;
+                            if (row_pos >= 0.0f) m->position = row_pos;
                         }
                     }
-                }
-
-                /* Parse saved value if present */
-                m->dests[0].current_value = -999999.0f;  /* Sentinel: no saved value */
-                const char *val_pos = strstr(obj_start, "\"value\"");
-                if (val_pos && val_pos < obj_end) {
-                    const char *colon = strchr(val_pos, ':');
-                    if (colon) m->dests[0].current_value = strtof(colon + 1, NULL);
-                }
-
-                if (m->cc >= KNOB_CC_START && m->cc <= KNOB_CC_END && m->dests[0].param[0]) {
-                    /* Accepted: one whole-range destination. The memset above
-                     * left lo=hi=0, which would read as a zero-width window. */
-                    m->dests[0].lo = 0.0f;
-                    m->dests[0].hi = 1.0f;
-                    m->dest_count = 1;
-                    patch->knob_mapping_count++;
                 }
 
                 obj_start = obj_end;

--- a/src/modules/chain/dsp/chain_reorder.c
+++ b/src/modules/chain/dsp/chain_reorder.c
@@ -119,8 +119,26 @@ static void chain_perm_retarget_all(chain_instance_t *inst, const char *prefix,
     }
     for (int i = 0; i < inst->knob_mapping_count && i < MAX_KNOB_MAPPINGS; i++) {
         knob_mapping_t *k = &inst->knob_mappings[i];
-        if (chain_perm_retarget(k->target, sizeof(k->target), prefix, max, map, count) < 0) {
-            k->param[0] = '\0';
+        /* EVERY destination, not just the first: each one names a chain
+         * position by string, so a shape edit that renumbered positions would
+         * otherwise leave the rest aimed at whatever slid into their index. */
+        for (int d = 0; d < k->dest_count && d < MAX_KNOB_DESTS; d++) {
+            knob_dest_t *dest = &k->dests[d];
+            if (chain_perm_retarget(dest->target, sizeof(dest->target),
+                                    prefix, max, map, count) >= 0) continue;
+
+            /* The module this destination pointed at is gone. With others
+             * still live, drop it and close the gap; as the last one, blank
+             * the param and leave the mapping in place -- which is what a
+             * single-destination knob has always done here. */
+            if (k->dest_count > 1) {
+                for (int j = d; j < k->dest_count - 1; j++) k->dests[j] = k->dests[j + 1];
+                memset(&k->dests[k->dest_count - 1], 0, sizeof(k->dests[0]));
+                k->dest_count--;
+                d--;
+            } else {
+                dest->param[0] = '\0';
+            }
         }
     }
 }

--- a/src/modules/chain/ui.js
+++ b/src/modules/chain/ui.js
@@ -387,6 +387,85 @@ const INPUT_SOURCE_OPTIONS = [
     { id: "external", name: "External Only", isInputOption: true }
 ];
 
+/*
+ * A patch's knob rows -> this editor's model, plus the rows kept verbatim.
+ *
+ * A knob may drive SEVERAL parameters, stored as several rows sharing one cc.
+ * This editor only ever showed one target and one param, and it rebuilds the
+ * patch's knob array from what it holds -- so reading one row per knob and
+ * writing one back DELETED every extra destination and every window,
+ * permanently, the first time a chain built on the device was saved from here.
+ * It looked correct on both screens throughout.
+ *
+ * The rows are therefore kept. The first is what this editor edits; the rest
+ * ride along untouched until something that understands them writes them again.
+ */
+function parseKnobMappings(knobMappings) {
+    const knobs = createEmptyKnobs();
+    const knobRows = createEmptyKnobRows();
+    if (!Array.isArray(knobMappings)) return { knobs, knobRows };
+
+    const rowsByKnob = {};
+    for (const mapping of knobMappings) {
+        const knobIndex = mapping.cc - KNOB_CC_START;
+        if (knobIndex < 0 || knobIndex >= NUM_KNOBS) continue;
+        if (!rowsByKnob[knobIndex]) rowsByKnob[knobIndex] = [];
+        rowsByKnob[knobIndex].push(mapping);
+    }
+    for (const key in rowsByKnob) {
+        const knobIndex = Number(key);
+        /* `dest` when present, file order otherwise -- an older patch has one
+         * row per knob and no index at all. */
+        const rows = rowsByKnob[key].slice().sort((a, b) => (a.dest || 0) - (b.dest || 0));
+        knobs[knobIndex] = { slot: rows[0].target, param: rows[0].param };
+        knobRows[knobIndex] = rows;
+    }
+    return { knobs, knobRows };
+}
+
+/* ...and back. The first row follows this editor; the rest go out exactly as
+ * they came in, windows and all. Re-pointing the first destination here is a
+ * real edit and is kept; the others are not this screen's to change. */
+function buildKnobMappings(chain) {
+    const out = [];
+    if (!chain || !chain.knobs) return out;
+
+    for (let i = 0; i < NUM_KNOBS; i++) {
+        const knob = chain.knobs[i];
+        if (!knob || !knob.slot || !knob.param) continue;
+
+        const rows = chain.knobRows && chain.knobRows[i];
+        if (rows && rows.length) {
+            out.push(Object.assign({}, rows[0], {
+                cc: KNOB_CC_START + i, target: knob.slot, param: knob.param
+            }));
+            for (let r = 1; r < rows.length; r++) {
+                out.push(Object.assign({}, rows[r], { cc: KNOB_CC_START + i }));
+            }
+            continue;
+        }
+
+        const mapping = { cc: KNOB_CC_START + i, target: knob.slot, param: knob.param };
+        /* Preset param needs integer type and dynamic max from synth */
+        if (knob.param === "preset") {
+            mapping.type = "int";
+            mapping.min = 0;
+            mapping.max_param = "preset_count";
+        }
+        out.push(mapping);
+    }
+    return out;
+}
+
+/* Raw knob rows from the patch, one array per knob, kept so destinations this
+ * editor does not show survive a save. Parallel to `knobs` rather than inside
+ * it: `knobs` is this screen's editable model and is rebuilt freely. */
+function createEmptyKnobRows() {
+    const rows = [];
+    for (let i = 0; i < NUM_KNOBS; i++) rows.push(null);
+    return rows;
+}
+
 function createEmptyKnobs() {
     const knobs = [];
     for (let i = 0; i < NUM_KNOBS; i++) {
@@ -423,7 +502,8 @@ function createEditorState(existingPatch = null) {
                 fx1_config: {},
                 fx2: existingPatch.audio_fx?.[1] || null,
                 fx2_config: {},
-                knobs: existingPatch.knobs || createEmptyKnobs()
+                knobs: existingPatch.knobs || createEmptyKnobs(),
+                knobRows: existingPatch.knobRows || createEmptyKnobRows()
             }
         };
     }
@@ -452,7 +532,8 @@ function createEditorState(existingPatch = null) {
             fx1_config: {},
             fx2: null,
             fx2_config: {},
-            knobs: createEmptyKnobs()
+            knobs: createEmptyKnobs(),
+            knobRows: createEmptyKnobRows()
         }
     };
 }
@@ -497,7 +578,8 @@ function enterEditor(patchIndex = -1) {
                 fx1_config: {},
                 fx2: null,
                 fx2_config: {},
-                knobs: config.knobs || createEmptyKnobs()
+                knobs: config.knobs || createEmptyKnobs(),
+                knobRows: config.knobRows || createEmptyKnobRows()
             }
         };
 
@@ -525,17 +607,13 @@ function enterEditor(patchIndex = -1) {
             }
         }
 
-        /* Parse Knob Mappings */
-        if (Array.isArray(config.knob_mappings)) {
-            for (const mapping of config.knob_mappings) {
-                const knobIndex = mapping.cc - KNOB_CC_START;
-                if (knobIndex >= 0 && knobIndex < NUM_KNOBS) {
-                    editorState.chain.knobs[knobIndex] = {
-                        slot: mapping.target,
-                        param: mapping.param
-                    };
-                }
-            }
+        /* Parse Knob Mappings -- see parseKnobMappings for why the rows are
+         * kept rather than reduced to one target per knob. */
+        {
+            const parsed = parseKnobMappings(config.knob_mappings);
+            editorState.chain.knobs = parsed.knobs;
+            editorState.chain.knobRows = parsed.knobRows;
+        }
         }
     } else {
         /* New chain */
@@ -1520,25 +1598,8 @@ function buildChainJson() {
     }
 
     /* Knob assignments */
-    if (chain.knobs) {
-        const knobs = [];
-        for (let i = 0; i < NUM_KNOBS; i++) {
-            const knob = chain.knobs[i];
-            if (knob && knob.slot && knob.param) {
-                const mapping = {
-                    cc: KNOB_CC_START + i,
-                    target: knob.slot,
-                    param: knob.param
-                };
-                /* Preset param needs integer type and dynamic max from synth */
-                if (knob.param === "preset") {
-                    mapping.type = "int";
-                    mapping.min = 0;
-                    mapping.max_param = "preset_count";
-                }
-                knobs.push(mapping);
-            }
-        }
+    {
+        const knobs = buildKnobMappings(chain);
         if (knobs.length > 0) {
             patch.chain.knob_mappings = knobs;
         }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -13386,9 +13386,28 @@ function getKnobPickerLevelItems(hierarchy, levelName) {
 function findFirstParamLevel(hierarchy) {
     if (!hierarchy || !hierarchy.levels) return "root";
 
-    /* Check if root has children, follow to first real params level */
-    let level = hierarchy.levels.root;
+    /*
+     * Where the walk STARTS.
+     *
+     * "root" is only a convention, not a guarantee. A mode-based module names
+     * its top levels after its modes (`modes: ["patch","performance","system"]`
+     * with no `root` at all), and asking for a level that does not exist
+     * returns nothing -- so the knob picker showed an EMPTY parameter list for
+     * every such module, while the all-levels scan sitting right next to it
+     * would have found them. Prefer root, then the first declared mode, then
+     * simply the first level there is.
+     */
     let levelName = "root";
+    if (!hierarchy.levels.root) {
+        if (Array.isArray(hierarchy.modes) && hierarchy.modes.length &&
+            hierarchy.levels[hierarchy.modes[0]]) {
+            levelName = hierarchy.modes[0];
+        } else {
+            const first = Object.keys(hierarchy.levels)[0];
+            if (first) levelName = first;
+        }
+    }
+    let level = hierarchy.levels[levelName];
 
     /* Skip preset browser levels (those with list_param) */
     while (level && level.list_param && level.children) {
@@ -18942,6 +18961,17 @@ function handleSelect() {
                                 /* Find first level with actual params (skip preset browser) */
                                 knobParamPickerLevel = findFirstParamLevel(knobParamPickerHierarchy);
                                 knobParamPickerParams = getKnobPickerLevelItems(knobParamPickerHierarchy, knobParamPickerLevel);
+                                if (knobParamPickerParams.length === 0) {
+                                    /* A hierarchy that parses but yields no
+                                     * parameters at the level we entered leaves
+                                     * the user staring at an empty list. The
+                                     * all-levels scan is right here and finds
+                                     * them wherever they live, so use it rather
+                                     * than showing nothing. */
+                                    knobParamPickerHierarchy = null;
+                                    knobParamPickerLevel = null;
+                                    knobParamPickerParams = getKnobParamsForTarget(knobEditorSlot, selected.id);
+                                }
                             } catch (e) {
                                 /* Parse error - fall back to flat mode */
                                 knobParamPickerHierarchy = null;

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -440,6 +440,7 @@ const VIEWS = {
     FILEPATH_BROWSER: "filepathbrowser", // Generic filepath picker for filepath params
     KNOB_EDITOR: "knobedit",  // Edit knob assignments for a slot
     KNOB_PARAM_PICKER: "knobpick", // Pick parameter for a knob assignment
+    KNOB_DEST_LIST: "knobdests",   // A knob's destination list (several params, each with a window)
     DYNAMIC_PARAM_PICKER: "dynamicpick", // Dedicated picker UI for module_picker/parameter_picker
     STORE_PICKER_RESULT: "storepickerresult",  // Store: success/error message
     OVERTAKE_MENU: "overtakemenu",   // Overtake module selection menu
@@ -1832,6 +1833,17 @@ let knobEditorCcOut = 0;         // Cached knob_cc_out for the slot being edited
                                  // same as Off: this row is a TOGGLE, so a
                                  // failed read shown as "Off" makes the next
                                  // click write the value it already had.
+/* A knob may drive up to this many parameters. MUST equal MAX_KNOB_DESTS in
+ * src/modules/chain/dsp/chain_internal.h -- a JS copy that drifted high would
+ * offer a destination the DSP silently refuses, which reads as a dead row.
+ * test_chain_knob_dest_cap_js.sh pins the two together. */
+const MAX_KNOB_DESTS = 4;
+
+let knobEditorDests = [];        // Per knob: array of {target, param, lo, hi}
+let knobDestIndex = 0;           // Selected row in the destination list
+let knobDestEditing = null;      // null, or {di, field:"lo"|"hi"} being jogged
+let knobEditorDestIndex = 0;     // Which destination the param picker is editing
+
 let knobParamPickerFolder = null; // null = main (targets), string = target name for params
 let knobParamPickerIndex = 0;    // Selected index in param picker
 let knobParamPickerParams = [];  // Available params in current folder
@@ -12754,9 +12766,32 @@ function enterKnobEditor(slot) {
 /* Load current knob assignments from DSP */
 function loadKnobAssignments(slot) {
     knobEditorAssignments = [];
+    knobEditorDests = [];
     for (let i = 0; i < NUM_KNOBS; i++) {
+        /* One read for the whole destination list, which also carries the
+         * first destination -- so this is one read per knob where it used to
+         * be two, not three, even though it now returns strictly more. */
+        const raw = getSlotParam(slot, `knob_${i + 1}_dests`);
+        let dests = null;
+        if (raw) { try { dests = JSON.parse(raw); } catch (e) { dests = null; } }
+
+        if (Array.isArray(dests)) {
+            knobEditorDests.push(dests);
+            knobEditorAssignments.push(dests.length
+                ? { target: dests[0].target, param: dests[0].param }
+                : { target: "", param: "" });
+            continue;
+        }
+
+        /* Three answers, not two, and the same rule as knob_cc_out below.
+         * "" is a chain DSP older than destinations -- the two keys that have
+         * always answered still do, and one whole-range destination is exactly
+         * what such a knob has. null is a read that did not complete, and the
+         * fallback is harmless there too: it asks again rather than inventing
+         * an empty list, which would show the knob as unassigned. */
         const target = getSlotParam(slot, `knob_${i + 1}_target`) || "";
         const param = getSlotParam(slot, `knob_${i + 1}_param`) || "";
+        knobEditorDests.push(target && param ? [{ target, param, lo: 0, hi: 1 }] : []);
         knobEditorAssignments.push({ target, param });
     }
     /* Three answers, not two (CLAUDE.md). "" is a chain DSP older than this
@@ -13244,6 +13279,40 @@ function getKnobAssignmentLabel(assignment) {
     return `${assignment.target}: ${assignment.param}`;
 }
 
+/* Is this destination anything other than the whole of its parameter? */
+function knobDestIsRanged(d) {
+    return !!d && (d.lo !== 0 || d.hi !== 1);
+}
+
+/* A window as the user set it. An inverted one is shown the way it behaves --
+ * high to low -- rather than tidied into ascending order, because "100-0%" is
+ * the whole point of setting it that way. */
+function knobWindowLabel(d) {
+    if (!d) return "";
+    return `${Math.round(d.lo * 100)}-${Math.round(d.hi * 100)}%`;
+}
+
+/*
+ * The knob list's value column. Three shapes, in the 12 characters that column
+ * has:
+ *
+ *   unassigned          (None)
+ *   one destination     synth: cutoff        -- unchanged
+ *   one, ranged         synth: cutoff ~      -- the tilde is the only room there is
+ *   several             cutoff +2            -- what it drives, not what it is
+ */
+function knobRowLabel(knobIndex) {
+    const dests = knobEditorDests[knobIndex];
+    if (!dests || dests.length === 0) {
+        return getKnobAssignmentLabel(knobEditorAssignments[knobIndex]);
+    }
+    if (dests.length === 1) {
+        const base = `${dests[0].target}: ${dests[0].param}`;
+        return knobDestIsRanged(dests[0]) ? `${base} ~` : base;
+    }
+    return `${dests[0].param} +${dests.length - 1}`;
+}
+
 /* Enter param picker for current knob */
 function enterKnobParamPicker() {
     knobParamPickerFolder = null;
@@ -13345,25 +13414,51 @@ function applyKnobAssignment(target, param) {
 
     /* Save to DSP via set_param */
     const knobNum = knobEditorIndex + 1;
+    const destNum = knobEditorDestIndex + 1;
+    const hadDests = (knobEditorDests[knobEditorIndex] || []).length;
+
     if (target && param) {
-        /* Set knob mapping - DSP uses "target:param" format internally */
-        setSlotParam(knobEditorSlot, `knob_${knobNum}_set`, `${target}:${param}`);
-    } else {
+        /*
+         * knob_N_set means "this knob has ONE whole-range destination, here" --
+         * it collapses whatever the knob had. That is right for assigning an
+         * empty knob and WRONG for re-pointing the first destination of one
+         * that drives several: it would delete the others with no error.
+         *
+         * So the first destination of an assigned knob goes through
+         * knob_N_dest_1_set, which keeps its window and its siblings.
+         */
+        if (hadDests === 0 && knobEditorDestIndex === 0) {
+            setSlotParam(knobEditorSlot, `knob_${knobNum}_set`, `${target}:${param}`);
+        } else {
+            setSlotParam(knobEditorSlot, `knob_${knobNum}_dest_${destNum}_set`,
+                         `${target}:${param}`);
+        }
+    } else if (hadDests <= 1) {
         /* Clear knob mapping */
         setSlotParam(knobEditorSlot, `knob_${knobNum}_clear`, "1");
+    } else {
+        setSlotParam(knobEditorSlot, `knob_${knobNum}_dest_${destNum}_clear`, "1");
     }
 
     /* Refresh knob mappings cache */
+    loadKnobAssignments(knobEditorSlot);
     fetchKnobMappings(knobEditorSlot);
     invalidateKnobContextCache();
 
-    /* Announce and return to knob editor */
+    /* Announce and return to whichever screen this was reached from: an empty
+     * knob was assigned straight from the list, a knob with destinations was
+     * being edited in its own. */
     if (target && param) {
-        announce(`Knob ${knobNum} assigned to ${param}`);
+        announce(`Knob ${knobNum} destination ${destNum} assigned to ${param}`);
     } else {
         announce(`Knob ${knobNum} cleared`);
     }
-    setView(VIEWS.KNOB_EDITOR);
+    if ((knobEditorDests[knobEditorIndex] || []).length > 0) {
+        knobDestIndex = Math.min(knobDestIndex, knobDestRows().length - 1);
+        setView(VIEWS.KNOB_DEST_LIST);
+    } else {
+        setView(VIEWS.KNOB_EDITOR);
+    }
     needsRedraw = true;
 }
 
@@ -17977,6 +18072,9 @@ function handleJog(delta, shift = isShiftHeld()) {
                 announceMenuItem(`Knob ${knobNum}`, assignLabel);
             }
             break;
+        case VIEWS.KNOB_DEST_LIST:
+            knobDestListTurn(delta);
+            break;
         case VIEWS.KNOB_PARAM_PICKER:
             if (knobParamPickerFolder === null) {
                 /* Navigate targets list */
@@ -18814,10 +18912,20 @@ function handleSelect() {
                 setSlotParam(knobEditorSlot, "knob_cc_out", String(knobEditorCcOut));
                 announceMenuItem("Knob CC Out", knobCcOutLabel());
                 needsRedraw = true;
-            } else {
-                /* Edit this knob's assignment */
+            } else if ((knobEditorDests[knobEditorIndex] || []).length === 0) {
+                /* An empty knob goes straight to choosing -- a list with
+                 * nothing in it but "+ Add" is a click for nothing. */
+                knobEditorDestIndex = 0;
                 enterKnobParamPicker();
+            } else {
+                /* An assigned knob opens its destination list. One extra click
+                 * for the common case, and one route in and out of a mapping:
+                 * re-pointing, windows, adding and removing all live there. */
+                enterKnobDestList();
             }
+            break;
+        case VIEWS.KNOB_DEST_LIST:
+            knobDestListClick();
             break;
         case VIEWS.KNOB_PARAM_PICKER:
             if (knobParamPickerFolder === null) {
@@ -19370,6 +19478,20 @@ function handleBack() {
              * user onto the list on the way back out, regardless of which
              * one they actually came from. */
             enterChainSettings(knobEditorSlot);
+            break;
+        case VIEWS.KNOB_DEST_LIST:
+            if (knobDestEditing) {
+                /* Back out of adjusting a window without leaving the list. The
+                 * window itself stays where it was jogged to -- every detent
+                 * already applied, which is the point of editing it by ear. */
+                knobDestEditing = null;
+                announce("Done");
+                needsRedraw = true;
+            } else {
+                setView(VIEWS.KNOB_EDITOR);
+                announce("Knob Editor");
+                needsRedraw = true;
+            }
             break;
         case VIEWS.KNOB_PARAM_PICKER:
             if (knobParamPickerFolder !== null) {
@@ -19966,6 +20088,7 @@ function drawKnobEditor() {
         items.push({
             type: "knob",
             label: `Knob ${i + 1}`,
+            knobIndex: i,
             assignment: knobEditorAssignments[i]
         });
     }
@@ -19982,7 +20105,7 @@ function drawKnobEditor() {
         selectedIndex: knobEditorIndex,
         getLabel: (item) => item.label,
         getValue: (item) => item.type === "knob"
-            ? truncateText(getKnobAssignmentLabel(item.assignment), 12)
+            ? truncateText(knobRowLabel(item.knobIndex), 12)
             : (item.type === "toggle" ? knobCcOutLabel() : ""),
         listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
         valueAlignRight: true,
@@ -19990,6 +20113,189 @@ function drawKnobEditor() {
     });
 
     drawFooter(["Back: cancel", "Click: edit"]);
+}
+
+/* ========== A knob's destination list ========== */
+
+/*
+ * The rows, derived rather than stored, so nothing can go stale between a
+ * write and the next draw:
+ *
+ *   Dest 1   synth: cutoff        <- click re-points it, Shift+click removes it
+ *     Lo       0%                 <- click starts jogging; each detent applies
+ *     Hi     100%
+ *   ...
+ *   + Add destination             (while there is room)
+ *   Remove knob
+ */
+function knobDestRows() {
+    const dests = knobEditorDests[knobEditorIndex] || [];
+    const rows = [];
+    for (let i = 0; i < dests.length; i++) {
+        rows.push({ kind: "dest", di: i });
+        rows.push({ kind: "lo", di: i });
+        rows.push({ kind: "hi", di: i });
+    }
+    if (dests.length < MAX_KNOB_DESTS) rows.push({ kind: "add" });
+    rows.push({ kind: "remove" });
+    return rows;
+}
+
+function knobDestRowLabel(row) {
+    const dests = knobEditorDests[knobEditorIndex] || [];
+    switch (row.kind) {
+        case "dest": return `Dest ${row.di + 1}`;
+        case "lo": return "  Lo";
+        case "hi": return "  Hi";
+        case "add": return "+ Add destination";
+        default: return "Remove knob";
+    }
+}
+
+function knobDestRowValue(row) {
+    const dests = knobEditorDests[knobEditorIndex] || [];
+    const d = dests[row.di];
+    switch (row.kind) {
+        case "dest": return d ? `${d.target}: ${d.param}` : "(None)";
+        case "lo": return d ? `${Math.round(d.lo * 100)}%` : "";
+        case "hi": return d ? `${Math.round(d.hi * 100)}%` : "";
+        default: return "";
+    }
+}
+
+function enterKnobDestList() {
+    knobDestIndex = 0;
+    knobDestEditing = null;
+    setView(VIEWS.KNOB_DEST_LIST);
+    needsRedraw = true;
+    const rows = knobDestRows();
+    announce(`Knob ${knobEditorIndex + 1} destinations, ` +
+             `${knobDestRowLabel(rows[0])}: ${knobDestRowValue(rows[0])}`);
+}
+
+function drawKnobDestList() {
+    clear_screen();
+    drawHeader(`Knob ${knobEditorIndex + 1}`);
+
+    const rows = knobDestRows();
+    drawMenuList({
+        items: rows,
+        selectedIndex: knobDestIndex,
+        getLabel: knobDestRowLabel,
+        getValue: (r) => truncateText(knobDestRowValue(r), 12),
+        listArea: { topY: LIST_TOP_Y, bottomY: FOOTER_RULE_Y },
+        valueAlignRight: true,
+        prioritizeSelectedValue: true,
+        editMode: knobDestEditing !== null
+    });
+
+    drawFooter(knobDestEditing
+        ? ["Click: done", "Jog: adjust"]
+        : ["Back: knobs", "Click: edit"]);
+}
+
+/* Write one destination's window and let the DSP apply it immediately -- the
+ * whole reason a window is edited here rather than in a dialog is that it is
+ * being set by ear. */
+function knobDestWriteWindow(di) {
+    const d = (knobEditorDests[knobEditorIndex] || [])[di];
+    if (!d) return;
+    setSlotParam(knobEditorSlot, `knob_${knobEditorIndex + 1}_dest_${di + 1}_range`,
+                 `${d.lo.toFixed(4)}:${d.hi.toFixed(4)}`);
+}
+
+/* Jog inside the destination list: move the cursor, or adjust a window. */
+function knobDestListTurn(delta) {
+    const rows = knobDestRows();
+
+    if (knobDestEditing) {
+        const d = (knobEditorDests[knobEditorIndex] || [])[knobDestEditing.di];
+        if (!d) { knobDestEditing = null; return; }
+        /* 1% a detent. A window is a musical boundary, not a value being
+         * dialled in, so it wants a grain you can land on rather than the
+         * parameter's own step. */
+        const next = Math.max(0, Math.min(1,
+            d[knobDestEditing.field] + delta * 0.01));
+        if (next !== d[knobDestEditing.field]) {
+            d[knobDestEditing.field] = next;
+            knobDestWriteWindow(knobDestEditing.di);
+        }
+        announceMenuItem(knobDestEditing.field === "lo" ? "Lo" : "Hi",
+                         `${Math.round(next * 100)}%`);
+        needsRedraw = true;
+        return;
+    }
+
+    knobDestIndex = Math.max(0, Math.min(rows.length - 1, knobDestIndex + delta));
+    const row = rows[knobDestIndex];
+    announceMenuItem(knobDestRowLabel(row).trim(), knobDestRowValue(row) || "");
+    needsRedraw = true;
+}
+
+/* Click inside the destination list. */
+function knobDestListClick() {
+    const rows = knobDestRows();
+    const row = rows[knobDestIndex];
+    if (!row) return;
+
+    if (knobDestEditing) {          /* finish adjusting a window */
+        knobDestEditing = null;
+        announce("Done");
+        needsRedraw = true;
+        return;
+    }
+
+    switch (row.kind) {
+        case "dest":
+            /* Re-point THIS destination. Seeding the picker from the
+             * destination being edited rather than from the first one matters:
+             * opening destination 3's picker on destination 1's component
+             * reads as a wrong answer, never as an error. */
+            knobEditorDestIndex = row.di;
+            enterKnobParamPicker();
+            break;
+        case "add":
+            knobEditorDestIndex = (knobEditorDests[knobEditorIndex] || []).length;
+            enterKnobParamPicker();
+            break;
+        case "lo":
+        case "hi":
+            knobDestEditing = { di: row.di, field: row.kind };
+            announce(row.kind === "lo" ? "Lo" : "Hi");
+            needsRedraw = true;
+            break;
+        default:
+            setSlotParam(knobEditorSlot, `knob_${knobEditorIndex + 1}_clear`, "1");
+            loadKnobAssignments(knobEditorSlot);
+            fetchKnobMappings(knobEditorSlot);
+            invalidateKnobContextCache();
+            announce(`Knob ${knobEditorIndex + 1} cleared`);
+            setView(VIEWS.KNOB_EDITOR);
+            needsRedraw = true;
+            break;
+    }
+}
+
+/* Shift+click on a destination row removes that one destination. */
+function knobDestListShiftClick() {
+    const rows = knobDestRows();
+    const row = rows[knobDestIndex];
+    if (!row || row.kind !== "dest") return;
+
+    setSlotParam(knobEditorSlot, `knob_${knobEditorIndex + 1}_dest_${row.di + 1}_clear`, "1");
+    loadKnobAssignments(knobEditorSlot);
+    fetchKnobMappings(knobEditorSlot);
+    invalidateKnobContextCache();
+
+    const left = (knobEditorDests[knobEditorIndex] || []).length;
+    if (left === 0) {
+        announce(`Knob ${knobEditorIndex + 1} cleared`);
+        setView(VIEWS.KNOB_EDITOR);
+    } else {
+        knobDestIndex = Math.min(knobDestIndex, knobDestRows().length - 1);
+        announce(`Destination removed, ${left} left`);
+    }
+    needsRedraw = true;
 }
 
 /* Draw param picker - select target then param for knob assignment */
@@ -21660,6 +21966,7 @@ function dispatchCoRunDraw() {
             break;
         case VIEWS.CANVAS:               drawCanvasPreview(); break;
         case VIEWS.KNOB_EDITOR:          drawKnobEditor(); break;
+        case VIEWS.KNOB_DEST_LIST:       drawKnobDestList(); break;
         case VIEWS.KNOB_PARAM_PICKER:    drawKnobParamPicker(); break;
         case VIEWS.DYNAMIC_PARAM_PICKER: drawDynamicParamPicker(); break;
         case VIEWS.LFO_EDIT:             drawLfoEdit(); break;
@@ -22886,6 +23193,9 @@ globalThis.tick = function() {
         case VIEWS.KNOB_EDITOR:
             drawKnobEditor();
             break;
+        case VIEWS.KNOB_DEST_LIST:
+            drawKnobDestList();
+            break;
         case VIEWS.KNOB_PARAM_PICKER:
             drawKnobParamPicker();
             break;
@@ -23597,8 +23907,13 @@ globalThis.onMidiMessageInternal = function(data) {
                  */
                 return;
             }
+            /* Shift+Click on a destination row removes that one destination.
+             * Plain click there re-points it, which is the common case; the
+             * destructive one takes the modifier. */
+            if (isShiftHeld() && view === VIEWS.KNOB_DEST_LIST) {
+                knobDestListShiftClick();
             /* Shift+Click in chain edit enters component edit mode */
-            if (isShiftHeld() && view === VIEWS.CHAIN_EDIT && selectedChainComponent >= 0) {
+            } else if (isShiftHeld() && view === VIEWS.CHAIN_EDIT && selectedChainComponent >= 0) {
                 handleShiftSelect();
             } else if (isShiftHeld() && view === VIEWS.MASTER_FX && masterFxSelectedIsModule()) {
                 /* Shift+Click in Master FX view enters module selector for the slot */

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -1836,7 +1836,7 @@ let knobEditorCcOut = 0;         // Cached knob_cc_out for the slot being edited
 /* A knob may drive up to this many parameters. MUST equal MAX_KNOB_DESTS in
  * src/modules/chain/dsp/chain_internal.h -- a JS copy that drifted high would
  * offer a destination the DSP silently refuses, which reads as a dead row.
- * test_chain_knob_dest_cap_js.sh pins the two together. */
+ * test_knob_dest_list.sh pins the two together. */
 const MAX_KNOB_DESTS = 4;
 
 let knobEditorDests = [];        // Per knob: array of {target, param, lo, hi}
@@ -13284,14 +13284,6 @@ function knobDestIsRanged(d) {
     return !!d && (d.lo !== 0 || d.hi !== 1);
 }
 
-/* A window as the user set it. An inverted one is shown the way it behaves --
- * high to low -- rather than tidied into ascending order, because "100-0%" is
- * the whole point of setting it that way. */
-function knobWindowLabel(d) {
-    if (!d) return "";
-    return `${Math.round(d.lo * 100)}-${Math.round(d.hi * 100)}%`;
-}
-
 /*
  * The knob list's value column. Three shapes, in the 12 characters that column
  * has:
@@ -19513,6 +19505,12 @@ function handleBack() {
                     needsRedraw = true;
                     announce("Knob Target");
                 }
+            } else if ((knobEditorDests[knobEditorIndex] || []).length > 0) {
+                /* Back to the destination list this was entered from -- landing
+                 * on the knob list instead loses the row the user was on. */
+                setView(VIEWS.KNOB_DEST_LIST);
+                announce(`Knob ${knobEditorIndex + 1} destinations`);
+                needsRedraw = true;
             } else {
                 /* Return to knob editor */
                 setView(VIEWS.KNOB_EDITOR);
@@ -20247,10 +20245,11 @@ function knobDestListClick() {
 
     switch (row.kind) {
         case "dest":
-            /* Re-point THIS destination. Seeding the picker from the
-             * destination being edited rather than from the first one matters:
-             * opening destination 3's picker on destination 1's component
-             * reads as a wrong answer, never as an error. */
+            /* Re-point THIS destination. What the picker carries is which
+             * destination its RESULT applies to -- get that wrong and
+             * choosing a parameter for destination 3 silently rewrites
+             * destination 1, which reads as a wrong answer and never as an
+             * error. (The picker's own cursor starts at the top either way.) */
             knobEditorDestIndex = row.di;
             enterKnobParamPicker();
             break;

--- a/tests/host/test_chain_editor_keeps_destinations.sh
+++ b/tests/host/test_chain_editor_keeps_destinations.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# The chain editor must not FLATTEN a knob that drives several parameters.
+#
+# It shows one target and one param per knob and rebuilds the patch's knob
+# array from what it holds. Reading one row per knob and writing one back
+# deleted every extra destination and every window, permanently, the first time
+# a chain built on the device was saved from here -- and it looked correct on
+# both screens the whole time. That is the only silent data-loss path in this
+# feature, so it is pinned by RUNNING the real round trip, not by grepping.
+
+if ! command -v node >/dev/null 2>&1; then echo "FAIL: node required" >&2; exit 1; fi
+
+node --input-type=module -e '
+import { readFileSync } from "node:fs";
+const src = readFileSync(process.cwd() + "/src/modules/chain/ui.js", "utf8");
+
+let failures = 0;
+const fail = (m) => { console.error("FAIL: " + m); failures++; };
+const ok = (m) => console.log("  ok  " + m);
+const check = (c, m) => c ? ok(m) : fail(m);
+
+/* Lift the two pure helpers and the two constructors they use. */
+function lift(name) {
+  const at = src.indexOf("function " + name + "(");
+  if (at < 0) { fail(name + " is gone"); return -1; }
+  const end = src.indexOf("\n}\n", at);
+  if (end < 0) { fail(name + " has no end"); return -1; }
+  return src.slice(at, end + 2);
+}
+const parts = ["createEmptyKnobs", "createEmptyKnobRows", "parseKnobMappings", "buildKnobMappings"].map(lift);
+if (parts.some((p) => p === -1)) process.exit(1);
+
+const mk = new Function("NUM_KNOBS", "KNOB_CC_START",
+  parts.join("\n") + "\nreturn { parseKnobMappings, buildKnobMappings };");
+const { parseKnobMappings, buildKnobMappings } = mk(8, 71);
+
+/* A knob driving three parameters, one of them through an inverted window,
+   plus an ordinary single-destination knob alongside it. */
+const patchRows = [
+  { cc: 71, target: "synth", param: "cutoff", value: 0.4, dest: 0, pos: 0.75 },
+  { cc: 71, target: "fx1",   param: "mix",    value: 0.2, lo: 0.2, hi: 0.8, dest: 1, pos: 0.75 },
+  { cc: 71, target: "fx2",   param: "drive",  value: 0.1, lo: 1.0, hi: 0.0, dest: 2, pos: 0.75 },
+  { cc: 72, target: "fx1",   param: "gain",   value: 0.5 }
+];
+
+const parsed = parseKnobMappings(patchRows);
+check(parsed.knobs[0].param === "cutoff", "the editor edits the FIRST destination");
+check(parsed.knobs[1].param === "gain", "an ordinary knob is unaffected");
+
+const out = buildKnobMappings({ knobs: parsed.knobs, knobRows: parsed.knobRows });
+check(out.length === patchRows.length,
+      "a save writes back as many rows as it read (" + out.length + " of " + patchRows.length + ")");
+check(JSON.stringify(out) === JSON.stringify(patchRows),
+      "and they are IDENTICAL -- windows, positions and destination indices all survive");
+
+/* Re-pointing the first destination is a real edit and must be kept, while the
+   others stay exactly as they were. */
+const edited = { knobs: parsed.knobs.slice(), knobRows: parsed.knobRows };
+edited.knobs[0] = { slot: "synth", param: "resonance" };
+const out2 = buildKnobMappings(edited);
+check(out2[0].param === "resonance", "re-pointing the first destination is kept");
+check(out2[0].lo === undefined && out2[0].dest === 0,
+      "...and the rest of its row rides along");
+check(out2[1].param === "mix" && out2[1].lo === 0.2,
+      "the second destination is untouched by an edit to the first");
+check(out2[2].lo === 1.0 && out2[2].hi === 0.0,
+      "and the inverted window is still inverted");
+
+/* An older patch -- one bare row per knob -- must still round-trip, including
+   the preset special case this editor has always added. */
+const legacy = [{ cc: 71, target: "synth", param: "preset" }];
+const lp = parseKnobMappings(legacy);
+const lout = buildKnobMappings({ knobs: lp.knobs, knobRows: lp.knobRows });
+check(lout.length === 1 && lout[0].param === "preset", "an old single-row knob round-trips");
+
+/* A knob assigned in this editor, with no rows behind it, takes the original
+   path -- including the preset metadata. */
+const fresh = buildKnobMappings({
+  knobs: [{ slot: "synth", param: "preset" }], knobRows: [null]
+});
+check(fresh.length === 1 && fresh[0].type === "int" && fresh[0].max_param === "preset_count",
+      "a knob newly assigned here still gets the preset metadata");
+
+if (failures) { console.error("\n" + failures + " check(s) failed"); process.exit(1); }
+console.log("\nPASS: the chain editor carries a knob every destination it was given");
+'

--- a/tests/host/test_chain_knob_accel.c
+++ b/tests/host/test_chain_knob_accel.c
@@ -1,0 +1,112 @@
+/*
+ * The chain-knob acceleration curve, run rather than grepped.
+ *
+ * Three paths turn a chain knob — the relative CC decode and the absolute CC
+ * in chain_midi.c, and knob_N_adjust in chain_host.c, which is the path the
+ * device's own encoders use. Each carried its own copy of this curve. Two
+ * copies survived to be compared and they nested their bounds differently:
+ *
+ *   chain_midi.c   if (elapsed <  SLOW) { if (elapsed <= FAST) MAX; else ratio }
+ *   chain_host.c   if (elapsed <= FAST) MAX; else if (elapsed < SLOW) ratio
+ *
+ * Both happen to compute the same answer, which is exactly why nobody noticed
+ * they had drifted apart. Neither TU can be compiled natively, so no test could
+ * ever have said so — the arithmetic had to move somewhere testable first.
+ *
+ * The contract:
+ *   1. a gap at or under FAST is the maximum multiplier
+ *   2. a gap at or over SLOW is the minimum — a deliberate slow turn
+ *   3. in between it is monotone non-increasing, and stays within the ends
+ *   4. the FIRST message of a session is slow (no previous timestamp)
+ *   5. the type caps: enums never accelerate on time, ints are limited
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "chain_internal.h"
+
+/* ------------------------------------------------------------------ stubs */
+void chain_log(const char *msg) { (void)msg; }
+void parse_debug_log(const char *msg) { (void)msg; }
+void v2_chain_log(chain_instance_t *inst, const char *msg) { (void)inst; (void)msg; }
+void v2_synth_panic(chain_instance_t *inst) { (void)inst; }
+void chain_mod_clear_source(void *ctx, const char *source_id) { (void)ctx; (void)source_id; }
+int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *t) {
+    (void)inst; (void)t; return 0;
+}
+int chain_mod_is_target_active(chain_instance_t *inst, const char *t, const char *p) {
+    (void)inst; (void)t; (void)p; return 0;
+}
+void chain_mod_update_base_from_set_param(chain_instance_t *inst, const char *t,
+                                          const char *p, const char *v) {
+    (void)inst; (void)t; (void)p; (void)v;
+}
+mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *inst, const char *t,
+                                                const char *p) {
+    (void)inst; (void)t; (void)p; return NULL;
+}
+void chain_mod_apply_effective_value(chain_instance_t *inst, mod_target_state_t *e, int f) {
+    (void)inst; (void)e; (void)f;
+}
+
+/* ---------------------------------------------------------------- harness */
+static int failures = 0;
+static void check(int cond, const char *what) {
+    if (cond) printf("  ok  %s\n", what);
+    else { printf("FAIL: %s\n", what); failures++; }
+}
+
+int main(void) {
+    check(chain_knob_accel_for_gap(0) == KNOB_ACCEL_MAX_MULT,
+          "an instantaneous gap is the maximum multiplier");
+    check(chain_knob_accel_for_gap(KNOB_ACCEL_FAST_MS) == KNOB_ACCEL_MAX_MULT,
+          "a gap exactly at FAST is still the maximum (the bound is inclusive)");
+    check(chain_knob_accel_for_gap(KNOB_ACCEL_SLOW_MS) == KNOB_ACCEL_MIN_MULT,
+          "a gap exactly at SLOW is the minimum (that bound is exclusive)");
+    check(chain_knob_accel_for_gap(KNOB_ACCEL_SLOW_MS * 100) == KNOB_ACCEL_MIN_MULT,
+          "and any longer gap stays at the minimum");
+
+    /* Monotone across the whole ramp, and never outside its own ends. A curve
+     * that dipped or overshot in the middle would feel like a knob that speeds
+     * up as you slow down, which is the #404 symptom one octave quieter. */
+    int prev = KNOB_ACCEL_MAX_MULT + 1;
+    int monotone = 1, in_range = 1;
+    for (uint64_t gap = 0; gap <= KNOB_ACCEL_SLOW_MS + 5; gap++) {
+        int a = chain_knob_accel_for_gap(gap);
+        if (a > prev) monotone = 0;
+        if (a < KNOB_ACCEL_MIN_MULT || a > KNOB_ACCEL_MAX_MULT) in_range = 0;
+        prev = a;
+    }
+    check(monotone, "the curve never speeds up as the gap grows");
+    check(in_range, "and never leaves [MIN_MULT, MAX_MULT]");
+
+    /* The first message of a session has no previous timestamp. Reading the
+     * zero as an elapsed time would make it the FASTEST turn instead of the
+     * slowest — a knob that jumps on first touch. */
+    uint64_t last = 0;
+    check(chain_knob_accel(&last) == KNOB_ACCEL_MIN_MULT,
+          "the first turn of a session is slow, not maximal");
+    check(last != 0, "and the timestamp is recorded for the next message");
+
+    /* Two messages back to back are as fast as it gets. */
+    int a2 = chain_knob_accel(&last);
+    check(a2 == KNOB_ACCEL_MAX_MULT,
+          "a message immediately after another is the maximum multiplier");
+
+    /* The type caps. */
+    check(chain_knob_accel_cap(KNOB_ACCEL_MAX_MULT, KNOB_TYPE_FLOAT) == KNOB_ACCEL_MAX_MULT,
+          "a float keeps the full multiplier");
+    check(chain_knob_accel_cap(KNOB_ACCEL_MAX_MULT, KNOB_TYPE_ENUM) == KNOB_ACCEL_ENUM_MULT,
+          "an enum never accelerates on time");
+    check(chain_knob_accel_cap(KNOB_ACCEL_MIN_MULT, KNOB_TYPE_ENUM) == KNOB_ACCEL_ENUM_MULT,
+          "...whatever the gap was");
+    check(chain_knob_accel_cap(KNOB_ACCEL_MAX_MULT, KNOB_TYPE_INT) == KNOB_ACCEL_MAX_MULT_INT,
+          "an int is capped, not pinned");
+    check(chain_knob_accel_cap(KNOB_ACCEL_MIN_MULT, KNOB_TYPE_INT) == KNOB_ACCEL_MIN_MULT,
+          "...and a slow int turn is left alone");
+
+    if (failures) { printf("\n%d check(s) failed\n", failures); return 1; }
+    printf("\nall checks passed\n");
+    return 0;
+}

--- a/tests/host/test_chain_knob_accel.sh
+++ b/tests/host/test_chain_knob_accel.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+#   RUN   the real acceleration curve (tests/host/test_chain_knob_accel.c).
+#
+#   PIN   that the three knob paths ask for it rather than carrying their own
+#         copy. Two copies had already drifted apart unnoticed; neither TU can
+#         be compiled natively, so this half is a source pin.
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+bin="build/tests/test_chain_knob_accel"
+mkdir -p "$(dirname "$bin")"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+printf '#include <stdlib.h>\n' > "$work/malloc.h"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
+  -Wno-sign-compare \
+  -I"$work" -Isrc -Isrc/host -Isrc/modules/chain/dsp \
+  tests/host/test_chain_knob_accel.c \
+  src/modules/chain/dsp/chain_params.c \
+  src/modules/chain/dsp/chain_json.c \
+  -o "$bin"
+
+"$bin"
+
+# ------------------------------------------------------------------ pin half
+
+# Nobody hand-rolls the curve any more. KNOB_ACCEL_SLOW_MS appearing outside
+# the header and chain_params.c means a fourth copy has grown back.
+for f in src/modules/chain/dsp/chain_midi.c src/modules/chain/dsp/chain_host.c; do
+  command grep -q 'chain_knob_accel(&inst->knob_last_time_ms\[i\])' "$f" \
+    || fail "$f does not use chain_knob_accel"
+  # Spelled as an if rather than `grep && fail`: in that form a grep that
+  # finds nothing is the list's exit status, and whether set -e acts on it is
+  # subtle enough that a later reader could "tidy" it either way.
+  if command grep -q 'KNOB_ACCEL_SLOW_MS' "$f"; then
+    fail "$f still hand-rolls the acceleration curve"
+  fi
+done
+
+# ...and each still applies the type cap, which is the caller's job because
+# only the caller knows the parameter's type.
+for f in src/modules/chain/dsp/chain_midi.c src/modules/chain/dsp/chain_host.c; do
+  command grep -q 'chain_knob_accel_cap(accel, pinfo->type)' "$f" \
+    || fail "$f does not apply the type cap"
+done
+
+echo "PASS: one acceleration curve, asked for by every knob path"

--- a/tests/host/test_chain_knob_accel.sh
+++ b/tests/host/test_chain_knob_accel.sh
@@ -32,22 +32,41 @@ cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
 
 # Nobody hand-rolls the curve any more. KNOB_ACCEL_SLOW_MS appearing outside
 # the header and chain_params.c means a fourth copy has grown back.
+P=src/modules/chain/dsp/chain_params.c
+command grep -q 'chain_knob_accel(&inst->knob_last_time_ms\[idx\])' "$P" \
+  || fail "knob_turn does not use chain_knob_accel"
+command grep -q 'chain_knob_accel_cap(' "$P" \
+  || fail "knob_turn does not apply the type cap for a single destination"
+
+# The two TUs that cannot be compiled natively must hold NO knob arithmetic at
+# all -- they decode an input and delegate. That is a stronger claim than "they
+# call the shared helper", and it is the one worth pinning, because the whole
+# reason this moved is that nothing can run what lives in those files.
 for f in src/modules/chain/dsp/chain_midi.c src/modules/chain/dsp/chain_host.c; do
-  command grep -q 'chain_knob_accel(&inst->knob_last_time_ms\[i\])' "$f" \
-    || fail "$f does not use chain_knob_accel"
+  command grep -q 'knob_turn(inst, i,' "$f" \
+    || fail "$f does not delegate its knob turn to knob_turn()"
   # Spelled as an if rather than `grep && fail`: in that form a grep that
   # finds nothing is the list's exit status, and whether set -e acts on it is
   # subtle enough that a later reader could "tidy" it either way.
-  if command grep -q 'KNOB_ACCEL_SLOW_MS' "$f"; then
-    fail "$f still hand-rolls the acceleration curve"
-  fi
+  for token in KNOB_ACCEL_SLOW_MS chain_knob_accel_cap KNOB_STEP_INT; do
+    if command grep -q "$token" "$f"; then
+      fail "$f still carries knob-turn arithmetic ($token); it should decode and delegate"
+    fi
+  done
 done
 
-# ...and each still applies the type cap, which is the caller's job because
-# only the caller knows the parameter's type.
-for f in src/modules/chain/dsp/chain_midi.c src/modules/chain/dsp/chain_host.c; do
-  command grep -q 'chain_knob_accel_cap(accel, pinfo->type)' "$f" \
-    || fail "$f does not apply the type cap"
-done
+# knob_N_adjust hands knob_turn ONE detent per message, deliberately.
+#
+# handleKnobTurn in shadow_ui.js sums every detent for a knob between frames,
+# so its `val` is an accumulated COUNT and the sign discards a fast turn.
+# Honouring the count would make the device's own encoders travel further for
+# the same gesture -- a feel change on every existing chain knob, which this
+# work must not make. Pinned in both directions so neither drifts back.
+H=src/modules/chain/dsp/chain_host.c
+command grep -q 'knob_turn(inst, i, (delta_int > 0) ? 1 : -1,' "$H" \
+  || fail "knob_N_adjust no longer passes ONE detent per message; upstream knob feel would change"
+if command grep -q 'knob_turn(inst, i, delta_int,' "$H"; then
+  fail "knob_N_adjust passes its accumulated detent count, which changes the feel of every chain knob"
+fi
 
 echo "PASS: one acceleration curve, asked for by every knob path"

--- a/tests/host/test_chain_knob_cc_out.c
+++ b/tests/host/test_chain_knob_cc_out.c
@@ -41,6 +41,28 @@ int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *tar
     (void)inst; (void)target;
     return 0;
 }
+
+/*
+ * knob_forward_value now routes a modulated parameter through the modulation
+ * bus (a knob turn edits the RESTING value, like any other edit). No case in
+ * this fixture involves a modulated parameter, so "no target is active" is its
+ * honest answer and the behaviour under test is unchanged.
+ */
+int chain_mod_is_target_active(chain_instance_t *inst, const char *target, const char *param) {
+    (void)inst; (void)target; (void)param; return 0;
+}
+void chain_mod_update_base_from_set_param(chain_instance_t *inst, const char *target,
+                                          const char *param, const char *val) {
+    (void)inst; (void)target; (void)param; (void)val;
+}
+mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *inst, const char *target,
+                                                const char *param) {
+    (void)inst; (void)target; (void)param; return NULL;
+}
+void chain_mod_apply_effective_value(chain_instance_t *inst, mod_target_state_t *entry,
+                                     int force_write) {
+    (void)inst; (void)entry; (void)force_write;
+}
 int v2_load_synth(chain_instance_t *inst, const char *module_name) {
     (void)inst; (void)module_name;
     return 0;

--- a/tests/host/test_chain_knob_cc_out.c
+++ b/tests/host/test_chain_knob_cc_out.c
@@ -124,9 +124,9 @@ static void map_knob(chain_instance_t *inst, int idx, int cc, const char *param,
                      float value) {
     memset(&inst->knob_mappings[idx], 0, sizeof(inst->knob_mappings[idx]));
     inst->knob_mappings[idx].cc = cc;
-    snprintf(inst->knob_mappings[idx].target, sizeof(inst->knob_mappings[idx].target), "synth");
-    snprintf(inst->knob_mappings[idx].param, sizeof(inst->knob_mappings[idx].param), "%s", param);
-    inst->knob_mappings[idx].current_value = value;
+    snprintf(inst->knob_mappings[idx].dests[0].target, sizeof(inst->knob_mappings[idx].dests[0].target), "synth");
+    snprintf(inst->knob_mappings[idx].dests[0].param, sizeof(inst->knob_mappings[idx].dests[0].param), "%s", param);
+    inst->knob_mappings[idx].dests[0].current_value = value;
     inst->knob_mappings[idx].last_cc_out = -1;
     if (idx >= inst->knob_mapping_count) inst->knob_mapping_count = idx + 1;
 }
@@ -173,20 +173,20 @@ int main(void) {
     cap_reset();
     knob_emit_cc_out(inst, 0);
     check(cap_count == 0, "same value emits nothing");
-    inst->knob_mappings[0].current_value = 0.5001f;  /* still CC 64 */
+    inst->knob_mappings[0].dests[0].current_value = 0.5001f;  /* still CC 64 */
     knob_emit_cc_out(inst, 0);
     check(cap_count == 0, "a move too small to change the CC emits nothing");
-    inst->knob_mappings[0].current_value = 1.0f;
+    inst->knob_mappings[0].dests[0].current_value = 1.0f;
     knob_emit_cc_out(inst, 0);
     check(cap_count == 1 && cap[0][3] == 127, "max emits 127");
-    inst->knob_mappings[0].current_value = 0.0f;
+    inst->knob_mappings[0].dests[0].current_value = 0.0f;
     cap_reset();
     knob_emit_cc_out(inst, 0);
     check(cap_count == 1 && cap[0][3] == 0, "min emits 0");
 
     /* 4. NO CHANNEL TO ANSWER ON. */
     printf("silence rather than a guess\n");
-    inst->knob_mappings[0].current_value = 0.5f;
+    inst->knob_mappings[0].dests[0].current_value = 0.5f;
     inst->knob_mappings[0].last_cc_out = -1;
     cap_reset();
     g_recv_ch = -1;  /* All */
@@ -213,7 +213,7 @@ int main(void) {
     for (int c = 0; c <= 127; c++) {
         /* Exactly what chain_midi.c does with an inbound CC 102-109. */
         float abs_val = 0.0f + ((float)c / 127.0f) * (1.0f - 0.0f);
-        inst->knob_mappings[0].current_value = abs_val;
+        inst->knob_mappings[0].dests[0].current_value = abs_val;
         inst->knob_mappings[0].last_cc_out = -1;
         cap_reset();
         knob_emit_cc_out(inst, 0);

--- a/tests/host/test_chain_knob_cc_out.c
+++ b/tests/host/test_chain_knob_cc_out.c
@@ -127,6 +127,11 @@ static void map_knob(chain_instance_t *inst, int idx, int cc, const char *param,
     snprintf(inst->knob_mappings[idx].dests[0].target, sizeof(inst->knob_mappings[idx].dests[0].target), "synth");
     snprintf(inst->knob_mappings[idx].dests[0].param, sizeof(inst->knob_mappings[idx].dests[0].param), "%s", param);
     inst->knob_mappings[idx].dests[0].current_value = value;
+    /* Whole range. A knob's position is measured against its destination's
+     * WINDOW, and the memset above leaves lo=hi=0, which is no window at all. */
+    inst->knob_mappings[idx].dests[0].lo = 0.0f;
+    inst->knob_mappings[idx].dests[0].hi = 1.0f;
+    inst->knob_mappings[idx].dest_count = 1;
     inst->knob_mappings[idx].last_cc_out = -1;
     if (idx >= inst->knob_mapping_count) inst->knob_mapping_count = idx + 1;
 }
@@ -264,6 +269,53 @@ int main(void) {
     check(cap_count == 1, "the retry goes out once the ring drains");
     check(cap[0][3] == 32, "and it carries the value that was dropped");
     check(inst->knob_mappings[0].last_cc_out == 32, "now it is recorded");
+
+    /* ---- what a knob's POSITION means, out and back in ----------------
+     *
+     * One sentence for both kinds of knob: where the knob sits across its own
+     * travel. The cases above are the whole-range single destination, which is
+     * why they read as the parameter's value and did not change.
+     */
+
+    /* A RANGED single destination is measured against its WINDOW. Without
+     * that, an external fader's travel maps outside the window at both ends
+     * and clamps, so a third of its throw would do nothing. */
+    map_knob(inst, 0, 71, "cutoff", 0.25f);
+    inst->knob_mappings[0].dests[0].lo = 0.0f;
+    inst->knob_mappings[0].dests[0].hi = 0.5f;   /* window is 0.0 .. 0.5 */
+    inst->knob_mappings[0].last_cc_out = -1;
+    cap_reset();
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 1 && cap[0][3] == 64,
+          "a ranged destination halfway through its WINDOW emits 64, not 32");
+
+    inst->knob_mappings[0].dests[0].current_value = 0.5f;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 2 && cap[1][3] == 127,
+          "and the top of the window is 127, so the whole fader is usable");
+
+    /* SEVERAL destinations have no single parameter value to send, so the
+     * knob's own position is what goes out. */
+    map_knob(inst, 0, 71, "cutoff", 0.0f);
+    knob_dest_assign(&inst->knob_mappings[0].dests[1], "synth", "cutoff2");
+    inst->knob_mappings[0].dest_count = 2;
+    inst->knob_mappings[0].position = 0.5f;
+    inst->knob_mappings[0].last_cc_out = -1;
+    cap_reset();
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 1 && cap[0][3] == 64,
+          "a multi-destination knob emits its own position");
+
+    inst->knob_mappings[0].position = 1.0f;
+    knob_emit_cc_out(inst, 0);
+    check(cap_count == 2 && cap[1][3] == 127, "...across its full travel");
+
+    /* Inbound is the same rule read backwards: a controller that echoes what
+     * it was told lands where it started. */
+    knob_set_position(inst, 0, 64.0f / 127.0f);
+    check(inst->knob_mappings[0].position > 0.49f &&
+          inst->knob_mappings[0].position < 0.51f,
+          "an inbound CC puts the knob back at the position it reported");
 
     free(inst);
     if (failures) {

--- a/tests/host/test_chain_knob_dests.c
+++ b/tests/host/test_chain_knob_dests.c
@@ -1,0 +1,149 @@
+/*
+ * Editing a knob's destination list.
+ *
+ * One owner for every change, because two things must happen alongside one and
+ * are easy to forget at a call site: SEEDING the knob's position when it first
+ * gains a second destination, and RE-WRITING a destination when its window
+ * moves. Both are invisible when missed -- the first as a jump on the next
+ * turn, the second as a range that does nothing until you turn the knob again.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "chain_internal.h"
+
+/* ------------------------------------------------------------------ stubs */
+void chain_log(const char *msg) { (void)msg; }
+void parse_debug_log(const char *msg) { (void)msg; }
+void v2_chain_log(chain_instance_t *inst, const char *msg) { (void)inst; (void)msg; }
+void v2_synth_panic(chain_instance_t *inst) { (void)inst; }
+int v2_load_synth(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_synth(chain_instance_t *inst) { (void)inst; }
+int v2_load_audio_fx(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_all_audio_fx(chain_instance_t *inst) { inst->fx_count = 0; }
+int v2_load_midi_fx(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_all_midi_fx(chain_instance_t *inst) { inst->midi_fx_count = 0; }
+void chain_mod_clear_source(void *c, const char *s) { (void)c; (void)s; }
+int chain_mod_refresh_target_param_cache(chain_instance_t *i, const char *t) { (void)i; (void)t; return 0; }
+int chain_mod_is_target_active(chain_instance_t *i, const char *t, const char *p) { (void)i; (void)t; (void)p; return 0; }
+void chain_mod_update_base_from_set_param(chain_instance_t *i, const char *t, const char *p, const char *v) {
+    (void)i; (void)t; (void)p; (void)v;
+}
+mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *i, const char *t, const char *p) {
+    (void)i; (void)t; (void)p; return NULL;
+}
+void chain_mod_apply_effective_value(chain_instance_t *i, mod_target_state_t *e, int f) {
+    (void)i; (void)e; (void)f;
+}
+
+/* --------------------------------------------------------- fake synth */
+static char v_cutoff[32] = "0.750";
+static char v_reso[32]   = "0.000";
+static void fake_set(void *i, const char *k, const char *v) {
+    (void)i;
+    if (!strcmp(k, "cutoff")) snprintf(v_cutoff, sizeof(v_cutoff), "%s", v);
+    else if (!strcmp(k, "reso")) snprintf(v_reso, sizeof(v_reso), "%s", v);
+}
+static int fake_get(void *i, const char *k, char *b, int n) {
+    (void)i;
+    if (!strcmp(k, "cutoff")) return snprintf(b, n, "%s", v_cutoff);
+    if (!strcmp(k, "reso")) return snprintf(b, n, "%s", v_reso);
+    return -1;
+}
+
+static int failures = 0;
+static void check(int c, const char *w) {
+    if (c) printf("  ok  %s\n", w); else { printf("FAIL: %s\n", w); failures++; }
+}
+
+int main(void) {
+    chain_instance_t *inst = calloc(1, sizeof(*inst));
+    static plugin_api_v2_t api;
+    api.api_version = 2; api.set_param = fake_set; api.get_param = fake_get;
+    inst->synth_plugin_v2 = &api; inst->synth_instance = (void *)0x1;
+
+    for (int i = 0; i < 2; i++) {
+        chain_param_info_t *p = &inst->synth_params[i];
+        snprintf(p->key, sizeof(p->key), "%s", i ? "reso" : "cutoff");
+        p->type = KNOB_TYPE_FLOAT; p->min_val = 0.0f; p->max_val = 1.0f; p->step = 0.01f;
+    }
+    inst->synth_param_count = 2;
+
+    /* ---- creating and finding ---- */
+    check(knob_mapping_for_cc(inst, 71, 0) == NULL, "an unmapped CC is not invented on a lookup");
+    knob_mapping_t *km = knob_mapping_for_cc(inst, 71, 1);
+    check(km != NULL && inst->knob_mapping_count == 1, "and is created on request");
+    check(knob_mapping_for_cc(inst, 71, 1) == km, "a second request finds the same one");
+
+    /* ---- pointing ---- */
+    check(knob_dest_point(inst, km, 0, "synth", "cutoff") == 0, "destination 0 points at cutoff");
+    check(km->dest_count == 1, "one destination");
+    check(km->dests[0].lo == 0.0f && km->dests[0].hi == 1.0f, "whole-range by default");
+    check(km->dests[0].current_value > 0.74f && km->dests[0].current_value < 0.76f,
+          "and takes the parameter's LIVE value, not a default");
+
+    check(knob_dest_point(inst, km, 3, "synth", "reso") == -1,
+          "a destination cannot be created past the end of the list");
+    check(km->dest_count == 1, "and nothing was added");
+
+    /* ---- the seed ---- */
+    check(knob_dest_point(inst, km, 1, "synth", "reso") == 0, "a second destination appends");
+    check(km->dest_count == 2, "two destinations");
+    check(km->position > 0.74f && km->position < 0.76f,
+          "the knob's position is SEEDED from the first destination, so nothing "
+          "jumps the moment a second one is added");
+
+    /* ---- re-pointing keeps the window ---- */
+    km->dests[1].lo = 0.25f; km->dests[1].hi = 0.75f;
+    knob_dest_point(inst, km, 1, "synth", "cutoff");
+    check(km->dests[1].lo == 0.25f && km->dests[1].hi == 0.75f,
+          "re-pointing a destination KEEPS its window (a window is a fraction, "
+          "so it is portable by construction)");
+
+    /* ---- a window applies immediately ---- */
+    km->position = 0.0f;
+    snprintf(v_reso, sizeof(v_reso), "0.000");
+    knob_dest_point(inst, km, 1, "synth", "reso");
+    knob_dest_set_window(inst, km, 1, 0.40f, 0.90f);
+    check(atof(v_reso) > 0.39f && atof(v_reso) < 0.41f,
+          "setting a window on a multi-destination knob MOVES that destination now, "
+          "not on the next turn");
+
+    /* ...and on a single-destination knob it clamps the value into the window. */
+    knob_dest_remove(inst, km, 1);
+    check(km->dest_count == 1, "removing a destination closes the gap");
+    snprintf(v_cutoff, sizeof(v_cutoff), "0.900");
+    km->dests[0].current_value = 0.9f;
+    knob_dest_set_window(inst, km, 0, 0.0f, 0.5f);
+    check(atof(v_cutoff) > 0.49f && atof(v_cutoff) < 0.51f,
+          "and on a single destination it clamps the parameter into the new window");
+
+    /* ---- removal order ---- */
+    knob_dest_point(inst, km, 1, "synth", "reso");
+    knob_dest_point(inst, km, 2, "synth", "cutoff");
+    check(km->dest_count == 3, "three destinations");
+    knob_dest_remove(inst, km, 0);
+    check(km->dest_count == 2 && strcmp(km->dests[0].param, "reso") == 0,
+          "removing the FIRST shifts the rest down rather than leaving a hole");
+
+    check(knob_dest_remove(inst, km, 0) == 1, "removing again leaves one");
+    check(knob_dest_remove(inst, km, 0) == 0, "and then none");
+
+    /* ---- dropping a mapping blanks the slot it vacates ---- */
+    knob_mapping_t *a = knob_mapping_for_cc(inst, 72, 1);
+    knob_dest_point(inst, a, 0, "synth", "cutoff");
+    knob_mapping_t *b = knob_mapping_for_cc(inst, 73, 1);
+    knob_dest_point(inst, b, 0, "synth", "reso");
+    int before = inst->knob_mapping_count;
+    knob_mapping_drop(inst, knob_mapping_for_cc(inst, 72, 0));
+    check(inst->knob_mapping_count == before - 1, "dropping a mapping shrinks the table");
+    check(inst->knob_mappings[inst->knob_mapping_count].dest_count == 0,
+          "and blanks the slot the shift vacated, so a mapping added later "
+          "inherits no destinations from it");
+
+    free(inst);
+    if (failures) { printf("\n%d check(s) failed\n", failures); return 1; }
+    printf("\nall checks passed\n");
+    return 0;
+}

--- a/tests/host/test_chain_knob_dests.sh
+++ b/tests/host/test_chain_knob_dests.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+fail() { echo "FAIL: $1"; exit 1; }
+
+bin="build/tests/test_chain_knob_dests"
+mkdir -p "$(dirname "$bin")"
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+printf '#include <stdlib.h>\n' > "$work/malloc.h"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -Wno-sign-compare \
+  -I"$work" -Isrc -Isrc/host -Isrc/modules/chain/dsp \
+  tests/host/test_chain_knob_dests.c \
+  src/modules/chain/dsp/chain_params.c \
+  src/modules/chain/dsp/chain_json.c \
+  -o "$bin"
+
+"$bin"
+
+# ------------------------------------------------------------------ pin half
+#
+# The keys themselves live in chain_host.c, which dlopens plugins and cannot be
+# compiled natively. What is pinned is that they exist and that each routes to
+# the owner above rather than editing the list in place -- an edit that skipped
+# the owner would skip the seed or the immediate apply, and both fail silently.
+H=src/modules/chain/dsp/chain_host.c
+
+command grep -q 'strncmp(action, "dest_", 5) == 0' "$H" \
+  || fail "the knob_N_dest_M_* key family is gone"
+command grep -q 'sscanf(action + 5, "%d_%15s", &dest_num, sub)' "$H" \
+  || fail "the destination index is no longer parsed out of the action"
+
+for pair in 'set:knob_dest_point' 'clear:knob_dest_remove' 'range:knob_dest_set_window'; do
+  sub="${pair%%:*}"; fn="${pair##*:}"
+  command grep -q "strcmp(sub, \"$sub\")" "$H" || fail "knob_N_dest_M_$sub is gone"
+  command grep -q "$fn(" "$H" || fail "knob_N_dest_M_$sub no longer routes through $fn()"
+done
+
+command grep -q 'strcmp(action, "position") == 0' "$H" \
+  || fail "knob_N_position is gone"
+
+# The readbacks the editor and the touched-knob card depend on. The card takes
+# only name and value, so a multi-destination knob must be describable through
+# those two and NOT need a third read -- test_knob_card_open_budget counts them.
+for q in name value dest_count position dests; do
+  command grep -q "strcmp(query_param, \"$q\")" "$H" || fail "knob_N_$q readback is gone"
+done
+
+echo "PASS: a knob's destination list has one owner, and the keys route to it"

--- a/tests/host/test_chain_knob_mod_base.c
+++ b/tests/host/test_chain_knob_mod_base.c
@@ -1,0 +1,152 @@
+/*
+ * A chain knob turn is an EDIT of the resting value, not a write past the
+ * modulation bus.
+ *
+ * An LFO holds a target's BASE and rewrites `base + contribution` into the
+ * plugin on every tick (chain_mod_apply_effective_value). The prefixed
+ * `synth:` / `fxN:` / `midi_fxN:` set_param routes therefore update the base
+ * first, so the wobble follows what the user just set — #276 established that
+ * contract and tests/host/test_chain_mod_plain_read_base.c pins it.
+ *
+ * knob_forward_value did not. It called the plugin's set_param directly and
+ * told the bus nothing, so the very next tick recomputed from the STALE base
+ * and overwrote the turn. Assign a chain knob to a parameter an LFO is driving
+ * and the knob reads as dead, or moves and snaps back — within milliseconds,
+ * every time, on a path that has shipped for a long time.
+ *
+ * The contract under test:
+ *   1. a knob turn on a MODULATED parameter updates the base
+ *   2. ...and the next tick does NOT erase it   <- the bug
+ *   3. the parameter is still audibly modulated (base + contribution)
+ *   4. a knob turn on an UNMODULATED parameter still writes straight through
+ *   5. ...and is not disturbed by a later tick on an unrelated target
+ *
+ * Runs the real chain_mod.c and the real knob_forward_value from
+ * chain_params.c against a fake two-param synth.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "chain_internal.h"
+
+/* ------------------------------------------------------------------ stubs */
+void chain_log(const char *msg) { (void)msg; }
+void parse_debug_log(const char *msg) { (void)msg; }
+void v2_chain_log(chain_instance_t *inst, const char *msg) { (void)inst; (void)msg; }
+void v2_synth_panic(chain_instance_t *inst) { (void)inst; }
+int v2_load_synth(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_synth(chain_instance_t *inst) { (void)inst; }
+int v2_load_audio_fx(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_all_audio_fx(chain_instance_t *inst) { inst->fx_count = 0; }
+int v2_load_midi_fx(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_all_midi_fx(chain_instance_t *inst) { inst->midi_fx_count = 0; }
+
+/* ------------------------------------------------- fake synth (the module) */
+static char fake_cutoff[64] = "10";
+static char fake_gain[64]   = "20";
+
+static void fake_set_param(void *instance, const char *key, const char *val) {
+    (void)instance;
+    if (strcmp(key, "cutoff") == 0) snprintf(fake_cutoff, sizeof(fake_cutoff), "%s", val);
+    else if (strcmp(key, "gain") == 0) snprintf(fake_gain, sizeof(fake_gain), "%s", val);
+}
+static int fake_get_param(void *instance, const char *key, char *buf, int buf_len) {
+    (void)instance;
+    if (strcmp(key, "cutoff") == 0) return snprintf(buf, buf_len, "%s", fake_cutoff);
+    if (strcmp(key, "gain") == 0) return snprintf(buf, buf_len, "%s", fake_gain);
+    return -1;
+}
+
+/* ---------------------------------------------------------------- harness */
+static int failures = 0;
+
+static void check(int cond, const char *what) {
+    if (cond) {
+        printf("  ok  %s\n", what);
+    } else {
+        printf("FAIL: %s\n", what);
+        failures++;
+    }
+}
+
+/* What the LFO does every render block for each live target. */
+static void lfo_tick(chain_instance_t *inst, const char *param) {
+    mod_target_state_t *e = chain_mod_find_target_entry(inst, "synth", param);
+    if (e) chain_mod_apply_effective_value(inst, e, 1);
+}
+
+static void add_param(chain_instance_t *inst, int i, const char *key) {
+    chain_param_info_t *p = &inst->synth_params[i];
+    snprintf(p->key, sizeof(p->key), "%s", key);
+    snprintf(p->name, sizeof(p->name), "%s", key);
+    p->type = KNOB_TYPE_FLOAT;
+    p->min_val = 0.0f;
+    p->max_val = 127.0f;
+    p->default_val = 0.0f;
+    inst->synth_param_count = i + 1;
+}
+
+int main(void) {
+    chain_instance_t *inst = calloc(1, sizeof(*inst));
+    static plugin_api_v2_t fake_api;
+    fake_api.api_version = 2;
+    fake_api.set_param = fake_set_param;
+    fake_api.get_param = fake_get_param;
+    inst->synth_plugin_v2 = &fake_api;
+    inst->synth_instance = (void *)0x1;   /* non-NULL is all that is checked */
+
+    add_param(inst, 0, "cutoff");
+    add_param(inst, 1, "gain");
+
+    /* An LFO routes to cutoff: signal 0.5, depth 1, bipolar
+     * -> contribution 0.5 * (0.5 * 127) = 31.75 on top of the base. */
+    chain_mod_emit_value(inst, "lfo1", "synth", "cutoff", 0.5f, 1.0f, 0.0f, 1, 1);
+
+    mod_target_state_t *e = chain_mod_find_target_entry(inst, "synth", "cutoff");
+    check(e != NULL && e->base_value == 10.0f,
+          "the bus captured the pre-existing value as the base");
+
+    /* THE TURN. This is the real function every chain-knob path calls. */
+    knob_forward_value(inst, "synth", "cutoff", "64");
+
+    e = chain_mod_find_target_entry(inst, "synth", "cutoff");
+    check(e != NULL && e->base_value == 64.0f,
+          "a knob turn on a modulated parameter updates the BASE");
+
+    check(atof(fake_cutoff) == 64.0 + 31.75,
+          "the parameter is still modulated around the new base");
+
+    /* The bug: the next tick used to recompute from the stale base and put
+     * the parameter back to 10 + 31.75, erasing the turn. */
+    lfo_tick(inst, "cutoff");
+    check(atof(fake_cutoff) == 64.0 + 31.75,
+          "the next LFO tick does NOT erase the turn");
+
+    /* Ten more ticks, because the failure was persistent rather than a
+     * one-frame glitch — a knob that snapped back stayed back. */
+    for (int i = 0; i < 10; i++) lfo_tick(inst, "cutoff");
+    check(atof(fake_cutoff) == 64.0 + 31.75,
+          "and does not erase it on any later tick either");
+
+    /* An UNMODULATED parameter is untouched by this: straight through to the
+     * plugin, exactly as before. This is the half that must not regress. */
+    knob_forward_value(inst, "synth", "gain", "77");
+    check(atof(fake_gain) == 77.0,
+          "a knob turn on an unmodulated parameter writes straight through");
+
+    check(chain_mod_find_target_entry(inst, "synth", "gain") == NULL,
+          "and does not create a modulation entry for it");
+
+    lfo_tick(inst, "cutoff");
+    check(atof(fake_gain) == 77.0,
+          "an unrelated tick leaves the unmodulated parameter alone");
+
+    free(inst);
+    if (failures) {
+        printf("\n%d check(s) failed\n", failures);
+        return 1;
+    }
+    printf("\nall checks passed\n");
+    return 0;
+}

--- a/tests/host/test_chain_knob_mod_base.sh
+++ b/tests/host/test_chain_knob_mod_base.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A chain knob turn is an EDIT of the resting value, not a write past the
+# modulation bus.
+#
+#   RUN   the real knob_forward_value against the real chain_mod.c and a fake
+#         synth, and prove a turn on a modulated parameter updates the BASE and
+#         survives every later LFO tick — while an unmodulated parameter still
+#         goes straight through (tests/host/test_chain_knob_mod_base.c).
+#
+#   PIN   that knob_forward_value stays the ONE place a chain knob reaches a
+#         plugin. The three knob paths — the external CC decode in chain_midi.c,
+#         the absolute CC in the same file, and knob_N_adjust in chain_host.c
+#         (which is the path the device's own encoders use) — must all go
+#         through it, or a fourth route reintroduces the bug for one input
+#         method only, which is exactly the kind of asymmetry nobody notices.
+#         Neither TU can be compiled natively, so this half is a source pin.
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+# ------------------------------------------------------------------ run half
+bin="build/tests/test_chain_knob_mod_base"
+mkdir -p "$(dirname "$bin")"
+
+# chain_internal.h includes <malloc.h>, which is glibc-only; one shim header
+# lets this compile on macOS too and changes nothing about the code under test.
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+printf '#include <stdlib.h>\n' > "$work/malloc.h"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
+  -Wno-sign-compare \
+  -I"$work" -Isrc -Isrc/host -Isrc/modules/chain/dsp \
+  tests/host/test_chain_knob_mod_base.c \
+  src/modules/chain/dsp/chain_mod.c \
+  src/modules/chain/dsp/chain_params.c \
+  src/modules/chain/dsp/chain_json.c \
+  -o "$bin"
+
+"$bin"
+
+# ------------------------------------------------------------------ pin half
+
+# The fix itself: knob_forward_value consults the bus before writing through.
+P=src/modules/chain/dsp/chain_params.c
+command grep -q 'chain_mod_is_target_active(inst, target, param)' "$P" \
+  || fail "knob_forward_value does not ask whether the target is modulated"
+command grep -q 'chain_mod_update_base_from_set_param(inst, target, param, val_str)' "$P" \
+  || fail "knob_forward_value does not update the base"
+
+# ...and it does so BEFORE any plugin write, not after one. A write that
+# already happened cannot be taken back, and the ordering is the whole fix.
+awk '/^void knob_forward_value/,/^}/' "$P" > "$work/kfv.c"
+base_line=$(command grep -n 'chain_mod_update_base_from_set_param' "$work/kfv.c" | head -1 | cut -d: -f1)
+# '->set_param(' is the plugin write specifically. A bare 'set_param(' also
+# matches chain_mod_update_base_from_set_param on the very line being located,
+# which made this comparison compare a line with itself.
+set_line=$(command grep -n -- '->set_param(' "$work/kfv.c" | head -1 | cut -d: -f1)
+[ -n "$base_line" ] && [ -n "$set_line" ] || fail "could not locate both calls in knob_forward_value"
+[ "$base_line" -lt "$set_line" ] \
+  || fail "knob_forward_value writes the plugin before telling the modulation bus"
+
+# Every knob path reaches a plugin through it. Counted, not merely present:
+# a path that grew its own plugin->set_param call would still match a bare
+# grep for the helper elsewhere in the file.
+for f in src/modules/chain/dsp/chain_midi.c src/modules/chain/dsp/chain_host.c; do
+  command grep -q 'knob_forward_value(inst, target, param, val_str)' "$f" \
+    || fail "$f does not forward knob values through knob_forward_value"
+done
+
+n=$(command grep -c 'knob_forward_value(inst, target, param, val_str)' src/modules/chain/dsp/chain_midi.c)
+[ "$n" -eq 2 ] \
+  || fail "chain_midi.c has $n knob_forward_value call sites, expected 2 (relative + absolute CC)"
+
+echo "PASS: a knob turn edits the base, and every knob path goes through it"

--- a/tests/host/test_chain_knob_mod_base.sh
+++ b/tests/host/test_chain_knob_mod_base.sh
@@ -63,16 +63,39 @@ set_line=$(command grep -n -- '->set_param(' "$work/kfv.c" | head -1 | cut -d: -
 [ "$base_line" -lt "$set_line" ] \
   || fail "knob_forward_value writes the plugin before telling the modulation bus"
 
-# Every knob path reaches a plugin through it. Counted, not merely present:
-# a path that grew its own plugin->set_param call would still match a bare
-# grep for the helper elsewhere in the file.
-for f in src/modules/chain/dsp/chain_midi.c src/modules/chain/dsp/chain_host.c; do
-  command grep -q 'knob_forward_value(inst, target, param, val_str)' "$f" \
-    || fail "$f does not forward knob values through knob_forward_value"
-done
+# Every knob path reaches a plugin through it, and the two TUs that cannot be
+# compiled natively must not reach one any OTHER way. A path that grew its own
+# plugin->set_param call would bypass the modulation bus again and nothing
+# would say so, which is precisely how this bug survived.
+# chain_midi.c has no legitimate direct plugin write at all, so the whole file
+# is the window.
+if command grep -qE '(synth_plugin_v2|fx_plugins_v2|midi_fx_plugins)\[?[a-z]*\]?->set_param' \
+     src/modules/chain/dsp/chain_midi.c; then
+  fail "chain_midi.c writes a plugin parameter directly; a knob path must go through knob_forward_value"
+fi
 
-n=$(command grep -c 'knob_forward_value(inst, target, param, val_str)' src/modules/chain/dsp/chain_midi.c)
-[ "$n" -eq 2 ] \
-  || fail "chain_midi.c has $n knob_forward_value call sites, expected 2 (relative + absolute CC)"
+# chain_host.c does have legitimate ones -- the prefixed synth:/fxN:/midi_fxN:
+# set_param routes, which update the modulation base themselves. So the window
+# is the knob_ branch only, bounded by its own opening line and the next
+# same-indent `else if`. Both anchors are REQUIRED: a window that silently
+# found nothing would pass this check while examining an empty string.
+H=src/modules/chain/dsp/chain_host.c
+kstart=$(command grep -n 'else if (strncmp(key, "knob_", 5) == 0)' "$H" | head -1 | cut -d: -f1)
+[ -n "$kstart" ] || fail "could not find the knob_ set_param branch in $H"
+kend=$(awk -v s="$kstart" 'NR>s && /^    else if \(/ {print NR; exit}' "$H")
+[ -n "$kend" ] || fail "could not find the end of the knob_ branch in $H (its next sibling moved)"
+[ "$kend" -gt "$kstart" ] || fail "the knob_ branch window in $H is empty"
+# kend is the NEXT branch's own line, so the window stops before it.
+if sed -n "${kstart},$((kend - 1))p" "$H" \
+     | command grep -qE '(synth_plugin_v2|fx_plugins_v2|midi_fx_plugins)\[?[a-z]*\]?->set_param'; then
+  fail "the knob_ branch of $H writes a plugin parameter directly, bypassing the modulation bus"
+fi
+
+# The relative path delegates the whole turn; the absolute CC path still
+# formats and forwards its own value. Both must end at the helper.
+command grep -q 'knob_turn(inst, i, ticks,' src/modules/chain/dsp/chain_midi.c \
+  || fail "the relative CC path does not delegate to knob_turn"
+command grep -q 'knob_forward_value(inst, target, param, val_str)' src/modules/chain/dsp/chain_midi.c \
+  || fail "the absolute CC path no longer forwards through knob_forward_value"
 
 echo "PASS: a knob turn edits the base, and every knob path goes through it"

--- a/tests/host/test_chain_knob_mod_base.sh
+++ b/tests/host/test_chain_knob_mod_base.sh
@@ -95,7 +95,7 @@ fi
 # formats and forwards its own value. Both must end at the helper.
 command grep -q 'knob_turn(inst, i, ticks,' src/modules/chain/dsp/chain_midi.c \
   || fail "the relative CC path does not delegate to knob_turn"
-command grep -q 'knob_forward_value(inst, target, param, val_str)' src/modules/chain/dsp/chain_midi.c \
-  || fail "the absolute CC path no longer forwards through knob_forward_value"
+command grep -q 'knob_set_position(inst, i,' src/modules/chain/dsp/chain_midi.c \
+  || fail "the absolute CC path does not delegate to knob_set_position"
 
 echo "PASS: a knob turn edits the base, and every knob path goes through it"

--- a/tests/host/test_chain_knob_target_lookup.c
+++ b/tests/host/test_chain_knob_target_lookup.c
@@ -37,6 +37,28 @@ int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *tar
     (void)inst; (void)target;
     return 0;
 }
+
+/*
+ * knob_forward_value now routes a modulated parameter through the modulation
+ * bus (a knob turn edits the RESTING value, like any other edit). No case in
+ * this fixture involves a modulated parameter, so "no target is active" is its
+ * honest answer and the behaviour under test is unchanged.
+ */
+int chain_mod_is_target_active(chain_instance_t *inst, const char *target, const char *param) {
+    (void)inst; (void)target; (void)param; return 0;
+}
+void chain_mod_update_base_from_set_param(chain_instance_t *inst, const char *target,
+                                          const char *param, const char *val) {
+    (void)inst; (void)target; (void)param; (void)val;
+}
+mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *inst, const char *target,
+                                                const char *param) {
+    (void)inst; (void)target; (void)param; return NULL;
+}
+void chain_mod_apply_effective_value(chain_instance_t *inst, mod_target_state_t *entry,
+                                     int force_write) {
+    (void)inst; (void)entry; (void)force_write;
+}
 int v2_load_synth(chain_instance_t *inst, const char *module_name) {
     (void)inst; (void)module_name;
     return 0;

--- a/tests/host/test_chain_knob_turn.c
+++ b/tests/host/test_chain_knob_turn.c
@@ -53,9 +53,9 @@ void chain_mod_apply_effective_value(chain_instance_t *i, mod_target_state_t *e,
 }
 
 /* --------------------------------------------------- fake synth (3 params) */
-#define NPARAM 3
-static const char *pkeys[NPARAM] = { "cutoff", "voices", "wave" };
-static char pvals[NPARAM][32] = { "0", "0", "0" };
+#define NPARAM 4
+static const char *pkeys[NPARAM] = { "cutoff", "voices", "wave", "bipolar" };
+static char pvals[NPARAM][32] = { "0", "0", "0", "0" };
 
 static int pindex(const char *key) {
     for (int i = 0; i < NPARAM; i++) if (strcmp(key, pkeys[i]) == 0) return i;
@@ -234,7 +234,36 @@ int main(void) {
     }
     check(inverse_ok, "fraction -> value -> fraction round-trips on a float parameter");
 
-    /* ---- 10. a turn with no movement writes nothing ---- */
+    /* ---- 10. a SIGNED parameter still reaches its bottom ----
+     *
+     * The clamp a window adds must be a no-op on a whole-range destination,
+     * and it very nearly was not: taking the window's bounds through the
+     * quantiser rounded them, and `(int)` truncates TOWARD ZERO, so the bottom
+     * of a -64..63 parameter came back as -63. A knob that had always reached
+     * -64 would have stopped one step short -- on pan, on transpose, on any
+     * bipolar depth -- with nothing to show for it but a value that would not
+     * go all the way down. */
+    add_param(3, "bipolar", KNOB_TYPE_INT, -64.0f, 63.0f, 0.0f);
+    snprintf(pvals[3], sizeof(pvals[3]), "-60");
+    {
+        chain_param_info_t *bp = &inst->synth_params[3];
+        knob_mapping_t *b = &inst->knob_mappings[0];
+        memset(b, 0, sizeof(*b));
+        b->cc = 71;
+        knob_dest_assign(&b->dests[0], "synth", "bipolar");
+        b->dests[0].current_value = -60.0f;
+        b->dest_count = 1;
+        inst->knob_mapping_count = 1;
+        inst->knob_last_time_ms[0] = 0;
+
+        for (int i = 0; i < 20; i++) { inst->knob_last_time_ms[0] = 1; knob_turn(inst, 0, -1, KNOB_STEP_FLOAT); }
+        check(b->dests[0].current_value == -64.0f,
+              "a whole-range destination on a signed parameter still reaches its bottom");
+        check(knob_dest_clamp(&b->dests[0], -64.0f, bp) == -64.0f,
+              "...because a whole-range window clamps to the parameter's own range exactly");
+    }
+
+    /* ---- 11. a turn with no movement writes nothing ---- */
     snprintf(pvals[0], sizeof(pvals[0]), "0.400");
     knob(1, "cutoff", NULL, NULL);
     knob_turn(inst, 0, 0, KNOB_STEP_FLOAT);

--- a/tests/host/test_chain_knob_turn.c
+++ b/tests/host/test_chain_knob_turn.c
@@ -1,0 +1,247 @@
+/*
+ * One knob, several destinations -- and the line between the two branches.
+ *
+ * THE LINE IS "SEVERAL DESTINATIONS", NOT "HAS A RANGE". A knob with one
+ * destination keeps that parameter's own step, acceleration and enum feel and
+ * is merely clamped into its window. Only a knob with several has no single
+ * parameter to be, so its own 0..1 position becomes the thing being turned.
+ *
+ * The asymmetry is arithmetic, not taste, and check 3 below is the proof: an
+ * 8-option enum driven by a position needs ~1/7 of that position's travel to
+ * advance one option, which at the float step is ~95 detents instead of 1. A
+ * parameter sharing a knob with others pays that by necessity. A parameter
+ * that does not must never be made to -- and "give this one knob a range"
+ * must not silently move it into the paying branch.
+ *
+ * Runs the real knob_turn against a fake synth.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "chain_internal.h"
+
+/* ------------------------------------------------------------------ stubs */
+void chain_log(const char *msg) { (void)msg; }
+void parse_debug_log(const char *msg) { (void)msg; }
+void v2_chain_log(chain_instance_t *inst, const char *msg) { (void)inst; (void)msg; }
+void v2_synth_panic(chain_instance_t *inst) { (void)inst; }
+int v2_load_synth(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_synth(chain_instance_t *inst) { (void)inst; }
+int v2_load_audio_fx(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_all_audio_fx(chain_instance_t *inst) { inst->fx_count = 0; }
+int v2_load_midi_fx(chain_instance_t *inst, const char *m) { (void)inst; (void)m; return 0; }
+void v2_unload_all_midi_fx(chain_instance_t *inst) { inst->midi_fx_count = 0; }
+void chain_mod_clear_source(void *ctx, const char *s) { (void)ctx; (void)s; }
+int chain_mod_refresh_target_param_cache(chain_instance_t *i, const char *t) {
+    (void)i; (void)t; return 0;
+}
+/* No destination here is modulated, so the bus is not in the picture. */
+int chain_mod_is_target_active(chain_instance_t *i, const char *t, const char *p) {
+    (void)i; (void)t; (void)p; return 0;
+}
+void chain_mod_update_base_from_set_param(chain_instance_t *i, const char *t,
+                                          const char *p, const char *v) {
+    (void)i; (void)t; (void)p; (void)v;
+}
+mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *i, const char *t,
+                                                const char *p) {
+    (void)i; (void)t; (void)p; return NULL;
+}
+void chain_mod_apply_effective_value(chain_instance_t *i, mod_target_state_t *e, int f) {
+    (void)i; (void)e; (void)f;
+}
+
+/* --------------------------------------------------- fake synth (3 params) */
+#define NPARAM 3
+static const char *pkeys[NPARAM] = { "cutoff", "voices", "wave" };
+static char pvals[NPARAM][32] = { "0", "0", "0" };
+
+static int pindex(const char *key) {
+    for (int i = 0; i < NPARAM; i++) if (strcmp(key, pkeys[i]) == 0) return i;
+    return -1;
+}
+static void fake_set_param(void *inst, const char *key, const char *val) {
+    (void)inst; int i = pindex(key);
+    if (i >= 0) snprintf(pvals[i], sizeof(pvals[i]), "%s", val);
+}
+static int fake_get_param(void *inst, const char *key, char *buf, int len) {
+    (void)inst; int i = pindex(key);
+    return (i >= 0) ? snprintf(buf, len, "%s", pvals[i]) : -1;
+}
+static float pval(const char *key) { int i = pindex(key); return (float)atof(pvals[i]); }
+
+/* ---------------------------------------------------------------- harness */
+static int failures = 0;
+static void check(int cond, const char *what) {
+    if (cond) printf("  ok  %s\n", what);
+    else { printf("FAIL: %s\n", what); failures++; }
+}
+
+static chain_instance_t *inst;
+static plugin_api_v2_t fake_api;
+
+static void add_param(int i, const char *key, knob_type_t type,
+                      float mn, float mx, float step) {
+    chain_param_info_t *p = &inst->synth_params[i];
+    snprintf(p->key, sizeof(p->key), "%s", key);
+    snprintf(p->name, sizeof(p->name), "%s", key);
+    p->type = type; p->min_val = mn; p->max_val = mx; p->step = step;
+    if (i + 1 > inst->synth_param_count) inst->synth_param_count = i + 1;
+}
+
+/* A knob with `n` destinations, all on the synth, all whole-range. */
+static knob_mapping_t *knob(int n, const char *a, const char *b, const char *c) {
+    knob_mapping_t *km = &inst->knob_mappings[0];
+    memset(km, 0, sizeof(*km));
+    km->cc = 71;
+    const char *keys[3] = { a, b, c };
+    for (int i = 0; i < n; i++) {
+        knob_dest_assign(&km->dests[i], "synth", keys[i]);
+        km->dests[i].current_value = pval(keys[i]);
+    }
+    km->dest_count = n;
+    inst->knob_mapping_count = 1;
+    inst->knob_last_time_ms[0] = 0;
+    return km;
+}
+
+/* Detents slow enough that acceleration is never in the picture: this file is
+ * about the travel law, and test_chain_knob_accel owns the curve. */
+static void turn_slow(int n) {
+    for (int i = 0; i < n; i++) {
+        inst->knob_last_time_ms[0] = 1;          /* an ancient previous message */
+        knob_turn(inst, 0, 1, KNOB_STEP_FLOAT);
+    }
+}
+
+int main(void) {
+    inst = calloc(1, sizeof(*inst));
+    fake_api.api_version = 2;
+    fake_api.set_param = fake_set_param;
+    fake_api.get_param = fake_get_param;
+    inst->synth_plugin_v2 = &fake_api;
+    inst->synth_instance = (void *)0x1;
+
+    add_param(0, "cutoff", KNOB_TYPE_FLOAT, 0.0f, 1.0f, 0.01f);
+    add_param(1, "voices", KNOB_TYPE_INT,   1.0f, 8.0f, 0.0f);
+    add_param(2, "wave",   KNOB_TYPE_ENUM,  0.0f, 7.0f, 0.0f);   /* 8 options */
+
+    /* ---- 1. one destination, whole range: the parameter's own step ---- */
+    snprintf(pvals[0], sizeof(pvals[0]), "0.500");
+    knob(1, "cutoff", NULL, NULL);
+    turn_slow(1);
+    /* step 0.01, one detent, no acceleration: 0.500 -> 0.510. */
+    check(pval("cutoff") > 0.5099f && pval("cutoff") < 0.5101f,
+          "one float destination moves by its own declared step");
+
+    snprintf(pvals[2], sizeof(pvals[2]), "3");
+    knob(1, "wave", NULL, NULL);
+    turn_slow(1);
+    check(pval("wave") == 4.0f, "one enum destination advances ONE option per detent");
+
+    /* ---- 2. one destination, RANGED: same feel, just bounded ---- */
+    snprintf(pvals[1], sizeof(pvals[1]), "1");
+    knob_mapping_t *km = knob(1, "voices", NULL, NULL);
+    km->dests[0].lo = 0.0f;
+    km->dests[0].hi = 3.0f / 7.0f;             /* voices 1..4 of 1..8 */
+    turn_slow(1);
+    check(pval("voices") == 2.0f, "a RANGED int destination still moves one unit per detent");
+    turn_slow(10);
+    check(pval("voices") == 4.0f, "...and stops at the top of its window, not the parameter's");
+
+    /* ---- 3. THE PROOF: the same enum, alone vs sharing a knob ---- */
+    snprintf(pvals[2], sizeof(pvals[2]), "0");
+    knob(1, "wave", NULL, NULL);
+    turn_slow(1);
+    int alone = (int)pval("wave");
+
+    snprintf(pvals[2], sizeof(pvals[2]), "0");
+    snprintf(pvals[0], sizeof(pvals[0]), "0.000");
+    knob(2, "wave", "cutoff", NULL);
+    turn_slow(1);
+    int shared_1 = (int)pval("wave");
+    turn_slow(93);                              /* 94 detents in total */
+    int shared_94 = (int)pval("wave");
+
+    check(alone == 1, "alone: one detent, one option");
+    check(shared_1 == 0, "sharing a knob: one detent moves the enum by NOTHING");
+    check(shared_94 == 1,
+          "...and it takes ~95 detents to reach the next option. THIS is why a "
+          "single destination is never driven by the position");
+
+    /* ---- 4. several destinations follow one position ---- */
+    snprintf(pvals[0], sizeof(pvals[0]), "0.000");
+    snprintf(pvals[1], sizeof(pvals[1]), "1");
+    km = knob(2, "cutoff", "voices", NULL);
+    km->position = 0.0f;
+    turn_slow(200);                             /* ~0.3 of the position */
+    check(pval("cutoff") > 0.25f && pval("cutoff") < 0.35f,
+          "a shared float follows the knob's position");
+    check(pval("voices") == 3.0f,
+          "and a shared int lands where that same position puts it");
+
+    /* ---- 5. an INVERTED destination ---- */
+    snprintf(pvals[0], sizeof(pvals[0]), "0.000");
+    snprintf(pvals[1], sizeof(pvals[1]), "1");
+    km = knob(2, "cutoff", "voices", NULL);
+    km->dests[1].lo = 1.0f;                     /* voices runs backwards */
+    km->dests[1].hi = 0.0f;
+    km->position = 0.0f;
+    knob_turn(inst, 0, 1, KNOB_STEP_FLOAT);
+    check(pval("voices") == 8.0f,
+          "an inverted destination starts at the TOP of its parameter");
+    km->position = 1.0f;
+    knob_turn(inst, 0, 1, KNOB_STEP_FLOAT);
+    check(pval("voices") == 1.0f, "...and reaches the bottom as the knob goes up");
+
+    /* ---- 6. an enum SUB-RANGE reaches both of its ends ---- */
+    km = knob(2, "wave", "cutoff", NULL);
+    km->dests[0].lo = 2.0f / 7.0f;              /* options 2..5 */
+    km->dests[0].hi = 5.0f / 7.0f;
+    km->position = 0.0f;
+    knob_turn(inst, 0, 1, KNOB_STEP_FLOAT);
+    check(pval("wave") == 2.0f, "an enum sub-range starts at its own first option");
+    km->position = 1.0f;
+    knob_turn(inst, 0, 1, KNOB_STEP_FLOAT);
+    check(pval("wave") == 5.0f, "...and its LAST option is reachable, not one short");
+
+    /* ---- 7. a destination whose module is gone is skipped, not fatal ---- */
+    snprintf(pvals[0], sizeof(pvals[0]), "0.000");
+    km = knob(2, "cutoff", "voices", NULL);
+    knob_dest_assign(&km->dests[1], "fx7", "nonexistent");
+    km->position = 0.0f;
+    turn_slow(100);
+    check(pval("cutoff") > 0.0f,
+          "a dead destination is skipped and its siblings still move");
+
+    /* ---- 8. the position cannot leave 0..1 ---- */
+    km = knob(2, "cutoff", "voices", NULL);
+    km->position = 0.99f;
+    turn_slow(50);
+    check(km->position == 1.0f, "the position stops at 1");
+    km->position = 0.01f;
+    for (int i = 0; i < 50; i++) { inst->knob_last_time_ms[0] = 1; knob_turn(inst, 0, -1, KNOB_STEP_FLOAT); }
+    check(km->position == 0.0f, "...and at 0");
+
+    /* ---- 9. the two conversions are inverses ---- */
+    chain_param_info_t *pf = &inst->synth_params[0];
+    int inverse_ok = 1;
+    for (int i = 0; i <= 20; i++) {
+        float f = (float)i / 20.0f;
+        float back = knob_value_to_frac(knob_frac_to_value(f, pf), pf);
+        if (back < f - 0.0001f || back > f + 0.0001f) inverse_ok = 0;
+    }
+    check(inverse_ok, "fraction -> value -> fraction round-trips on a float parameter");
+
+    /* ---- 10. a turn with no movement writes nothing ---- */
+    snprintf(pvals[0], sizeof(pvals[0]), "0.400");
+    knob(1, "cutoff", NULL, NULL);
+    knob_turn(inst, 0, 0, KNOB_STEP_FLOAT);
+    check(pval("cutoff") == 0.4f, "a zero-detent message changes nothing");
+
+    free(inst);
+    if (failures) { printf("\n%d check(s) failed\n", failures); return 1; }
+    printf("\nall checks passed\n");
+    return 0;
+}

--- a/tests/host/test_chain_knob_turn.sh
+++ b/tests/host/test_chain_knob_turn.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+fail() { echo "FAIL: $1"; exit 1; }
+
+bin="build/tests/test_chain_knob_turn"
+mkdir -p "$(dirname "$bin")"
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+printf '#include <stdlib.h>\n' > "$work/malloc.h"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
+  -Wno-sign-compare \
+  -I"$work" -Isrc -Isrc/host -Isrc/modules/chain/dsp \
+  tests/host/test_chain_knob_turn.c \
+  src/modules/chain/dsp/chain_params.c \
+  src/modules/chain/dsp/chain_json.c \
+  -o "$bin"
+
+"$bin"
+echo "PASS: one knob, several destinations"

--- a/tests/host/test_chain_midi_fx_slot.c
+++ b/tests/host/test_chain_midi_fx_slot.c
@@ -87,6 +87,9 @@ CHAIN_INTERNAL int chain_knob_accel_cap(int accel, int type) { (void)type; retur
 CHAIN_INTERNAL void knob_turn(chain_instance_t *inst, int idx, int ticks, float fb) {
     (void)inst; (void)idx; (void)ticks; (void)fb;
 }
+CHAIN_INTERNAL void knob_set_position(chain_instance_t *inst, int idx, float position) {
+    (void)inst; (void)idx; (void)position;
+}
 CHAIN_INTERNAL void knob_forward_value(chain_instance_t *inst, const char *target,
                                        const char *param, const char *val_str) {
     (void)inst; (void)target; (void)param; (void)val_str;

--- a/tests/host/test_chain_midi_fx_slot.c
+++ b/tests/host/test_chain_midi_fx_slot.c
@@ -78,6 +78,12 @@ CHAIN_INTERNAL chain_param_info_t *knob_find_param(chain_instance_t *inst,
     (void)inst; (void)target; (void)param;
     return NULL;
 }
+/* The knob-turn law also lives in chain_params.c, which this file does not
+ * link. knob_find_param above answers NULL, so no knob message here ever
+ * reaches these -- they exist to satisfy the linker, and their behaviour is
+ * proved in test_chain_knob_mod_base and test_chain_knob_cc_out. */
+CHAIN_INTERNAL int chain_knob_accel(uint64_t *last_ms) { (void)last_ms; return 1; }
+CHAIN_INTERNAL int chain_knob_accel_cap(int accel, int type) { (void)type; return accel; }
 CHAIN_INTERNAL void knob_forward_value(chain_instance_t *inst, const char *target,
                                        const char *param, const char *val_str) {
     (void)inst; (void)target; (void)param; (void)val_str;

--- a/tests/host/test_chain_midi_fx_slot.c
+++ b/tests/host/test_chain_midi_fx_slot.c
@@ -84,6 +84,9 @@ CHAIN_INTERNAL chain_param_info_t *knob_find_param(chain_instance_t *inst,
  * proved in test_chain_knob_mod_base and test_chain_knob_cc_out. */
 CHAIN_INTERNAL int chain_knob_accel(uint64_t *last_ms) { (void)last_ms; return 1; }
 CHAIN_INTERNAL int chain_knob_accel_cap(int accel, int type) { (void)type; return accel; }
+CHAIN_INTERNAL void knob_turn(chain_instance_t *inst, int idx, int ticks, float fb) {
+    (void)inst; (void)idx; (void)ticks; (void)fb;
+}
 CHAIN_INTERNAL void knob_forward_value(chain_instance_t *inst, const char *target,
                                        const char *param, const char *val_str) {
     (void)inst; (void)target; (void)param; (void)val_str;

--- a/tests/host/test_chain_params_max_param.c
+++ b/tests/host/test_chain_params_max_param.c
@@ -33,6 +33,28 @@ int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *tar
     (void)inst; (void)target; return 0;
 }
 
+/*
+ * knob_forward_value now routes a modulated parameter through the modulation
+ * bus (a knob turn edits the RESTING value, like any other edit). No case in
+ * this fixture involves a modulated parameter, so "no target is active" is its
+ * honest answer and the behaviour under test is unchanged.
+ */
+int chain_mod_is_target_active(chain_instance_t *inst, const char *target, const char *param) {
+    (void)inst; (void)target; (void)param; return 0;
+}
+void chain_mod_update_base_from_set_param(chain_instance_t *inst, const char *target,
+                                          const char *param, const char *val) {
+    (void)inst; (void)target; (void)param; (void)val;
+}
+mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *inst, const char *target,
+                                                const char *param) {
+    (void)inst; (void)target; (void)param; return NULL;
+}
+void chain_mod_apply_effective_value(chain_instance_t *inst, mod_target_state_t *entry,
+                                     int force_write) {
+    (void)inst; (void)entry; (void)force_write;
+}
+
 static int failures = 0;
 
 static void check_range(const char *what, const char *param_json) {

--- a/tests/host/test_chain_patch_roundtrip.c
+++ b/tests/host/test_chain_patch_roundtrip.c
@@ -623,6 +623,101 @@ static void test_knob_high_slots(chain_instance_t *inst, patch_info_t *patch) {
  * Each row below omits exactly one field, so an inherited value is the only
  * way it could come back non-empty.
  */
+/*
+ * A knob with several destinations is stored as several FLAT ROWS sharing one
+ * cc, merged back into one mapping here.
+ *
+ * Flat rather than nested because this parser -- and every build already in
+ * the field -- walks the array by scanning for braces. Nesting a destination
+ * list inside a mapping object would end each object at the first inner brace,
+ * and an older host would read the leftovers as further mappings pointed at
+ * whatever those inner fields happened to name.
+ */
+static void test_knob_destinations(chain_instance_t *inst, patch_info_t *patch) {
+    if (MAX_AUDIO_FX < 2 || MAX_KNOB_DESTS < 3) return;
+
+    static const char json[] =
+        "{\n  \"name\": \"dests\",\n"
+        "  \"audio_fx\": [{\"type\": \"afx1\"}, {\"type\": \"afx2\"}],\n"
+        "  \"knob_mappings\": ["
+        /* one knob, three destinations, all on cc 71 */
+        "{\"cc\": 71, \"target\": \"synth\", \"param\": \"cutoff\", \"value\": 0.4,"
+        " \"dest\": 0, \"pos\": 0.75}, "
+        "{\"cc\": 71, \"target\": \"fx1\", \"param\": \"mix\", \"value\": 0.2,"
+        " \"lo\": 0.2000, \"hi\": 0.8000, \"dest\": 1, \"pos\": 0.75}, "
+        "{\"cc\": 71, \"target\": \"fx2\", \"param\": \"drive\", \"value\": 0.1,"
+        " \"lo\": 1.0000, \"hi\": 0.0000, \"dest\": 2, \"pos\": 0.75}, "
+        /* a second knob, ONE destination with a window and no dest index */
+        "{\"cc\": 72, \"target\": \"fx1\", \"param\": \"gain\", \"value\": 0.5,"
+        " \"lo\": 0.1000, \"hi\": 0.6000}, "
+        /* a row naming a destination past the cap is DROPPED, not folded onto
+         * another one -- silently landing on destination 0 would rewrite a
+         * different parameter's assignment */
+        "{\"cc\": 73, \"target\": \"synth\", \"param\": \"res\", \"dest\": 99}"
+        "]\n}\n";
+
+    write_patch(json);
+    memset(patch, 0, sizeof(*patch));
+    CHECK(v2_parse_patch_file(inst, patch_path, patch) == 0, "destination patch parsed");
+
+    CHECK(patch->knob_mapping_count == 3,
+          "three rows on one cc merged into ONE mapping (got %d mappings)",
+          patch->knob_mapping_count);
+
+    knob_mapping_t *k71 = NULL, *k72 = NULL, *k73 = NULL;
+    for (int i = 0; i < patch->knob_mapping_count; i++) {
+        if (patch->knob_mappings[i].cc == 71) k71 = &patch->knob_mappings[i];
+        if (patch->knob_mappings[i].cc == 72) k72 = &patch->knob_mappings[i];
+        if (patch->knob_mappings[i].cc == 73) k73 = &patch->knob_mappings[i];
+    }
+
+    CHECK(k71 && k71->dest_count == 3, "cc 71 has three destinations");
+    if (k71) {
+        CHECK(strcmp(k71->dests[0].param, "cutoff") == 0, "destination 0 is cutoff");
+        CHECK(strcmp(k71->dests[1].param, "mix") == 0, "destination 1 is mix");
+        CHECK(strcmp(k71->dests[2].param, "drive") == 0, "destination 2 is drive");
+        CHECK(k71->dests[0].lo == 0.0f && k71->dests[0].hi == 1.0f,
+              "a destination with no window is whole-range, not zero-width");
+        CHECK(k71->dests[1].lo > 0.19f && k71->dests[1].hi < 0.81f,
+              "a window round-trips");
+        CHECK(k71->dests[2].lo > k71->dests[2].hi,
+              "an INVERTED window survives as inverted, not reordered");
+        CHECK(k71->position > 0.74f && k71->position < 0.76f,
+              "the knob's position round-trips");
+    }
+
+    CHECK(k72 && k72->dest_count == 1, "cc 72 has one destination");
+    if (k72) {
+        CHECK(k72->dests[0].lo > 0.09f && k72->dests[0].hi < 0.61f,
+              "a SINGLE destination can carry a window too");
+    }
+
+    CHECK(k73 && k73->dest_count == 0,
+          "a row past the destination cap is dropped, not folded onto destination 0");
+}
+
+/*
+ * An older patch -- every knob a bare cc/target/param/value with none of the
+ * fields above -- must load as exactly what it was: one whole-range
+ * destination. This is the migration, and it is the absence of code.
+ */
+static void test_knob_legacy_rows_are_whole_range(chain_instance_t *inst, patch_info_t *patch) {
+    static const char json[] =
+        "{\n  \"name\": \"legacy\",\n"
+        "  \"knob_mappings\": ["
+        "{\"cc\": 71, \"target\": \"synth\", \"param\": \"cutoff\", \"value\": 0.4}"
+        "]\n}\n";
+
+    write_patch(json);
+    memset(patch, 0, sizeof(*patch));
+    CHECK(v2_parse_patch_file(inst, patch_path, patch) == 0, "legacy patch parsed");
+    CHECK(patch->knob_mapping_count == 1, "one mapping");
+    CHECK(patch->knob_mappings[0].dest_count == 1, "one destination");
+    CHECK(patch->knob_mappings[0].dests[0].lo == 0.0f &&
+          patch->knob_mappings[0].dests[0].hi == 1.0f,
+          "whole-range, so it behaves exactly as it did before destinations existed");
+}
+
 static void test_knob_rejected_row_does_not_bleed(chain_instance_t *inst, patch_info_t *patch) {
     if (MAX_AUDIO_FX < 2) return;
 
@@ -843,6 +938,8 @@ int main(int argc, char **argv) {
     }
 
     test_full_capacity(inst, patch);
+    test_knob_destinations(inst, patch);
+    test_knob_legacy_rows_are_whole_range(inst, patch);
     test_legacy_two_fx(inst, patch);
     test_hostile_json(inst, patch);
     test_midi_fx_state_forms(inst, patch);

--- a/tests/host/test_chain_patch_roundtrip.c
+++ b/tests/host/test_chain_patch_roundtrip.c
@@ -264,10 +264,10 @@ static void test_full_capacity(chain_instance_t *inst, patch_info_t *patch) {
      * no-metadata default. */
     CHECK(inst->knob_mapping_count == 2, "knob_mapping_count=%d", inst->knob_mapping_count);
     for (int i = 0; i < inst->knob_mapping_count; i++) {
-        CHECK(inst->knob_mappings[i].current_value > 0.24f &&
-              inst->knob_mappings[i].current_value < 0.26f,
+        CHECK(inst->knob_mappings[i].dests[0].current_value > 0.24f &&
+              inst->knob_mappings[i].dests[0].current_value < 0.26f,
               "knob mapping on %s did not re-read from the plugin (value=%.3f)",
-              inst->knob_mappings[i].target, (double)inst->knob_mappings[i].current_value);
+              inst->knob_mappings[i].dests[0].target, (double)inst->knob_mappings[i].dests[0].current_value);
     }
 }
 
@@ -303,8 +303,8 @@ static void test_legacy_two_fx(chain_instance_t *inst, patch_info_t *patch) {
     CHECK(strstr(fake_fx[1].log, "gain=0.3;") != NULL, "legacy fx2 params [%s]", fake_fx[1].log);
     CHECK(fake_fx[2].log[0] == '\0', "legacy touched fx3 [%s]", fake_fx[2].log);
     CHECK(inst->knob_mapping_count == 1 &&
-          inst->knob_mappings[0].current_value > 0.24f &&
-          inst->knob_mappings[0].current_value < 0.26f,
+          inst->knob_mappings[0].dests[0].current_value > 0.24f &&
+          inst->knob_mappings[0].dests[0].current_value < 0.26f,
           "legacy fx2 knob did not re-read from the plugin");
 }
 
@@ -560,9 +560,9 @@ static void test_knob_high_slots(chain_instance_t *inst, patch_info_t *patch) {
     for (int i = 0; i < 3; i++) {
         CHECK(patch->knob_mappings[i].cc == want_cc[i],
               "knob %d parsed CC %d, want %d", i, patch->knob_mappings[i].cc, want_cc[i]);
-        CHECK(strcmp(patch->knob_mappings[i].target, want_target[i]) == 0,
+        CHECK(strcmp(patch->knob_mappings[i].dests[0].target, want_target[i]) == 0,
               "knob %d parsed target \"%s\", want \"%s\"",
-              i, patch->knob_mappings[i].target, want_target[i]);
+              i, patch->knob_mappings[i].dests[0].target, want_target[i]);
     }
 
     CHECK(v2_load_from_patch_info(inst, patch) == 0, "knob patch load failed");
@@ -572,27 +572,27 @@ static void test_knob_high_slots(chain_instance_t *inst, patch_info_t *patch) {
     /* The two live ones re-read from THEIR plugin (0.25), not the saved 0.9 and
      * not the 0.5 no-metadata default. 0.9 would mean the lookup fell through;
      * 0.5 would mean it resolved nothing at all. */
-    CHECK(inst->knob_mappings[0].current_value > 0.24f &&
-          inst->knob_mappings[0].current_value < 0.26f,
+    CHECK(inst->knob_mappings[0].dests[0].current_value > 0.24f &&
+          inst->knob_mappings[0].dests[0].current_value < 0.26f,
           "the knob on fx6 did not re-read from its plugin (value=%.3f)",
-          (double)inst->knob_mappings[0].current_value);
-    CHECK(inst->knob_mappings[1].current_value > 0.24f &&
-          inst->knob_mappings[1].current_value < 0.26f,
+          (double)inst->knob_mappings[0].dests[0].current_value);
+    CHECK(inst->knob_mappings[1].dests[0].current_value > 0.24f &&
+          inst->knob_mappings[1].dests[0].current_value < 0.26f,
           "the knob on midi_fx6 did not re-read from its plugin (value=%.3f)",
-          (double)inst->knob_mappings[1].current_value);
-    CHECK(strcmp(inst->knob_mappings[0].target, "fx6") == 0,
-          "the loaded knob target became \"%s\"", inst->knob_mappings[0].target);
-    CHECK(strcmp(inst->knob_mappings[1].target, "midi_fx6") == 0,
-          "the loaded knob target became \"%s\"", inst->knob_mappings[1].target);
+          (double)inst->knob_mappings[1].dests[0].current_value);
+    CHECK(strcmp(inst->knob_mappings[0].dests[0].target, "fx6") == 0,
+          "the loaded knob target became \"%s\"", inst->knob_mappings[0].dests[0].target);
+    CHECK(strcmp(inst->knob_mappings[1].dests[0].target, "midi_fx6") == 0,
+          "the loaded knob target became \"%s\"", inst->knob_mappings[1].dests[0].target);
 
     /* Past the chain: must resolve to nothing. A read of 0.25 here means the
      * target was coerced onto a real slot -- almost certainly slot 0, which is
      * a knob driving the first module in the chain. */
-    CHECK(inst->knob_mappings[2].current_value < 0.24f ||
-          inst->knob_mappings[2].current_value > 0.26f,
+    CHECK(inst->knob_mappings[2].dests[0].current_value < 0.24f ||
+          inst->knob_mappings[2].dests[0].current_value > 0.26f,
           "a knob naming fx7 in a six-long chain read a plugin value (%.3f) -- it "
           "resolved onto a slot that is not the one it names",
-          (double)inst->knob_mappings[2].current_value);
+          (double)inst->knob_mappings[2].dests[0].current_value);
     /* ...and the cleared row is not among the loaded ones at all. */
     for (int i = 0; i < inst->knob_mapping_count; i++)
         CHECK(inst->knob_mappings[i].cc != 74,
@@ -657,14 +657,14 @@ static void test_knob_rejected_row_does_not_bleed(chain_instance_t *inst, patch_
 
     CHECK(patch->knob_mappings[0].cc == 71, "first mapping CC %d, want 71",
           patch->knob_mappings[0].cc);
-    CHECK(strcmp(patch->knob_mappings[0].target, "fx1") == 0,
-          "first mapping target \"%s\", want fx1", patch->knob_mappings[0].target);
+    CHECK(strcmp(patch->knob_mappings[0].dests[0].target, "fx1") == 0,
+          "first mapping target \"%s\", want fx1", patch->knob_mappings[0].dests[0].target);
 
     CHECK(patch->knob_mappings[1].cc == 73, "second mapping CC %d, want 73",
           patch->knob_mappings[1].cc);
-    CHECK(patch->knob_mappings[1].target[0] == '\0',
+    CHECK(patch->knob_mappings[1].dests[0].target[0] == '\0',
           "a mapping that names no target came back aimed at \"%s\" -- inherited "
-          "from the rejected row before it", patch->knob_mappings[1].target);
+          "from the rejected row before it", patch->knob_mappings[1].dests[0].target);
 }
 
 /* ---- 3. Modulation / knob targets reach every slot ---- */

--- a/tests/host/test_chain_patch_roundtrip.c
+++ b/tests/host/test_chain_patch_roundtrip.c
@@ -697,6 +697,47 @@ static void test_knob_destinations(chain_instance_t *inst, patch_info_t *patch) 
 }
 
 /*
+ * A parameter NAMED like one of the row's own fields must not rewrite the row
+ * around it.
+ *
+ * Each field is found by searching the object for its name, so a row whose
+ * param VALUE is the word being searched for answers the search first and the
+ * colon that follows belongs to the next field. A module is free to expose a
+ * parameter called `lo`, `hi`, `pos` or `dest`; before the field names carried
+ * their own colons, `{"param":"hi","value":0.5}` came back with a window of
+ * 0..0.5, and `{"param":"dest","value":3}` built a mapping claiming four
+ * destinations whose first three were empty -- which then persisted through a
+ * save, because the row it re-emitted was the one it had invented.
+ */
+static void test_knob_param_named_like_a_field(chain_instance_t *inst, patch_info_t *patch) {
+    static const char json[] =
+        "{\n  \"name\": \"shadow\",\n"
+        "  \"knob_mappings\": ["
+        "{\"cc\": 71, \"target\": \"synth\", \"param\": \"hi\", \"value\": 0.500}, "
+        "{\"cc\": 72, \"target\": \"synth\", \"param\": \"lo\", \"value\": 0.500}, "
+        "{\"cc\": 73, \"target\": \"synth\", \"param\": \"pos\", \"value\": 0.500}, "
+        "{\"cc\": 74, \"target\": \"synth\", \"param\": \"dest\", \"value\": 3.000}"
+        "]\n}\n";
+
+    write_patch(json);
+    memset(patch, 0, sizeof(*patch));
+    CHECK(v2_parse_patch_file(inst, patch_path, patch) == 0, "field-named patch parsed");
+    CHECK(patch->knob_mapping_count == 4, "four ordinary knobs, one per cc (got %d)",
+          patch->knob_mapping_count);
+
+    for (int i = 0; i < patch->knob_mapping_count; i++) {
+        knob_mapping_t *m = &patch->knob_mappings[i];
+        CHECK(m->dest_count == 1,
+              "cc %d has ONE destination, not a list invented from its param name (got %d)",
+              m->cc, m->dest_count);
+        CHECK(m->dests[0].lo == 0.0f && m->dests[0].hi == 1.0f,
+              "cc %d is whole-range; its param name did not become a window (%.3f..%.3f)",
+              m->cc, (double)m->dests[0].lo, (double)m->dests[0].hi);
+        CHECK(m->position == 0.0f, "cc %d has no position from a param named pos", m->cc);
+    }
+}
+
+/*
  * An older patch -- every knob a bare cc/target/param/value with none of the
  * fields above -- must load as exactly what it was: one whole-range
  * destination. This is the migration, and it is the absence of code.
@@ -939,6 +980,7 @@ int main(int argc, char **argv) {
 
     test_full_capacity(inst, patch);
     test_knob_destinations(inst, patch);
+    test_knob_param_named_like_a_field(inst, patch);
     test_knob_legacy_rows_are_whole_range(inst, patch);
     test_legacy_two_fx(inst, patch);
     test_hostile_json(inst, patch);

--- a/tests/host/test_chain_patch_roundtrip.c
+++ b/tests/host/test_chain_patch_roundtrip.c
@@ -78,6 +78,28 @@ int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *tar
     (void)inst; (void)target; return 0;
 }
 
+/*
+ * knob_forward_value now routes a modulated parameter through the modulation
+ * bus (a knob turn edits the RESTING value, like any other edit). No case in
+ * this fixture involves a modulated parameter, so "no target is active" is its
+ * honest answer and the behaviour under test is unchanged.
+ */
+int chain_mod_is_target_active(chain_instance_t *inst, const char *target, const char *param) {
+    (void)inst; (void)target; (void)param; return 0;
+}
+void chain_mod_update_base_from_set_param(chain_instance_t *inst, const char *target,
+                                          const char *param, const char *val) {
+    (void)inst; (void)target; (void)param; (void)val;
+}
+mod_target_state_t *chain_mod_find_target_entry(chain_instance_t *inst, const char *target,
+                                                const char *param) {
+    (void)inst; (void)target; (void)param; return NULL;
+}
+void chain_mod_apply_effective_value(chain_instance_t *inst, mod_target_state_t *entry,
+                                     int force_write) {
+    (void)inst; (void)entry; (void)force_write;
+}
+
 int v2_load_synth(chain_instance_t *inst, const char *module_name) {
     snprintf(loaded_synth, sizeof(loaded_synth), "%s", module_name);
     inst->synth_plugin_v2 = &fake_synth_api;

--- a/tests/host/test_chain_patch_roundtrip.sh
+++ b/tests/host/test_chain_patch_roundtrip.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../.."
 
+fail() { echo "FAIL: $1"; exit 1; }
+
 bin="build/tests/test_chain_patch_roundtrip"
 mkdir -p "$(dirname "$bin")"
 
@@ -26,3 +28,23 @@ cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter -Wno-unused-function \
   -o "$bin"
 
 "$bin" "$work"
+
+# ---------------------------------------------------------------- format pin
+#
+# The serializer lives in chain_host.c, which dlopens plugins and so cannot be
+# compiled natively. What matters about it is a property the parser cannot see:
+# an ORDINARY knob must re-save byte-identically to what shipped before
+# destinations existed, or every patch file in the field is rewritten the first
+# time it is touched. That holds only while the new fields are emitted
+# CONDITIONALLY, so the condition is pinned here.
+H=src/modules/chain/dsp/chain_host.c
+command grep -q 'if (km->dests\[di\].lo != 0.0f || km->dests\[di\].hi != 1.0f)' "$H" \
+  || fail "the knob serializer no longer emits lo/hi only for a non-whole-range destination"
+command grep -q 'if (multi) {' "$H" \
+  || fail "the knob serializer no longer emits dest/pos only for a multi-destination knob"
+
+# ...and a truncated array must not be emitted half-written. JSON.parse in the
+# shadow UI throws that into a silent catch, so the knobs would vanish from the
+# saved patch with no error anywhere.
+command grep -q 'return snprintf(buf, buf_len, "\[\]");' "$H" \
+  || fail "the knob serializer no longer answers [] rather than half an array on truncation"

--- a/tests/host/test_chain_reorder_routing.c
+++ b/tests/host/test_chain_reorder_routing.c
@@ -255,9 +255,12 @@ static void add_knob(int cc, const char *target, const char *param, float value)
     knob_mapping_t *k = &inst->knob_mappings[i];
     memset(k, 0, sizeof(*k));
     k->cc = cc;
-    snprintf(k->target, sizeof(k->target), "%s", target);
-    snprintf(k->param, sizeof(k->param), "%s", param);
-    k->current_value = value;
+    snprintf(k->dests[0].target, sizeof(k->dests[0].target), "%s", target);
+    snprintf(k->dests[0].param, sizeof(k->dests[0].param), "%s", param);
+    k->dests[0].lo = 0.0f;
+    k->dests[0].hi = 1.0f;
+    k->dests[0].current_value = value;
+    k->dest_count = 1;   /* a mapping with no destinations is not a mapping */
 }
 
 static knob_mapping_t *knob_by_cc(int cc) {
@@ -287,7 +290,7 @@ static void check_no_dangling(const char *what) {
         rows[n].id = inst->lfos[i].target; rows[n].kind = "an LFO"; n++;
     }
     for (int i = 0; i < inst->knob_mapping_count; i++) {
-        rows[n].id = inst->knob_mappings[i].target; rows[n].kind = "a knob mapping"; n++;
+        rows[n].id = inst->knob_mappings[i].dests[0].target; rows[n].kind = "a knob mapping"; n++;
     }
     for (int i = 0; i < n; i++) {
         const char *id = rows[i].id;
@@ -510,15 +513,15 @@ static void test_knob_mapping_follows(void) {
         char what[96];
         if (!k) { failf("the knob mapping on CC %d disappeared", 71 + i); continue; }
         snprintf(what, sizeof(what), "CC %d (was fx%d) after moving fx6 to fx2", 71 + i, i + 1);
-        EXPECT_STR(k->target, want[i], what);
+        EXPECT_STR(k->dests[0].target, want[i], what);
         snprintf(what, sizeof(what), "CC %d kept its parameter", 71 + i);
         {
             char p[8];
             snprintf(p, sizeof(p), "p%d", i + 1);
-            EXPECT_STR(k->param, p, what);
+            EXPECT_STR(k->dests[0].param, p, what);
         }
         snprintf(what, sizeof(what), "CC %d kept the value the knob was left at", 71 + i);
-        EXPECT_EXACT(k->current_value, 0.1f * (float)(i + 1), what);
+        EXPECT_EXACT(k->dests[0].current_value, 0.1f * (float)(i + 1), what);
     }
     EXPECT_INT(inst->knob_mapping_count, 8, "a move changed how many knobs are mapped");
     check_no_dangling("after a move with a full knob table");
@@ -534,15 +537,15 @@ static void test_knob_mapping_follows(void) {
         knob_mapping_t *k = knob_by_cc(71);
         if (!k) failf("the knob mapping row vanished on a removal");
         else {
-            EXPECT_STR(k->target, "", "the knob still names the position of a deleted module");
-            EXPECT_STR(k->param, "", "the knob kept the deleted module parameter name");
+            EXPECT_STR(k->dests[0].target, "", "the knob still names the position of a deleted module");
+            EXPECT_STR(k->dests[0].param, "", "the knob kept the deleted module parameter name");
         }
         k = knob_by_cc(72);
         if (!k) failf("the second knob mapping vanished");
         else {
-            EXPECT_STR(k->target, "fx7", "the knob behind the deletion did not follow down");
-            EXPECT_STR(k->param, "p8", "the following knob lost its parameter");
-            EXPECT_EXACT(k->current_value, 0.8f, "the following knob lost its value");
+            EXPECT_STR(k->dests[0].target, "fx7", "the knob behind the deletion did not follow down");
+            EXPECT_STR(k->dests[0].param, "p8", "the following knob lost its parameter");
+            EXPECT_EXACT(k->dests[0].current_value, 0.8f, "the following knob lost its value");
         }
     }
     check_no_dangling("after removing a mapped fx6");
@@ -553,14 +556,14 @@ static void test_knob_mapping_follows(void) {
     add_knob(71, "midi_fx6", "m6", 0.66f);
     add_knob(72, "synth", "cutoff", 0.5f);
     chain_reorder_move(inst, 0, 5, 1);
-    EXPECT_STR(knob_by_cc(71)->target, "midi_fx6",
+    EXPECT_STR(knob_by_cc(71)->dests[0].target, "midi_fx6",
                "an AUDIO FX move rewrote a MIDI FX knob mapping");
-    EXPECT_STR(knob_by_cc(72)->target, "synth", "an audio FX move rewrote a synth knob mapping");
+    EXPECT_STR(knob_by_cc(72)->dests[0].target, "synth", "an audio FX move rewrote a synth knob mapping");
 
     /* ...and the MIDI side moves its own. */
     chain_reorder_move(inst, 1, 5, 1);
-    EXPECT_STR(knob_by_cc(71)->target, "midi_fx2", "a MIDI FX move did not carry its knob mapping");
-    EXPECT_EXACT(knob_by_cc(71)->current_value, 0.66f, "the MIDI FX knob lost its value");
+    EXPECT_STR(knob_by_cc(71)->dests[0].target, "midi_fx2", "a MIDI FX move did not carry its knob mapping");
+    EXPECT_EXACT(knob_by_cc(71)->dests[0].current_value, 0.66f, "the MIDI FX knob lost its value");
 }
 
 /* ======================================================================== */
@@ -584,7 +587,7 @@ static void test_refusal_is_inert(void) {
     EXPECT_INT(chain_reorder_insert(inst, 0, -1), 0, "an insert at a negative position was accepted");
 
     EXPECT_STR(inst->lfos[0].target, "fx2", "a refused edit moved an LFO routing");
-    EXPECT_STR(knob_by_cc(71)->target, "fx2", "a refused edit moved a knob mapping");
+    EXPECT_STR(knob_by_cc(71)->dests[0].target, "fx2", "a refused edit moved a knob mapping");
     {
         mod_target_state_t *e = mod_by_param("p2");
         if (!e) failf("a refused edit destroyed a modulation entry");

--- a/tests/host/test_chain_reorder_routing.sh
+++ b/tests/host/test_chain_reorder_routing.sh
@@ -121,16 +121,50 @@ struct_body=$(awk '/^typedef struct chain_instance \{/,/^\} chain_instance_t;/' 
 checked=0
 
 for type in $keyed; do
+  # `|| true`: a type with no DIRECT chain_instance_t member is now a legitimate
+  # case (see the nested branch below), and without this the failing grep in a
+  # command substitution takes the assignment's exit status down with it -- which
+  # under `set -e` ends the script silently, and a silent end reads as a pass.
   members=$(printf '%s\n' "$struct_body" | command grep "^ *$type " \
-    | sed -E "s/^ *$type +([a-z_0-9]+)\[.*/\1/")
-  [ -n "$members" ] || fail "found the position-keyed type $type but no chain_instance_t member of it"
-  for m in $members; do
-    checked=$((checked + 1))
-    command grep -q "inst->$m\[" "$src" || fail \
+    | sed -E "s/^ *$type +([a-z_0-9]+)\[.*/\1/" || true)
+
+  if [ -n "$members" ]; then
+    for m in $members; do
+      checked=$((checked + 1))
+      command grep -q "inst->$m\[" "$src" || fail \
 "chain_instance_t.$m is an array of $type, which names a chain position by \
 string, but chain_reorder.c never walks it. A shape edit will leave every \
 routing in it pointing at whatever module slides into the index it names. \
 Add it to chain_perm_retarget_all."
+    done
+    continue
+  fi
+
+  # No direct member. A position-keyed type may also be reached one level
+  # down -- knob_dest_t lives in an array inside knob_mapping_t, which is the
+  # chain_instance_t member. Being nested makes it no less position-keyed:
+  # every one of those destinations names a chain position by string too, and
+  # a walk that only ever touched index 0 would leave the rest aimed at
+  # whatever slid into their index.
+  inner=$(command grep -E "^ *$type +[a-z_0-9]+\[" "$hdr" \
+    | sed -E "s/^ *$type +([a-z_0-9]+)\[.*/\1/" | sort -u)
+  [ -n "$inner" ] || fail "found the position-keyed type $type but no member of it anywhere in $hdr"
+
+  for m in $inner; do
+    checked=$((checked + 1))
+    # The walk must index it, and must not stop at the first one: a literal
+    # [0] and nothing else is exactly the shape that reads as handled.
+    command grep -q "\.$m\[" "$src" || command grep -q -- "->$m\[" "$src" || fail \
+"$type is nested as .$m[] inside a chain_instance_t member, and names a chain \
+position by string, but chain_reorder.c never indexes it. Add it to \
+chain_perm_retarget_all."
+    # A NON-NUMERIC subscript. `[a-z_0-9]+` would have accepted the literal
+    # `[0]` this check exists to reject, which is the whole failure it guards
+    # against -- it passed a deliberately-broken walk when first written.
+    if [ "$(command grep -c -E "[.>]$m\[[a-z_][a-z_0-9]*\]" "$src" || true)" -eq 0 ]; then
+      fail "chain_reorder.c only ever reaches .$m[] at a literal index, so it \
+walks one entry and leaves the others pointing at a renumbered position."
+    fi
   done
 done
 

--- a/tests/host/test_knob_dest_list.sh
+++ b/tests/host/test_knob_dest_list.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# A knob's destination list, RUN rather than grepped.
+#
+# node --check is the wrong gate for shadow_ui.js -- it passes JavaScript that
+# kills the UI at eval -- and a source pin cannot tell a row list that is right
+# from one that is one row short. So the real functions are lifted and driven.
+#
+# It also pins MAX_KNOB_DESTS against the C header. A JS copy that drifted high
+# would offer a destination the DSP silently refuses, which reads as a dead row
+# rather than as an error.
+
+if ! command -v node >/dev/null 2>&1; then echo "FAIL: node required" >&2; exit 1; fi
+
+node --input-type=module -e '
+import { readFileSync } from "node:fs";
+const src = readFileSync("src/shadow/shadow_ui.js", "utf8");
+const hdr = readFileSync("src/modules/chain/dsp/chain_internal.h", "utf8");
+
+let failures = 0;
+const fail = (m) => { console.error("FAIL: " + m); failures++; };
+const check = (c, m) => c ? console.log("  ok  " + m) : fail(m);
+
+/* ---- the cap must match the header ---- */
+const cHit = hdr.match(/#define\s+MAX_KNOB_DESTS\s+(\d+)/);
+const jsHit = src.match(/const\s+MAX_KNOB_DESTS\s*=\s*(\d+)\s*;/);
+if (!cHit) fail("MAX_KNOB_DESTS is gone from chain_internal.h");
+if (!jsHit) fail("MAX_KNOB_DESTS is gone from shadow_ui.js");
+if (cHit && jsHit) {
+  check(cHit[1] === jsHit[1],
+        `the JS destination cap (${jsHit && jsHit[1]}) matches the C one (${cHit && cHit[1]})`);
+}
+
+/* ---- lift the list, its labels and its gestures as ONE block: they share
+       module state (knobDestIndex, knobDestEditing), and lifted separately
+       each would close over its own copy and none would see the others. ---- */
+const NAMES = ["knobDestRows", "knobDestRowLabel", "knobDestRowValue",
+               "knobDestWriteWindow", "knobDestListTurn", "knobDestListClick",
+               "knobRowLabel", "knobDestIsRanged", "knobWindowLabel",
+               "getKnobAssignmentLabel"];
+let body = "";
+for (const n of NAMES) {
+  const at = src.indexOf("function " + n + "(");
+  if (at < 0) { fail(n + " is gone"); continue; }
+  const end = src.indexOf("\n}\n", at);
+  if (end < 0) { fail("no end for " + n); continue; }
+  body += src.slice(at, end + 2) + "\n";
+}
+if (failures) process.exit(1);
+
+const writes = [];
+const world = () => {
+  const state = {
+    knobEditorIndex: 0,
+    knobEditorSlot: 0,
+    knobDestIndex: 0,
+    knobDestEditing: null,
+    knobEditorDests: [],
+    knobEditorAssignments: [],
+    knobEditorDestIndex: 0
+  };
+  const mk = new Function(
+    "MAX_KNOB_DESTS", "setSlotParam", "announce", "announceMenuItem",
+    "enterKnobParamPicker", "setView", "VIEWS", "loadKnobAssignments",
+    "fetchKnobMappings", "invalidateKnobContextCache", "state",
+    `
+    let { knobEditorIndex, knobEditorSlot, knobDestIndex, knobDestEditing,
+          knobEditorDests, knobEditorAssignments, knobEditorDestIndex } = state;
+    let needsRedraw = false;
+    ${body}
+    return {
+      rows: () => knobDestRows(),
+      label: (r) => knobDestRowLabel(r),
+      value: (r) => knobDestRowValue(r),
+      knobRowLabel: (i) => knobRowLabel(i),
+      turn: (d) => knobDestListTurn(d),
+      click: () => knobDestListClick(),
+      setDests: (d) => { knobEditorDests = d; },
+      cursor: () => knobDestIndex,
+      setCursor: (i) => { knobDestIndex = i; },
+      editing: () => knobDestEditing,
+      dests: () => knobEditorDests,
+      destIndex: () => knobEditorDestIndex
+    };`);
+  return mk(4,
+    (slot, key, val) => writes.push(key + "=" + val),
+    () => {}, () => {}, () => { writes.push("PICKER"); },
+    () => {}, { KNOB_EDITOR: "knobedit", KNOB_DEST_LIST: "knobdests" },
+    () => {}, () => {}, () => {}, state);
+};
+
+const THREE = [
+  { target: "synth", param: "cutoff", lo: 0, hi: 1 },
+  { target: "fx1", param: "mix", lo: 0.2, hi: 0.8 },
+  { target: "fx2", param: "drive", lo: 1, hi: 0 }
+];
+
+/* ---- the rows ---- */
+let w = world();
+w.setDests([THREE]);
+let rows = w.rows();
+check(rows.length === 3 * 3 + 2,
+      "three destinations give three rows each, plus Add and Remove (" + rows.length + ")");
+check(rows[0].kind === "dest" && rows[1].kind === "lo" && rows[2].kind === "hi",
+      "each destination is followed by its own Lo and Hi");
+check(rows[rows.length - 1].kind === "remove", "Remove knob is last");
+check(w.value(rows[0]) === "synth: cutoff", "a destination row shows what it drives");
+check(w.value(rows[4]) === "20%" && w.value(rows[5]) === "80%", "its window reads as percentages");
+check(w.value(rows[7]) === "100%" && w.value(rows[8]) === "0%",
+      "an INVERTED window is shown high-to-low, the way it behaves");
+
+/* At the cap there is no Add row -- offering one the DSP would refuse reads as
+   a dead row rather than as a limit. */
+w = world();
+w.setDests([[...THREE, { target: "synth", param: "res", lo: 0, hi: 1 }]]);
+check(!w.rows().some((r) => r.kind === "add"),
+      "at the destination cap the Add row is gone");
+
+/* ---- the knob list label ---- */
+w = world();
+w.setDests([THREE]);
+check(w.knobRowLabel(0) === "cutoff +2",
+      "a multi-destination knob says what it DRIVES, not what it is");
+w.setDests([[{ target: "synth", param: "cutoff", lo: 0, hi: 1 }]]);
+check(w.knobRowLabel(0) === "synth: cutoff", "one whole-range destination reads exactly as before");
+w.setDests([[{ target: "synth", param: "cutoff", lo: 0, hi: 0.5 }]]);
+check(w.knobRowLabel(0) === "synth: cutoff ~", "one RANGED destination is marked");
+
+/* ---- adjusting a window applies on every detent ---- */
+w = world();
+w.setDests([THREE]);
+w.setCursor(1);              /* the Lo row of destination 1 */
+w.click();
+check(w.editing() !== null, "clicking Lo starts adjusting it");
+writes.length = 0;
+w.turn(5);
+check(writes.length === 1 && writes[0].startsWith("knob_1_dest_1_range="),
+      "a detent writes the window immediately, not on leaving the row");
+check(w.dests()[0][0].lo > 0.049 && w.dests()[0][0].lo < 0.051,
+      "1% a detent -- a window is a boundary you land on, not a value you dial");
+w.click();
+check(w.editing() === null, "clicking again finishes");
+
+/* ---- clicking a destination row re-points THAT destination ---- */
+w = world();
+w.setDests([THREE]);
+w.setCursor(6);              /* destination 3 */
+writes.length = 0;
+w.click();
+check(writes.includes("PICKER"), "clicking a destination opens the picker");
+check(w.destIndex() === 2,
+      "and seeds it from the destination being edited -- opening destination 3 on "
+      + "destination 1 would read as a wrong answer, never as an error");
+
+/* ---- Add ---- */
+w = world();
+w.setDests([THREE]);
+w.setCursor(9);              /* + Add destination */
+w.click();
+check(w.destIndex() === 3, "Add aims the picker past the end of the list");
+
+if (failures) { console.error("\n" + failures + " check(s) failed"); process.exit(1); }
+console.log("\nPASS: a knob'"'"'s destination list");
+'

--- a/tests/host/test_knob_dest_list.sh
+++ b/tests/host/test_knob_dest_list.sh
@@ -38,7 +38,7 @@ if (cHit && jsHit) {
        each would close over its own copy and none would see the others. ---- */
 const NAMES = ["knobDestRows", "knobDestRowLabel", "knobDestRowValue",
                "knobDestWriteWindow", "knobDestListTurn", "knobDestListClick",
-               "knobRowLabel", "knobDestIsRanged", "knobWindowLabel",
+               "knobRowLabel", "knobDestIsRanged",
                "getKnobAssignmentLabel"];
 let body = "";
 for (const n of NAMES) {

--- a/tests/host/test_knob_picker_level_entry.sh
+++ b/tests/host/test_knob_picker_level_entry.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# Which level the knob parameter picker enters, RUN rather than grepped.
+#
+# "root" is a convention, not a guarantee. A mode-based module names its top
+# levels after its modes and has no `root` at all, and asking the hierarchy for
+# a level that does not exist returns nothing -- so the picker showed an EMPTY
+# parameter list for every such module. Found on hardware: a mode-based synth
+# offered nothing while a root-based one beside it was fine.
+
+if ! command -v node >/dev/null 2>&1; then echo "FAIL: node required" >&2; exit 1; fi
+
+node --input-type=module -e '
+import { readFileSync } from "node:fs";
+const src = readFileSync("src/shadow/shadow_ui.js", "utf8");
+let failures = 0;
+const fail = (m) => { console.error("FAIL: " + m); failures++; };
+const check = (c, m) => c ? console.log("  ok  " + m) : fail(m);
+
+function lift(name) {
+  const at = src.indexOf("function " + name + "(");
+  if (at < 0) { fail(name + " is gone"); return ""; }
+  const end = src.indexOf("\n}\n", at);
+  if (end < 0) { fail("no end for " + name); return ""; }
+  return src.slice(at, end + 2);
+}
+const body = lift("findFirstParamLevel");
+if (failures) process.exit(1);
+const findFirstParamLevel = new Function(body + "\nreturn findFirstParamLevel;")();
+
+/* Root-based, with a preset browser in front of the params: unchanged
+   behaviour, and the reason the walk exists at all. */
+const rootBased = { modes: null, levels: {
+  root: { list_param: "preset", count_param: "preset_count", children: "main" },
+  main: { params: [{ key: "cutoff" }] }
+}};
+check(findFirstParamLevel(rootBased) === "main",
+      "a preset browser at root is skipped, as it always was");
+
+const flatRoot = { levels: { root: { params: [{ key: "gain" }] } } };
+check(findFirstParamLevel(flatRoot) === "root", "a root that holds params is entered directly");
+
+/* Mode-based, no root at all -- the case that showed an empty picker. Its
+   entry is the first declared mode, and the walk then follows two preset
+   browsers down to the parameters. */
+const modeBased = { modes: ["patch", "performance", "system"], mode_param: "mode", levels: {
+  patch:      { list_param: "bank_list", children: "patch_list", params: [] },
+  performance:{ list_param: "bank_list", children: "perf_list", params: [] },
+  patch_list: { list_param: "patch", children: "patch_main", params: [] },
+  perf_list:  { list_param: "performance", children: "perf_main", params: [] },
+  patch_main: { params: [{ key: "cutoff" }, { key: "resonance" }] },
+  system:     { params: [] }
+}};
+check(findFirstParamLevel(modeBased) === "patch_main",
+      "a mode-based module lands on its parameters, not on a level that does not exist");
+
+/* No root and no modes: take the first level there is rather than a name
+   nothing declared. */
+const noRootNoModes = { levels: { alpha: { params: [{ key: "a" }] }, beta: { params: [] } } };
+check(findFirstParamLevel(noRootNoModes) === "alpha",
+      "with neither root nor modes, the first declared level is entered");
+
+/* Degenerate inputs answer something harmless rather than throwing. */
+check(findFirstParamLevel(null) === "root", "a missing hierarchy answers root");
+check(findFirstParamLevel({}) === "root", "a hierarchy with no levels answers root");
+
+/* The safety net: even if the entered level yields nothing, the picker falls
+   back to the all-levels scan instead of showing an empty list. */
+check(/knobParamPickerParams\.length === 0/.test(src) &&
+      /knobParamPickerParams = getKnobParamsForTarget\(knobEditorSlot, selected\.id\);/.test(src),
+      "an empty level falls through to the all-levels scan rather than showing nothing");
+
+if (failures) { console.error("\n" + failures + " check(s) failed"); process.exit(1); }
+console.log("\nPASS: the knob picker enters a level that exists");
+'

--- a/tests/host/test_relative_cc.sh
+++ b/tests/host/test_relative_cc.sh
@@ -30,8 +30,17 @@ grep -q '#include "relative_cc.h"' "$midi" \
   || fail "chain_midi.c no longer includes relative_cc.h"
 grep -q 'relative_cc_ticks(' "$midi" \
   || fail "the relative CC path no longer decodes through relative_cc_ticks()"
-grep -q 'relative_cc_multiplier(' "$midi" \
-  || fail "the relative CC path no longer scales through relative_cc_multiplier()"
+# The scaling moved into knob_turn (chain_params.c) when a knob became able to
+# drive several destinations, so chain_midi.c decodes and delegates. Both ends
+# are still required: a decode that reached a hand-rolled scale, or a delegation
+# that lost the decode, would each pass a check on only one of them.
+params=src/modules/chain/dsp/chain_params.c
+grep -q 'knob_turn(inst, i, ticks,' "$midi" \
+  || fail "the relative CC path no longer hands its decoded detents to knob_turn()"
+grep -q 'relative_cc_multiplier(' "$params" \
+  || fail "knob_turn no longer scales through relative_cc_multiplier()"
+grep -q '#include "relative_cc.h"' "$params" \
+  || fail "chain_params.c no longer includes relative_cc.h"
 
 # A SECOND decode is the failure mode worth naming: the original bug was a
 # hand-rolled two-branch decode inline here, and the fix is only a fix while


### PR DESCRIPTION
# One knob, several destinations — each through its own window

**#347 proposes the same feature.** This is built to converge with it: it takes
#347's flat patch rows, its acceleration helper and its four-destination cap,
and arrives on current `main` so the change can be read on its own.

There is **one deliberate difference** — the model — and it is a musical
question rather than a technical one. Everything else here is the same idea or
groundwork for it.

## Three commits stand alone — take them without the rest

Each of these is a bug on `main` today, none of them changes how an ordinary
knob feels, and each can be taken independently of the destinations work. They
are first in the series so they can be cherry-picked or merged on their own if
you would rather land them separately.

**1. `chain: a knob turn is an EDIT of the resting value, not a write past the LFO`**

Assign a chain knob to a parameter a slot LFO is driving and the knob reads as
dead — or moves and snaps back a frame later.

The modulation bus holds a **base** per modulated target and rewrites
`base + contribution` into the plugin on every tick. That is why the prefixed
`synth:` / `fxN:` / `midi_fxN:` `set_param` routes update the base *first*, so an
edit sticks and the wobble follows it — the contract #276 established.
`knob_forward_value` never joined in: it called the plugin's `set_param`
directly and told the bus nothing, so the next tick recomputed from the stale
base and overwrote the turn within milliseconds. The fix is the prefixed route's
own three lines, in the one place every chain-knob path already funnels through.
Realtime-safe: the added call is the one those routes already make on this
thread, and it allocates nothing.

**2. `chain: one knob-turn acceleration curve, not three copies that disagree`**

Three paths turn a chain knob — the relative CC decode and the absolute CC in
`chain_midi.c`, and `knob_N_adjust` in `chain_host.c`. Each carried its own copy
of the time-based acceleration curve, and two had drifted into different shapes:

```
chain_midi.c   if (elapsed <  SLOW) { if (elapsed <= FAST) MAX; else ratio }
chain_host.c   if (elapsed <= FAST) MAX; else if (elapsed < SLOW) ratio
```

They compute the same answer, which is exactly why nobody noticed. Neither TU
can be compiled natively, so no test could ever have said whether they agreed —
that asymmetry is why `relative_cc.h` exists, and this follows it: the
arithmetic moves somewhere testable and the call sites ask for it.

**No behaviour change**, verified by compiling the old and new arithmetic side
by side and comparing at every millisecond gap from 0 to 400, including the
first-message case. The destinations work later builds on this extraction, but
the commit is worth having without it.

**3. `shadow_ui: the knob picker asked for a level that need not exist`**

Pick a **mode-based** module as a knob target and the parameter list is empty.

`"root"` is a convention, not a guarantee: a module with modes names its top
levels after them and has no `root` at all. `findFirstParamLevel` started its
walk there, the skip-the-preset-browser loop never ran, and the picker asked for
a level that does not exist — so every mode-based module was silently
unassignable to a chain knob. An empty list reads as "this module exposes
nothing", not as "we asked the wrong question". The walk now starts at `root`
when there is one, otherwise the first declared mode, otherwise the first level
there is; and a hierarchy that parses but yields nothing falls through to
`getKnobParamsForTarget`, the all-levels scan beside it that would have found
these parameters immediately but was reachable only when the hierarchy failed to
parse. Entirely independent of everything else here.

## The difference: an amount, or a window?

**#347 gives each destination a signed amount.** The macro is a modulation
source on the existing bus, so the knob at rest does nothing and each parameter
keeps its own value; turning up adds to it. That composes with the LFOs for
free, and the knob can never fight one.

**This gives each destination a window** — `lo`/`hi` as fractions of that
parameter's own range. "Cutoff sweeps exactly 20% to 60%." `lo > hi` is an
inverted destination, an enum takes a sub-range of its option list.

The two cannot be combined, and it is worth seeing why: *"this parameter ends at
exactly 60%"* and *"your hand-set value is preserved"* are contradictory claims
about the same parameter. Exact endpoints mean the macro owns it. **So the model
also picks the mechanism** — amounts want the modulation bus, windows want
writes.

What the window costs, stated so nobody has to rediscover it: the parameter
keeps its full travel when edited directly, but the macro takes it back inside
the window on the next turn. With one destination that barely shows, because
such a knob follows its parameter. With several, the first is followed and the
others are pulled into line. That is inherent to one knob imposing one position
on several parameters.

This model has been in daily use on a module in this ecosystem for a week, so
the trade above is described from experience rather than predicted. Both models
are defensible and only one can ship; the window is what this implements, and
if amounts are preferred the change back is small.

## The secondary difference: one destination is the ordinary case

#347 makes a knob *simple* or *macro*, switched through a picker with a confirm,
discarding the other mode's state. Here there is one model in which a single
destination is the degenerate case — so a knob gains a second destination
without a mode switch or state loss, and a single destination can still be given
a window.

That matters for one reason worth spelling out:

> **The line is "several destinations", not "has a range".**

A knob with ONE destination stays on the path that ships today plus a clamp,
keeping that parameter's own step, acceleration and enum feel. Only a knob with
SEVERAL is driven by the knob's own 0..1 position. This is arithmetic, not
taste: an 8-option enum spans 7 units, so a position moving by the float step
shifts it ~0.01 per detent — `4 -> 4.0105 -> (int) 4`, the same value — needing
~95 detents per option instead of one. A parameter that shares a knob pays that
by necessity; one that does not must never be made to, which is why giving a
single destination a window does not move it onto the position path.
`test_chain_knob_turn` measures both cases side by side rather than asserting it.

## What is deliberately the same as #347

- Up to four destinations per knob.
- **Flat patch rows** — several ordinary objects sharing one `cc`, merged on
  load. Reached independently, for the same reason: this parser walks the array
  by scanning for braces, so nesting would break every build in the field.
- The acceleration helper, and its name.

## On the device

CC 102-109 carry **where the knob sits across its own travel**: its position for
a multi-destination knob, that parameter's value across its own window for a
single one. With one whole-range destination that reduces to exactly today's
arithmetic, so no existing rig changes.

Clicking an assigned knob opens its destination list — destinations, a Lo and Hi
under each, add and remove. A window applies **as it is set**, because a window
is adjusted by ear and one you cannot hear until the next turn is one you are
setting blind. An unassigned knob still goes straight to the picker.

The touched-knob card needed no change: `knob_N_name` answers `cutoff +2` and
`knob_N_value` the position, and the card already reads exactly those two keys —
so no extra IPC read on the path `test_knob_card_open_budget` counts.

## Honest limits

- **An older host can parse one of these patches but not round-trip one.** Its
  parser stops after `MAX_KNOB_MAPPINGS` *mappings* and each row is a mapping to
  it, so a four-destination knob plus seven ordinary ones loads eight rows and a
  save there deletes the rest. Documented in `docs/CHAIN.md`; there is no fix on
  this side. An ordinary patch is byte-identical, so only patches that use the
  feature are affected.
- **A stepped multi-destination window has up to half a step of dead travel at
  each end**, because the window's edges are the whole steps inside it. That is
  the price of a window having the same edges however many destinations share
  the knob.
- `(int)(v + 0.5f)` truncates toward zero, so the bottom of a signed parameter
  is a step out of reach through absolute CC. **Pre-existing and deliberately
  left alone** — correcting it would shift every inbound CC value by one step on
  every signed parameter, which does not belong in this change.

## Notes on the standalone fixes

Four existing fixtures gain stubs for the modulation symbols `chain_params.c`
now references. They answer "no target is active", which is those fixtures'
honest state and leaves the behaviour they test unchanged.

`tests/host/test_chain_patch_roundtrip.sh` had no `fail()` helper, so a failing
source pin died with `fail: command not found` rather than a message. Defined.

The two knob paths also disagree on the fallback base step for a parameter that
declares none — `KNOB_STEP_FLOAT` (0.0015) against `0.01f`, a 6.7x difference on
the same parameter. Either value is a behaviour change for somebody, so it is
recorded in a comment rather than picked silently. Happy to follow up if you
have a view.

## Test plan

- `make -C tests/host test` and all `tests/host/*.sh` green; the pre-existing
  suite is the control for "an ordinary knob is unchanged".
- Old and new arithmetic compiled side by side and compared at every step of
  every sweep — float, int, enum, signed and wide ranges, both call sites'
  fallbacks — for the turn, for CC in and out, and for the acceleration curve.
  That comparison caught a real regression: a whole-range window's clamp made
  the bottom of a `-64..63` parameter unreachable.
- The one silent data-loss path — the chain editor rebuilding the knob array
  from what it shows — is mutation-tested in both directions.
- Built for ARM and installed on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AAm718kmDm3uZLAe85up1g
