### PR TITLE
Module draw surfaces: several widgets, a card that sees the page, and pages a module owns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,6 +533,27 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   was pixel-identical to a control.
 - A momentary fires from the knob too, **latched per gesture** — a rate limit
   still fires eight times across a two-second spin.
+- **A widget can NAME a value that has no cell** — `viz.extra_keys`, capped at
+  four, one read stop each. Before it, the only way to get a fact to a widget
+  was to give it a knob, which is how a module shipped a read-only cell whose
+  whole job was carrying a number to the cell beside it.
+- **A module can own a PAGE (`as_page`), and it is a PAGE_KNOBS page with a
+  drawer, NOT a new kind.** That is what makes the encoders work with no input
+  code and the reads happen at all: 22 controller branches test PAGE_KNOBS, and
+  threading a new kind through every one is how you get a page that looks right
+  and does not respond. Three gates now ask `pageHasKnobs` — "does it have
+  keys" — instead. `preset_browser` makes such a page the level's BROWSER, so a
+  picture replaces a row of text; it must tick BOTH lanes, because a preset page
+  returns early after its own. **The branch belongs in BOTH renderers** —
+  `render_page_movy` is the one the device uses, and a version only in
+  `render_page.mjs` is correct everywhere except on hardware.
+- **`"live": true` says the MODULE drives this param**, so `:effective` is
+  re-read every tick instead of on the rotation (which comes round ~4x/sec — an
+  animation drawn from that is a slideshow). Two traps behind it: the chain host
+  OWNED `:effective` and, for a key it was not modulating, asked the plugin for
+  the PLAIN key, so a module serving its own driven value was never asked; and
+  **the shim skips `render_block` on a silent slot** (one probe frame in 172),
+  so an effective value computed there looks frozen until something plays.
 - **A module may declare SEVERAL widgets, and for a long time exactly one
   registered.** The registry was always a Map; the single call site read
   `ov.widgetKind`, one *string*, so a second declared kind was dropped — and a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -533,6 +533,21 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   was pixel-identical to a control.
 - A momentary fires from the knob too, **latched per gesture** — a rate limit
   still fires eight times across a two-second spin.
+- **A module may declare SEVERAL widgets, and for a long time exactly one
+  registered.** The registry was always a Map; the single call site read
+  `ov.widgetKind`, one *string*, so a second declared kind was dropped — and a
+  dropped kind is not an error, it falls through to a built-in dial. Correct
+  page, no log line. `widgetKinds` takes an ARRAY (several names, one
+  `drawCell`, told apart by `group.keys[0]`) or an OBJECT (a drawer and a
+  nominal each); the rule lives in `registerOverlayWidgets`, beside the
+  registry, so `tests/host/` can run it, and an unusable declaration is LOGGED
+  rather than dropped.
+- **A card is handed the PAGE's values, not only its own.** The payload is
+  `{w, h, name, value, raw, values, nowMs}`. A card whose meaning depends on a
+  sibling — the vowel of *which* character — otherwise had no route to it at
+  all: no `getParam` on that path, and the card script is its own closure, so it
+  cannot see what the module's `drawCell` set. The first module to need it used
+  `globalThis` and a staleness stamp, which worked and was a side channel.
 - **A module's OTHER draw surface is a CARD, and it FLOATS.** `drawCell` gives it
   one cell; `card_script` gives it the page — a bordered picture raised while a
   knob is held, gone on release. It is centred in the page's **FRAME**, not on

--- a/docs/CHAIN.md
+++ b/docs/CHAIN.md
@@ -64,6 +64,22 @@ shows the LFO's number and the knob reads as dead (#276). A UI that wants the
 driven value asks for `:effective` by name; the plugin itself is not the place
 to ask, since it holds whatever effective value the overlay last wrote.
 
+**`:effective` ON AN UNMODULATED KEY REACHES THE PLUGIN.** The chain owns the
+suffix and answers from its own table while a source is routed. When none is,
+it used to strip `:effective` and ask the plugin for the PLAIN key — which is
+right only if the chain is the sole thing that can move a parameter, and it is
+not. A synth driving its own value (MonkSynth sweeps its vowel from pad
+pressure) serves `<key>:effective` itself, and that answer was being thrown
+away: the suffix consumed, the plain key asked, the knob's value returned. Every
+picture of that parameter sat still while the sound moved.
+
+It now asks the plugin **by name first** and falls back to the plain key only on
+a miss, so a module that has never heard of the suffix is unaffected. An empty
+answer counts as a miss — an unserved key comes back as an empty buffer, and
+taking that for a value would blank the reading. See `"live": true` in
+`docs/MODULES.md` for the UI half: it is what makes the host ask often enough
+for the answer to be worth serving.
+
 ### `synth:last_note` — the chain host's own key, and why it is a NOTE
 
 **`synth:last_note`** — the MIDI note last played *into* the synth,

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2012,6 +2012,37 @@ globalThis.canvas_overlay = {
 };
 ```
 
+##### Declaring more than one widget
+
+A module may supply several widgets. `widgetKind` is the single-widget spelling
+and is unchanged; `widgetKinds` is the plural, in either of two forms:
+
+```javascript
+globalThis.canvas_overlay = {
+    /* several names, ONE drawer -- right when they are one drawing at two
+     * crops, told apart by group.keys[0] */
+    widgetKinds: ["custom:face", "custom:mouth"],
+    drawCell(ctx, { values, group }) { /* branch on group.keys[0] */ },
+};
+```
+
+```javascript
+globalThis.canvas_overlay = {
+    /* a drawer EACH -- right when the widgets are unrelated, and the only form
+     * that lets each carry its own nominal */
+    widgetKinds: {
+        "custom:meter": (ctx, o) => { /* ... */ },
+        "custom:mode":  { draw(ctx, o) { /* ... */ }, nominal: { w: 17, h: 15 } },
+    },
+};
+```
+
+Both forms may be combined with `widgetKind`. A kind that cannot be registered —
+no drawer, or a name outside the `custom:` namespace — is **named in
+`debug.log`** rather than dropped: a declared widget that never registers falls
+through to a built-in, which looks completely correct, so the log line is the
+only way to find out the picture is not yours.
+
 **What you can draw with.** The frame context carries `fillRect`, `print`,
 `textWidth`, `setPixel`, `line`, `fillCircle`, `drawCircle` and `drawArc`. All of
 them are always present — they are implemented on the frame's own clipped
@@ -2079,10 +2110,12 @@ eight knob boxes: per-pixel blitting would cost ~1 ms of the 1.68 ms page render
 ##### The reference module
 
 `src/modules/audio_fx/widget-test/` is a working example of **all three**
-module-supplied surfaces on one parameter: `canvas.js` supplies the `drawCell`
-segmented meter and the fullscreen `draw`, `cards.js` supplies the card that
-floats while the knob turns, and a passthrough DSP makes it a real, loadable
-chain FX.
+module-supplied surfaces: `canvas.js` supplies the `drawCell` segmented meter on
+`level`, a SECOND widget kind on `mode` (through `widgetKinds`, to show that one
+module may declare several), and the fullscreen `draw`; `cards.js` supplies the
+card that floats while `level` turns — and that card reads `mode` out of
+`o.values`, which is the worked example of a card whose meaning lives on another
+parameter. A passthrough DSP makes it a real, loadable chain FX.
 
 Its card is also the reference for the null contract: `raw` may be null, and the
 drawer prints `--` with **no bar** rather than a bar at zero, because a bar at
@@ -2154,6 +2187,19 @@ the wire value — **and `o.raw` may be `null`**, meaning the module did not ans
 that read. Draw a word and stop when it does; a read that did not answer must
 never become a picture. There is no `getParam` on this path (~2.8 ms, against a
 1.68 ms whole-page render).
+
+**You also get the rest of the page.** `o.values` is the page's value map — the
+same object a cell widget is handed — for a card whose meaning depends on a
+sibling: the vowel of *which* character, a ratio against *which* base, a time in
+*whose* clock division. `o.nowMs` is a wall clock, for a card that animates
+during the gesture that raised it. The null rules are identical: a sibling may
+be missing or `null`, and an absent one must not become a picture either.
+
+Without `o.values` such a card had no route to that fact at all — no `getParam`
+here, and the card script is loaded into its own closure, so it cannot see a
+variable the module's own `drawCell` set. The first module to need it went
+through `globalThis` with a staleness timestamp, which worked and was a hidden
+side channel between two files the contract said were unrelated.
 
 **One strike.** A drawer that throws is retired for the session, the card is
 left as an empty frame rather than a hole, and the parameter goes back to

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -48,7 +48,15 @@ Optional fields: `description`, `author`, `ui`, `ui_chain`, `dsp`, `defaults`, `
 - `abbrev`: Short display name (3-6 chars) for Shadow UI slot display (e.g., "SF2", "Dexed", "CLAP")
 - `module.json` is parsed by a minimal JSON reader. Use double quotes for keys, lowercase `true`/`false`, and avoid comments.
 - Keep `module.json` reasonably small (the loader caps it at 8KB).
-- `dsp`: any filename inside the module directory. The host loads whatever path you specify here, so `dsp.so`, `<module-id>.so`, or anything else is fine for standalone modules. **Exception — `audio_fx` modules used inside Signal Chain:** the chain host loads the FX directly as `modules/audio_fx/<id>/<id>.so` (it does not consult the FX's `module.json`), so audio FX shared libraries **must** be named `<module-id>.so`. Sound generators and MIDI sources loaded by the chain are hardcoded to `dsp.so`.
+- `dsp`: any filename inside the module directory — **but only for the standalone/menu load**, which is the only path that reads this field (`module_manager.c`). **Inside Signal Chain the chain host builds the path itself and never consults `module.json`**, using a different rule per component type:
+
+  | `component_type` | What the chain host opens | Source |
+  |---|---|---|
+  | `sound_generator` | `modules/sound_generators/<id>/**dsp.so**` | `chain_host.c` |
+  | `midi_fx` | `modules/midi_fx/<id>/**dsp.so**` | `chain_midi.c` |
+  | `audio_fx` | `modules/audio_fx/<id>/**<module-id>.so**` | `chain_host.c` |
+
+  Get it wrong and the module does not load, with **no error on screen** — the only symptom is one line in `debug.log`: `dlopen failed: ... cannot open shared object file`. The failure mode is worth stating because the rules differ: copying an audio FX's build script to make a sound generator produces `<id>.so`, which is correct for the template and silently wrong for the copy. Set `dsp` to match whichever name your type requires, so the two agree.
 
 ### Capabilities
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2051,6 +2051,55 @@ no drawer, or a name outside the `custom:` namespace — is **named in
 through to a built-in, which looks completely correct, so the log line is the
 only way to find out the picture is not yours.
 
+##### A widget that needs a value with no cell on the page
+
+A widget is handed the page's value map and cannot read. So a picture that
+depends on a value with **no cell on this page** — the vowel of *which*
+character, a ratio against *which* base — has to name it:
+
+```json
+{ "key": "vowel", "type": "float", "min": 0, "max": 1,
+  "viz": { "kind": "custom:mouth", "extra_keys": ["face"] } }
+```
+
+The controller adds each to its value rotation as one extra stop and hands it
+over in `values`, exactly like a key that does have a cell.
+
+**One read per stop, so declare what the picture needs and nothing else.**
+Capped at four: a cell asking for twenty would spend the page's whole read
+budget and starve every other value on screen. An unavailable custom kind
+contributes none, since its group is abandoned whole.
+
+Without this the only way to get a fact to a widget was to give it a knob —
+which is how a module ended up shipping a read-only cell that existed purely to
+carry a number to the cell beside it.
+
+##### A parameter the module drives itself
+
+A knob is not always the only thing moving a parameter. A synth that sweeps its
+own vowel from pad pressure, a step sequencer walking its own position — the
+picture of that value should follow what it is *doing*, not where its knob was
+left.
+
+```json
+{ "key": "vowel", "type": "float", "min": 0, "max": 1, "live": true }
+```
+
+`live` buys the treatment a chain-modulated key already gets: the module is
+asked for `<key>:effective` **every tick**, rather than on the value rotation,
+and graphics are handed base-merged-with-effective. The rotation comes round
+about four times a second on an eight-knob page, and an animation drawn from
+that is a slideshow — the per-tick refresh is the entire point.
+
+Serve `<key>:effective` from your `get_param`, and `<key>:base` too if you want
+to save the host a fallback read. `values` stays the BASE everywhere a value is
+edited, because that is what a turn changes.
+
+**A silent slot is barely rendered.** The shim skips `render_block` on a slot
+making no sound — one probe frame in 172 — so an effective value computed inside
+`render_block` will appear frozen until something plays. Compute it from state
+your `set_param` already holds.
+
 **What you can draw with.** The frame context carries `fillRect`, `print`,
 `textWidth`, `setPixel`, `line`, `fillCircle`, `drawCircle` and `drawArc`. All of
 them are always present — they are implemented on the frame's own clipped
@@ -2145,6 +2194,65 @@ under `src/modules/`, so a fixture also has to be scrubbed from `build/` when
 the gate is off. A `module.json` shipped without its `.so` still appears in the
 FX picker, and a chain slot pointing at a module that cannot load is restored on
 every boot. `tests/host/test_test_fixtures_not_shipped.sh` pins both halves.
+
+#### Custom UI pages (`as_page`)
+
+A `type: "canvas"` param is a CELL you click to dive into a fullscreen view.
+Add `as_page` and it becomes a **page in the level's jog rotation** instead,
+carrying that level's own knobs:
+
+```json
+{ "key": "face", "name": "Face", "type": "canvas",
+  "canvas_script": "canvas.js", "as_page": true, "show_value": false }
+```
+
+```javascript
+globalThis.canvas_overlay = {
+    drawPage(ctx, { values, base, keys, touched, nowMs, preset }) {
+        /* ctx is frame-scoped to the BODY BAND. (0,0) is its top-left. */
+    },
+};
+```
+
+- **It is reached by paging, not by diving**, and the canvas key gets no cell of
+  its own — so it does not also appear as an orphan overflow page.
+- **The eight encoders work**, doing exactly what they do on that level's grid.
+  You write no input code: the page carries the same keys.
+- **It animates.** The host redraws every tick and the page's keys are already
+  in the read rotation, so `values` is fresh at no extra cost. `nowMs` is a wall
+  clock for anything driven by time.
+- **The chrome is the host's.** You are handed the band the eight cells would
+  have occupied — the header (including the touch strip while a knob is held),
+  the bank bar and the footer are drawn around you. You cannot paint over them
+  and you should not draw any of your own.
+- `values` carries live values merged over the base; `base` is the knob
+  positions, for a page that wants to show both.
+- **One strike**, as everywhere else: a `drawPage` that throws is retired for
+  the session and the body is left empty under a normal page.
+
+Internally a custom page is an ordinary knobs page carrying a drawer, not a new
+page kind — which is why every knobs-page behaviour (reads, turns, touch,
+announce) applies to it unchanged.
+
+##### A custom page as the level's preset browser
+
+If the level declares the preset triple (`list_param` / `count_param` /
+`name_param`), add `preset_browser` and the custom page **becomes** that browser
+rather than a second page beside it:
+
+```json
+{ "key": "face", "name": "Face", "type": "canvas", "canvas_script": "canvas.js",
+  "as_page": true, "preset_browser": true, "show_value": false }
+```
+
+Same jog, same enter/exit, same announcements — and it is emitted first, so it
+is what you land on. `drawPage` additionally receives
+`preset: { name, index, count, entered }`, because what is being browsed is not
+a parameter and no read would find it.
+
+Use it when a picture is a better picker than a row of text — a face per
+character, a waveform per sample. Two pages, one showing the thing and one
+naming it, are two doors onto the same choice.
 
 #### The parameter card (`card_script`)
 

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1480,6 +1480,63 @@ and its own nominal. Anything unusable is returned as a reason and logged
 against the module, because "declared a widget and did not get one" is precisely
 what an author cannot otherwise see.
 
+### A widget can name a value with NO CELL, and before it could not
+
+A widget cannot read — it is handed the page's value map. So a picture
+depending on a value that has no cell on this page had exactly one route: give
+that value a knob. A real module did, and shipped a read-only cell occupying one
+of eight slots on a 128x64 screen, drawing a 17x15 head nobody could interpret,
+whose only job was carrying a number to the cell beside it. Judged on hardware
+in three words: not useful.
+
+`extraKeys` already existed for this shape — `detectSample` sets it for an
+off-page filepath, and the controller already spends one rotation stop on each —
+but only an internal detector could produce one. `viz.extra_keys` lets a module
+declare them. Capped at four: one read per stop, and a cell asking for twenty
+would spend the page's whole read budget and starve every other value on screen.
+
+### A page the MODULE draws, and it is still a page
+
+`type: "canvas"` gives a cell you dive into. `as_page` gives a page in the
+level's jog rotation carrying that level's own knobs — reached by paging,
+turned by the encoders, redrawn every tick so it can animate, and wearing the
+host's own header and footer. `preset_browser` goes further and makes it the
+level's browser, so a face per character replaces a row of text.
+
+**IT IS A PAGE_KNOBS PAGE WITH A DRAWER, NOT A NEW KIND**, and that is the whole
+reason it works. Twenty-two places in `page_controller` branch on PAGE_KNOBS:
+reads, knob turns, touch, the touch strip, announce, dive targets, the list
+layout. A new kind would have to be threaded through every one, and missing one
+gives a page that looks right and does not respond. As a knobs page it inherits
+all of it and only the picture differs — which is also why the encoders work
+with no input code at all.
+
+Three gates asked "is this PAGE_KNOBS" when they meant "does this page have
+keys" (`pageHasKnobs`). A browser page also has to tick BOTH lanes: an ordinary
+preset page returns early after its own, which is right with no knobs and wrong
+the moment it has some.
+
+**THE BRANCH IS IN BOTH RENDERERS.** `render_page_movy` is the layout the device
+uses; putting it only in `render_page.mjs` produced a page whose header said
+FACE and whose body was eight knobs — correct everywhere except on hardware.
+
+### A module may declare a param LIVE, and the picture then follows the SOUND
+
+`isModulated` asks the chain's modulation system, which knows about LFOs and
+macros. It cannot know a synth drives its own vowel from pad pressure, so the
+widget drawing that vowel sat frozen at the knob while the sound moved.
+`"live": true` buys the treatment a modulated key already gets: `:effective`
+re-read EVERY TICK rather than on the rotation, which on an eight-knob page
+comes round about four times a second — an animation drawn from that is a
+slideshow.
+
+Two traps behind it, both found on hardware. The chain host OWNED `:effective`
+and, for a key it was not modulating, stripped the suffix and asked the plugin
+for the plain key — so a module serving its own effective value was never asked
+and the UI got the knob back. And **the shim skips `render_block` on a silent
+slot** (one probe frame in 172), so a module computing its effective value
+inside `render_block` appears frozen until something plays.
+
 ### A module's OTHER draw surface is a CARD, and it floats
 
 `drawCell` gives a module one cell. `card_script` gives it the page: a bordered

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1457,11 +1457,46 @@ shipped `src/modules/audio_fx/widget-test/{module.json,canvas.js}` rather than
 calling `registerWidget()` directly. Every other widget test registers directly,
 and that is exactly why none of them saw this.
 
+### A module may declare SEVERAL widgets, and one call site said otherwise
+
+The registry has always been a `Map`, and `registerWidget` has always taken a
+kind. Nothing in the design limited a module to one widget — but the single call
+site in `shadow_ui.js` read `ov.widgetKind`, one **string**, so a module naming
+two kinds got the first registered and the second dropped.
+
+Dropped is not an error here, and that is the whole problem. An unregistered
+kind does not claim its key, so the key stays in the detector pool and a
+built-in dial draws — which is the same fall-through that makes a typo, a failed
+load and an older host all degrade safely. Correct-looking page, no log line,
+nothing to search for. The fixture's own author hit it: two reasonable names,
+one silent dial.
+
+`registerOverlayWidgets` in `widget_registry.mjs` owns the rule now, so the
+resolution lives beside the registry rather than in a UI file, and
+`tests/host/` can run it. `widgetKind` is unchanged; `widgetKinds` takes either
+an **array** of names sharing one `drawCell` (they are one drawing at two crops,
+told apart by `group.keys[0]`) or an **object** giving each kind its own drawer
+and its own nominal. Anything unusable is returned as a reason and logged
+against the module, because "declared a widget and did not get one" is precisely
+what an author cannot otherwise see.
+
 ### A module's OTHER draw surface is a CARD, and it floats
 
 `drawCell` gives a module one cell. `card_script` gives it the page: a bordered
 picture, centred, raised while a knob is held or has just been turned, and gone
 on release. `param_card.mjs` owns the frame and the module owns the inside.
+
+**A card sees the PAGE, not only its own value.** The payload is `{ w, h, name,
+value, raw, values, nowMs }`. `values` is the page's value map — the same object
+`drawCell` is handed — and it exists because a card whose meaning depends on a
+sibling had no route to that fact at all: there is no `getParam` here, and the
+card script is loaded into its own closure, so it cannot even see a variable the
+module's own `drawCell` set. The first module to need it (which character's
+vowel is this?) went through `globalThis` plus a staleness timestamp. That
+worked, and it was a hidden side channel between two files this contract said
+were unrelated — which is a thing to remove, not to document. The null rules
+carry over unchanged: a sibling may be missing or `null`, and an absent one must
+not become a picture any more than an absent `raw` may.
 
 **Why a second surface rather than a bigger cell.** A cell is 17×15 and the
 grid's business is eight values at once. A card answers a different question —

--- a/src/modules/audio_fx/widget-test/canvas.js
+++ b/src/modules/audio_fx/widget-test/canvas.js
@@ -35,6 +35,45 @@ globalThis.canvas_overlay = {
      *   "viz": { "kind": "custom:wtmeter" } */
     widgetKind: "custom:wtmeter",
 
+    /*
+     * A SECOND WIDGET, because one module may declare several.
+     *
+     * This used to be impossible, and impossible in the quiet way: the host
+     * read a single `widgetKind` string, so a module naming two kinds got the
+     * first registered and the second ignored -- and an ignored kind is not an
+     * error, it just falls through to a built-in dial. A correct-looking page
+     * and nothing to search for.
+     *
+     * The object form gives each kind its own drawer, which is what you want
+     * when the two widgets have nothing to do with each other. (An ARRAY of
+     * names is the other form: several kinds sharing one drawCell, told apart
+     * by group.keys -- right when they really are one drawing at two crops.)
+     */
+    widgetKinds: {
+        "custom:wtmode": {
+            nominal: null,
+            /* Three states, drawn as a filled box that grows. Deliberately not
+             * a meter: it is here to look like a DIFFERENT widget, so that a
+             * page carrying both shows two kinds rather than one twice. */
+            draw(ctx, { values, group }) {
+                const key = group && group.keys && group.keys[0];
+                const v = key && values ? Number(values[key]) : NaN;
+                const w = ctx.width, h = ctx.height;
+                if (w < 5 || h < 5) return;
+                /* Frame, then a bar whose height reads the state. */
+                ctx.fillRect(0, 0, w, 1, 1);
+                ctx.fillRect(0, h - 1, w, 1, 1);
+                ctx.fillRect(0, 0, 1, h, 1);
+                ctx.fillRect(w - 1, 0, 1, h, 1);
+                if (!Number.isFinite(v)) return;   /* no answer, no picture */
+                const steps = 3;
+                const lit = Math.max(1, Math.min(steps, Math.round(v) + 1));
+                const barH = Math.max(1, Math.round((h - 4) * (lit / steps)));
+                ctx.fillRect(2, h - 2 - barH, w - 4, barH, 1);
+            },
+        },
+    },
+
     /* Only sprite-based widgets need a nominal frame. This one draws
      * proportionally, so it has none and works at every size. */
 

--- a/src/modules/audio_fx/widget-test/cards.js
+++ b/src/modules/audio_fx/widget-test/cards.js
@@ -24,6 +24,17 @@
  * drawer draws nothing interpretive then, rather than drawing zero. A read that
  * did not answer must never become a picture.
  *
+ * THE REST OF THE PAGE IS HANDED IN TOO, as `values` -- the same map a cell
+ * widget gets. That matters for a card whose MEANING depends on a sibling: this
+ * one names what the blend is between, which is a fact about `mode`, not about
+ * `level`. Before it existed, such a card had no route to that fact at all --
+ * no getParam on this path, and the card script is its own closure, so it
+ * cannot see a variable the module drawCell set either. The first module to
+ * need it went through globalThis, which worked and was a side channel.
+ *
+ * Same null rules apply: a sibling may be missing or null, and an absent one
+ * must not become a picture either -- here the label is simply omitted.
+ *
  * ONE STRIKE. If this throws it is retired for the session and the card is left
  * empty; the page keeps working.
  *
@@ -31,7 +42,9 @@
  *     "card_script": "cards.js#blend_card", "card_w": 96, "card_h": 34
  */
 
-globalThis.blend_card = function (ctx, { name, value, raw }) {
+const MODE_NAMES = ["Dry/Wet", "In/Out", "A/B"];
+
+globalThis.blend_card = function (ctx, { name, value, raw, values }) {
     const w = ctx.width, h = ctx.height;
     if (w < 8 || h < 8) return;
 
@@ -59,6 +72,16 @@ globalThis.blend_card = function (ctx, { name, value, raw }) {
     const s = String(value || "");
     const tw = ctx.textWidth(s);
     if (tw <= w) ctx.print(w - tw, 0, s, 1);
+
+    /*
+     * WHAT THE BLEND IS BETWEEN -- a fact that lives on a DIFFERENT parameter.
+     * Omitted rather than guessed when `mode` is absent or unanswered.
+     */
+    const mode = values ? Number(values.mode) : NaN;
+    if (Number.isFinite(mode) && MODE_NAMES[mode | 0]) {
+        const label = MODE_NAMES[mode | 0];
+        if (ctx.textWidth(label) <= w) ctx.print(0, 8, label, 1);
+    }
 
     /* A bar, sized from the frame rather than from a constant. */
     const barY = Math.max(9, h - 10);

--- a/src/modules/audio_fx/widget-test/help.json
+++ b/src/modules/audio_fx/widget-test/help.json
@@ -1,14 +1,14 @@
 {
   "title": "Widget Test",
-  "summary": "Reference module for the three module-supplied draw surfaces: an in-grid widget, a card that floats while the knob turns, and a fullscreen canvas view.",
+  "summary": "Reference module for the three module-supplied draw surfaces: in-grid widgets (two of them, from one module), a card that floats while the knob turns, and a fullscreen canvas view.",
   "sections": [
     {
       "heading": "What it shows",
-      "body": "The Level knob draws as a segmented meter supplied by the module rather than a built-in dial. Turn it and a card floats over the page with the reading and a bar. Click Detail for the module's own fullscreen view. All three come from files beside the module."
+      "body": "The Level knob draws as a segmented meter supplied by the module rather than a built-in dial, and Mode draws as a different widget from the SAME module. Turn Level and a card floats over the page with the reading, a bar, and the name of what the blend is between - which is a fact about Mode, read off the page rather than off Level. Click Detail for the module's own fullscreen view. All of it comes from files beside the module."
     },
     {
       "heading": "For module authors",
-      "body": "In grid: viz: { kind: \"custom:<name>\" } plus widgetKind and drawCell in canvas.js. On a turn: card_script: \"cards.js#export\" plus card_w and card_h. Fullscreen: type \"canvas\". Coordinates are frame-local everywhere: (0,0) is your own box and ctx.width/ctx.height are its size."
+      "body": "In grid: viz: { kind: \"custom:<name>\" } plus drawCell in canvas.js, named by widgetKind for one widget or widgetKinds for several (an array shares one drawer, an object gives each its own). On a turn: card_script: \"cards.js#export\" plus card_w and card_h; the drawer gets values and nowMs as well as raw, so it can read a sibling parameter. Fullscreen: type \"canvas\". Coordinates are frame-local everywhere: (0,0) is your own box and ctx.width/ctx.height are its size."
     },
     {
       "heading": "No reads on any of them",

--- a/src/modules/audio_fx/widget-test/help.json
+++ b/src/modules/audio_fx/widget-test/help.json
@@ -1,22 +1,125 @@
 {
   "title": "Widget Test",
-  "summary": "Reference module for the three module-supplied draw surfaces: in-grid widgets (two of them, from one module), a card that floats while the knob turns, and a fullscreen canvas view.",
-  "sections": [
+  "children": [
     {
-      "heading": "What it shows",
-      "body": "The Level knob draws as a segmented meter supplied by the module rather than a built-in dial, and Mode draws as a different widget from the SAME module. Turn Level and a card floats over the page with the reading, a bar, and the name of what the blend is between - which is a fact about Mode, read off the page rather than off Level. Click Detail for the module's own fullscreen view. All of it comes from files beside the module."
+      "title": "What it shows",
+      "lines": [
+        "Every draw surface a",
+        "module can supply,",
+        "on one page.",
+        "",
+        "Level draws as the",
+        "module's own meter,",
+        "not a built-in dial.",
+        "Mode draws as a",
+        "SECOND widget from",
+        "the same module.",
+        "",
+        "Turn Level and a",
+        "card floats up with",
+        "the reading and the",
+        "name of what the",
+        "blend is between -",
+        "which is a fact",
+        "about Mode, read off",
+        "the page.",
+        "",
+        "Click Detail for the",
+        "fullscreen view."
+      ]
     },
     {
-      "heading": "For module authors",
-      "body": "In grid: viz: { kind: \"custom:<name>\" } plus drawCell in canvas.js, named by widgetKind for one widget or widgetKinds for several (an array shares one drawer, an object gives each its own). On a turn: card_script: \"cards.js#export\" plus card_w and card_h; the drawer gets values and nowMs as well as raw, so it can read a sibling parameter. Fullscreen: type \"canvas\". Coordinates are frame-local everywhere: (0,0) is your own box and ctx.width/ctx.height are its size."
+      "title": "For authors",
+      "children": [
+        {
+          "title": "In the grid",
+          "lines": [
+            "viz: { kind:",
+            "\"custom:<name>\" }",
+            "plus drawCell in",
+            "canvas.js.",
+            "",
+            "Name it with",
+            "widgetKind for one,",
+            "or widgetKinds for",
+            "several: an array",
+            "shares one drawer,",
+            "an object gives",
+            "each its own."
+          ]
+        },
+        {
+          "title": "On a turn",
+          "lines": [
+            "card_script:",
+            "\"cards.js#export\"",
+            "plus card_w and",
+            "card_h.",
+            "",
+            "The drawer gets",
+            "values and nowMs as",
+            "well as raw, so it",
+            "can read a sibling",
+            "parameter."
+          ]
+        },
+        {
+          "title": "Coordinates",
+          "lines": [
+            "Frame-local",
+            "everywhere: (0,0)",
+            "is your own box and",
+            "ctx.width and",
+            "ctx.height are its",
+            "size.",
+            "",
+            "There is no way to",
+            "name a screen",
+            "pixel, and anything",
+            "outside the frame",
+            "is clipped."
+          ]
+        }
+      ]
     },
     {
-      "heading": "No reads on any of them",
-      "body": "Values are handed in; there is no getParam. A card's raw value may be null, meaning the read did not answer, and the contract is to draw nothing interpretive rather than to draw zero. Watch the card at null: it shows -- and no bar."
+      "title": "No reads",
+      "lines": [
+        "Values are handed",
+        "in; there is no",
+        "getParam on a draw",
+        "path.",
+        "",
+        "A card's raw value",
+        "may be null, meaning",
+        "the read did not",
+        "answer. Draw nothing",
+        "interpretive then -",
+        "a bar at zero looks",
+        "exactly like a real",
+        "zero.",
+        "",
+        "Watch the card at",
+        "null: it shows --",
+        "and no bar."
+      ]
     },
     {
-      "heading": "If something does not appear",
-      "body": "An unknown or broken drawer falls back to the built-in rather than leaving a hole, so the page always looks correct. Check debug.log: a drawer that threw is retired for the session and names itself there."
+      "title": "If nothing appears",
+      "lines": [
+        "An unknown or broken",
+        "drawer falls back to",
+        "the built-in rather",
+        "than leaving a hole,",
+        "so the page always",
+        "looks correct.",
+        "",
+        "Check debug.log: a",
+        "drawer that threw is",
+        "retired for the",
+        "session and names",
+        "itself there."
+      ]
     }
   ]
 }

--- a/src/modules/audio_fx/widget-test/module.json
+++ b/src/modules/audio_fx/widget-test/module.json
@@ -10,6 +10,21 @@
     "canvas_script": "canvas.js",
     "chain_params": [
       {
+        "key": "mode",
+        "name": "Mode",
+        "short_name": "Mod",
+        "type": "enum",
+        "options": [
+          "Dry/Wet",
+          "In/Out",
+          "A/B"
+        ],
+        "default": 0,
+        "viz": {
+          "kind": "custom:wtmode"
+        }
+      },
+      {
         "key": "level",
         "name": "Level",
         "type": "float",
@@ -22,7 +37,8 @@
         },
         "card_script": "cards.js#blend_card",
         "card_w": 96,
-        "card_h": 34
+        "card_h": 34,
+        "short_name": "Lvl"
       },
       {
         "key": "detail",
@@ -38,11 +54,15 @@
       "root": {
         "label": "Widget Test",
         "knobs": [
-          "level"
+          "level",
+          "mode"
         ],
         "params": [
           {
             "key": "level"
+          },
+          {
+            "key": "mode"
           },
           {
             "key": "detail"

--- a/src/modules/audio_fx/widget-test/widget_test.c
+++ b/src/modules/audio_fx/widget-test/widget_test.c
@@ -13,9 +13,15 @@
  * test fixture is a real module that is not built by default -- which is why
  * this, like gesture-test, is gated on SCHWUNG_BUILD_TEST_MODULES.
  *
- * One knob:
+ * Two knobs, and DELIBERATELY TWO DIFFERENT CUSTOM WIDGETS:
  *   level   float 0..1, drawn by the module's own segmented meter rather than
  *           the built-in dial. Turn it and the staircase grows.
+ *   mode    enum, drawn by a SECOND kind the same module declares. A module
+ *           used to be limited to one widget -- not by the registry, which was
+ *           always a map, but by a call site that read one string -- and the
+ *           second kind was dropped silently onto a built-in dial. It is also
+ *           the sibling `level`'s card reads, to name what the blend is
+ *           between.
  *
  * One canvas param:
  *   detail  clicks into the same overlay's fullscreen draw, which is the whole
@@ -35,6 +41,7 @@ static const host_api_v1_t *g_host = NULL;
 
 typedef struct {
     float level;
+    int mode;      /* 0..2, drawn by the module's SECOND widget kind */
 } inst_t;
 
 static void *v2_create_instance(const char *dir, const char *cfg) {
@@ -60,6 +67,8 @@ static void v2_set_param(void *inst, const char *key, const char *val) {
         /* Restore is deliberately forgiving: find the number and take it. */
         const char *p = strstr(val, "\"level\"");
         if (p) { const char *c = strchr(p, ':'); if (c) v2_set_param(inst, "level", c + 1); }
+        p = strstr(val, "\"mode\"");
+        if (p) { const char *c = strchr(p, ':'); if (c) v2_set_param(inst, "mode", c + 1); }
         return;
     }
     if (strcmp(key, "level") == 0) {
@@ -67,6 +76,13 @@ static void v2_set_param(void *inst, const char *key, const char *val) {
         if (v < 0.0f) v = 0.0f;
         if (v > 1.0f) v = 1.0f;
         s->level = v;
+        return;
+    }
+    if (strcmp(key, "mode") == 0) {
+        int m = atoi(val);
+        if (m < 0) m = 0;
+        if (m > 2) m = 2;
+        s->mode = m;
     }
 }
 
@@ -77,12 +93,15 @@ static int v2_get_param(void *inst, const char *key, char *buf, int len) {
     if (strcmp(key, "level") == 0)
         return snprintf(buf, len, "%.4f", s->level);
 
+    if (strcmp(key, "mode") == 0)
+        return snprintf(buf, len, "%d", s->mode);
+
     /* Per-component preset/autosave snapshot. Without it the shadow UI logs
      * "fx1:state read FAILED after retries" every ~7 seconds and declines to
      * write the slot file at all -- a chain component is expected to answer
      * this even when it has almost nothing to say. */
     if (strcmp(key, "state") == 0)
-        return snprintf(buf, len, "{\"level\":%.4f}", s->level);
+        return snprintf(buf, len, "{\"level\":%.4f,\"mode\":%d}", s->level, s->mode);
 
     /* The custom kind is declared HERE, on the viz field, exactly as a
      * built-in kind would be. An older host that has never heard of
@@ -91,6 +110,13 @@ static int v2_get_param(void *inst, const char *key, char *buf, int len) {
     if (strcmp(key, "chain_params") == 0) {
         const char *p =
         "["
+          /* TWO CUSTOM KINDS ON ONE PAGE. `mode` carries the module's second
+           * widget, which exists here to prove a module may declare more than
+           * one -- and it is a SIBLING the card below reads, which is the other
+           * thing this fixture now covers. */
+          "{\"key\":\"mode\",\"name\":\"Mode\",\"short_name\":\"Mod\","
+           "\"type\":\"enum\",\"options\":[\"Dry/Wet\",\"In/Out\",\"A/B\"],\"default\":0,"
+           "\"viz\":{\"kind\":\"custom:wtmode\"}},"
           "{\"key\":\"level\",\"name\":\"Level\",\"short_name\":\"Lvl\","
            "\"type\":\"float\",\"min\":0,\"max\":1,\"step\":0.01,\"default\":0.5,"
            /* THE SAME PARAM CARRIES BOTH SURFACES: the in-grid cell widget and
@@ -114,7 +140,8 @@ static int v2_get_param(void *inst, const char *key, char *buf, int len) {
           "\"levels\":{"
             "\"root\":{"
               "\"label\":\"Widget Test\","
-              "\"params\":[{\"key\":\"level\"},{\"key\":\"detail\"}]"
+              "\"knobs\":[\"level\",\"mode\"],"
+              "\"params\":[{\"key\":\"level\"},{\"key\":\"mode\"},{\"key\":\"detail\"}]"
             "}"
           "}"
         "}";

--- a/src/modules/chain/dsp/chain_mod.c
+++ b/src/modules/chain/dsp/chain_mod.c
@@ -432,7 +432,32 @@ int chain_mod_get_effective_for_subkey(chain_instance_t *inst,
         return snprintf(buf, buf_len, "%.6f", entry->effective_value);
     }
 
-    /* If not modulated, return current plugin value for compatibility. */
+    /*
+     * NOT MODULATED BY THE CHAIN -- BUT THE PLUGIN MAY STILL BE DRIVING IT.
+     *
+     * This stripped ":effective" and asked for the plain key, which is right
+     * only if the chain is the sole thing that can move a parameter. It is not.
+     * A synth that drives its own value serves `<key>:effective` itself --
+     * MonkSynth sweeps its vowel from pad pressure, exactly as the original
+     * swept it from the pitch wheel -- and that answer was thrown away here:
+     * the suffix consumed, the plain key asked, the KNOB value returned. Every
+     * picture of that vowel sat still while the sound moved.
+     *
+     * So ask the plugin BY NAME first, and fall back to the plain key only when
+     * it does not answer. A module that has never heard of `:effective` misses,
+     * and the old behaviour is exactly what remains.
+     *
+     * "" is a MISS, not a value: an unserved key comes back as an empty buffer,
+     * and taking that as an answer would blank the reading on screen.
+     */
+    char eff_key[96];
+    const int n = snprintf(eff_key, sizeof(eff_key), "%s:effective", param);
+    if (n > 0 && n < (int)sizeof(eff_key)) {
+        const int r = chain_mod_get_param_string(inst, target, eff_key, buf, buf_len);
+        if (r > 0 && buf[0] != '\0') return r;
+    }
+
+    /* Nothing is driving it: the plugin's current value IS the effective one. */
     return chain_mod_get_param_string(inst, target, param, buf, buf_len);
 }
 

--- a/src/modules/tools/file-browser/help.json
+++ b/src/modules/tools/file-browser/help.json
@@ -38,7 +38,7 @@
           "title": "Play",
           "lines": [
             "Preview WAV files",
-            "through Move speakers.",
+            "through the speakers.",
             "",
             "Select a .wav file,",
             "choose Play from the",
@@ -72,7 +72,7 @@
             "",
             "Opens the on-screen",
             "keyboard, pre-filled",
-            "with the current name."
+            "with the current name"
           ]
         },
         {

--- a/src/modules/tools/song-mode/help.json
+++ b/src/modules/tools/song-mode/help.json
@@ -193,7 +193,7 @@
         {
           "title": "Undo",
           "lines": [
-            "Press Undo to restore",
+            "Press Undo to put",
             "the previous state.",
             "",
             "Supports up to 20",

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -113,6 +113,9 @@ import { resolveViz, isSprayMeta } from '/data/UserData/schwung/shared/param_pag
 import { registerWidget, registerOverlayWidgets, clearWidgets, setWidgetLogger }
     from '/data/UserData/schwung/shared/param_pages/widget_registry.mjs';
 import { listKnobInit, listKnobStep } from '/data/UserData/schwung/shared/param_pages/list_knob.mjs';
+/* Frame-scoping for a custom UI page's body — the same clipped, origin-shifted
+ * context a widget and a card get, so a module author writes one thing. */
+import { frameCtx } from '/data/UserData/schwung/shared/param_pages/frame_ctx.mjs';
 /* Which user preset a component is currently on, and whether the live state
  * has moved away from it since — the "My Presets" trailing page's row 1
  * (see componentTrailingMenus below). Pure: the caller supplies the record and
@@ -16936,6 +16939,73 @@ function resolveCardScriptPath(slot, component, scriptRef) {
     return moduleFileExists(scriptPath) ? scriptPath : "";
 }
 
+
+/*
+ * CUSTOM UI PAGES — a module draws a whole page's body.
+ *
+ * Loaded and cached exactly like a card drawer, and for the same reason:
+ * nothing module-side is resident while the grid is up and the host loader has
+ * no cache of its own, so loading on the draw path would evaluate the script on
+ * every frame. Here that matters more than for a card, because a custom page is
+ * redrawn CONTINUOUSLY so it can animate.
+ *
+ * A null result is cached, so a missing file or a bad export costs one attempt
+ * for the session rather than one per frame.
+ *
+ * ONE STRIKE, like every other module-supplied drawer: a thrower is retired for
+ * the session and the page falls back to an empty body under the host's normal
+ * header and footer. A module cannot take the shadow UI down by shipping a bad
+ * page.
+ */
+const canvasPageDrawers = {};      /* "moduleDir|script|overlay" -> fn | null */
+const canvasPageDisabled = {};
+
+function canvasPageDrawer(slot, component, canvas) {
+    if (!canvas || !canvas.script) return null;
+    const path = resolveCardScriptPath(slot, component, canvas.script);
+    if (!path) return null;
+    const ref = canvas.overlay || "";
+    const cacheKey = `${path}|${ref}`;
+    if (canvasPageDisabled[cacheKey]) return null;
+    if (Object.prototype.hasOwnProperty.call(canvasPageDrawers, cacheKey))
+        return canvasPageDrawers[cacheKey];
+
+    /* The overlay object is resolved the same way the fullscreen canvas view
+     * resolves one, so a module uses the SAME object for both if it wants. */
+    const loaded = loadCanvasOverlayScript(path, ref);
+    const ov = loaded && loaded.overlay;
+    const fn = ov && typeof ov.drawPage === "function" ? ov.drawPage.bind(ov) : null;
+    if (!fn) {
+        debugLog(`canvas page: ${path} exposes no drawPage${loaded && loaded.error ? ` (${loaded.error})` : ""}`);
+    }
+    canvasPageDrawers[cacheKey] = fn;
+    return fn;
+}
+
+function drawCanvasPageBody(slot, component, drawCtx, band, canvas, payload) {
+    const fn = canvasPageDrawer(slot, component, canvas);
+    if (!fn) return;
+    const path = resolveCardScriptPath(slot, component, canvas.script);
+    const cacheKey = `${path}|${canvas.overlay || ""}`;
+    /* Frame-scoped, so (0,0) is the top-left of the BAND and nothing the module
+     * draws can reach the header or the footer. Same contract as a widget and a
+     * card; a module author already knows it. */
+    const fctx = frameCtx(drawCtx, band);
+    try {
+        fn(fctx, {
+            key: canvas.key,
+            values: payload && payload.values ? payload.values : {},
+            keys: payload && payload.keys ? payload.keys : [],
+            touched: payload && typeof payload.touched === "number" ? payload.touched : -1,
+            nowMs: payload && typeof payload.nowMs === "number" ? payload.nowMs : Date.now(),
+            width: band.w, height: band.h,
+        });
+    } catch (e) {
+        canvasPageDisabled[cacheKey] = true;
+        debugLog(`canvas page ${cacheKey} disabled after throw: ${e}`);
+    }
+}
+
 function loadCanvasOverlayScript(scriptPath, overlayRef) {
     if (!scriptPath || typeof shadow_load_ui_module !== "function") {
         return { overlay: null, error: "canvas script unavailable" };
@@ -20555,6 +20625,8 @@ function drawHelpDetail() {
         return loadCardDrawer(
             resolveCardScriptPath(slot, component, scriptPath), exportRef);
     };
+    _ctx.drawCanvasPageBody = (slot, component, drawCtx, band, canvas, payload) =>
+        drawCanvasPageBody(slot, component, drawCtx, band, canvas, payload);
     _ctx.isMuteHeld = () => hostMuteHeld;
 
     /* Overtake session state (for tools menu "Resume" indicator) */

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -110,7 +110,7 @@ import { resolveViz, isSprayMeta } from '/data/UserData/schwung/shared/param_pag
  * absolute path, and ./shadow_ui_param_pages.mjs above relies on exactly that),
  * so the prefix here is convention rather than necessity — do not diverge from
  * it in one import. */
-import { registerWidget, clearWidgets, setWidgetLogger }
+import { registerWidget, registerOverlayWidgets, clearWidgets, setWidgetLogger }
     from '/data/UserData/schwung/shared/param_pages/widget_registry.mjs';
 import { listKnobInit, listKnobStep } from '/data/UserData/schwung/shared/param_pages/list_knob.mjs';
 /* Which user preset a component is currently on, and whether the live state
@@ -16688,16 +16688,25 @@ function ensureComponentWidgets(moduleId, chainParams) {
 
     const loaded = loadCanvasOverlayScript(`${dir}/canvas.js`, "");
     const ov = loaded && loaded.overlay;
-    if (ov && typeof ov.drawCell === "function" && typeof ov.widgetKind === "string") {
-        registerWidget(ov.widgetKind, {
-            draw: ov.drawCell.bind(ov),
-            nominal: ov.widgetNominal || null,
-        });
-    } else {
-        /* Declared a custom kind and we could not load a widget for it. Not
-         * fatal: the kind stays unregistered, so resolveViz leaves those keys to
-         * the detector and the built-in draws. But say so, because otherwise the
-         * author sees a reasonable picture and no reason it is not theirs. */
+    /* A module may declare MORE THAN ONE widget -- see registerOverlayWidgets,
+     * which owns the shapes. This used to read a single `widgetKind` string,
+     * which meant a second declared kind was never registered and its cell
+     * silently drew a built-in dial instead. */
+    const { registered, skipped } = registerOverlayWidgets(ov);
+    if (registered.length) {
+        debugLog(`widgets: ${id} registered ${registered.join(", ")}`);
+    }
+    /* Declared a custom kind and we could not load a widget for it. Not fatal:
+     * the kind stays unregistered, so resolveViz leaves those keys to the
+     * detector and the built-in draws. But say so, because otherwise the author
+     * sees a reasonable picture and no reason it is not theirs. Each skipped
+     * kind names ITSELF and why -- a module registering one of two widgets used
+     * to log nothing at all, because the old branch only spoke when it got
+     * nothing. */
+    for (const s2 of skipped) {
+        debugLog(`widgets: ${id} declared ${s2.kind} but ${s2.why}`);
+    }
+    if (!registered.length && !skipped.length) {
         debugLog(`widgets: ${id} declares a custom viz kind but no usable drawCell` +
                  (loaded && loaded.error ? ` (${loaded.error})` : ""));
     }

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16995,8 +16995,12 @@ function drawCanvasPageBody(slot, component, drawCtx, band, canvas, payload) {
         fn(fctx, {
             key: canvas.key,
             values: payload && payload.values ? payload.values : {},
+            base: payload && payload.base ? payload.base : {},
             keys: payload && payload.keys ? payload.keys : [],
             touched: payload && typeof payload.touched === "number" ? payload.touched : -1,
+            /* Browser state, for a module drawing its own preset picker. Null
+             * on an ordinary custom page. */
+            preset: (payload && payload.preset) || null,
             nowMs: payload && typeof payload.nowMs === "number" ? payload.nowMs : Date.now(),
             width: band.w, height: band.h,
         });

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -299,6 +299,17 @@ export function enterParamPages(slot, component, prefix, restorePageName, io, ch
                      * states for the other accessors. */
                     ? ctx.loadCardScript(currentSlot, currentComponent, scriptPath, exportRef)
                     : null),
+            /*
+             * A CUSTOM UI PAGE's body. Same shape and same reasoning as
+             * loadCard: resolving the module's script needs its directory and
+             * the host loader, so it comes from the consumer. A consumer that
+             * offers none simply gets an empty body under a normal header and
+             * footer, rather than a broken page.
+             */
+            drawCanvasPage: (drawCtx, band, canvas, payload) => {
+                if (typeof ctx.drawCanvasPageBody !== 'function') return;
+                ctx.drawCanvasPageBody(currentSlot, currentComponent, drawCtx, band, canvas, payload);
+            },
         }, io || {}));
     }
     /* Entering the view is the only way the module behind it can have changed,

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -4164,6 +4164,13 @@ export function createController(io = {}) {
              * strip above it would be a second formatter by another name. */
             value: knobRowValue(key),
             raw: s.values[key] === undefined ? null : s.values[key],
+            /* The whole page's values, so a card can read a sibling the way a
+             * cell widget always could -- see param_card's note. Passed by
+             * reference deliberately: drawCell is already handed this exact
+             * object, and copying it per frame to give the card a weaker
+             * guarantee than the cell has would be the odd choice. */
+            values: s.values,
+            nowMs: now(),
             /*
              * ONE STRIKE. A drawer that threw is retired for the session rather
              * than re-entered up to sixty times a second, and the parameter

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -4071,6 +4071,19 @@ export function createController(io = {}) {
         });
     }
 
+    /*
+     * Base values with any live/modulated ones merged over them.
+     *
+     * The same merge render_page_movy does for graphics, in ONE place so the
+     * card and the renderers cannot disagree about what a value is. Returns the
+     * base object untouched when nothing is live, so the common case allocates
+     * nothing.
+     */
+    function liveValues() {
+        for (const _k in s.modValues) return Object.assign({}, s.values, s.modValues);
+        return s.values;
+    }
+
     /** True when the page on screen is drawn by the module. */
     function onCanvasPage() {
         const p = page();
@@ -4225,12 +4238,17 @@ export function createController(io = {}) {
              * strip above it would be a second formatter by another name. */
             value: knobRowValue(key),
             raw: s.values[key] === undefined ? null : s.values[key],
-            /* The whole page's values, so a card can read a sibling the way a
-             * cell widget always could -- see param_card's note. Passed by
-             * reference deliberately: drawCell is already handed this exact
-             * object, and copying it per frame to give the card a weaker
-             * guarantee than the cell has would be the odd choice. */
-            values: s.values,
+            /*
+             * The whole page's values, so a card can read a sibling the way a
+             * cell widget always could -- see param_card's note.
+             *
+             * LIVE VALUES MERGED OVER THE BASE, exactly as a graphic gets them.
+             * A card is a picture of what a parameter MEANS, and for a param
+             * something else is driving, what it means is what it is DOING --
+             * not where its knob was left. `raw` stays the base, because that
+             * is the number the turn is editing.
+             */
+            values: liveValues(),
             nowMs: now(),
             /*
              * ONE STRIKE. A drawer that threw is retired for the session rather

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -494,6 +494,26 @@ const TRIGGER_BURST_MAX = 4;
  */
 const TRIGGER_KNOB_GESTURE_GAP_MS = 270;
 
+/*
+ * A page whose eight encoders address parameters.
+ *
+ * Normally that is exactly PAGE_KNOBS. A CUSTOM UI PAGE may also be a browser
+ * -- a module drawing its own preset picker, where jog steps presets and the
+ * knobs still edit the sound -- and that page has to be PAGE_PRESET for the
+ * jog, the enter/exit gesture and the announcements to work. It carries `keys`
+ * as well, and this is what lets those keys be turned.
+ *
+ * Deliberately narrow: it asks whether the page HAS keys, not what kind it is,
+ * so a preset or items page that carries none behaves exactly as before. That
+ * is the property that made this safe to relax at all -- twenty-two places
+ * branch on PAGE_KNOBS and only the three that mean "can this be turned or
+ * read" use this.
+ */
+function pageHasKnobs(p) {
+    return !!(p && Array.isArray(p.keys) && p.keys.length &&
+              (p.kind === PAGE_KNOBS || p.canvas));
+}
+
 export function createController(io = {}) {
     const getParam = io.getParam || (() => null);
     const setParam = io.setParam || (() => {});
@@ -840,7 +860,7 @@ export function createController(io = {}) {
     }
     const keyAt = (slot) => {
         const p = page();
-        return p && p.kind === PAGE_KNOBS ? (p.keys[slot] || null) : null;
+        return pageHasKnobs(p) ? (p.keys[slot] || null) : null;
     };
     const metaAt = (slot) => {
         const k = keyAt(slot);
@@ -1988,9 +2008,24 @@ export function createController(io = {}) {
         }
 
         const p = page();
-        if (p && p.kind === PAGE_PRESET) { tickPreset(p); return null; }
+        /*
+         * A MODULE-DRAWN BROWSER ticks BOTH lanes.
+         *
+         * An ordinary preset page has no knobs, so the preset lane is all there
+         * is and returning here is right. One that carries knobs must also run
+         * the value lane below, or its picture is drawn from values nobody ever
+         * fetched -- which showed as a face page reading the vowel it happened
+         * to inherit from a neighbouring page rather than the live one.
+         *
+         * Two reads per tick on that page instead of one. That is the cost of a
+         * screen that is a browser and a knob page at once, and it is bounded:
+         * only this page, only while it is up.
+         */
+        if (p && p.kind === PAGE_PRESET) { tickPreset(p); if (!p.canvas) return null; }
         if (p && p.kind === PAGE_ITEMS) { tickItems(p); return null; }
-        if (!p || p.kind !== PAGE_KNOBS || p.keys.length === 0) return null;
+        /* Reads AND live values: a custom browser page carrying knobs needs
+         * both, or its picture is drawn from values nobody ever fetched. */
+        if (!pageHasKnobs(p)) return null;
 
         refreshModulatedValues(p);
 
@@ -3958,10 +3993,24 @@ export function createController(io = {}) {
                 const prect = { x: MENU_FRAME_X, y: MENU_FRAME_Y,
                                 w: MENU_FRAME_W, h: pbottom - MENU_FRAME_Y - MENU_FRAME_BOTTOM_INSET };
                 const pst = presetState(mp) || {};
-                drawPresetBody(ctx, prect, {
-                    name: pst.name, index: pst.index, count: pst.count,
-                    entered: menuEntered(),
-                });
+                /*
+                 * A MODULE-DRAWN BROWSER paints the body itself. It is handed
+                 * the preset state as well as the values, because the thing it
+                 * is browsing is not a parameter and no read would find it --
+                 * "Fish, 2 of 12" lives in the controller, not on the wire.
+                 */
+                if (mp.canvas) {
+                    drawCanvasPageBody(ctx, prect, mp.canvas, {
+                        touched: s.touched,
+                        preset: { name: pst.name, index: pst.index,
+                                  count: pst.count, entered: menuEntered() },
+                    });
+                } else {
+                    drawPresetBody(ctx, prect, {
+                        name: pst.name, index: pst.index, count: pst.count,
+                        entered: menuEntered(),
+                    });
+                }
                 /* Inert: it wears the same brackets a divable cell and an
                  * un-entered menu wear, because it is the same offer. */
                 if (!menuEntered()) {
@@ -4057,16 +4106,34 @@ export function createController(io = {}) {
      * used), so the header, the touch strip and the footer are the host's own
      * and a module cannot paint over them.
      */
+    /*
+     * Draw a custom page's body, if the host can.
+     *
+     * The band comes from the caller (render_page's cell area, or the preset
+     * page's own frame), so the header, the touch strip and the footer are the
+     * host's own and a module cannot paint over them.
+     */
     function drawCanvasPageBody(ctx, band, canvas, extra) {
         if (typeof io.drawCanvasPage !== "function") return;
         io.drawCanvasPage(ctx, band, canvas, {
-            values: s.values,
-            /* Effective values for anything declared `live` — a custom page is
-             * redrawn every tick precisely so it can show them move. */
-            effective: s.modValues,
+            /*
+             * MERGED, like a graphic gets — a custom page is redrawn every tick
+             * precisely so it can show a live value move, and handing it the
+             * base would make that impossible by construction.
+             */
+            values: liveValues(),
+            /* The knob positions, for a page that wants to show both what is
+             * set and what is sounding. Same split as a widget's baseValues. */
+            base: s.values,
             metaIndex: s.metaIndex,
             keys: (page() || {}).keys || [],
             touched: extra && typeof extra.touched === "number" ? extra.touched : -1,
+            /*
+             * Browser state, when this page IS the level's preset browser.
+             * Handed over because it is not a parameter: "Fish, 2 of 12" lives
+             * in the controller and no read would find it. Null otherwise.
+             */
+            preset: (extra && extra.preset) || null,
             nowMs: now(),
         });
     }
@@ -4267,7 +4334,7 @@ export function createController(io = {}) {
     let vizCache = null;
     function vizGroups() {
         const p = page();
-        if (!p || p.kind !== PAGE_KNOBS || !s.metaIndex) return [];
+        if (!pageHasKnobs(p) || !s.metaIndex) return [];
         /*
          * THE FOCUSED CHILD IS PART OF THE KEY.
          *

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -3813,6 +3813,11 @@ export function createController(io = {}) {
                 page: page(), metaIndex: s.metaIndex, values: s.values,
                 title: title || "", pageIndex: s.pageIndex, pageCount: s.pages.length,
                 touched: s.hintLines ? -1 : s.touched,
+                /* A custom UI page's body drawer — inert for every ordinary
+                 * page. This layout is the one the device uses, so a page that
+                 * drew correctly under the dial renderer and not here would be
+                 * a page that works everywhere except on hardware. */
+                drawCanvasPage: drawCanvasPageBody,
                 /* Both undefined for the device's own full-screen draw, which
                  * is what keeps that path byte-identical. */
                 rect, bands,
@@ -3991,6 +3996,7 @@ export function createController(io = {}) {
                 page: page(), metaIndex: s.metaIndex, values: s.values,
                 title: title || "", pageIndex: s.pageIndex, pageCount: s.pages.length,
                 touched: -1, layout: s.layout, rect,
+                drawCanvasPage: drawCanvasPageBody,
             });
             renderHint(ctx, { rect, lines: s.hintLines.lines, title: s.hintLines.title });
             return;
@@ -4013,7 +4019,38 @@ export function createController(io = {}) {
              * which of them is locked, so graphics stand down while
              * decorations are active. */
             viz: (vizEnabled && !s.decorations) ? vizGroups() : [],
+            /*
+             * A CUSTOM UI PAGE's body drawer. Only a page carrying `canvas`
+             * uses it, so this is inert for every ordinary page — and absent
+             * when the host offers none, which is what makes a module's custom
+             * page degrade to an empty body rather than to a broken screen.
+             */
+            drawCanvasPage: drawCanvasPageBody,
         });
+    }
+
+    /*
+     * Draw a custom page's body, if the host can.
+     *
+     * The band comes from render_page (the area the eight cells would have
+     * used), so the header, the touch strip and the footer are the host's own
+     * and a module cannot paint over them.
+     */
+    function drawCanvasPageBody(ctx, band, canvas, extra) {
+        if (typeof io.drawCanvasPage !== "function") return;
+        io.drawCanvasPage(ctx, band, canvas, {
+            values: s.values,
+            metaIndex: s.metaIndex,
+            keys: (page() || {}).keys || [],
+            touched: extra && typeof extra.touched === "number" ? extra.touched : -1,
+            nowMs: now(),
+        });
+    }
+
+    /** True when the page on screen is drawn by the module. */
+    function onCanvasPage() {
+        const p = page();
+        return !!(p && p.canvas);
     }
 
     /*
@@ -4438,6 +4475,9 @@ export function createController(io = {}) {
     }
 
     return {
+        /* True when the module draws this page's body — the host redraws
+         * every tick while it is up, so a custom page can animate. */
+        onCanvasPage,
         load, reloadIfChanged, tick, refreshTrailing, revalue,
         describePage,
         /* For a selection made OUTSIDE the controller — the list editor drives

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -2136,7 +2136,25 @@ export function createController(io = {}) {
          *
          * On the cursor it costs one read per tick and the whole page is
          * current within `stops` ticks — under 0.2s, for a tick mark. */
-        s.modCache[key] = !!isModulated(fullKey(key));
+        /*
+         * A MODULE MAY DECLARE A PARAM LIVE, and that is not the same question
+         * as "is something routed to it".
+         *
+         * `isModulated` asks the chain's modulation system, which knows about
+         * LFOs and macros. It cannot know that a synth drives its own vowel
+         * from pad pressure, or that a value moves for any other reason inside
+         * the module -- so a picture of that value sat frozen at whatever the
+         * knob last said while the sound changed underneath it.
+         *
+         * `"live": true` on the param says so. It costs what any modulated key
+         * costs: the effective value is refreshed EVERY TICK
+         * (refreshModulatedValues, MOD_FAST_READS_PER_TICK) rather than waiting
+         * for the value rotation, which is the whole point -- a rotation stop
+         * on an eight-knob page lands about four times a second, and an
+         * animation drawn from that is a slideshow.
+         */
+        const _lm = s.metaIndex ? s.metaIndex.getOrGuess(key) : null;
+        s.modCache[key] = !!isModulated(fullKey(key)) || !!(_lm && _lm.live === true);
 
         /* The pointer wants the base — what the user set — so ask for it
          * directly. (Since #276 the plain key also answers with the base for
@@ -4011,6 +4029,9 @@ export function createController(io = {}) {
             touched: s.touched, decorations: s.decorations,
             layout: s.layout, revealValues: s.revealValues, rect,
             modulated: (key) => !!s.modCache[key],
+            /* The live values, so a module-supplied widget can draw what the
+             * param is ACTUALLY doing rather than where its knob was left. */
+            modValues: s.modValues,
             /* Section ids for the page rule, so it groups the way Shift+jog
              * navigates. Cached — it only changes when the page set does. */
             pageGroups: pageGroups(),
@@ -4040,6 +4061,9 @@ export function createController(io = {}) {
         if (typeof io.drawCanvasPage !== "function") return;
         io.drawCanvasPage(ctx, band, canvas, {
             values: s.values,
+            /* Effective values for anything declared `live` — a custom page is
+             * redrawn every tick precisely so it can show them move. */
+            effective: s.modValues,
             metaIndex: s.metaIndex,
             keys: (page() || {}).keys || [],
             touched: extra && typeof extra.touched === "number" ? extra.touched : -1,

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -434,6 +434,9 @@ function canvasPageParams(chainParams) {
         if (!(p.as_page === true || p.asPage === true)) continue;
         out.set(p.key, {
             key: p.key,
+            /* `preset_browser` merges this page WITH the level's preset browser
+             * instead of adding a second one -- see the emission below. */
+            presetBrowser: p.preset_browser === true || p.presetBrowser === true,
             script: typeof p.canvas_script === "string" ? p.canvas_script : "canvas.js",
             overlay: typeof p.canvas_overlay === "string" ? p.canvas_overlay
                    : (typeof p.overlay === "string" ? p.overlay : ""),
@@ -769,14 +772,48 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
          * 13 nav entries and the preset triple), and a knob is the wrong control
          * for minijv's 2427 or surge's 675 presets. */
         if (lvl.list_param && lvl.count_param) {
+            /*
+             * A MODULE MAY DRAW ITS OWN BROWSER.
+             *
+             * A canvas page declaring `preset_browser` becomes THIS page rather
+             * than a second one beside it: same jog, same enter/exit, same
+             * announcements, but the module paints the body. A synth with a
+             * face per preset is a better picker than a row of text, and two
+             * pages -- one showing the character, one naming it -- would be two
+             * doors onto the same choice.
+             *
+             * It carries the level's knobs too, so the sound is still editable
+             * while you browse. See pageHasKnobs in page_controller.
+             */
+            let browserCanvas = null;
+            for (const key of paramKeys(lvl)) {
+                const cp2 = canvasPages.get(key);
+                if (cp2 && cp2.presetBrowser && !isHiddenParam(lvl, key, isVisible)) {
+                    browserCanvas = cp2;
+                    emitted.add(key);
+                    break;
+                }
+            }
             pages.push({
                 /* "Presets", not the level's name — the preset browser is a
-                 * different thing from the knob page that shares its level. */
+                 * different thing from the knob page that shares its level.
+                 * A module-drawn one takes the param's name instead, because
+                 * it IS that screen. */
                 kind: PAGE_PRESET,
-                name: claimName(declaredName(levelKey, lvl) && !isRoot ? nameOf(levelKey, lvl) : "Presets"),
+                name: claimName(browserCanvas ? browserCanvas.name
+                     : (declaredName(levelKey, lvl) && !isRoot ? nameOf(levelKey, lvl) : "Presets")),
                 level: levelKey,
                 listParam: lvl.list_param, countParam: lvl.count_param,
                 nameParam: lvl.name_param || "preset_name",
+                ...(browserCanvas ? {
+                    canvas: { key: browserCanvas.key, script: browserCanvas.script,
+                              overlay: browserCanvas.overlay },
+                    keys: knobKeys(lvl).filter(
+                        (k) => !isHiddenParam(lvl, k, isVisible) && !selectorKeys.has(k))
+                        .slice(0, perPage === Infinity ? undefined : perPage),
+                    childLevel: hasChildren(lvl) ? lvl : null,
+                    shortNames: levelShortNames(lvl),
+                } : {}),
             });
         }
 
@@ -1014,6 +1051,8 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
             const cp = canvasPages.get(key);
             if (!cp) continue;
             if (isHiddenParam(lvl, key, isVisible)) continue;
+            /* Already merged into the level's preset browser above. */
+            if (cp.presetBrowser && lvl.list_param && lvl.count_param) continue;
             emitted.add(key);
             pages.push({
                 kind: PAGE_KNOBS,

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -414,6 +414,35 @@ export function levelShortNames(lvl) {
     return out;
 }
 
+/*
+ * Params a module wants drawn as a WHOLE PAGE of its own.
+ *
+ *     { "key": "face", "type": "canvas", "canvas_script": "canvas.js",
+ *       "canvas_overlay": "face_page", "as_page": true }
+ *
+ * Without `as_page` a canvas param is a CELL you click to dive into, which is
+ * the behaviour that already existed. With it, the level gains an extra page in
+ * the jog rotation carrying the level's own knobs -- so it is reached by paging
+ * rather than by diving, and the eight encoders do there exactly what they do
+ * on the level's grid.
+ */
+function canvasPageParams(chainParams) {
+    const out = new Map();
+    for (const p of chainParams || []) {
+        if (!p || typeof p.key !== "string") continue;
+        if (p.type !== "canvas") continue;
+        if (!(p.as_page === true || p.asPage === true)) continue;
+        out.set(p.key, {
+            key: p.key,
+            script: typeof p.canvas_script === "string" ? p.canvas_script : "canvas.js",
+            overlay: typeof p.canvas_overlay === "string" ? p.canvas_overlay
+                   : (typeof p.overlay === "string" ? p.overlay : ""),
+            name: p.name || p.short_name || p.key,
+        });
+    }
+    return out;
+}
+
 export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
                             trailingMenus, paginate = true } = {}) {
     /*
@@ -498,6 +527,7 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
      * count and no level — hashing the length alone would call that unchanged
      * and leave the placeholder on screen for the rest of the session. */
     const fingerprint = fingerprintOf([hierarchy || null, chainParams || null, mode || null]);
+    const canvasPages = canvasPageParams(chainParams);
 
     /*
      * "the module declares no hierarchy" and "we could not READ the hierarchy"
@@ -866,6 +896,12 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
             !isHiddenParam(lvl, k, isVisible) &&
             !selectorKeys.has(k) &&
             !/^ui_/.test(k) &&
+            /* A canvas PAGE key gets a page of its own below; a cell for it as
+             * well would be a second door to the same screen, and on a level
+             * whose knobs already fill the grid it lands as an overflow page
+             * holding one control. Reported from the device as "one page that
+             * is just the face". */
+            !canvasPages.has(k) &&
             !emitted.has(k));
 
         /* Dedupe applies to the AUTHORED key list only. 16 modules publish a
@@ -953,6 +989,47 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
                      * false, including a page that mixes the two. */
                     authored: keys.every((k) => authored.includes(k)),
                 });
+            });
+        }
+
+        /*
+         * CUSTOM UI PAGES, after this level's grids and before its menu.
+         *
+         * A page the MODULE draws, carrying THIS LEVEL'S OWN KNOBS. That is the
+         * whole trick and it is why this is a PAGE_KNOBS page and not a new
+         * kind: reads, knob turns, touch, the touch strip, announce, dive
+         * targets and the list layout are twenty-two branches in the
+         * controller, and a new kind would have to be threaded through every
+         * one of them. As a knobs page it inherits all of it and only the
+         * picture differs.
+         *
+         * So a custom page is reached by PAGING, responds to the eight encoders
+         * exactly as the level's grid does, and wears the host's own header and
+         * footer. The module supplies the body and nothing else.
+         *
+         * `alignKnobs` is deliberately NOT applied: its business is reflowing
+         * cells so a graphic stays inside one row, and there are no cells here.
+         */
+        for (const key of paramKeys(lvl)) {
+            const cp = canvasPages.get(key);
+            if (!cp) continue;
+            if (isHiddenParam(lvl, key, isVisible)) continue;
+            emitted.add(key);
+            pages.push({
+                kind: PAGE_KNOBS,
+                name: claimName(cp.name || title),
+                level: levelKey,
+                /* The level's own knobs, so the mapping matches its grid. A
+                 * level with no knobs still gets the page -- it simply has
+                 * nothing to turn, which is a legitimate thing for a display
+                 * page to be. */
+                keys: authored.slice(0, perPage === Infinity ? authored.length : perPage),
+                childLevel: hasChildren(lvl) ? lvl : null,
+                shortNames: levelShortNames(lvl),
+                authored: true,
+                /* What makes it custom. render_page hands the module this and
+                 * the body band; everything else about the page is ordinary. */
+                canvas: { key: cp.key, script: cp.script, overlay: cp.overlay },
             });
         }
 

--- a/src/shared/param_pages/param_card.mjs
+++ b/src/shared/param_pages/param_card.mjs
@@ -193,6 +193,33 @@ export function drawParamCard(ctx, o) {
              * pixels are somebody else`s.
              */
             raw: o.raw === undefined ? null : o.raw,
+            /*
+             * THE PAGE'S OTHER VALUES, and why a card needs them at all.
+             *
+             * `raw` is this parameter and nothing else, which is enough for a
+             * card that only has to picture its own number -- and was assumed
+             * to be enough for every card. It is not. A card whose meaning
+             * DEPENDS on a sibling (the vowel of WHICH character; a ratio
+             * against which base; a time in whose clock division) had no way to
+             * ask: there is no getParam on this path, and the card script is
+             * loaded into its own closure, so it cannot even see a variable
+             * that the module's own drawCell set.
+             *
+             * The first module to hit this reached for globalThis and a
+             * timestamp, which worked and was the wrong shape -- a hidden side
+             * channel between two files that the contract said were unrelated.
+             *
+             * This is the SAME map drawCell is handed (page_controller's own
+             * value cache), so the two surfaces now see exactly the same facts
+             * and neither is privileged. Same rules as there: a key may be
+             * missing or null, meaning a read that did not answer, and a
+             * drawer must not turn that into a picture.
+             */
+            values: o.values || null,
+            /* Wall clock, for a card that animates. drawCell has always had
+             * this; without it a card's animation sat frozen while the very
+             * gesture that raised it was in progress. */
+            nowMs: typeof o.nowMs === "number" ? o.nowMs : 0,
         });
     } catch (e) {
         /*

--- a/src/shared/param_pages/render_page.mjs
+++ b/src/shared/param_pages/render_page.mjs
@@ -631,6 +631,22 @@ export function renderPage(ctx, o) {
      * would have occupied and nothing else -- it cannot paint chrome, and it
      * does not have to draw any.
      */
+    /*
+     * GRAPHICS SEE THE LIVE VALUE, exactly as they do under the movy layout.
+     *
+     * A key that is modulated -- or that a module declared `live` -- has its
+     * effective value refreshed every tick into modValues, while `values` stays
+     * the base the knob edits. render_page_movy has always merged the two for
+     * its graphics; this renderer did not, so the same widget animated on one
+     * layout and sat frozen on the other. That class of split already shipped
+     * once today (a custom page drew under the dial renderer and not under the
+     * one the device uses), which is reason enough to keep them in step.
+     */
+    let vizValues = o.values;
+    if (o.modValues) {
+        for (const _k in o.modValues) { vizValues = Object.assign({}, o.values, o.modValues); break; }
+    }
+
     const geo = geometry(rect, layout);
     if (page.canvas && typeof o.drawCanvasPage === "function") {
         const top = geo.gridTop;
@@ -695,7 +711,7 @@ export function renderPage(ctx, o) {
                 y: geo.gridTop + row * geo.rowH,
                 w: cellW * Math.min(g.slotSpan, COLS - col),
                 h: geo.rowH,
-            }, g, o.values, o.metaIndex);
+            }, g, vizValues, o.metaIndex);
             continue;
         }
         if (vizCovered[slot]) continue;   /* drawn by this group's anchor cell */

--- a/src/shared/param_pages/render_page.mjs
+++ b/src/shared/param_pages/render_page.mjs
@@ -614,7 +614,32 @@ export function renderPage(ctx, o) {
         drawTouchStrip(ctx, rect, m, v, dec && dec.locked);
     }
 
+    /*
+     * A CUSTOM UI PAGE: the module draws the body, the host draws the chrome.
+     *
+     * It is an ordinary PAGE_KNOBS page that happens to carry a drawer, which
+     * is the whole design. Making it a new page KIND would have meant auditing
+     * twenty-two places in the controller that branch on PAGE_KNOBS -- reads,
+     * knob turns, touch, announce, the list layout, dive targets -- and getting
+     * one wrong means a page that looks right and does not respond. As a knobs
+     * page it inherits every one of those behaviours untouched, and only the
+     * picture changes.
+     *
+     * So the header above (including the touch strip that replaces it while a
+     * knob is held) and the footer the caller draws underneath are the SAME
+     * ones every other page gets. The module is handed the band the eight cells
+     * would have occupied and nothing else -- it cannot paint chrome, and it
+     * does not have to draw any.
+     */
     const geo = geometry(rect, layout);
+    if (page.canvas && typeof o.drawCanvasPage === "function") {
+        const top = geo.gridTop;
+        const band = { x: rect.x, y: top, w: rect.w, h: Math.max(0, rect.y + rect.h - top) };
+        /* ctx is passed through: the module's body must be frame-scoped to the
+         * band, and only the host knows how to build that context. */
+        if (band.h > 0) o.drawCanvasPage(ctx, band, page.canvas, { touched });
+        return;
+    }
     if (geo.rowH < 6) return;   /* nothing meaningful fits */
     const cellW = Math.floor(rect.w / COLS);
     /* Labels are resolved for the whole page at once so cells can be

--- a/src/shared/param_pages/render_page_movy.mjs
+++ b/src/shared/param_pages/render_page_movy.mjs
@@ -3209,6 +3209,28 @@ export function renderPageMovy(ctx, o) {
 
     if (!page || !page.keys) return;
     if (!L.rows.length) { drawFooterBand(); return; }
+
+    /*
+     * A CUSTOM UI PAGE: the module draws the body, this draws the chrome.
+     *
+     * IT HAS TO BE HERE AS WELL AS IN render_page.mjs. This is the layout the
+     * device actually uses -- "Knobs" in Param View -- and putting the branch
+     * only in the dial/bar renderer produced a Face page whose header said FACE
+     * and whose body was eight knobs, which is precisely what the first attempt
+     * shipped to hardware.
+     *
+     * The band is the two knob ROWS and nothing else, so the header, the bank
+     * bar and the footer above and below it are the host's own.
+     */
+    if (page.canvas && typeof o.drawCanvasPage === "function") {
+        const top = L.rows[0].rowY;
+        const bottom = L.footer !== null ? L.footer : (L.rows[1].lblY + FOOTER_Y);
+        const band = { x: L.x, y: top, w: L.cellW * 4, h: Math.max(0, bottom - top) };
+        if (band.h > 0) o.drawCanvasPage(ctx, band, page.canvas, { touched: o.touched, values: o.values });
+        drawFooterBand();
+        return;
+    }
+
     const hasParams = page.keys.some(Boolean);
     if (!hasParams) {
         tzPrint(ctx, L.x + 2, L.rows[0].rowY + 4, caps("No params"), 1);

--- a/src/shared/param_pages/viz.mjs
+++ b/src/shared/param_pages/viz.mjs
@@ -253,7 +253,7 @@ function collectDeclared(keys, metaIndex, invalid) {
              * abandoned at once.
              */
             if (isCustomKind(v.kind) && !isWidgetAvailable(v.kind)) return;
-            singles.push({ kind: v.kind, key, slot });
+            singles.push({ kind: v.kind, key, slot, extraKeys: declaredExtraKeys(v) });
         }
     });
 
@@ -280,19 +280,60 @@ function collectDeclared(keys, metaIndex, invalid) {
             invalid.push({ group: g.groupId, kind, reason: "roles not adjacent on one row" });
             continue;
         }
-        out.push({
+        const built = {
             kind, group: g.groupId, roles: mapRoles(g.roles),
             keys: spanning.map((r) => r.key),
             ...span(slots), source: VIZ_SOURCE_DECLARED,
-        });
+        };
+        /* A group's kind may be declared on any member, so its extra keys may
+         * be too — take the first member that names some. */
+        for (const r of Object.values(g.roles)) {
+            const ek = declaredExtraKeys(r.viz);
+            if (ek) { built.extraKeys = ek; break; }
+        }
+        out.push(built);
     }
     for (const s of singles) {
-        out.push({
+        const g2 = {
             kind: s.kind, group: null, roles: { value: s.key }, keys: [s.key],
             slotStart: s.slot, slotSpan: 1, source: VIZ_SOURCE_DECLARED,
-        });
+        };
+        if (s.extraKeys && s.extraKeys.length) g2.extraKeys = s.extraKeys;
+        out.push(g2);
     }
     return { groups: out, excluded };
+}
+
+/*
+ * Off-page keys a MODULE says its widget needs.
+ *
+ * `extraKeys` already existed for exactly this shape, but only detectSample
+ * could set it, for an off-page filepath. The general problem is the same one:
+ * a widget's picture can depend on a value that has no cell on this page. Keys
+ * claim cells; a key with no cell cannot be a key; so it rides here and the
+ * controller adds it to the value rotation as one extra stop.
+ *
+ * Without it the only way to get a fact to a widget was to give it a knob --
+ * which is how a module ended up with a read-only cell existing purely to carry
+ * a value to the cell beside it, occupying one of eight slots on a 128x64
+ * screen to draw something nobody needed to see.
+ *
+ * ONE READ PER STOP, so this is not free: declare what the picture needs and
+ * nothing else. Capped, because a module asking for twenty keys would spend the
+ * page's whole read budget on one cell and starve every other value on screen.
+ */
+const MAX_DECLARED_EXTRA_KEYS = 4;
+
+function declaredExtraKeys(v) {
+    const raw = v && (v.extra_keys || v.extraKeys);
+    if (!Array.isArray(raw)) return null;
+    const out = [];
+    for (const k of raw) {
+        if (typeof k !== "string" || !k) continue;
+        if (out.indexOf(k) < 0) out.push(k);
+        if (out.length >= MAX_DECLARED_EXTRA_KEYS) break;
+    }
+    return out.length ? out : null;
 }
 
 function mapRoles(roleMap) {

--- a/src/shared/param_pages/widget_registry.mjs
+++ b/src/shared/param_pages/widget_registry.mjs
@@ -63,6 +63,86 @@ export function registerWidget(kind, impl) {
     return true;
 }
 
+/**
+ * Register every widget one canvas overlay declares.
+ *
+ * WHY THIS IS NOT JUST `registerWidget(ov.widgetKind, ...)`. It was, and the
+ * registry has always been a Map, so the ONLY thing limiting a module to a
+ * single widget was this one call site reading a single string. A module with
+ * two genuinely different pictures -- a face in one cell and that face's mouth
+ * in another -- had to declare ONE kind on both parameters and branch on the
+ * key inside its own drawCell. That works, but nothing says so: declaring
+ * `custom:a` and `custom:b` looked completely reasonable, the second one was
+ * never registered, and its cell quietly fell back to a built-in dial. A
+ * correct-looking page and no error, which is the failure mode this file's own
+ * header is otherwise careful about.
+ *
+ * Three shapes are accepted, and a module may use more than one:
+ *
+ *   widgetKind:  "custom:a"                     + drawCell   (unchanged)
+ *   widgetKinds: ["custom:a", "custom:b"]       + drawCell   (one drawer,
+ *                                                  told apart by group.keys)
+ *   widgetKinds: { "custom:a": fn,                            (a drawer each)
+ *                  "custom:b": { draw, nominal } }
+ *
+ * The array form keeps the dispatch-on-key style for a module whose widgets
+ * really are one drawing at two crops; the object form is for widgets that
+ * have nothing to do with each other, and lets each carry its own nominal.
+ *
+ * Returns what happened rather than a bare boolean, because "declared a custom
+ * kind and got no widget" is exactly what the caller needs to log -- an author
+ * who sees a reasonable picture has no other way to find out it is not theirs.
+ *
+ * @param {object} ov  the loaded canvas overlay
+ * @returns {{registered: string[], skipped: {kind: string, why: string}[]}}
+ */
+export function registerOverlayWidgets(ov) {
+    const registered = [];
+    const skipped = [];
+    if (!ov || typeof ov !== "object") return { registered, skipped };
+
+    const fallbackDraw = typeof ov.drawCell === "function" ? ov.drawCell.bind(ov) : null;
+    const fallbackNominal = ov.widgetNominal || null;
+
+    const add = (kind, draw, nominal) => {
+        if (!isCustomKind(kind)) {
+            skipped.push({ kind: String(kind), why: "not a custom: kind" });
+            return;
+        }
+        if (typeof draw !== "function") {
+            skipped.push({ kind, why: "no drawCell for it" });
+            return;
+        }
+        if (registerWidget(kind, { draw, nominal: nominal || null })) registered.push(kind);
+        else skipped.push({ kind, why: "registry refused it" });
+    };
+
+    /* Legacy single kind first, so an explicit widgetKinds entry for the same
+     * name wins -- a module spelling both means the richer one. */
+    if (typeof ov.widgetKind === "string") add(ov.widgetKind, fallbackDraw, fallbackNominal);
+
+    const many = ov.widgetKinds;
+    if (Array.isArray(many)) {
+        for (const kind of many) add(kind, fallbackDraw, fallbackNominal);
+    } else if (many && typeof many === "object") {
+        for (const kind of Object.keys(many)) {
+            const entry = many[kind];
+            if (typeof entry === "function") add(kind, entry.bind(ov), fallbackNominal);
+            else if (entry && typeof entry === "object") {
+                const d = typeof entry.draw === "function" ? entry.draw
+                        : (typeof entry.drawCell === "function" ? entry.drawCell : null);
+                add(kind, d ? d.bind(ov) : null, entry.nominal || entry.widgetNominal || fallbackNominal);
+            } else {
+                skipped.push({ kind, why: "entry is neither a function nor an object" });
+            }
+        }
+    } else if (many !== undefined) {
+        skipped.push({ kind: "widgetKinds", why: "must be an array or an object" });
+    }
+
+    return { registered, skipped };
+}
+
 /** Registered AND not disabled. This is the predicate viz.mjs consults. */
 export function isWidgetAvailable(kind) {
     return widgets.has(kind) && !disabled.has(kind);

--- a/tests/host/test_canvas_drawcell_wiring.sh
+++ b/tests/host/test_canvas_drawcell_wiring.sh
@@ -47,15 +47,28 @@ ok(/from\s+.\/data\/UserData\/schwung\/shared\/param_pages\/widget_registry\.mjs
    "widget_registry is imported by its absolute device path");
 ok(!/from\s+.[.][.]?\/shared\/param_pages\/widget_registry\.mjs./.test(src),
    "widget_registry is NOT imported by a relative path (fatal on device)");
-for (const fn of ["registerWidget", "clearWidgets", "setWidgetLogger"]) {
+for (const fn of ["registerOverlayWidgets", "clearWidgets", "setWidgetLogger"]) {
   ok(new RegExp("\\b" + fn + "\\b").test(src), `shadow_ui imports ${fn}`);
 }
 
-/* Registration is guarded on BOTH the hook and the kind. */
-ok(/typeof\s+\w+\.drawCell\s*===\s*"function"/.test(src),
+/*
+ * Registration is guarded on BOTH the hook and the kind -- but the guards no
+ * longer live HERE.
+ *
+ * They moved into widget_registry.registerOverlayWidgets when a module gained
+ * the ability to declare several widgets, because the rule got big enough that
+ * a copy of it in shadow_ui.js would be a second place to get it wrong. What
+ * this file still owns is that shadow_ui does not hand-roll its own version.
+ * The guards themselves are exercised behaviourally, on the real function, by
+ * test_widget_multiple_kinds.sh.
+ */
+const reg = readFileSync("./src/shared/param_pages/widget_registry.mjs", "utf8");
+ok(/typeof\s+draw\s*!==\s*"function"/.test(reg),
    "a non-function drawCell is ignored rather than registered");
-ok(/typeof\s+\w+\.widgetKind\s*===\s*"string"/.test(src),
-   "an overlay with no widgetKind string is ignored");
+ok(/isCustomKind\(kind\)/.test(reg),
+   "a kind outside the custom: namespace is ignored");
+ok(!/registerWidget\(ov\.widgetKind/.test(src),
+   "shadow_ui does not keep its own copy of the registration rule");
 
 /* WIDGET LIFETIME IS THE COMPONENTS, NOT THE CANVAS VIEWS.
  *
@@ -80,7 +93,7 @@ ok(ecwStart > 0, "ensureComponentWidgets exists");
 const ecwBody = code(src.slice(ecwStart, src.indexOf("\nfunction ", ecwStart + 1)));
 ok(/clearWidgets\s*\(\s*\)/.test(ecwBody),
    "ensureComponentWidgets owns the clear");
-ok(/registerWidget\s*\(/.test(ecwBody),
+ok(/registerOverlayWidgets\s*\(/.test(ecwBody),
    "ensureComponentWidgets owns the registration");
 ok(/widgetModuleLoaded/.test(ecwBody),
    "it is a no-op when the module has not changed, so it is safe on a hot path");

--- a/tests/host/test_canvas_page.sh
+++ b/tests/host/test_canvas_page.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A MODULE MAY OWN A WHOLE PAGE, AND IT IS STILL A PAGE.
+#
+# The existing custom-UI surface is a `type: "canvas"` param you CLICK to dive
+# into a fullscreen view. That view is not a page: you cannot jog to it, the
+# encoders do not reach it, and it draws its own chrome. Asked for on hardware
+# as "I have to dive in to see the faces instead of it being its own page, knobs
+# do not work on the face, and the face does not animate".
+#
+# `as_page: true` makes it a page in the level's jog rotation, carrying THAT
+# LEVEL'S OWN KNOBS.
+#
+# THE DESIGN DECISION WORTH KNOWING. It is an ordinary PAGE_KNOBS page that
+# happens to carry a `canvas` field -- NOT a new page kind. Twenty-two places in
+# page_controller branch on PAGE_KNOBS (reads, knob turns, touch, the touch
+# strip, announce, dive targets, the list layout); a new kind would have to be
+# threaded through every one, and missing one gives a page that looks right and
+# does not respond. As a knobs page it inherits all of that untouched and only
+# the picture differs.
+#
+# What must hold:
+#   - the page is planned, in the rotation, with the level's knobs
+#   - the canvas key does NOT also get a cell (it did, as an overflow page
+#     holding one control -- "one page that is just the face")
+#   - the module draws the BODY only; header and footer are the host's
+#   - a drawer that throws is retired and the page survives
+#
+# NO APOSTROPHES BELOW THIS LINE inside the node script: it is a single-quoted
+# bash string, and one apostrophe ends it early with an error pointing nowhere
+# near the real line.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+const R = process.cwd();
+const { planPages, PAGE_KNOBS } = await import(R + "/src/shared/param_pages/page_plan.mjs");
+const { renderPage } = await import(R + "/src/shared/param_pages/render_page.mjs");
+const { buildMetaIndex } = await import(R + "/src/shared/param_pages/param_meta.mjs");
+const { createController, LAYOUT_MOVY } = await import(R + "/src/shared/param_pages/page_controller.mjs");
+const { createFramebuffer, drawContext } = await import(R + "/tools/param-pages/harness.mjs");
+
+let fails = 0;
+const ok = (c, m) => { if (!c) { console.error("FAIL: " + m); fails++; } };
+
+const HIER = { levels: { root: { label: "Main",
+  knobs: ["a", "b", "c"],
+  params: [{ key: "a" }, { key: "b" }, { key: "c" }, { key: "face" }] } } };
+const CP = [
+  { key: "a", name: "A", type: "float", min: 0, max: 1, step: 0.01 },
+  { key: "b", name: "B", type: "float", min: 0, max: 1, step: 0.01 },
+  { key: "c", name: "C", type: "float", min: 0, max: 1, step: 0.01 },
+  { key: "face", name: "Face", type: "canvas", canvas_script: "canvas.js",
+    canvas_overlay: "face_page", as_page: true },
+];
+
+/* ---- planning ---- */
+const plan = planPages({ hierarchy: HIER, chainParams: CP });
+const canvasPages = plan.pages.filter((p) => p.canvas);
+ok(canvasPages.length === 1, "exactly one custom page is planned");
+const cp = canvasPages[0];
+ok(cp && cp.kind === PAGE_KNOBS,
+   "a custom page IS a knobs page, so it inherits every knobs-page behaviour");
+ok(cp && cp.name === "Face", "it is named after the param, not after the level");
+ok(cp && JSON.stringify(cp.keys) === JSON.stringify(["a", "b", "c"]),
+   "it carries the levels own knobs, so the encoders do what they do on the grid");
+ok(cp && cp.canvas.script === "canvas.js" && cp.canvas.overlay === "face_page",
+   "the script and overlay travel with the page");
+
+/* The canvas key must NOT also be a cell anywhere. */
+const celled = plan.pages.some((p) => (p.keys || []).indexOf("face") >= 0);
+ok(!celled, "the canvas key never gets a cell of its own");
+ok(!plan.pages.some((p) => !p.canvas && (p.keys || []).length === 1 && p.keys[0] === "face"),
+   "and there is no orphan page holding just it");
+
+/* Without as_page it stays a dive-in cell -- the OLD behaviour is untouched. */
+const CP2 = CP.map((p) => (p.key === "face" ? { ...p, as_page: false } : p));
+const plan2 = planPages({ hierarchy: HIER, chainParams: CP2 });
+ok(!plan2.pages.some((p) => p.canvas), "without as_page no custom page is planned");
+ok(plan2.pages.some((p) => (p.keys || []).indexOf("face") >= 0),
+   "and the key goes back to being an ordinary cell");
+
+/* ---- rendering: the module gets the BODY, the host keeps the chrome ---- */
+{
+  const fb = createFramebuffer(128, 64);
+  let got = null;
+  renderPage(drawContext(fb), {
+    page: cp, metaIndex: buildMetaIndex({ hierarchy: HIER, chainParams: CP }),
+    values: { a: "0.5" }, title: "MOD", pageIndex: 1, pageCount: 2,
+    touched: -1, rect: { x: 0, y: 0, w: 128, h: 64 },
+    drawCanvasPage: (ctx, band, canvas, extra) => { got = { band, canvas, extra }; },
+  });
+  ok(got !== null, "the drawer is called for a custom page");
+  ok(got && got.band.y > 0, "the band starts BELOW the header");
+  ok(got && got.band.y + got.band.h <= 64, "and stays inside the panel");
+  ok(got && got.band.x === 0 && got.band.w === 128, "it spans the full width");
+  ok(fb.countLit() > 0, "the host still drew its own header");
+
+  /* A page WITHOUT canvas must never call it. */
+  let called = false;
+  const grid = plan.pages.find((p) => !p.canvas && (p.keys || []).length);
+  renderPage(drawContext(createFramebuffer(128, 64)), {
+    page: grid, metaIndex: buildMetaIndex({ hierarchy: HIER, chainParams: CP }),
+    values: {}, title: "MOD", pageIndex: 0, pageCount: 2, touched: -1,
+    rect: { x: 0, y: 0, w: 128, h: 64 },
+    drawCanvasPage: () => { called = true; },
+  });
+  ok(!called, "an ordinary page never calls the canvas drawer");
+}
+
+/* ---- the controller reaches it, and knobs still work ---- */
+{
+  const store = { ui_hierarchy: JSON.stringify(HIER), chain_params: JSON.stringify(CP),
+                  a: "0.25", b: "0.5", c: "0.75" };
+  const writes = [];
+  let t = 0;
+  const ctrl = createController({
+    getParam: (k) => { const b = String(k).split(":").pop();
+                       return store[b] === undefined ? null : store[b]; },
+    setParam: (k, v) => { writes.push([String(k).split(":").pop(), v]); return true; },
+    announce: () => {}, now: () => (t += 16),
+  });
+  ctrl.load({ prefix: "synth" });
+  ctrl.setLayout(LAYOUT_MOVY);
+  for (let i = 0; i < 40; i++) ctrl.tick();
+
+  const idx = ctrl.describePage ? null : null;
+  /* Jog to the custom page. */
+  let found = -1;
+  for (let i = 0; i < 8; i++) {
+    ctrl.goToPage(i, { remember: false });
+    if (ctrl.onCanvasPage()) { found = i; break; }
+  }
+  ok(found >= 0, "the custom page is reachable by paging, not only by diving");
+  ok(ctrl.onCanvasPage(), "and the controller reports it as one");
+
+  /* Turning knob 0 on the custom page must write the levels first knob. */
+  for (let i = 0; i < 10; i++) ctrl.tick();
+  ctrl.onKnobTurn(0, 1);
+  ok(writes.some((w) => w[0] === "a"),
+     "an encoder on the custom page writes the levels own param");
+}
+
+/* ---- a thrower is retired, not fatal ---- */
+{
+  const fb = createFramebuffer(128, 64);
+  let threw = false;
+  try {
+    renderPage(drawContext(fb), {
+      page: cp, metaIndex: buildMetaIndex({ hierarchy: HIER, chainParams: CP }),
+      values: {}, title: "MOD", pageIndex: 1, pageCount: 2, touched: -1,
+      rect: { x: 0, y: 0, w: 128, h: 64 },
+      drawCanvasPage: () => { throw new Error("boom"); },
+    });
+  } catch (e) { threw = true; }
+  ok(threw, "render_page does not swallow the throw itself -- the HOST retires the drawer");
+}
+
+if (fails) { console.error(fails + " failure(s)"); process.exit(1); }
+console.log("PASS: a module can own a page, keep the hosts chrome, and still be turned");
+'

--- a/tests/host/test_canvas_page.sh
+++ b/tests/host/test_canvas_page.sh
@@ -162,6 +162,98 @@ ok(plan2.pages.some((p) => (p.keys || []).indexOf("face") >= 0),
   ok(threw, "render_page does not swallow the throw itself -- the HOST retires the drawer");
 }
 
+/* ---- preset_browser: the module DRAWS the level browser ---- */
+{
+  const HB = { levels: { root: { label: "Main", knobs: ["a", "b", "c"],
+    list_param: "preset", count_param: "preset_count", name_param: "preset_name",
+    params: [{ key: "a" }, { key: "b" }, { key: "c" }, { key: "face" }] } } };
+  const CB = CP.map((p) => (p.key === "face" ? { ...p, preset_browser: true } : p));
+  const plan3 = planPages({ hierarchy: HB, chainParams: CB });
+
+  const browsers = plan3.pages.filter((p) => p.listParam);
+  ok(browsers.length === 1,
+     "ONE browser page, not the modules page plus a text one beside it");
+  const b = browsers[0];
+  ok(!!b.canvas, "the browser carries the modules drawer");
+  ok(b.name === "Face", "and takes the params name, because it IS that screen");
+  ok(JSON.stringify(b.keys) === JSON.stringify(["a", "b", "c"]),
+     "it carries the levels knobs, so the sound stays editable while browsing");
+  ok(plan3.pages.indexOf(b) === 0,
+     "and it is FIRST, so it is what you land on");
+  ok(!plan3.pages.some((p) => p !== b && p.canvas),
+     "the canvas param does not also produce a standalone page");
+
+  /* Without preset_browser the two stay separate -- the old behaviour. */
+  const plan4 = planPages({ hierarchy: HB, chainParams: CP });
+  ok(plan4.pages.filter((p) => p.listParam).length === 1 &&
+     !plan4.pages.find((p) => p.listParam).canvas,
+     "without preset_browser the text browser is untouched");
+  ok(plan4.pages.some((p) => p.canvas && !p.listParam),
+     "and the custom page is a page of its own");
+}
+
+/* ---- a browser page with knobs must READ and be TURNABLE ---- */
+{
+  const HB = { levels: { root: { label: "Main", knobs: ["a", "b"],
+    list_param: "preset", count_param: "preset_count", name_param: "preset_name",
+    params: [{ key: "a" }, { key: "b" }, { key: "face" }] } } };
+  const CB = [
+    { key: "a", name: "A", type: "float", min: 0, max: 1, step: 0.01 },
+    { key: "b", name: "B", type: "float", min: 0, max: 1, step: 0.01 },
+    { key: "face", name: "Face", type: "canvas", canvas_script: "canvas.js",
+      as_page: true, preset_browser: true },
+  ];
+  const store = { ui_hierarchy: JSON.stringify(HB), chain_params: JSON.stringify(CB),
+                  preset: "1", preset_count: "12", preset_name: "Fish",
+                  a: "0.25", b: "0.75" };
+  const writes = [];
+  const reads = [];
+  let t = 0, payload = null;
+  const ctrl = createController({
+    getParam: (k) => { const bb = String(k).replace(/^synth:/, "");
+                       reads.push(bb);
+                       return store[bb] === undefined ? null : store[bb]; },
+    setParam: (k, v) => { writes.push([String(k).replace(/^synth:/, ""), v]); return true; },
+    announce: () => {}, now: () => (t += 16),
+    drawCanvasPage: (ctx2, band, canvas, pl) => { payload = pl; },
+  });
+  ctrl.load({ prefix: "synth" });
+  ctrl.setLayout(LAYOUT_MOVY);
+  ctrl.goToPage(0, { remember: false });
+  for (let i = 0; i < 60; i++) ctrl.tick();
+
+  const fb2 = createFramebuffer(128, 64);
+  ctrl.render(drawContext(fb2), { title: "M", footer: null });
+
+  ok(payload !== null, "the browser page calls the modules drawer");
+
+  /*
+   * THE VALUE LANE MUST RUN ON THIS PAGE.
+   *
+   * An ordinary preset page has no knobs and returns early from the tick; one
+   * carrying knobs has to read them too, or its picture is drawn from values
+   * nobody fetched.
+   *
+   * Asserted by watching for reads WHILE ON THIS PAGE, not by looking at the
+   * values. The first version checked `values.a` and passed even with the lane
+   * disabled, because the level browser shares its keys with the levels grid
+   * and they were already cached from there -- a probe that cannot fail is
+   * worse than no probe.
+   */
+  reads.length = 0;
+  for (let i = 0; i < 40; i++) ctrl.tick();
+  ok(reads.some((k) => k === "a" || k === "b"),
+     "its knob values are re-read while the browser page is up");
+  ok(payload && payload.values && payload.values.a === "0.25",
+     "and reach the drawer");
+  ok(payload && payload.preset && payload.preset.count === 12,
+     "and it is handed the browser state, which is not a param anyone could read");
+
+  ctrl.onKnobTurn(0, 1);
+  ok(writes.some((w) => w[0] === "a"),
+     "an encoder on the browser page still edits the sound");
+}
+
 if (fails) { console.error(fails + " failure(s)"); process.exit(1); }
 console.log("PASS: a module can own a page, keep the hosts chrome, and still be turned");
 '

--- a/tests/host/test_effective_asks_the_plugin.sh
+++ b/tests/host/test_effective_asks_the_plugin.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# `<key>:effective` MUST REACH THE PLUGIN.
+#
+# The chain owns one kind of modulation -- LFOs and macros routed to a target --
+# and chain_mod_get_effective_for_subkey answers from that table. When the key
+# is NOT in it, the old code stripped ":effective" and asked the plugin for the
+# plain key.
+#
+# That is right only if the chain is the sole thing that can move a parameter,
+# and it is not. A synth that drives its own value serves `<key>:effective`
+# itself: MonkSynth sweeps its vowel from pad pressure, exactly as the original
+# swept it from the pitch wheel. Its answer was thrown away here -- the suffix
+# consumed, the plain key asked, the KNOB value returned -- so every picture of
+# that vowel sat still while the sound moved. Reported from hardware twice: "the
+# mouth shape should animate with pressure", then "vowel doesnt change with
+# pressure".
+#
+# The convention is documented in CLAUDE.md ("the driven value is asked for as
+# <key>:effective") and this is the one place that could honour it for a module.
+#
+# Source-pinned rather than unit-tested: chain_mod.c needs a live
+# chain_instance_t with a loaded plugin, which is a device, not a fixture.
+
+C=src/modules/chain/dsp/chain_mod.c
+fail() { echo "FAIL: $1"; exit 1; }
+
+[ -f "$C" ] || fail "chain_mod.c is missing"
+
+body=$(awk '/int chain_mod_get_effective_for_subkey/,/^}/' "$C")
+[ -n "$body" ] || fail "chain_mod_get_effective_for_subkey not found"
+
+# It must build "<param>:effective" and ask the plugin with it.
+echo "$body" | grep -q '%s:effective' \
+    || fail "the fallback never asks the plugin for <key>:effective -- a module that drives its own value is ignored"
+
+# And that ask must come BEFORE the plain-key fallback, or the plain key wins
+# and the suffix is still being swallowed.
+eff_line=$(echo "$body" | grep -n '%s:effective' | head -n 1 | cut -d: -f1)
+plain_line=$(echo "$body" | grep -n 'chain_mod_get_param_string(inst, target, param,' | head -n 1 | cut -d: -f1)
+[ -n "$eff_line" ] && [ -n "$plain_line" ] || fail "could not locate both fallbacks"
+[ "$eff_line" -lt "$plain_line" ] \
+    || fail "the plain-key fallback runs first, so the plugin is never asked"
+
+# An empty answer is a MISS, not a value: an unserved key comes back as an empty
+# buffer, and taking that as an answer would blank the reading.
+echo "$body" | grep -q "buf\[0\] != '\\\\0'" \
+    || fail "an empty answer is treated as a value -- an unserved key would blank the reading"
+
+echo "PASS: an unmodulated <key>:effective asks the plugin before falling back"

--- a/tests/host/test_live_param_values.sh
+++ b/tests/host/test_live_param_values.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A MODULE MAY DECLARE A PARAM LIVE, AND ITS PICTURE MUST FOLLOW IT.
+#
+# `isModulated` asks the chain's modulation system, which knows about LFOs and
+# macros. It cannot know that a synth drives its own vowel from pad pressure --
+# so the widget drawing that vowel sat frozen at whatever the knob last said
+# while the sound moved underneath it. Reported from hardware as "the mouth
+# shape should animate with pressure".
+#
+# `"live": true` on the param says the value moves on its own. It buys the same
+# treatment a modulated key gets: the effective value refreshed EVERY TICK
+# rather than on the value rotation, which on an eight-knob page lands about
+# four times a second -- an animation drawn from that is a slideshow.
+#
+# The other half is that the picture must actually SEE it. `values` stays the
+# base (it is what a turn edits); graphics get base merged with effective. The
+# movy renderer always did that; render_page did not, so the same widget
+# animated on one layout and froze on the other -- and movy is the layout the
+# device uses.
+#
+# NO APOSTROPHES BELOW THIS LINE inside the node script: it is a single-quoted
+# bash string, and one apostrophe ends it early with an error pointing nowhere
+# near the real line.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+const R = process.cwd();
+const { createController, LAYOUT_MOVY } = await import(R + "/src/shared/param_pages/page_controller.mjs");
+const { registerWidget, clearWidgets } = await import(R + "/src/shared/param_pages/widget_registry.mjs");
+const { renderPage } = await import(R + "/src/shared/param_pages/render_page.mjs");
+const { renderPageMovy } = await import(R + "/src/shared/param_pages/render_page_movy.mjs");
+const { planPages } = await import(R + "/src/shared/param_pages/page_plan.mjs");
+const { buildMetaIndex } = await import(R + "/src/shared/param_pages/param_meta.mjs");
+const { createFramebuffer, drawContext } = await import(R + "/tools/param-pages/harness.mjs");
+
+let fails = 0;
+const ok = (c, m) => { if (!c) { console.error("FAIL: " + m); fails++; } };
+
+const HIER = { levels: { root: { label: "M", knobs: ["vowel", "b"],
+  params: [{ key: "vowel" }, { key: "b" }] } } };
+const CP = [
+  { key: "vowel", name: "Vowel", type: "float", min: 0, max: 1, step: 0.01,
+    live: true, viz: { kind: "custom:mouth" } },
+  { key: "b", name: "B", type: "float", min: 0, max: 1, step: 0.01 },
+];
+
+/* ---- the controller keeps the effective value fresh ---- */
+clearWidgets();
+registerWidget("custom:mouth", { draw() {} });
+{
+  const reads = [];
+  /* base 0.10, but PRESSURE has driven it to 0.90 */
+  const store = { ui_hierarchy: JSON.stringify(HIER), chain_params: JSON.stringify(CP),
+                  vowel: "0.10", "vowel:base": "0.10", "vowel:effective": "0.90", b: "0.5" };
+  let t = 0;
+  const ctrl = createController({
+    getParam: (k) => { const b = String(k).replace(/^synth:/, ""); reads.push(b);
+                       return store[b] === undefined ? null : store[b]; },
+    setParam: () => true, announce: () => {}, now: () => (t += 16),
+  });
+  ctrl.load({ prefix: "synth" });
+  ctrl.setLayout(LAYOUT_MOVY);
+  for (let i = 0; i < 30; i++) ctrl.tick();
+
+  ok(reads.indexOf("vowel:effective") >= 0,
+     "a live param has its effective value read");
+
+  /* It must be read REPEATEDLY, not once -- that is the difference between an
+   * animation and a value that happens to be right when you arrive. */
+  const before = reads.filter((k) => k === "vowel:effective").length;
+  for (let i = 0; i < 10; i++) ctrl.tick();
+  const after = reads.filter((k) => k === "vowel:effective").length;
+  ok(after - before >= 5,
+     `a live param is re-read every tick, not on the rotation (got ${after - before} in 10 ticks)`);
+
+  /* And the widget must be handed the EFFECTIVE value, not the base. */
+  let seen = null;
+  clearWidgets();
+  registerWidget("custom:mouth", { draw(ctx, o) { seen = o.values.vowel; } });
+  for (let i = 0; i < 6; i++) ctrl.tick();
+  ctrl.render({ fillRect() {}, print() {}, textWidth: (s2) => String(s2).length * 4,
+                line() {}, drawCircle() {}, fillCircle() {}, drawArc() {},
+                width: 128, height: 64 });
+  ok(seen === "0.90",
+     `the widget draws the effective value, not the knob (got ${JSON.stringify(seen)})`);
+}
+
+/* ---- BOTH renderers merge, or a widget animates on one layout only ---- */
+{
+  const plan = planPages({ hierarchy: HIER, chainParams: CP });
+  const page = plan.pages.find((p) => (p.keys || []).indexOf("vowel") >= 0);
+  const mi = buildMetaIndex({ hierarchy: HIER, chainParams: CP });
+  const args = {
+    page, metaIndex: mi, values: { vowel: "0.10", b: "0.5" },
+    modValues: { vowel: "0.90" },
+    title: "M", pageIndex: 0, pageCount: 1, touched: -1,
+    rect: { x: 0, y: 0, w: 128, h: 64 },
+    viz: [{ kind: "custom:mouth", group: null, roles: { value: "vowel" },
+            keys: ["vowel"], slotStart: 0, slotSpan: 1, source: "declared" }],
+  };
+  for (const [name, fn] of [["render_page", renderPage], ["render_page_movy", renderPageMovy]]) {
+    let got = null;
+    clearWidgets();
+    registerWidget("custom:mouth", { draw(ctx, o) { got = o.values.vowel; } });
+    fn(drawContext(createFramebuffer(128, 64)), args);
+    ok(got === "0.90", `${name} hands the widget the effective value (got ${JSON.stringify(got)})`);
+  }
+}
+
+if (fails) { console.error(fails + " failure(s)"); process.exit(1); }
+console.log("PASS: a live param is re-read every tick and both renderers draw it");
+'

--- a/tests/host/test_module_help_shape.sh
+++ b/tests/host/test_module_help_shape.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# EVERY SHIPPED help.json MUST BE READABLE, AND THE FAILURE IS SILENT.
+#
+# The loader's whole test is `if (helpData.children) helpMap[id] = ...`. A file
+# that parses as valid JSON but names its topics anything else -- `sections`,
+# `pages`, `parameters` -- is discarded WITHOUT A WORD, and the viewer says "No
+# help content available" as though the file were absent. A 2026-08 catalog
+# sweep found 12 modules in exactly that state, several carrying kilobytes of
+# help nobody could read.
+#
+# This repo had one too: widget-test, the reference module for the three
+# module-supplied draw surfaces, shipped `sections` and its help had never once
+# been displayed. A module author copying the reference copies the bug, which is
+# how this class of thing spreads.
+#
+# Also measures LINE WIDTH in pixels against the device font, because a help
+# line is drawn, never wrapped and never truncated: everything past x=127 is
+# dropped by set_pixel with no error anywhere.
+#
+# NO APOSTROPHES BELOW THIS LINE inside the node script.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+const R = process.cwd();
+const fs = await import("node:fs");
+const path = await import("node:path");
+const { createFramebuffer } = await import(R + "/tools/param-pages/harness.mjs");
+
+let fails = 0;
+const fail = (m) => { console.error("FAIL: " + m); fails++; };
+
+/* The real atlas, so this measures what the panel would draw. */
+const fb = createFramebuffer(128, 64);
+
+/* drawScrollableText prints at x=4, and the panel is 128 wide. */
+const BUDGET = 128 - 4;
+
+function walk(dir, out) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, out);
+    else if (e.name === "help.json") out.push(p);
+  }
+  return out;
+}
+
+const files = walk(path.join(R, "src", "modules"), []);
+if (!files.length) fail("no help.json found under src/modules -- did the layout move?");
+
+for (const f of files) {
+  const rel = path.relative(R, f);
+  let d;
+  try { d = JSON.parse(fs.readFileSync(f, "utf8")); }
+  catch (e) { fail(`${rel} is not valid JSON: ${e}`); continue; }
+
+  if (!Array.isArray(d.children) || d.children.length === 0) {
+    fail(`${rel} has no top-level children[] -- the loader discards it silently ` +
+         `(keys: ${Object.keys(d).join(", ")})`);
+    continue;
+  }
+
+  /* Every leaf line, measured. */
+  const over = [];
+  const seen = new Set();
+  (function rec(nodes, trail) {
+    for (const n of nodes || []) {
+      if (!n || typeof n !== "object") continue;
+      const where = trail ? `${trail} > ${n.title || "?"}` : (n.title || "?");
+      if (Array.isArray(n.lines)) {
+        for (const ln of n.lines) {
+          const s = String(ln);
+          const w = fb.textWidth(s);
+          if (w > BUDGET) over.push(`${where}: ${w}px "${s}"`);
+          for (const ch of s) if (ch.charCodeAt(0) > 126) seen.add(ch);
+        }
+      }
+      if (Array.isArray(n.children)) rec(n.children, where);
+    }
+  })(d.children, "");
+
+  if (over.length) {
+    fail(`${rel} has ${over.length} line(s) running off the display:`);
+    for (const o of over.slice(0, 5)) console.error("       " + o);
+  }
+  if (seen.size) {
+    fail(`${rel} uses characters the bitmap font has no glyph for: ${[...seen].join(" ")}`);
+  }
+}
+
+if (fails) { console.error(fails + " failure(s)"); process.exit(1); }
+console.log(`PASS: ${files.length} help.json files load, fit the display, and stay in ASCII`);
+'

--- a/tests/host/test_param_card_sees_siblings.sh
+++ b/tests/host/test_param_card_sees_siblings.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A CARD DRAWER CAN READ THE PAGE, THE SAME WAY A CELL WIDGET ALWAYS COULD.
+#
+# The card payload was { w, h, name, value, raw } -- this parameter and nothing
+# else. That is enough for a card that pictures its own number, and it was
+# assumed to be enough for all of them. It is not: a card whose MEANING depends
+# on a sibling (the vowel of which character, a ratio against which base) had no
+# route to that fact at all. There is no getParam on this path, and the card
+# script is loaded into its own closure, so it cannot see a variable the
+# module's own drawCell set either.
+#
+# The first module to hit this reached for globalThis plus a staleness
+# timestamp. It worked, and it was a hidden side channel between two files the
+# contract said were unrelated -- which is the thing to prevent, not to
+# document.
+#
+# What must hold:
+#   - `values` reaches the drawer, and is the SAME map drawCell is handed
+#   - `nowMs` reaches it too, so a card can animate during the gesture that
+#     raised it
+#   - the null contract is unchanged: a missing sibling is absent, and a drawer
+#     that throws still leaves an empty card rather than a hole
+#
+# NO APOSTROPHES BELOW THIS LINE inside the node script: it is a single-quoted
+# bash string, and one apostrophe ends it early with an error pointing nowhere
+# near the real line.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the param card tests" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { drawParamCard } from "./src/shared/param_pages/param_card.mjs";
+import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
+import { readFileSync } from "node:fs";
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error("FAIL: " + what); fails++; } };
+
+const surface = () => {
+  const fb = createFramebuffer(128, 64);
+  return { fb, ctx: drawContext(fb) };
+};
+
+/* ---- values and nowMs reach the drawer ---- */
+{
+  const s = surface();
+  const pageValues = { vowel: 0.5, face: 3 };
+  let got = null;
+  drawParamCard(s.ctx, {
+    meta: { name: "Vowel" },
+    draw: (ctx, o) => { got = o; ctx.fillRect(0, 0, 4, 4, 1); },
+    name: "Vowel", value: "0.50", raw: 0.5,
+    values: pageValues,
+    nowMs: 1234,
+  });
+  ok(got !== null, "the drawer ran");
+  ok(got && got.values === pageValues, "values is passed through, by reference");
+  ok(got && got.values.face === 3, "a sibling key is readable from the card");
+  ok(got && got.nowMs === 1234, "nowMs is passed through");
+}
+
+/* ---- absent values must be null, never invented ---- */
+{
+  const s = surface();
+  let got = null;
+  drawParamCard(s.ctx, {
+    meta: { name: "Vowel" },
+    draw: (ctx, o) => { got = o; },
+    name: "Vowel", value: "", raw: null,
+  });
+  ok(got && got.values === null, "no values supplied reads as null, not as {}");
+  ok(got && got.raw === null, "the raw null contract is unchanged");
+  ok(got && got.nowMs === 0, "nowMs defaults rather than being undefined");
+}
+
+/* ---- a drawer that throws still leaves an EMPTY card, not a hole ---- */
+{
+  const s = surface();
+  let errored = false;
+  drawParamCard(s.ctx, {
+    meta: { name: "Vowel" },
+    draw: (ctx) => { ctx.fillRect(0, 0, 40, 20, 1); throw new Error("boom"); },
+    name: "Vowel", value: "0.50", raw: 0.5,
+    values: { face: 1 },
+    onError: () => { errored = true; },
+  });
+  ok(errored, "onError fires so the caller can retire the drawer");
+
+  /* The real invariant, rather than a threshold: a drawer that painted and THEN
+   * threw must leave EXACTLY what a drawer that painted nothing leaves. An
+   * eyeballed pixel budget would pass for a card that kept half its picture. */
+  const empty = surface();
+  drawParamCard(empty.ctx, {
+    meta: { name: "Vowel" },
+    draw: () => {},
+    name: "Vowel", value: "0.50", raw: 0.5,
+  });
+  ok(s.fb.countLit() > 0, "the card frame is still on screen");
+  ok(s.fb.countLit() === empty.fb.countLit(),
+     "a thrower leaves exactly an empty card, not half a picture");
+}
+
+/* ---- the controller actually supplies them ---- */
+{
+  const pc = readFileSync("./src/shared/param_pages/page_controller.mjs", "utf8");
+  const call = pc.slice(pc.indexOf("function drawDeclaredCard"),
+                        pc.indexOf("function drawDeclaredCard") + 2000);
+  ok(/values:\s*s\.values/.test(call), "page_controller passes its value map to the card");
+  ok(/nowMs:\s*now\(\)/.test(call), "page_controller passes a clock to the card");
+}
+
+if (fails) { console.error(fails + " failure(s)"); process.exit(1); }
+console.log("PASS: a card sees the page values and a clock, and the null contract is intact");
+'

--- a/tests/host/test_param_card_sees_siblings.sh
+++ b/tests/host/test_param_card_sees_siblings.sh
@@ -111,7 +111,15 @@ const surface = () => {
   const pc = readFileSync("./src/shared/param_pages/page_controller.mjs", "utf8");
   const call = pc.slice(pc.indexOf("function drawDeclaredCard"),
                         pc.indexOf("function drawDeclaredCard") + 2000);
-  ok(/values:\s*s\.values/.test(call), "page_controller passes its value map to the card");
+  /* `liveValues()`, not `s.values`: the card is handed the base with any
+   * live/modulated values merged over it, so a card picturing a parameter
+   * something else is driving shows what it is DOING rather than where its knob
+   * was left. Pinned on the helper rather than on the raw field, because the
+   * merge is the point. */
+  ok(/values:\s*liveValues\(\)/.test(call),
+     "page_controller passes its value map to the card");
+  ok(/function liveValues\(\)/.test(pc),
+     "and that map merges the live values over the base");
   ok(/nowMs:\s*now\(\)/.test(call), "page_controller passes a clock to the card");
 }
 

--- a/tests/host/test_param_pages_wiring.sh
+++ b/tests/host/test_param_pages_wiring.sh
@@ -143,7 +143,12 @@ want(/masterFxIndexFromComponentKey\(componentKey\)[\s\S]{0,160}enterMasterFxHie
 want(/tts_get_enabled[\s\S]{0,80}return false/, "the screen reader does not force the list", v);
 
 /* ---- the view module owns no screens it should not --------------------- */
-if (/openTextEntry|filepathBrowser|drawCanvas/.test(v)) {
+/* `drawCanvasPreview`, not `drawCanvas`: the thing this forbids is the view
+ * module owning the fullscreen canvas VIEW, which is an editor the list already
+ * has. It is not a ban on the substring. A custom UI PAGE delegates its body
+ * through `drawCanvasPage` -- three lines handing a band to the host, owning no
+ * screen and reimplementing nothing -- and the looser pattern caught that too. */
+if (/openTextEntry|filepathBrowser|drawCanvasPreview/.test(v)) {
   fail("the view module is reimplementing an editor the list already has");
 }
 /* The grid owns KNOBS, MENU, PRESET and ITEMS — all four are drawn in its

--- a/tests/host/test_viz_extra_keys.sh
+++ b/tests/host/test_viz_extra_keys.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A MODULE MAY NAME OFF-PAGE VALUES ITS WIDGET NEEDS.
+#
+# A widget cannot read: it is handed the page's value map. So a picture that
+# depends on a value with no cell on this page had exactly one route -- give
+# that value a knob. A real module did, and the result was a read-only cell
+# occupying one of eight slots on a 128x64 screen to draw a 17x15 blob nobody
+# could interpret, purely so the cell beside it could see the number.
+#
+# `extraKeys` already existed for this shape (detectSample uses it for an
+# off-page filepath) and the controller already adds them to the value
+# rotation. This lets a MODULE declare them, on the viz object:
+#
+#     "viz": { "kind": "custom:mouth", "extra_keys": ["face"] }
+#
+# What must hold: they reach the group, they are actually READ by the lane, the
+# value lands in the map a widget is handed, and the count is capped -- a module
+# asking for twenty keys would spend the page's whole read budget on one cell.
+#
+# NO APOSTROPHES BELOW THIS LINE inside the node script: it is a single-quoted
+# bash string, and one apostrophe ends it early with an error pointing nowhere
+# near the real line.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+const R = process.cwd();
+const { resolveViz } = await import(R + "/src/shared/param_pages/viz.mjs");
+const { buildMetaIndex } = await import(R + "/src/shared/param_pages/param_meta.mjs");
+const { registerWidget, clearWidgets } = await import(R + "/src/shared/param_pages/widget_registry.mjs");
+const { createController, LAYOUT_MOVY } = await import(R + "/src/shared/param_pages/page_controller.mjs");
+
+let fails = 0;
+const ok = (c, m) => { if (!c) { console.error("FAIL: " + m); fails++; } };
+
+const HIER = { levels: { root: { label: "M",
+  knobs: ["vowel", "level"],
+  params: [{ key: "vowel" }, { key: "level" }, { key: "face" }] } } };
+const CP = [
+  { key: "vowel", name: "Vowel", type: "float", min: 0, max: 1, step: 0.01,
+    viz: { kind: "custom:mouth", extra_keys: ["face"] } },
+  { key: "level", name: "Level", type: "float", min: 0, max: 1, step: 0.01 },
+  { key: "face",  name: "Who",   type: "int",   min: 0, max: 11, step: 1, access: "read" },
+];
+
+/* ---- it reaches the resolved group ---- */
+clearWidgets();
+registerWidget("custom:mouth", { draw() {} });
+const mi = buildMetaIndex({ hierarchy: HIER, chainParams: CP });
+const r = resolveViz({ keys: ["vowel", "level", null, null, null, null, null, null], metaIndex: mi });
+const g = r.groups.find((x) => x.kind === "custom:mouth");
+ok(!!g, "the custom group resolves");
+ok(g && Array.isArray(g.extraKeys) && g.extraKeys[0] === "face",
+   "the modules extra_keys reaches the group as extraKeys");
+
+/* An UNREGISTERED kind must not smuggle its extra keys into the rotation --
+ * the group is abandoned entirely, so there is nothing to read for. */
+clearWidgets();
+const r2 = resolveViz({ keys: ["vowel", "level", null, null, null, null, null, null], metaIndex: mi });
+ok(!r2.groups.some((x) => Array.isArray(x.extraKeys) && x.extraKeys.indexOf("face") >= 0),
+   "an unavailable custom kind contributes no extra keys");
+
+/* ---- the CONTROLLER actually reads it ---- */
+clearWidgets();
+registerWidget("custom:mouth", { draw() {} });
+{
+  const reads = [];
+  /* The controller READS its contract from the device, so serve it. */
+  const store = {
+    ui_hierarchy: JSON.stringify(HIER),
+    chain_params: JSON.stringify(CP),
+    vowel: "0.5", level: "1", face: "7",
+  };
+  let t = 0;
+  const ctrl = createController({
+    getParam: (k) => { const b = String(k).split(":").pop(); reads.push(b);
+                       return store[b] === undefined ? null : store[b]; },
+    setParam: () => true,
+    announce: () => {},
+    now: () => (t += 16),
+  });
+  ctrl.load({ prefix: "synth" });
+  ctrl.setLayout(LAYOUT_MOVY);
+  for (let i = 0; i < 60; i++) ctrl.tick();
+
+  ok(reads.indexOf("face") >= 0,
+     "the read lane fetches the declared extra key (it has no cell of its own)");
+
+  /*
+   * AND IT REACHES THE WIDGET. Asserted by DRAWING, not by peeking at a
+   * private map: the controller exposes no values accessor, and a test that
+   * quietly skips when one is missing is a test that measures nothing. The
+   * widget records what it was handed.
+   */
+  let handed = null;
+  clearWidgets();
+  registerWidget("custom:mouth", { draw(ctx, o) { handed = o.values; } });
+  for (let i = 0; i < 12; i++) ctrl.tick();
+  ctrl.render({ fillRect() {}, print() {}, textWidth: (t) => String(t).length * 4,
+                line() {}, drawCircle() {}, fillCircle() {}, drawArc() {},
+                width: 128, height: 64 });
+  ok(handed !== null, "the custom widget was actually drawn");
+  ok(handed && handed.face === "7",
+     "and the off-page value is in the map it was handed");
+}
+
+/* ---- capped ---- */
+{
+  const many = { key: "vowel", name: "V", type: "float", min: 0, max: 1,
+                 viz: { kind: "custom:mouth", extra_keys: ["a","b","c","d","e","f"] } };
+  const mi2 = buildMetaIndex({ hierarchy: HIER, chainParams: [many, CP[1], CP[2]] });
+  const r3 = resolveViz({ keys: ["vowel","level",null,null,null,null,null,null], metaIndex: mi2 });
+  const g3 = r3.groups.find((x) => x.kind === "custom:mouth");
+  ok(g3 && g3.extraKeys.length <= 4,
+     "extra keys are capped, so one cell cannot eat the pages read budget");
+}
+
+/* ---- junk is ignored, not thrown on ---- */
+for (const bad of [null, "face", 42, [1, 2], [""], {}]) {
+  const cp = [{ key: "vowel", name: "V", type: "float", min: 0, max: 1,
+                viz: { kind: "custom:mouth", extra_keys: bad } }, CP[1]];
+  const mix = buildMetaIndex({ hierarchy: HIER, chainParams: cp });
+  let threw = false;
+  try { resolveViz({ keys: ["vowel","level",null,null,null,null,null,null], metaIndex: mix }); }
+  catch (e) { threw = true; }
+  ok(!threw, "a malformed extra_keys is ignored rather than thrown on");
+}
+
+if (fails) { console.error(fails + " failure(s)"); process.exit(1); }
+console.log("PASS: a module can name off-page values its widget needs, and they are read");
+'

--- a/tests/host/test_widget_module_poc.sh
+++ b/tests/host/test_widget_module_poc.sh
@@ -36,7 +36,7 @@ import { resolveViz } from "./src/shared/param_pages/viz.mjs";
 import { drawVizGroup } from "./src/shared/param_pages/viz_draw.mjs";
 import { buildMetaIndex } from "./src/shared/param_pages/param_meta.mjs";
 import { validateContract } from "./src/shared/param_pages/validate_contract.mjs";
-import { registerWidget, clearWidgets, isWidgetAvailable }
+import { registerOverlayWidgets, clearWidgets, isWidgetAvailable }
   from "./src/shared/param_pages/widget_registry.mjs";
 import { drawParamCard, paramCardRect } from "./src/shared/param_pages/param_card.mjs";
 
@@ -52,8 +52,16 @@ const CP = caps.chain_params || [];
 ok(typeof caps.canvas_script === "string", "module.json declares a canvas_script");
 const declared = CP.filter((p) => p.viz && typeof p.viz.kind === "string" &&
                                   p.viz.kind.startsWith("custom:"));
-ok(declared.length === 1, "exactly one param declares a custom viz kind");
-const KIND = declared[0].viz.kind;
+/* TWO kinds, from ONE module. The fixture declares both on purpose: a module
+ * used to be limited to a single widget, not by the registry (always a map) but
+ * by a call site that read one string, and the second kind fell through to a
+ * built-in dial with no error. This test is the consumer that proves it does
+ * not any more. */
+ok(declared.length === 2, "the fixture declares two custom viz kinds");
+const KIND = "custom:wtmeter";
+const KIND2 = "custom:wtmode";
+ok(declared.some((p) => p.viz.kind === KIND) && declared.some((p) => p.viz.kind === KIND2),
+   "both expected kinds are declared in chain_params");
 const declaredCard = CP.find((p) => typeof p.card_script === "string") || null;
 
 /* The validator is happy with it -- no errors, and no missing-script warning. */
@@ -72,22 +80,26 @@ new Function("globalThis", src)(g);
 const overlay = g.canvas_overlay;
 ok(!!overlay, "canvas.js sets globalThis.canvas_overlay");
 
-/* THE SAME GUARD shadow_ui applies before registering. */
-const registrable = !!(overlay && typeof overlay.drawCell === "function" &&
-                       typeof overlay.widgetKind === "string");
-ok(registrable, "the overlay satisfies the drawCell + widgetKind guard");
 ok(overlay.widgetKind === KIND,
    `the overlays widgetKind matches the chain_params declaration (${KIND})`);
+ok(overlay.widgetKinds && typeof overlay.widgetKinds === "object",
+   "and it declares a second kind through widgetKinds");
 ok(typeof overlay.draw === "function",
    "the same overlay also supplies the fullscreen draw");
 
-/* ---- register it exactly as shadow_ui would, then RESOLVE and DRAW ---- */
+/* ---- register exactly as shadow_ui does, then RESOLVE and DRAW ---- */
 clearWidgets();
-registerWidget(overlay.widgetKind, {
-  draw: overlay.drawCell.bind(overlay),
-  nominal: overlay.widgetNominal || null,
-});
+const reg = registerOverlayWidgets(overlay);
+ok(reg.skipped.length === 0,
+   "nothing the fixture declares is skipped: " + JSON.stringify(reg.skipped));
 ok(isWidgetAvailable(KIND), "the widget registers");
+ok(isWidgetAvailable(KIND2), "and so does the SECOND kind, from the same module");
+
+/* EVERY declared kind must actually be registered. The old failure was silent
+ * and partial -- one of two -- so counting is the assertion that catches it. */
+for (const d of declared) {
+  ok(isWidgetAvailable(d.viz.kind), `declared kind ${d.viz.kind} is available`);
+}
 
 const keys = ["level", null, null, null, null, null, null, null];
 const metaIndex = buildMetaIndex({ hierarchy: mod.ui_hierarchy, chainParams: CP });
@@ -108,6 +120,19 @@ const lit = (calls) => calls.reduce((n, [, , w, h]) => n + w * h, 0);
 
 ok(draw(0, FRAME).length > 0, "at 0 the widget still draws (a baseline, not a blank cell)");
 ok(lit(draw(1, FRAME)) > lit(draw(0, FRAME)), "a full value lights more than an empty one");
+
+/* ---- the SECOND widget resolves and draws too ---- */
+{
+  const keys2 = ["mode", null, null, null, null, null, null, null];
+  const r2 = resolveViz({ keys: keys2, metaIndex });
+  const g2 = r2.groups.find((x) => x.kind === KIND2);
+  ok(!!g2, "resolveViz gives the second key to the second widget");
+  const calls = [];
+  drawVizGroup({ fillRect: (...a) => calls.push(a), print() {},
+                 textWidth: (t) => String(t).length * 4 },
+               FRAME, g2, { mode: "1" }, metaIndex);
+  ok(calls.length > 0, "the second widget draws");
+}
 ok(lit(draw(0.5, FRAME)) > lit(draw(0, FRAME)) && lit(draw(0.5, FRAME)) < lit(draw(1, FRAME)),
    "a mid value sits between the two");
 

--- a/tests/host/test_widget_multiple_kinds.sh
+++ b/tests/host/test_widget_multiple_kinds.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A MODULE MAY DECLARE MORE THAN ONE CUSTOM WIDGET.
+#
+# The registry has always been a Map, so nothing about the design limited a
+# module to one widget -- the single limit was the shadow_ui call site reading
+# one `widgetKind` STRING. A module declaring two kinds got the first one
+# registered and the second silently ignored, and an ignored kind is not an
+# error: resolveViz leaves those keys to the detector, so the cell draws a
+# perfectly reasonable built-in dial. A correct-looking page, no log line, and
+# nothing to search for.
+#
+# What must hold:
+#   - the legacy single `widgetKind` keeps working, untouched
+#   - `widgetKinds` as an ARRAY registers every name against the one drawCell
+#   - `widgetKinds` as an OBJECT gives each kind its own drawer and nominal
+#   - anything unusable is REPORTED rather than dropped, because "declared a
+#     widget and did not get one" is the thing an author cannot otherwise see
+#   - the call site in shadow_ui.js actually uses this, rather than keeping its
+#     own copy of the rule
+#
+# NO APOSTROPHES BELOW THIS LINE inside the node script: it is a single-quoted
+# bash string, and one apostrophe ends it early with an error pointing nowhere
+# near the real line.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required for the widget registry tests" >&2
+  exit 1
+fi
+
+node --input-type=module -e '
+import { registerOverlayWidgets, clearWidgets, isWidgetAvailable, getWidget }
+  from "./src/shared/param_pages/widget_registry.mjs";
+import { readFileSync } from "node:fs";
+
+let fails = 0;
+const ok = (cond, what) => { if (!cond) { console.error("FAIL: " + what); fails++; } };
+
+/* ---- the legacy shape is untouched ---- */
+clearWidgets();
+let r = registerOverlayWidgets({ widgetKind: "custom:solo", drawCell() {} });
+ok(r.registered.length === 1 && r.registered[0] === "custom:solo", "legacy widgetKind registers");
+ok(isWidgetAvailable("custom:solo"), "legacy kind is available");
+ok(r.skipped.length === 0, "legacy kind reports nothing skipped");
+
+/* ---- an array: several names, one drawer ---- */
+clearWidgets();
+let drawn = [];
+r = registerOverlayWidgets({
+  widgetKinds: ["custom:face", "custom:mouth"],
+  drawCell(ctx, o) { drawn.push(o.group.keys[0]); },
+});
+ok(r.registered.length === 2, "array form registers both kinds");
+ok(isWidgetAvailable("custom:face") && isWidgetAvailable("custom:mouth"),
+   "both kinds from the array are available");
+/* Both must reach the SAME drawer -- that is the point of the array form. */
+getWidget("custom:face").draw({}, { group: { keys: ["a"] } });
+getWidget("custom:mouth").draw({}, { group: { keys: ["b"] } });
+ok(drawn.join(",") === "a,b", "both array kinds call the one drawCell");
+
+/* ---- an object: a drawer each, and its own nominal ---- */
+clearWidgets();
+let hitX = 0;
+r = registerOverlayWidgets({
+  widgetNominal: { w: 1, h: 1 },
+  widgetKinds: {
+    "custom:x": () => { hitX++; },
+    "custom:y": { draw() {}, nominal: { w: 17, h: 15 } },
+  },
+});
+ok(r.registered.length === 2, "object form registers both kinds");
+getWidget("custom:x").draw({}, {});
+ok(hitX === 1, "a bare function entry is used as the drawer");
+ok(getWidget("custom:y").nominal.w === 17, "an object entry carries its own nominal");
+ok(getWidget("custom:x").nominal.w === 1, "an entry without a nominal falls back to widgetNominal");
+
+/* ---- `this` must still be the overlay ---- */
+clearWidgets();
+const ov = {
+  tag: "me",
+  seen: null,
+  widgetKinds: { "custom:t": function () { this.seen = this.tag; } },
+};
+registerOverlayWidgets(ov);
+getWidget("custom:t").draw({}, {});
+ok(ov.seen === "me", "a drawer is bound to the overlay, so this.helper works");
+
+/* ---- unusable declarations are reported, not dropped ---- */
+clearWidgets();
+r = registerOverlayWidgets({ widgetKinds: ["plain", "custom:nodrawer"] });
+ok(r.registered.length === 0, "nothing usable registers");
+ok(r.skipped.length === 2, "both bad declarations are reported");
+ok(r.skipped.some((x) => x.kind === "plain" && /custom/.test(x.why)),
+   "a kind missing the custom: prefix says so");
+ok(r.skipped.some((x) => x.kind === "custom:nodrawer" && /drawCell/.test(x.why)),
+   "a kind with no drawer says so");
+
+clearWidgets();
+r = registerOverlayWidgets({ widgetKinds: 42 });
+ok(r.skipped.length === 1, "a widgetKinds that is neither array nor object is reported");
+
+/* ---- junk must not throw ---- */
+clearWidgets();
+for (const junk of [null, undefined, 7, "x", {}, { widgetKind: 5 }]) {
+  const out = registerOverlayWidgets(junk);
+  ok(out && Array.isArray(out.registered), "junk overlay returns a result rather than throwing");
+}
+
+/* ---- the call site USES it ---- */
+const ui = readFileSync("./src/shadow/shadow_ui.js", "utf8");
+ok(/registerOverlayWidgets\(/.test(ui),
+   "shadow_ui.js calls registerOverlayWidgets");
+ok(!/registerWidget\(ov\.widgetKind/.test(ui),
+   "shadow_ui.js no longer hand-rolls single-kind registration");
+
+if (fails) { console.error(fails + " failure(s)"); process.exit(1); }
+console.log("PASS: a module may declare several custom widgets, and an unusable one is reported");
+'

--- a/tools/param-pages/preview.mjs
+++ b/tools/param-pages/preview.mjs
@@ -56,6 +56,7 @@ import { createController, LAYOUT_LIST } from "../../src/shared/param_pages/page
 import { resolveViz } from "../../src/shared/param_pages/viz.mjs";
 import { registerOverlayWidgets, clearWidgets }
   from "../../src/shared/param_pages/widget_registry.mjs";
+import { frameCtx } from "../../src/shared/param_pages/frame_ctx.mjs";
 import { createFakeDevice } from "./fake_device.mjs";
 import { makeRecord, presetRowValue } from "../../src/shared/param_pages/current_preset.mjs";
 import { fakeValue } from "./fake_values.mjs";
@@ -88,6 +89,27 @@ const fx = JSON.parse(fs.readFileSync(FIXTURE, "utf8"));
  * that assigns to globalThis, and importing it would need it to be an ES
  * module, which on device it is not.
  */
+let moduleOverlay = null;
+
+/*
+ * A CUSTOM UI PAGE's body, drawn the way the device draws it: frame-scoped to
+ * the band render_page hands over, so the header and footer in the picture are
+ * the hosts own and the module cannot have painted them.
+ */
+function previewCanvasPage(ctx, band, canvas, extra) {
+    if (!moduleOverlay || typeof moduleOverlay.drawPage !== "function") return;
+    try {
+        moduleOverlay.drawPage(frameCtx(ctx, band), {
+            key: canvas.key,
+            values: (extra && extra.values) || {},
+            nowMs: 0,
+            width: band.w, height: band.h,
+        });
+    } catch (e) {
+        console.error(`--widgets: drawPage threw: ${e}`);
+    }
+}
+
 function loadModuleWidgets(dir) {
     const file = path.join(path.resolve(dir), "canvas.js");
     if (!fs.existsSync(file)) {
@@ -96,6 +118,7 @@ function loadModuleWidgets(dir) {
     }
     const g = {};
     new Function("globalThis", fs.readFileSync(file, "utf8"))(g);
+    moduleOverlay = g.canvas_overlay || null;
     clearWidgets();
     const { registered, skipped } = registerOverlayWidgets(g.canvas_overlay);
     for (const s2 of skipped) console.error(`--widgets: ${s2.kind} skipped (${s2.why})`);
@@ -197,6 +220,24 @@ for (const { p, i } of chosen) {
     const fb = createFramebuffer();
     const values = {};
     for (const k of (p.keys || [])) values[k] = fakeValue(k, metaIndex.getOrGuess(k));
+    /*
+     * Off-page values a widget declared it needs (viz extra_keys), and the key
+     * a custom page is built from. On the device the read lane fetches these;
+     * without them here every such widget draws its "no answer" state, which
+     * looks like a broken widget rather than a missing fake.
+     */
+    for (const g of resolveViz({ keys: p.keys || [], metaIndex }).groups) {
+        for (const k of (g.extraKeys || [])) {
+            if (values[k] === undefined) values[k] = fakeValue(k, metaIndex.getOrGuess(k));
+        }
+    }
+    if (p.canvas) {
+        for (const k of Object.keys(metaIndex.byKey || {})) {
+            if (values[k] === undefined && /^(face|face_id)$/.test(k)) {
+                values[k] = fakeValue(k, metaIndex.getOrGuess(k));
+            }
+        }
+    }
 
     if (layout === LAYOUT_LIST || p.kind !== PAGE_KNOBS) {
         /* Drive the REAL controller against a fake device serving this module's
@@ -228,6 +269,7 @@ for (const { p, i } of chosen) {
     } else if (layout === LAYOUT_MOVY) {
         const { groups } = resolveViz({ keys: p.keys || [], metaIndex });
         renderPageMovy(drawContext(fb), {
+            drawCanvasPage: previewCanvasPage,
             page: p, metaIndex, values, title,
             pageIndex: i, pageCount: pages.length, touched, viz: groups,
             /* Representative hints so previews show the real vertical budget.
@@ -238,6 +280,7 @@ for (const { p, i } of chosen) {
         });
     } else {
         renderPage(drawContext(fb), {
+            drawCanvasPage: previewCanvasPage,
             page: p, metaIndex, values, title,
             pageIndex: i, pageCount: pages.length, touched, layout, revealValues,
         });

--- a/tools/param-pages/preview.mjs
+++ b/tools/param-pages/preview.mjs
@@ -35,6 +35,13 @@
  *
  * Values are synthesised (mid-range, deterministic per key) since there is no
  * device to read them from — enough to judge layout, not to judge a patch.
+ *
+ * --widgets <dir> loads that module directory's canvas.js and registers its
+ * custom widgets, so a module shipping its own art is drawn WITH it. Without
+ * the flag every `custom:` kind falls through to a built-in, which is a correct
+ * page and the wrong picture — and it is the reason a module author cannot see
+ * their own widget here. Point it at the module directory (the one holding
+ * canvas.js), not at the file.
  */
 
 import fs from "node:fs";
@@ -47,6 +54,8 @@ import { renderPage, LAYOUT_DIAL, LAYOUT_BAR } from "../../src/shared/param_page
 import { renderPageMovy, LAYOUT_MOVY } from "../../src/shared/param_pages/render_page_movy.mjs";
 import { createController, LAYOUT_LIST } from "../../src/shared/param_pages/page_controller.mjs";
 import { resolveViz } from "../../src/shared/param_pages/viz.mjs";
+import { registerOverlayWidgets, clearWidgets }
+  from "../../src/shared/param_pages/widget_registry.mjs";
 import { createFakeDevice } from "./fake_device.mjs";
 import { makeRecord, presetRowValue } from "../../src/shared/param_pages/current_preset.mjs";
 import { fakeValue } from "./fake_values.mjs";
@@ -71,6 +80,34 @@ const flag = (name, dflt = null) => {
 const positional = argv.filter((a, i) => !a.startsWith("--") && (i === 0 || !argv[i - 1].startsWith("--") || argv[i - 1] === "--all"));
 
 const fx = JSON.parse(fs.readFileSync(FIXTURE, "utf8"));
+
+/*
+ * Register a module's own widgets, the way shadow_ui does on the device.
+ *
+ * Loaded as a SCRIPT over a bare object, not imported: canvas.js is a UI module
+ * that assigns to globalThis, and importing it would need it to be an ES
+ * module, which on device it is not.
+ */
+function loadModuleWidgets(dir) {
+    const file = path.join(path.resolve(dir), "canvas.js");
+    if (!fs.existsSync(file)) {
+        console.error(`--widgets: no canvas.js in ${dir}`);
+        process.exit(2);
+    }
+    const g = {};
+    new Function("globalThis", fs.readFileSync(file, "utf8"))(g);
+    clearWidgets();
+    const { registered, skipped } = registerOverlayWidgets(g.canvas_overlay);
+    for (const s2 of skipped) console.error(`--widgets: ${s2.kind} skipped (${s2.why})`);
+    if (!registered.length) {
+        console.error(`--widgets: ${file} registered nothing`);
+        process.exit(2);
+    }
+    console.error(`--widgets: registered ${registered.join(", ")}`);
+}
+
+const widgetsDir = flag("widgets");
+if (typeof widgetsDir === "string") loadModuleWidgets(widgetsDir);
 
 if (flag("list")) {
     const rows = fx.modules.map((m) => {


### PR DESCRIPTION
Five limits in the module-supplied draw surfaces, all found by building a real module against them (MonkSynth, a FOF vocal synth with twelve animated faces). Every one failed the same way: by drawing something plausible rather than by erroring.

## What a module can now do

| | |
|---|---|
| `widgetKinds` | declare **several** custom widgets, not one |
| `viz.extra_keys` | name a value the widget needs that has **no cell on the page** |
| `card_script` payload | a card gets `values` + `nowMs`, so it can read a sibling |
| `as_page` | own a **whole page** in the level's jog rotation |
| `preset_browser` | make that page the level's **browser** |
| `"live": true` | say the module drives this param itself |

## The defects behind each

**One widget per module.** The registry was always a `Map`; the single call site read `ov.widgetKind`, one *string*, so a second declared kind was dropped — and a dropped kind is not an error, it falls through to a built-in dial. Correct page, no log line. `registerOverlayWidgets` owns the rule now, beside the registry where `tests/host/` can run it.

**A card could not see the page.** The payload was this parameter and nothing else, so a card whose meaning depends on a sibling had no route to that fact: no `getParam` on the path, and the card script is its own closure. The first module to need it went through `globalThis` with a staleness timestamp — a side channel between two files the contract said were unrelated.

**A widget could not see an off-page value.** Same shape. `extraKeys` already existed (`detectSample` uses it for an off-page filepath) but only an internal detector could set one. Without it the only way to get a fact to a widget was to give it a knob — which is how a module shipped a read-only cell whose whole job was carrying a number to the cell beside it.

**Custom UI was a dive-in, not a page.** You could not jog to it, the encoders did not reach it, and it drew its own chrome. `as_page` puts it in the rotation carrying the level's knobs; `preset_browser` makes it the browser, so a face per character replaces a row of text.

**A module could not report a value it drives itself.** `isModulated` asks the chain's modulation system, which cannot know a synth sweeps its own vowel from pad pressure. And the chain host *owned* `:effective`: for a key it was not modulating it stripped the suffix and asked the plugin for the plain key, so a module serving its own driven value was never asked.

## The design decision worth reviewing

**A custom page is a `PAGE_KNOBS` page carrying a `canvas` field — deliberately not a new page kind.** Twenty-two places in `page_controller` branch on `PAGE_KNOBS`: reads, knob turns, touch, the touch strip, announce, dive targets, the list layout. A new kind would have to be threaded through every one, and missing one gives a page that looks right and does not respond. As a knobs page it inherits all of it and only the picture differs — which is why the encoders work with no input code at all. Three gates now ask `pageHasKnobs` ("does it have keys") instead, and that is narrow enough that a preset or items page carrying none behaves exactly as before.

## Also here

- **`widget-test`'s `help.json` was being discarded.** It used `sections`; the loader reads `children`. The reference module for these very surfaces had help that had never once been displayed — and an author copying the reference copies the bug, which is how it reached a new module this week. `tests/host/test_module_help_shape.sh` now checks every shipped `help.json` loads, fits the display (measured in **pixels**, against the real font) and stays in ASCII. It found two more modules quietly losing text off the right edge: `file-browser` and `song-mode`.
- **`preview.mjs --widgets`** loads a module's `canvas.js` and registers it, so a module shipping custom art can be previewed at all. Without it every `custom:` kind fell through to a built-in — a correct page with the wrong picture. It is also what caught the header collision that source review could not.
- `docs/MODULES.md`, `docs/PARAM_PAGES.md`, `docs/CHAIN.md` and three `CLAUDE.md` bullets.

## Verification

261 `tests/host` green, C units green, ARM cross-compile green. Every new test was mutation-checked — two of them passed against their mutation on the first try and were rewritten (one asserted values that were already cached from a neighbouring page; one silently skipped when an accessor was missing).

Exercised on hardware throughout: this branch and MonkSynth were installed on a Move after each change, and most of the defects above were reported from it rather than found in review.

Co-authored-by: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kj6KSrHs47Drr28dEsvBGc