### PR TITLE
enum peek: a LIST never peeks, and 700ms was shorter than the header it comes up with

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,6 +517,15 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   the peek was tracked on each detent, `applyInput` swallowed the Back that
   dismissed it, and it was painted nowhere. CW-78 and 6W6 both shipped that
   way.
+- **A LIST never peeks, and the peek must OUTLIVE the turn claim.** The enum
+  peek exists because a 30px grid CELL cannot show a word; a list row prints
+  the option in full, so the panel covered a legible answer with the same
+  answer and hid four rows doing it — worst on Global Settings, which is pinned
+  to the list (`Skipback` blanking the screen to spell `Cap / Vol+Cap`). And
+  `ENUM_PEEK_MS` was 700 against `TURN_CLAIM_MS` 1200 — matched to the chain
+  card's decay, a constant that never shares a screen with it — so the list
+  went while the header was still claiming the cell. 1500 now, pinned as an
+  ORDERING between the two.
 - **Two-option enums: the GRID flips on click, a LIST focuses instead** — and on
   the KNOB they split BY WIDGET, not by semantics: a **switch** has a track, so
   its form names a direction and it is direction-absolute (clockwise on,

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -581,7 +581,7 @@ those pages drawable.
 
 ### A turn PEEKS the list; a cell that is already big does not
 
-Turning a divable enum raises its option list over the grid for ~700ms
+Turning a divable enum raises its option list over the grid for 1500ms
 (`ENUM_PEEK_MS`), header `TURNING`, footer `TURN SET`. It is the same screen
 the picker draws (`enum_list.mjs`) with the opposite commit semantics: the
 detent has ALREADY written, so there is nothing to confirm and nothing to
@@ -623,6 +623,31 @@ obligation had to become a FUNCTION rather than a paragraph.
 the rows go through `menu_layout` (global `print`) while the header is a pixel
 font that never calls `print` at all — a recording `print()` reports a
 headerless screen as complete.
+
+**It must OUTLIVE `TURN_CLAIM_MS`** (1200), and for a year it did not: 700 was
+picked to match the chain editor card's `KNOB_CARD_DECAY_MS`, two numbers that
+never appear on the same screen. The same detent raises both — the header
+claims the cell and names the parameter, the peek shows what is either side of
+the value — so the shorter one took the list down while the header was still
+claiming, leaving the screen answering half a question. Reported from the
+device as simply "the peek disappears too quickly".
+`tests/host/test_enum_peek.sh` asserts the ORDER of the two constants rather
+than either number, so tuning one cannot silently re-cross them.
+
+**A LIST does not peek AT ALL** — the whole layout, not one graphic. The peek
+exists because a 30px GRID CELL cannot show a word; a list row prints the
+option in full, right-aligned beside its label, so the panel covers a legible
+answer with the same answer and hides the four rows around it as well.
+
+It was worst exactly where it was least needed. Global Settings is pinned to
+the list, and `skipback_shortcut` is two options: turning it blanked the screen
+to spell `Cap / Vol+Cap` over a row already reading `Skipback: Vol+Cap`.
+Reported from the device as a menu that should not be there — and it is not a
+two-option problem, a 47-model list is the same occlusion for the same reason.
+
+Gated on `s.layout`, not on `knobsAsList()`: by the time the turn is being
+handled the page is known to be a knobs page with a key under the cursor, and
+the remaining question is only what the layout can SHOW.
 
 **A parameter drawn across MORE THAN ONE CELL does not peek** (`drawnWide`).
 The peek exists because a 30px cell cannot show a list; once the picture has

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -364,12 +364,20 @@ export const TURN_CLAIM_MS = 1200;
  * a knob can be moved without the capacitive touch ever registering, which is
  * the same reason TURN_CLAIM_MS exists just above.
  *
- * 700 matches the chain editor card's KNOB_CARD_DECAY_MS. Deliberately NOT the
- * same variable: that card lives in the chain editor and this list on the knob
- * grid, so they never coexist, and one constant shared across two screens is a
- * coupling that reads as intent and is not.
+ * It must OUTLIVE TURN_CLAIM_MS (1200). The two are raised by the same detent
+ * and describe the same parameter -- the header names it, the list shows what
+ * is either side of it -- so a shorter peek takes the option list down while
+ * the header is still claiming the cell, and the screen answers half a
+ * question. Reported from the device as simply "the peek disappears too
+ * quickly".
+ *
+ * It USED to be 700, chosen to match the chain editor card's
+ * KNOB_CARD_DECAY_MS. That was a coincidence of two numbers rather than a
+ * shared rule -- the card lives in the chain editor and this list on the knob
+ * grid, so they never coexist -- and matching it bought nothing while costing
+ * the read. Still deliberately NOT the same variable, for that reason.
  */
-export const ENUM_PEEK_MS = 700;
+export const ENUM_PEEK_MS = 1500;
 
 /** How many times a page will re-read the contract waiting for late metadata. */
 export const META_RETRY_LIMIT = 8;
@@ -3210,7 +3218,28 @@ export function createController(io = {}) {
          * panel would replace something legible with something no more
          * informative, while hiding the rest of the row.
          */
-        if (meta.divable && meta.kind === KIND_ENUM
+        /*
+         * ...AND A LIST DOES NOT PEEK AT ALL.
+         *
+         * Same rule as drawnWide one paragraph down, applied to the whole
+         * layout instead of to one graphic: the peek exists because a 30px
+         * GRID CELL cannot show a word. A list row already prints the option
+         * in full, right-aligned beside its label, so the panel covers a
+         * legible answer with the same answer -- and takes the four rows
+         * around it with it.
+         *
+         * It is worst exactly where it is least needed. Global Settings is
+         * pinned to the list, and `skipback_shortcut` is two options: turning
+         * it blanked the screen to spell "Cap / Vol+Cap" over a row already
+         * reading "Skipback: Vol+Cap". Reported from the device as a menu that
+         * should not be there.
+         *
+         * Gated on s.layout rather than on knobsAsList(): the turn has already
+         * established that this is a knobs page with a key under the cursor,
+         * and the question here is only what the layout can SHOW.
+         */
+        if (s.layout !== LAYOUT_LIST
+            && meta.divable && meta.kind === KIND_ENUM
             && !drawnWide(key) && !drawnAsSwitch(key)
             && Array.isArray(meta.options) && meta.options.length >= 2) {
             const pi = Math.round(Number(value));

--- a/tests/host/test_enum_peek.sh
+++ b/tests/host/test_enum_peek.sh
@@ -32,7 +32,7 @@ fi
 
 node --input-type=module -e '
 import { readFileSync, readdirSync } from "node:fs";
-import { createController, ENUM_PEEK_MS }
+import { createController, ENUM_PEEK_MS, LAYOUT_LIST, TURN_CLAIM_MS }
   from "./src/shared/param_pages/page_controller.mjs";
 import { applyInput } from "./src/shared/param_pages/page_input.mjs";
 import { createFramebuffer, drawContext } from "./tools/param-pages/harness.mjs";
@@ -56,7 +56,7 @@ const HIER = { modes: null, levels: { root: { label: "T",
   params: CHAIN_PARAMS.map((p) => ({ key: p.key })) } } };
 
 let clock = 1000;
-function mk() {
+function mk(opts) {
   clock = 1000;
   const store = { shape: "0", onoff: "0", solo: "0", chorusout: "0", bare: "0", gain: "0.5" };
   const reads = [];
@@ -72,6 +72,7 @@ function mk() {
     announce: () => {},
     now: () => clock,
   });
+  if (opts && opts.layout) ctl.setLayout(opts.layout);
   ctl.load({ prefix: "synth" });
   /* Settle the value cursor the way a live page does, so the reads counted
      below are the turn path only and not first-touch seeding. */
@@ -118,6 +119,24 @@ const spin = (ctl, slot, n) => {
   ok(ctl.enumPeek() === null, "the peek is gone just outside the window");
   spin(ctl, s, 2);
   ok(ctl.enumPeek() !== null, "a further detent re-arms it");
+}
+
+/* ==================================================================== 2b ==
+ * ...AND IT OUTLIVES THE TURN CLAIM.
+ *
+ * The same detent raises both: the header claims the cell and names the
+ * parameter, the peek shows what is either side of the value. A peek shorter
+ * than TURN_CLAIM_MS takes the list down while the header is still claiming,
+ * so the screen is left answering half a question -- reported from the device
+ * as "the peek disappears too quickly".
+ *
+ * Asserted as an ORDERING between the two constants rather than as a number,
+ * so tuning either one cannot silently re-cross them.
+ */
+{
+  ok(ENUM_PEEK_MS > TURN_CLAIM_MS,
+     "ENUM_PEEK_MS (" + ENUM_PEEK_MS + ") must outlive TURN_CLAIM_MS ("
+     + TURN_CLAIM_MS + ")");
 }
 
 /* ===================================================================== 3 ==
@@ -179,6 +198,41 @@ const spin = (ctl, slot, n) => {
     spin(ctl, slotOf("shape"), 6);
     ok(ctl.enumPeek() !== null,
        "a five-option enum still peeks -- its graphic shows one value, not the list");
+  }
+}
+
+/* ===================================================================== 3b =
+ * A LIST DOES NOT PEEK AT ALL.
+ *
+ * The peek exists because a 30px GRID CELL cannot show a word. A list row
+ * prints the option in FULL beside its label, so the panel covers a legible
+ * answer with the same answer and hides the four rows around it as well.
+ *
+ * Reported from Global Settings, which is pinned to the list: turning
+ * Skipback (Cap / Vol+Cap) blanked the screen to spell two words over a row
+ * already reading "Skipback: Vol+Cap".
+ *
+ * Both halves are here on purpose. Asserting only the suppression would pass
+ * just as well if the peek were deleted outright, and the grid is where it
+ * earns its place -- a 47-model list you cannot see the end of.
+ */
+{
+  {
+    const { ctl, slotOf } = mk({ layout: LAYOUT_LIST });
+    spin(ctl, slotOf("chorusout"), 6);
+    ok(ctl.enumPeek() === null,
+       "a two-option CHOICE does not peek in the LIST -- the row spells it out");
+    spin(ctl, slotOf("shape"), 6);
+    ok(ctl.enumPeek() === null,
+       "nor does a five-option enum: the list row shows the value it landed on");
+  }
+  {
+    /* The same two keys, same fixture, GRID layout: unchanged. */
+    const { ctl, slotOf } = mk();
+    spin(ctl, slotOf("chorusout"), 6);
+    ok(ctl.enumPeek() !== null, "the grid still peeks on a two-option choice");
+    spin(ctl, slotOf("shape"), 6);
+    ok(ctl.enumPeek() !== null, "the grid still peeks on a five-option enum");
   }
 }
 


### PR DESCRIPTION
Two reports from the device, one screen.

### 1. A two-value option showed a menu

The "menu" is the **enum peek**. It exists because a 30px *grid cell* cannot show a word — but a **list row prints the option in full**, right-aligned beside its label, so the panel covered a legible answer with the same answer and took the four rows around it down as well.

Global Settings is pinned to the list, and `skipback_shortcut` is two options:

**Before** — turning `Skipback`:

```
SKIPBACK                TURNING
  Cap
  Vol+Cap                     *


[TURN] SET
```

**After** — the row is focused and the jog changes it in place:

```
GLOBAL > SETTINGS    SHORTCUTS
 Open With               Both
 Recall Q                 Off
 Skipback          [Vol+Cap]
 Skipback Len              30s
```

It is **not a two-option problem** — a 47-model list is the same occlusion for the same reason — so the gate is the LAYOUT. On `s.layout` rather than `knobsAsList()`: by the time the turn is handled the page is known to be a knobs page with a key under the cursor, and what is left to ask is only what the layout can *show*. **The grid is unchanged**, switches and wide graphics included.

### 2. The peek disappeared too quickly

`ENUM_PEEK_MS` 700 → **1500**, which is the rule rather than the number: it has to **outlive `TURN_CLAIM_MS` (1200)**. The same detent raises both — the header claims the cell and names the parameter, the peek shows what is either side of the value — so a shorter peek took the list down mid-claim and left the screen answering half a question. 700 was matched to the chain editor card's `KNOB_CARD_DECAY_MS`, a constant that never shares a screen with this one, so the match bought nothing and cost the read.

### Tests

`tests/host/test_enum_peek.sh` gains both, and **both halves of each**:

- the list suppression **and** the grid still peeking, on the same two keys and the same fixture — asserting only the suppression would pass just as well if the peek were deleted
- the duration as an **ordering between the two constants**, so tuning either cannot silently re-cross them

Reverting either fix fails it (verified: 3 FAILs). Full `tests/host/` suite green, `make -C tests/host test` green.

Not yet verified on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JsRb7WL9ZfTJU4Nozp4Y5