### PR TITLE
state restore: hand modules their state COMPACT, never the pretty file slice

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -524,7 +524,7 @@ if needs_rebuild build/modules/chain/dsp.so \
     src/modules/chain/dsp/chain_params.c src/modules/chain/dsp/chain_mod.c \
     src/modules/chain/dsp/chain_midi.c src/modules/chain/dsp/chain_patch.c \
     src/modules/chain/dsp/chain_reorder.c src/host/chain_permute.h \
-    src/host/chain_key_index.h \
+    src/host/chain_key_index.h src/host/json_compact.h \
     src/modules/chain/dsp/chain_internal.h src/host/unified_log.c \
     src/host/unified_log.h src/host/plugin_api_v1.h src/host/audio_fx_api_v1.h \
     src/host/audio_fx_api_v2.h src/host/midi_fx_api_v1.h src/host/lfo_common.h; then

--- a/src/host/json_compact.h
+++ b/src/host/json_compact.h
@@ -1,0 +1,66 @@
+/*
+ * Copy a JSON object MINIFIED: whitespace outside strings stripped, string
+ * contents preserved byte-for-byte (escape-aware).
+ *
+ * Why this exists: slot_N.json and master_fx_N.json are written by
+ * JSON.stringify(wrapper, null, 2), and the loaders do not re-serialize —
+ * they used to brace-match the module's "state" object in the FILE TEXT and
+ * hand the raw pretty-printed slice back to set_param("state"). A module
+ * parses what it emitted, which is compact, so every hand-rolled parser that
+ * matched `"key":"` (no space) silently missed the stored `"key": "` form.
+ * Field-confirmed in five modules (minijv lost every working-patch edit on
+ * set reload; mono ignored its entire state; work lost its patterns; smack
+ * its locks; noisemaker its bank) while whitespace-tolerant number parsers
+ * in the same modules kept restoring the headline fields — the right patch
+ * loaded, the modifications vanished. JP-8000 hit it, fixed it locally, and
+ * wrote "never match a JSON field with a whitespace-exact pattern" in a
+ * comment; this header is that lesson applied at the one altitude that fixes
+ * every module at once, including ones that will never update.
+ *
+ * Compacting at the LOAD boundary keeps the on-disk files pretty (they are
+ * hand-debugged often) while modules receive the same encoding they emitted.
+ *
+ * Header-only and dependency-free so tests/host can exercise it directly.
+ */
+#ifndef JSON_COMPACT_H
+#define JSON_COMPACT_H
+
+#include <stddef.h>
+
+/*
+ * src must point at the object's opening '{'. Copies through the matching
+ * closing brace (string-aware, like json_object_end). Returns the compacted
+ * length (excluding NUL), or -1 when src is not an object, the object never
+ * closes, or dst cannot hold the COMPACT form — the caller keeps its
+ * existing "state absent" behavior on -1.
+ */
+static inline int json_object_compact_copy(char *dst, size_t dst_len,
+                                           const char *src)
+{
+    if (!dst || dst_len == 0 || !src || *src != '{') return -1;
+    size_t w = 0;
+    int depth = 0, in_string = 0, escaped = 0;
+    for (const char *p = src; *p; p++) {
+        char c = *p;
+        if (in_string) {
+            if (escaped) escaped = 0;
+            else if (c == '\\') escaped = 1;
+            else if (c == '"') in_string = 0;
+        } else {
+            if (c == ' ' || c == '\t' || c == '\n' || c == '\r') continue;
+            if (c == '"') in_string = 1;
+            else if (c == '{') depth++;
+            else if (c == '}') {
+                if (w + 1 >= dst_len) return -1;
+                dst[w++] = c;
+                if (--depth == 0) { dst[w] = '\0'; return (int)w; }
+                continue;
+            }
+        }
+        if (w + 1 >= dst_len) return -1;
+        dst[w++] = c;
+    }
+    return -1; /* unterminated object */
+}
+
+#endif /* JSON_COMPACT_H */

--- a/src/host/master_fx_saved_state.h
+++ b/src/host/master_fx_saved_state.h
@@ -16,6 +16,8 @@
 #include <stddef.h>
 #include <string.h>
 
+#include "json_compact.h"
+
 static inline const char *master_fx_state_skip_ws(const char *p)
 {
     while (p && (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')) p++;
@@ -35,27 +37,10 @@ static inline int master_fx_saved_state_copy(const char *json, char *out, size_t
     if (!value) return -1;
 
     if (*value == '{') {
-        int depth = 0;
-        int in_string = 0;
-        int escaped = 0;
-        const char *end = NULL;
-        for (const char *p = value; *p; p++) {
-            if (in_string) {
-                if (escaped) escaped = 0;
-                else if (*p == '\\') escaped = 1;
-                else if (*p == '"') in_string = 0;
-                continue;
-            }
-            if (*p == '"') in_string = 1;
-            else if (*p == '{') depth++;
-            else if (*p == '}' && --depth == 0) { end = p + 1; break; }
-        }
-        if (!end) return -1;
-        size_t len = (size_t)(end - value);
-        if (len >= out_len) return -1;
-        memcpy(out, value, len);
-        out[len] = '\0';
-        return (int)len;
+        /* Compacted, never the raw pretty file slice: the file is written by
+         * JSON.stringify(w, null, 2) and modules parse what they emitted
+         * (compact) — see json_compact.h. */
+        return json_object_compact_copy(out, out_len, value);
     }
 
     if (*value != '"') return -1;

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -36,6 +36,7 @@
  * chain-specific, and a second copy is precisely the bug class that made
  * fx3..fx8 silent. Reached the same way as plugin_api_v1.h below. */
 #include "host/chain_key_index.h"
+#include "host/json_compact.h"
 #include "host/plugin_api_v1.h"
 #include "host/audio_fx_api_v2.h"
 #include "host/midi_fx_api_v1.h"

--- a/src/modules/chain/dsp/chain_patch.c
+++ b/src/modules/chain/dsp/chain_patch.c
@@ -741,14 +741,16 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
                     const char *sv = state_colon + 1;
                     while (*sv == ' ' || *sv == '\t' || *sv == '\n') sv++;
                     if (*sv == '{') {
-                        /* Extract state as JSON object (string-aware span). */
-                        const char *end = json_object_end(sv);
-                        if (end) {
-                            int len = end - sv + 1;
-                            if (len > 0 && len < MAX_SYNTH_STATE_LEN) {
-                                strncpy(patch->synth_state, sv, len);
-                                patch->synth_state[len] = '\0';
-                            }
+                        /* Extract the state object COMPACTED, never as the
+                         * raw pretty-printed file slice: modules parse what
+                         * they emitted (compact), and a `"key":"` matcher
+                         * silently misses the stored `"key": "` form — see
+                         * json_compact.h. -1 keeps state absent, as the old
+                         * over-length guard did. */
+                        if (json_object_compact_copy(patch->synth_state,
+                                                     sizeof(patch->synth_state),
+                                                     sv) < 0) {
+                            patch->synth_state[0] = '\0';
                         }
                     } else if (*sv == '"') {
                         /* JSON.stringify escapes opaque module state. Decode
@@ -854,15 +856,16 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
                                 const char *sv = state_colon + 1;
                                 while (sv < params_end && (*sv == ' ' || *sv == '\t' || *sv == '\n')) sv++;
                                 if (*sv == '{') {
-                                    /* Extract entire state object */
-                                    const char *state_start = sv;
                                     const char *se = json_object_end(sv);
                                     if (se && se <= params_end) {
-                                        int slen = se - state_start + 1;
-                                        if (slen > 0 && slen < MAX_FX_STATE_LEN) {
-                                            strncpy(cfg->state, state_start, slen);
-                                            cfg->state[slen] = '\0';
+                                        /* Compacted, never the raw pretty
+                                         * file slice — see json_compact.h. */
+                                        if (json_object_compact_copy(cfg->state,
+                                                                     sizeof(cfg->state),
+                                                                     sv) >= 0) {
                                             parse_debug_log("[parse] Extracted audio_fx state object");
+                                        } else {
+                                            cfg->state[0] = '\0';
                                         }
                                     }
                                 } else if (*sv == '"') {
@@ -1058,14 +1061,16 @@ int v2_parse_patch_file(chain_instance_t *inst, const char *path, patch_info_t *
                                     const char *sv = state_colon + 1;
                                     while (sv < params_end && (*sv == ' ' || *sv == '\t' || *sv == '\n')) sv++;
                                     if (*sv == '{') {
-                                        const char *state_start = sv;
                                         const char *se = json_object_end(sv);
                                         if (se && se <= params_end) {
-                                            int slen = se - state_start + 1;
-                                            if (slen > 0 && slen < MAX_FX_STATE_LEN) {
-                                                strncpy(cfg->state, state_start, slen);
-                                                cfg->state[slen] = '\0';
+                                            /* Compacted, never the raw pretty
+                                             * file slice — see json_compact.h. */
+                                            if (json_object_compact_copy(cfg->state,
+                                                                         sizeof(cfg->state),
+                                                                         sv) >= 0) {
                                                 parse_debug_log("[parse] Extracted midi_fx state object");
+                                            } else {
+                                                cfg->state[0] = '\0';
                                             }
                                         }
                                     } else if (*sv == '"') {

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -40,6 +40,7 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_rt_thread_audit \
 	$(BUILD_DIR)/test_master_fx_slot_routing \
 	$(BUILD_DIR)/test_master_fx_saved_state \
+	$(BUILD_DIR)/test_json_compact \
 	$(BUILD_DIR)/test_master_fx_snapshot \
 	$(BUILD_DIR)/test_spi_tally \
 	$(BUILD_DIR)/test_align_capture \

--- a/tests/host/test_chain_patch_roundtrip.c
+++ b/tests/host/test_chain_patch_roundtrip.c
@@ -406,8 +406,13 @@ static void test_midi_fx_state_forms(chain_instance_t *inst, patch_info_t *patch
     CHECK(strcmp(patch->midi_fx[0].state, "mode=a;b=2;") == 0,
           "opaque MIDI FX state came back as [%s], want [mode=a;b=2;]",
           patch->midi_fx[0].state);
-    /* Object form must be untouched by the new branch. */
-    CHECK(strcmp(patch->midi_fx[1].state, "{\"steps\": 4}") == 0,
+    /* Object form comes back COMPACT, never as the raw file slice: the file
+     * is pretty-printed and modules parse what they emitted — a `"key":"`
+     * matcher misses the stored `"key": "` form (json_compact.h). The
+     * fixture's space is deliberate: it is what JSON.stringify(w, null, 2)
+     * puts on disk, and asserting it back verbatim is what let the pretty
+     * slice reach every module. */
+    CHECK(strcmp(patch->midi_fx[1].state, "{\"steps\":4}") == 0,
           "object MIDI FX state came back as [%s]", patch->midi_fx[1].state);
     /* No state key at all stays empty -- an empty string must not be invented. */
     CHECK(patch->midi_fx[2].state[0] == '\0',
@@ -417,7 +422,7 @@ static void test_midi_fx_state_forms(chain_instance_t *inst, patch_info_t *patch
     CHECK(v2_load_from_patch_info(inst, patch) == 0, "midi_fx state load failed");
     CHECK(strstr(fake_midi_fx[0].log, "state=mode=a;b=2;;") != NULL,
           "opaque state did not reach MIDI FX slot 0 [%s]", fake_midi_fx[0].log);
-    CHECK(strstr(fake_midi_fx[1].log, "state={\"steps\": 4};") != NULL,
+    CHECK(strstr(fake_midi_fx[1].log, "state={\"steps\":4};") != NULL,
           "object state did not reach MIDI FX slot 1 [%s]", fake_midi_fx[1].log);
     CHECK(strstr(fake_midi_fx[2].log, "state=") == NULL,
           "a state was sent to the MIDI FX that had none [%s]", fake_midi_fx[2].log);

--- a/tests/host/test_json_compact.c
+++ b/tests/host/test_json_compact.c
@@ -1,0 +1,87 @@
+/*
+ * json_object_compact_copy — the loader-side minifier that hands modules
+ * their state in the encoding they emitted (compact), never the raw
+ * pretty-printed slot-file slice.
+ *
+ * The case that matters most is the field one: a JSON.stringify(w, null, 2)
+ * rendering of a state object must compact back to byte-equality with the
+ * compact original, because module parsers match patterns like `"patch":"`
+ * against it. Whitespace INSIDE strings is content and must survive; the
+ * escape rules mean a `\"` does not end a string and a `}` inside one does
+ * not close the object.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "json_compact.h"
+
+static int failures;
+
+static void expect(const char *label, const char *src, const char *want)
+{
+    char out[512] = "unchanged";
+    int got = json_object_compact_copy(out, sizeof(out), src);
+    if (got != (int)strlen(want) || strcmp(out, want) != 0) {
+        fprintf(stderr, "FAIL %s: got %d [%s], want %zu [%s]\n",
+                label, got, out, strlen(want), want);
+        failures++;
+    }
+}
+
+static void expect_rejected(const char *label, const char *src, size_t cap)
+{
+    char out[512];
+    if (cap > sizeof(out)) cap = sizeof(out);
+    if (json_object_compact_copy(out, cap, src) >= 0) {
+        fprintf(stderr, "FAIL %s: was accepted\n", label);
+        failures++;
+    }
+}
+
+int main(void)
+{
+    /* The exact defect shape: the pretty form of a state whose parser
+     * matches `"patch":"`. Compaction must restore byte-equality. */
+    expect("pretty state compacts to the emitted form",
+           "{\n"
+           "  \"version\": 2,\n"
+           "  \"preset\": 37,\n"
+           "  \"patch\": \"00AB63\",\n"
+           "  \"nested\": {\n"
+           "    \"x\": 1\n"
+           "  },\n"
+           "  \"arr\": [ 1, 2, 3 ]\n"
+           "}",
+           "{\"version\":2,\"preset\":37,\"patch\":\"00AB63\","
+           "\"nested\":{\"x\":1},\"arr\":[1,2,3]}");
+
+    /* Compact input is already the answer. */
+    expect("compact input unchanged",
+           "{\"a\":1,\"b\":\"two\"}", "{\"a\":1,\"b\":\"two\"}");
+
+    /* String contents are content: inner whitespace, braces, colons and
+     * escaped quotes all survive byte-for-byte, and none of them terminate
+     * the scan early. */
+    expect("string contents preserved",
+           "{ \"name\" : \"a } b { c \\\" d : e  f\" }",
+           "{\"name\":\"a } b { c \\\" d : e  f\"}");
+    expect("escaped backslash before quote still ends the string",
+           "{ \"k\" : \"x\\\\\" , \"n\" : 1 }",
+           "{\"k\":\"x\\\\\",\"n\":1}");
+
+    /* Only the addressed object is copied — a sibling after its closing
+     * brace is not. This is what lets the callers point it at a slice of a
+     * larger file. */
+    expect("stops at the matching brace",
+           "{ \"a\": { \"b\": 1 } } , \"next\": 2",
+           "{\"a\":{\"b\":1}}");
+
+    expect_rejected("not an object", "\"str\"", 512);
+    expect_rejected("unterminated object", "{ \"a\": { \"b\": 1 }", 512);
+    expect_rejected("unterminated string", "{ \"a\": \"oops }", 512);
+    expect_rejected("output too small for compact form", "{\"abcdef\":1}", 8);
+
+    if (failures) return 1;
+    puts("PASS: json_object_compact_copy minifies outside strings only");
+    return 0;
+}

--- a/tests/host/test_master_fx_saved_state.c
+++ b/tests/host/test_master_fx_saved_state.c
@@ -43,6 +43,20 @@ int main(void)
                  "{\"state\":\"line1\\nline2\\t\\\"quoted\\\"\\\\tail\"}",
                  "line1\nline2\t\"quoted\"\\tail");
 
+    /* The file is written by JSON.stringify(w, null, 2); the extracted object
+     * must come back COMPACT so a module parser matching `"key":"` (the form
+     * it emitted) still finds its fields. The raw pretty slice cost minijv
+     * every working-patch edit on set reload. */
+    expect_state("pretty file yields compact state",
+                 "{\n"
+                 "  \"module\": \"cloudseed\",\n"
+                 "  \"state\": {\n"
+                 "    \"preset\": 3,\n"
+                 "    \"blob\": \"AB CD\"\n"
+                 "  }\n"
+                 "}",
+                 "{\"preset\":3,\"blob\":\"AB CD\"}");
+
     expect_rejected("no state", "{\"module_id\":\"palette\"}");
     expect_rejected("unterminated string", "{\"state\":\"oops}");
     expect_rejected("unsupported state type", "{\"state\":42}");

--- a/tests/host/test_state_slice_compact.sh
+++ b/tests/host/test_state_slice_compact.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# A module's saved state must be handed back COMPACT, never as the raw
+# pretty-printed slot-file slice.
+#
+# slot_N.json and master_fx_N.json are written by JSON.stringify(w, null, 2),
+# and the loaders do not re-serialize: chain_patch.c used to brace-match the
+# "state" object in the FILE TEXT and strncpy the slice straight into
+# synth_state / cfg->state, so set_param("state") received `"key": "` where
+# the module's own emission — the thing its parser was written against — says
+# `"key":"`. Whitespace-exact parsers (strstr of `"patch":"` and friends)
+# silently missed, while whitespace-tolerant number parsers in the same
+# modules kept landing, so the headline fields restored and the payload
+# vanished. Field-confirmed in minijv (every working-patch edit lost on set
+# reload), mono (entire state ignored), work (patterns), smack (locks),
+# noisemaker (bank). The fix is json_object_compact_copy (json_compact.h),
+# applied at every site that extracts a state object from a stored file.
+#
+# chain_patch.c cannot be compiled standalone (see test_chain_knob_cc_out.sh),
+# so its three sites are pinned by source; the helper's behavior itself is
+# covered by tests/host/test_json_compact.c, and master_fx_saved_state.h's
+# use of it by test_master_fx_saved_state.c.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CHAIN_PATCH="$REPO_ROOT/src/modules/chain/dsp/chain_patch.c"
+MFX_STATE="$REPO_ROOT/src/host/master_fx_saved_state.h"
+
+fails=0
+fail() { echo "FAIL: $1"; fails=$((fails + 1)); }
+
+# The three chain_patch.c extraction sites (synth, midi_fx, audio_fx) all
+# route through the compactor.
+n=$(command grep -c 'json_object_compact_copy(' "$CHAIN_PATCH" || true)
+[ "$n" -ge 3 ] || fail "chain_patch.c has $n json_object_compact_copy call(s), want the 3 state sites"
+
+# No raw slice copy of a state object survives. The opaque-STRING branches
+# (json_decode_quoted_string) are fine — a string decode is already compact.
+if command grep -n 'strncpy(patch->synth_state, sv' "$CHAIN_PATCH"; then
+    fail "synth state is strncpy'd raw from the file slice again"
+fi
+if command grep -n 'strncpy(cfg->state, state_start' "$CHAIN_PATCH"; then
+    fail "fx state is strncpy'd raw from the file slice again"
+fi
+
+# Master FX boot restore compacts too.
+command grep -q 'json_object_compact_copy(' "$MFX_STATE" \
+    || fail "master_fx_saved_state.h no longer routes objects through json_object_compact_copy"
+
+[ "$fails" -eq 0 ] || exit 1
+echo "PASS: stored state objects are handed to modules compact"


### PR DESCRIPTION
Companion to charlesvestal/schwung-jv880#13, at the altitude that fixes the whole fleet.

## The defect

`slot_N.json` / `master_fx_N.json` are written by `JSON.stringify(w, null, 2)`; the loaders brace-match the `"state"` object in the file text and hand modules the **raw pretty-printed slice**. Modules parse what they emitted (compact), so every whitespace-exact parser (`strstr` of `"key":"`) silently missed the stored `"key": "` form — while the whitespace-tolerant number parsers beside them kept landing. Headline fields restored, payload vanished: "the right patches load but modifications are missing."

## Fleet sweep (all 122 catalog repos, shipping DSP sources)

Confirmed compact-assuming state parsers, i.e. data silently lost on set reload / reboot today:

| module | what's lost |
|---|---|
| **minijv** (charlesvestal) | every working-patch edit (fixed module-side too in jv880#13) |
| **mono** (timncox) | the **entire state** — `"data":"` miss makes restore treat it as ignorable legacy |
| **work** (timncox) | sequencer patterns (`"stp"`, `"sq"`) |
| **smack** (timncox) | slice locks + palette (`"locks"`, `"locks_r"`, `"pal"`) |
| **noisemaker** (legsmechanical) | bank (`"bank_name"` → falls back to Factory, preset index re-meant) |

JP-8000 (je8086) hit the same bug earlier, fixed it module-side, and left the moral in a comment — *"never match a JSON field with a whitespace-exact pattern"* — which never generalized. This PR is that lesson applied once, where it covers modules that will never update.

## The fix

`src/host/json_compact.h::json_object_compact_copy` — string-aware, escape-aware minify-on-copy — replaces the raw-slice `strncpy` at all four extraction sites: `chain_patch.c` synth / midi_fx / audio_fx and `master_fx_saved_state.h`'s object branch. On-disk files stay pretty; only what modules **receive** changes, back to the encoding they emitted. The `MAX_*_STATE_LEN` guards now measure compact bytes, returning the headroom pretty overhead was eating.

## Tests

- `test_json_compact.c` — minifier unit (pretty→compact byte-equality, string contents inviolate, unterminated/overflow refused)
- `test_chain_patch_roundtrip.c` — object expectations now assert the compact form; the old *"object form must be untouched"* check codified the defect
- `test_master_fx_saved_state.c` — pretty-input case
- `test_state_slice_compact.sh` — pins the three `chain_patch.c` call sites (not compilable standalone)

Full host gate: 255 shell tests + all compiled units green. Verified end-to-end against the real jv880 `dsp.so` on the Mac harness: a compacted slice restores the edit through the released (un-patched) module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XC32bQ6KNcw88bzUfobwAJ