### PR TITLE
A module may claim buttons (capabilities.claims_ccs, claims_edit_ccs)

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -78,6 +78,8 @@ for keys anywhere in `module.json`).
 | `midi_out` | Module sends MIDI output (chain MIDI FX, generator tools) |
 | `aftertouch` | Module uses aftertouch |
 | `claims_master_knob` | Module handles volume knob (CC 79) instead of host |
+| `claims_ccs` | A list of CC numbers the module handles while its UI is on screen; they are withheld from Move firmware for that window. See "Claiming buttons" below. |
+| `claims_edit_ccs` | Shorthand for `claims_ccs: [56, 60, 119]` — Undo, Copy and Delete. Default off. |
 | `raw_midi` | Skip host MIDI transforms (velocity curve, aftertouch filter); module may also bypass internal MIDI filters when set |
 | `raw_ui` | Module owns UI input handling; host won't intercept Back to return to menu (use `host_return_to_menu()` to exit) |
 | `chainable` | Marks a module as usable inside Signal Chain patches (metadata) |
@@ -638,23 +640,57 @@ Only consume Back while you actually have somewhere to go back *to*. If `handleB
 always returns truthy the user can never leave your module via Back — it is the only
 host-processed exit in this screen, so the sole remaining way out is to exit shadow mode.
 
-#### Copy / Delete / Undo (`ui_chain.js`)
+#### Claiming buttons (`capabilities.claims_ccs`, `claims_edit_ccs`)
 
-While the shadow UI is on screen, CC 56 (Undo), CC 60 (Copy), and CC 119
-(Delete) are delivered exclusively to the loaded module's `ui_chain.js` via
-`onMidiMessageInternal` — they are blocked from reaching Move firmware for
-the duration, so a press can never double-fire into Move's own undo/copy/
-delete while you're editing a module (e.g. a Delete press won't also delete
-a Move clip in the background).
+Move's buttons reach Move firmware by default and are **not** forwarded to
+modules. A module that wants some of them for its own gestures opts in:
 
-This makes the three buttons safe to repurpose for module-specific gestures
-— e.g. hold Copy/Delete + tap a pad to target it, tap Undo to revert the
-last such operation. They join the existing forwarded set (jog wheel/click,
-Back, track buttons, knobs, Mute) that a chain module already receives in
-this screen.
+```json
+{
+  "capabilities": {
+    "claims_edit_ccs": true,
+    "claims_ccs": [85, 58]
+  }
+}
+```
 
-Outside shadow display (or outside COMPONENT_EDIT), these CCs behave as
-normal Move hardware buttons and are not intercepted.
+`claims_edit_ccs: true` is shorthand for Undo (CC 56), Copy (CC 60) and
+Delete (CC 119) — the drum-rack trio. `claims_ccs` lists any others by CC
+number; the two combine.
+
+While that module's UI is on screen, a claimed button is delivered to the
+module (a `type: "canvas"` UI receives it in `onMidi`; on the knob grid Undo,
+Copy and Delete drive the instance copy/clear gesture under *Child Selectors*)
+**and withheld from Move firmware**, so a press cannot double-fire into Move's
+own action — hold Copy and tap a pad without also copying the Move clip behind
+the screen. The claim applies on the knob grid, the hierarchy editor, the
+component edit/params screens, and a canvas UI (fullscreen or co-run overlay).
+Leave any of those and the buttons return to Move immediately; the shim also
+drops every claim on its own when the shadow display closes, so a shadow UI
+that exits without reconciling cannot strand one.
+
+> **Opt-in is the whole point.** #154 withheld Undo/Copy/Delete unconditionally
+> whenever the shadow display was up, and #175 reverted it: it stole Move's
+> native Undo during ordinary chain use, so you could not undo a note edit
+> while any Schwung module was on screen. Modules that declare no claim are
+> unaffected, and Move keeps its own buttons everywhere else.
+
+**What cannot be claimed.** The controls the host itself owns are refused by
+the shim whatever a module lists, and the shadow UI logs the refusal: Shift,
+Menu and Back (how you leave a screen), the jog wheel and click, the eight
+knobs and the master knob, the four track buttons, Mute (Move-native Mute+Pad
+depends on it reaching firmware), and the two jack-detect CCs. Everything
+else is the module's to claim, transport included: a module that claims Play
+(CC 85) takes Move's transport button away while its UI is up, which is what
+a claim means.
+
+**Shift is the host's.** A press with Shift held is never claimed:
+Shift+Copy / Shift+Delete stay the host's snapshot and recall over a claiming
+module, and a module gets the bare buttons only.
+
+Press/release pairing is latched per button: whoever receives the press also
+receives the release, even if the claim changes mid-hold. Neither Move nor the
+module can be left believing a button is still held.
 
 ### Menu Layout Helpers
 

--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -420,6 +420,25 @@ typedef struct shadow_control_t {
      * writes features.json and JS pushes it back down at startup.
      */
     volatile uint8_t save_stems;
+    /*
+     * Runtime button claim: one bit per CC number (bit cc&7 of byte cc>>3).
+     * A set bit withholds that CC from Move firmware and forwards it to the
+     * shadow UI instead, so a module can build its own gestures on a button
+     * without a press ALSO firing Move's action behind the screen.
+     *
+     * Opt-in on purpose. #154 blocked Undo/Copy/Delete unconditionally whenever
+     * the shadow display was up and was reverted in #175 because it stole
+     * Move's native Undo during ordinary chain use. This is the runtime
+     * complement to the STATIC capabilities.claims_ccs / claims_edit_ccs:
+     * shadow_ui reconciles it from whichever module's UI is actually on
+     * screen, so Move keeps its own buttons everywhere else. The shim refuses
+     * bits for the controls the host itself owns (Shift, Menu, Back, jog,
+     * knobs, Mute, tracks) whatever is set here. Same shape as pad_block.
+     *
+     * APPENDED, like save_stems above: sizeof is a contract between two
+     * binaries. Appending is free; inserting is not.
+     */
+    volatile uint8_t claim_cc_bits[16];
 } shadow_control_t;
 
 /* Values for shadow_control_t.save_stems. */

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -6882,6 +6882,32 @@ static inline void midi_in_swallow(uint8_t *shadow_midi_in, uint8_t *hw_midi_in,
     }
 }
 
+/* Button-claim press latch -- see the filter site in shim_post_transfer.
+ * Records, per CC, whether the module received its PRESS, so the same consumer
+ * receives its RELEASE even if the claim (capabilities.claims_ccs) changes
+ * mid-hold. Read by both the Move-firmware filter and the forward-to-shadow_ui
+ * site; the filter runs first in the frame, so the forward site sees this
+ * frame's decision. Touched only from the SPI callback -- no locking. */
+static uint8_t claim_press_blocked[128];
+
+/* Controls the host owns and a module may NEVER claim: how you leave the
+ * screen (Menu, Back, Shift), what the host routes itself (jog, the eight
+ * knobs, the master knob, the track buttons), and Mute, on which Move-native
+ * Mute+Pad depends. A claim on one of these is ignored here whatever shadow_ui
+ * wrote, so the shim stays correct even against a UI that forgot the list. */
+static int claim_denied_cc(uint8_t cc) {
+    if (cc == CC_SHIFT || cc == CC_MENU || cc == CC_BACK) return 1;
+    if (cc == CC_JOG_WHEEL || cc == CC_JOG_CLICK) return 1;
+    if (cc >= CC_KNOB1 && cc <= CC_KNOB8) return 1;
+    if (cc == CC_MASTER_KNOB || cc == CC_MUTE) return 1;
+    if (cc >= 40 && cc <= 43) return 1;                 /* track buttons */
+    if (cc == CC_MIC_IN_DETECT || cc == CC_LINE_OUT_DETECT) return 1;
+    return 0;
+}
+static inline int claim_cc_set(uint8_t cc) {
+    return shadow_control && ((shadow_control->claim_cc_bits[cc >> 3] >> (cc & 7)) & 1);
+}
+
 static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, int size)
 {
     (void)ctx;
@@ -7144,6 +7170,24 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
         prev_overtake_mode = overtake_mode;
     }
 
+    /* Drop any edit-CC claim when the shadow display goes away. The claim only
+     * means anything while a module's UI is on screen, and a shadow_ui that
+     * exited (or crashed) before reconciling it to 0 would otherwise leave
+     * Move's Undo / Copy / Delete captured with nothing left to deliver them
+     * to. Same reasoning as the runtime-claim drops on overtake exit above:
+     * this edge covers EVERY exit path. Also disarms the press latch so a
+     * release arriving after the display closed is routed to Move, matching
+     * where its press went. Runs unconditionally -- the filter itself is inside
+     * the shadow_display_mode branch below, so this must not be. */
+    {
+        static int prev_display_mode = 0;
+        if (prev_display_mode && !shadow_display_mode) {
+            if (shadow_control) memset((void *)shadow_control->claim_cc_bits, 0, sizeof(shadow_control->claim_cc_bits));
+            memset(claim_press_blocked, 0, sizeof(claim_press_blocked));
+        }
+        prev_display_mode = shadow_display_mode;
+    }
+
     /* Boot jack-state re-assert: worker arms shim_inject_boot_jack ~5 s after
      * start (Move firmware is up by then). Inject a CC 115 into Move's MIDI_IN
      * via the safe MPSC inject ring so Move's speaker enhancer corrects when
@@ -7313,6 +7357,40 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                     if (cin == 0x0B && type == 0xB0) {
                         if (d1 == CC_JOG_WHEEL || d1 == CC_JOG_CLICK || d1 == CC_BACK) {
                             filter = 1;
+                        }
+                        /* A CLAIMED button: withheld from Move firmware ONLY while
+                         * the module on screen has claimed it
+                         * (shadow_control->claim_cc_bits, reconciled by shadow_ui
+                         * from capabilities.claims_ccs / claims_edit_ccs). Unclaimed
+                         * it passes through untouched, so Move keeps its native
+                         * Undo during ordinary chain use -- precisely what the
+                         * unconditional version (#154) broke and why it was
+                         * reverted (#175). Forwarded to the shadow UI under the
+                         * same latch by the post-ioctl loop. The host-owned
+                         * controls (claim_denied_cc) can never be claimed. */
+                        if (d1 < 128) {
+                            /* Latch per button so a claim that changes MID-HOLD
+                             * cannot desync Move's view of the button: whoever
+                             * received the PRESS also receives the RELEASE.
+                             * Without this, a claim engaging between press and
+                             * release leaves Move believing the button is still
+                             * held, and a claim dropping mid-hold delivers Move an
+                             * orphan release. */
+                            if (d2 > 0) {
+                                /* Shift+<button> is the host's own vocabulary
+                                 * (Shift+Copy / Shift+Delete = snapshot and
+                                 * recall, handled and swallowed in the post-ioctl
+                                 * loop). A press with Shift held is never claimed:
+                                 * the module gets the BARE buttons only. */
+                                claim_press_blocked[d1] =
+                                    (claim_cc_set(d1) && !claim_denied_cc(d1) && !shadow_shift_held) ? 1 : 0;
+                            }
+                            if (claim_press_blocked[d1]) filter = 1;
+                            /* Deliberately NOT cleared on release: the latch is
+                             * re-armed by the next press, which keeps it valid
+                             * for the forward-to-shadow_ui site that runs LATER
+                             * in this same frame and must route the release the
+                             * same way it routed the press. */
                         }
                         /* Filter Menu unless long-press mode dismisses shadow on tap */
                         if (d1 == CC_MENU && !LONG_PRESS_ACTIVE()) {
@@ -8584,10 +8662,16 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                  * - CC 14 (jog wheel), CC 3 (jog click), CC 51 (back)
                  * - CC 40-43 (track buttons)
                  * - CC 71-78 (knobs)
-                 * - CC 88 (mute) — used as a modifier for Mute+JogClick module bypass */
+                 * - CC 88 (mute) — used as a modifier for Mute+JogClick module bypass
+                 * - any CC the module on screen has CLAIMED (capabilities.claims_ccs
+                 *   / claims_edit_ccs), by the latch the firmware filter above set
+                 *   on its press -- so a claimed press drives the module and
+                 *   nothing else. Unclaimed, a button is not forwarded and reaches
+                 *   Move unchanged. */
                 int forward_to_shadow = (d1 == 14 || d1 == 3 || d1 == 51 ||
                                          (d1 >= 40 && d1 <= 43) || (d1 >= 71 && d1 <= 78) ||
-                                         d1 == 88);
+                                         d1 == 88 ||
+                                         (d1 < 128 && claim_press_blocked[d1]));
 
                 if (forward_to_shadow && shadow_ui_midi_shm) {
                     shadow_ui_midi_publish(0x0B, status, d1, d2);

--- a/src/shadow/shadow_ui.c
+++ b/src/shadow/shadow_ui.c
@@ -2655,6 +2655,47 @@ static JSValue js_shadow_set_display_overlay(JSContext *ctx, JSValueConst this_v
 #define PREVIEW_CMD_PATH "/data/UserData/schwung/preview_cmd_path.txt"
 
 /* host_pad_block(enable) - suppress pad notes from reaching Move firmware */
+/* host_claim_ccs([cc, ...]) - claim buttons at runtime. Every listed CC is
+ * withheld from Move firmware and forwarded to the shadow UI (the runtime
+ * complement to the static capabilities.claims_ccs / claims_edit_ccs), so a
+ * module can build gestures on them without a press ALSO firing Move's own
+ * action behind the screen. An empty array releases everything.
+ *
+ * Replaces the whole claim each call and logs only on a TRANSITION, so the
+ * caller reconciles it from whatever is on screen rather than tracking the
+ * claim at each write site. Callers MUST drive it to [] when they stop wanting
+ * the buttons -- nothing clears it on their behalf except the shim's own drop
+ * when the shadow display closes. The shim refuses the host-owned controls
+ * (Shift, Menu, Back, jog, knobs, Mute, tracks) whatever is listed. */
+static JSValue js_host_claim_ccs(JSContext *ctx, JSValueConst this_val,
+                                 int argc, JSValueConst *argv) {
+    (void)this_val;
+    if (argc < 1 || !shadow_control) return JS_FALSE;
+    uint8_t bits[16];
+    memset(bits, 0, sizeof(bits));
+    int n = 0;
+    if (JS_IsArray(ctx, argv[0])) {
+        JSValue lenv = JS_GetPropertyStr(ctx, argv[0], "length");
+        int len = 0;
+        JS_ToInt32(ctx, &len, lenv);
+        JS_FreeValue(ctx, lenv);
+        for (int i = 0; i < len && i < 128; i++) {
+            JSValue e = JS_GetPropertyUint32(ctx, argv[0], (uint32_t)i);
+            int cc = -1;
+            JS_ToInt32(ctx, &cc, e);
+            JS_FreeValue(ctx, e);
+            if (cc >= 0 && cc < 128) { bits[cc >> 3] |= (uint8_t)(1u << (cc & 7)); n++; }
+        }
+    }
+    if (memcmp((const void *)shadow_control->claim_cc_bits, bits, sizeof(bits)) != 0) {
+        memcpy((void *)shadow_control->claim_cc_bits, bits, sizeof(bits));
+        char line[64];
+        snprintf(line, sizeof(line), "shadow_ui: claim_ccs %s (%d)", n ? "ON" : "OFF", n);
+        shadow_ui_log_line(line);
+    }
+    return JS_TRUE;
+}
+
 static JSValue js_host_pad_block(JSContext *ctx, JSValueConst this_val,
                                   int argc, JSValueConst *argv) {
     (void)this_val;
@@ -3143,6 +3184,7 @@ static void init_javascript(JSRuntime **prt, JSContext **pctx) {
 
     /* Register pad block function */
     JS_SetPropertyStr(ctx, global_obj, "host_pad_block", JS_NewCFunction(ctx, js_host_pad_block, "host_pad_block", 1));
+    JS_SetPropertyStr(ctx, global_obj, "host_claim_ccs", JS_NewCFunction(ctx, js_host_claim_ccs, "host_claim_ccs", 1));
 
     /* Register preview player functions */
     JS_SetPropertyStr(ctx, global_obj, "host_preview_play", JS_NewCFunction(ctx, js_host_preview_play, "host_preview_play", 1));

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16703,6 +16703,116 @@ function ensureComponentWidgets(moduleId, chainParams) {
     }
 }
 
+/* ── Button claims: capabilities.claims_ccs / claims_edit_ccs ─────────────────
+ *
+ * A module declaring `capabilities.claims_ccs` (a list of CC numbers) or the
+ * shorthand `claims_edit_ccs: true` (Undo 56, Copy 60, Delete 119) gets those
+ * buttons delivered to it while its UI is on screen, and Move firmware does
+ * not see them for that window -- so a hold-Copy + tap-pad style gesture
+ * cannot also copy a Move clip behind the screen.
+ *
+ * ⚠ ENTRY-CONDITION TABLE. Every screen that may hold a claim, what opens it,
+ * and where that condition is re-checked. A new screen wanting these buttons
+ * declares itself HERE:
+ *
+ *   screen                       opened by                    re-checked in
+ *   ──────────────────────────   ──────────────────────────   ─────────────────
+ *   PARAM_PAGES (the knob grid)  a component whose module     reconcileCcClaim()
+ *   HIERARCHY_EDITOR             declares a claim              -- and ONLY there
+ *   COMPONENT_EDIT
+ *   COMPONENT_PARAMS
+ *   CANVAS (fullscreen)          a canvas param opened on
+ *   CANVAS (co-run overlay)      such a component
+ *
+ * The claim is re-derived in ONE place from what is on screen right now, never
+ * bookkept at the flag's write sites. That is the whole design: #154 blocked
+ * Undo/Copy/Delete unconditionally whenever the shadow display was up, and was
+ * reverted (#175) because it stole Move's native Undo during ordinary chain
+ * use. The revert asked for a capability opt-in; this is it.
+ *
+ * The shim independently drops every claim when the shadow display closes, so
+ * a shadow_ui that exits or crashes without reconciling cannot strand one; it
+ * also refuses the host-owned controls below whatever is written. */
+const CC_CLAIM_VIEWS = {};
+CC_CLAIM_VIEWS[VIEWS.PARAM_PAGES] = true;
+CC_CLAIM_VIEWS[VIEWS.HIERARCHY_EDITOR] = true;
+CC_CLAIM_VIEWS[VIEWS.COMPONENT_EDIT] = true;
+CC_CLAIM_VIEWS[VIEWS.COMPONENT_PARAMS] = true;
+CC_CLAIM_VIEWS[VIEWS.CANVAS] = true;
+
+/* The controls the host owns: how you leave a screen (Shift 49, Menu 50,
+ * Back 51), what the host routes itself (jog 14/3, knobs 71-78, master 79,
+ * tracks 40-43) and Mute 88 (Move-native Mute+Pad). Mirrors claim_denied_cc in
+ * the shim, which is the enforcing copy; this one only tells the author. */
+const CC_CLAIM_DENIED = new Set([49, 50, 51, 14, 3, 71, 72, 73, 74, 75, 76, 77, 78, 79, 88, 40, 41, 42, 43, 114, 115]);
+const EDIT_CCS = [56, 60, 119];
+
+let ccClaimCache = {};
+let ccClaimKey = null;
+let ccClaimed = "";
+
+/* The sorted, host-permitted list of CCs `moduleId` claims, as a string
+ * ("" = none). Cached per module: the lookup is a file read. */
+function moduleClaimedCcs(moduleId) {
+    if (!moduleId) return "";
+    if (moduleId in ccClaimCache) return ccClaimCache[moduleId];
+    let meta = null;
+    try {
+        if (typeof host_get_module_metadata === "function") {
+            meta = host_get_module_metadata(moduleId);
+        }
+    } catch (e) { meta = null; }
+    const caps = (meta && meta.capabilities) || {};
+    const want = new Set();
+    if (caps.claims_edit_ccs) for (const cc of EDIT_CCS) want.add(cc);
+    if (Array.isArray(caps.claims_ccs)) {
+        for (const v of caps.claims_ccs) {
+            const cc = Number(v);
+            if (Number.isInteger(cc) && cc >= 0 && cc < 128) want.add(cc);
+        }
+    }
+    const denied = [...want].filter((cc) => CC_CLAIM_DENIED.has(cc));
+    if (denied.length) {
+        debugLog(`claims_ccs: ${moduleId} asked for host-owned CC(s) ${denied.join(",")} -- ignored`);
+        for (const cc of denied) want.delete(cc);
+    }
+    const v = [...want].sort((a, b) => a - b).join(",");
+    ccClaimCache[moduleId] = v;
+    return v;
+}
+
+function reconcileCcClaim() {
+    if (typeof host_claim_ccs !== "function") return;
+    const onScreen = !!CC_CLAIM_VIEWS[view] ||
+        (coRunUiActive() && coRunView === VIEWS.CANVAS);
+    /* Cheap identity of "whose UI is on screen". The module-id read costs a
+     * blocking get_param round-trip (~2.8 ms), so it is consulted only when
+     * this tuple changes -- not on every one of the ~44 ticks/sec. A module
+     * SWAP always transits COMPONENT_SELECT, which moves `view`, so the tuple
+     * catches swaps too. The knob grid keeps its own slot/component
+     * (enterParamPages never touches hierEditorSlot), so on that view the
+     * identity comes from the grid. */
+    const onGrid = view === VIEWS.PARAM_PAGES && paramPagesActive();
+    const slot = onGrid ? paramPagesSlot() : hierEditorSlot;
+    const comp = onGrid ? paramPagesComponent() : hierEditorComponent;
+    const key = onScreen
+        ? (view + "|" + coRunView + "|" + slot + "|" + comp)
+        : "";
+    if (key === ccClaimKey) return;
+    ccClaimKey = key;
+    let moduleId = "";
+    if (onScreen && onGrid) {
+        const prefix = getComponentParamPrefix(comp);
+        moduleId = prefix ? (getSlotParam(slot, `${prefix}_module`) || "") : "";
+    } else if (onScreen) {
+        moduleId = getHierarchyActiveModuleId();
+    }
+    const claim = onScreen ? moduleClaimedCcs(moduleId) : "";
+    if (claim === ccClaimed) return;
+    ccClaimed = claim;
+    host_claim_ccs(claim ? claim.split(",").map(Number) : []);
+}
+
 function getModuleBasePath(moduleId) {
     if (!moduleId) return "";
     const searchDirs = [
@@ -21677,6 +21787,11 @@ function dispatchCoRunDraw() {
 
 let lastDrawError = null;  /* one-shot log guard for the tick draw catch */
 globalThis.tick = function() {
+    /* Button claims, re-derived from whatever is on screen. Kept at the top of
+     * the tick as the SINGLE re-check point for that entry condition -- see the
+     * table above reconcileCcClaim(). */
+    reconcileCcClaim();
+
     /* Background tick for JS-suspended overtake modules.
      * Each parked module's tick() keeps firing so it can emit MIDI or advance
      * internal state. Display and LED bindings are swapped for no-ops so the

--- a/tests/host/test_claims_ccs.sh
+++ b/tests/host/test_claims_ccs.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A module may claim buttons -- and ONLY a module that asks, ONLY the buttons
+# the host does not own.
+#
+# #154 withheld CC 56 / 60 / 119 from Move firmware whenever the shadow display
+# was up, and #175 reverted it: Move's native Undo was gone during ordinary
+# chain use. The revert named the acceptable shape, a capability opt-in. This
+# pins the properties that make the opt-in honest, each of which a plausible
+# simplification would lose:
+#
+#   1. the firmware filter is gated on the RUNTIME claim bitmap, never on the
+#      display being up (the #154 regression, in one line)
+#   2. the press/release pairing is latched per button, so a claim changing
+#      mid-hold cannot leave Move or the module believing a button is held
+#   3. a Shift-held press is never claimed -- Shift+Copy / Shift+Delete are
+#      the host's snapshot and recall
+#   4. the host-owned controls are refused BY THE SHIM, whatever was written
+#   5. the JS derives the claim from module metadata in ONE place, re-checked
+#      every tick, honours the claims_edit_ccs shorthand, and the shim drops
+#      every claim itself when the display closes
+#
+# Style-of-house grep pins (see test_contract_capture_scope.sh): the shim is
+# cross-compiled and the routing runs in the SPI callback, so the seams are
+# pinned by their text rather than driven.
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+shim="src/schwung_shim.c"
+ui_c="src/shadow/shadow_ui.c"
+ui_js="src/shadow/shadow_ui.js"
+hdr="src/host/shadow_constants.h"
+docs="docs/MODULES.md"
+
+# ---- 1. gated on the claim, not on the display -------------------------------
+command grep -q 'volatile uint8_t claim_cc_bits\[16\];' "$hdr" \
+  || fail "shadow_control_t has no claim_cc_bits -- the runtime claim has nowhere to live"
+
+# The struct is a contract between two binaries: the field was APPENDED, which
+# means nothing sits in front of it that was not already there. Pinned as its
+# predecessor rather than as "last" -- a later register appended after it is
+# correct, and a last-field check would fail on every one of them.
+prev=$(command grep -oE 'volatile [a-z0-9_]+ [a-z_0-9]+(\[[0-9]+\])?;' "$hdr" | command grep -B1 'claim_cc_bits' | head -1 | awk '{print $3}' | tr -d ';')
+[ "$prev" = "save_stems" ] || fail "claim_cc_bits no longer directly follows save_stems (preceded by \"$prev\") -- a field was INSERTED, which moves every field behind it"
+
+command grep -q 'claim_press_blocked\[d1\] =' "$shim" \
+  || fail "the per-button press latch is gone from the firmware filter"
+command grep -A1 'claim_press_blocked\[d1\] =' "$shim" | command grep -q 'claim_cc_set(d1)' \
+  || fail "the press latch is not derived from the claim bitmap -- that is #154 again"
+if command grep -B2 -A2 'claim_press_blocked\[d1\] =' "$shim" | command grep -q 'shadow_display_mode'; then
+  fail "the claim site tests the display, not the claim -- the #175 revert exists because of exactly this"
+fi
+echo "  ok  the firmware filter withholds a button only under the runtime claim"
+
+# ---- 2. the latch pairs release with press -----------------------------------
+command grep -q 'if (claim_press_blocked\[d1\]) filter = 1;' "$shim" \
+  || fail "a release is not routed by the latch its press set"
+command grep -q '(d1 < 128 && claim_press_blocked\[d1\])' "$shim" \
+  || fail "the forward-to-shadow_ui site does not consult the same latch as the filter"
+echo "  ok  whoever received the press receives the release"
+
+# ---- 3. Shift-held presses are never claimed ---------------------------------
+command grep -A1 'claim_press_blocked\[d1\] =' "$shim" | command grep -q '!shadow_shift_held' \
+  || fail "a Shift-held button can be claimed -- Shift+Copy / Shift+Delete are the host's snapshot/recall"
+echo "  ok  Shift+<button> stays the host's"
+
+# ---- 4. the host-owned controls are refused by the shim ----------------------
+command grep -A1 'claim_press_blocked\[d1\] =' "$shim" | command grep -q '!claim_denied_cc(d1)' \
+  || fail "the latch does not consult claim_denied_cc -- a module could claim Shift, Mute or the jog"
+denied=$(sed -n '/^static int claim_denied_cc(uint8_t cc) {/,/^}/p' "$shim")
+[ -n "$denied" ] || fail "claim_denied_cc is gone"
+for sym in CC_SHIFT CC_MENU CC_BACK CC_JOG_WHEEL CC_JOG_CLICK CC_KNOB1 CC_KNOB8 CC_MASTER_KNOB CC_MUTE; do
+  echo "$denied" | command grep -q "$sym" || fail "claim_denied_cc no longer refuses $sym"
+done
+echo "$denied" | command grep -q 'cc >= 40 && cc <= 43' || fail "claim_denied_cc no longer refuses the track buttons"
+# ...and NOT the buttons a module may want: a denylist that grew to cover the
+# transport or the edit trio would make the capability decorative.
+for sym in CC_PLAY CC_REC CC_UNDO CC_COPY CC_DELETE CC_LOOP CC_CAPTURE; do
+  if echo "$denied" | command grep -q "$sym"; then fail "claim_denied_cc refuses $sym -- that button is a module's to claim"; fi
+done
+echo "  ok  Shift/Menu/Back/jog/knobs/Mute/tracks can never be claimed; Play, Rec and the edit trio can"
+
+# ---- 5. one reconcile point, the shorthand, and the shim's own drop -----------
+command grep -q '"host_claim_ccs"' "$ui_c" || fail "host_claim_ccs is not bound for the shadow UI"
+n=$(command grep -c 'host_claim_ccs(claim ? claim.split' "$ui_js" || true)
+[ "$n" -eq 1 ] || fail "host_claim_ccs must be written from exactly ONE reconcile site (found $n)"
+command grep -q '^    reconcileCcClaim();' "$ui_js" || fail "reconcileCcClaim() is not called from the tick"
+command grep -q 'caps.claims_edit_ccs' "$ui_js" || fail "the claims_edit_ccs shorthand is not honoured"
+command grep -q 'const EDIT_CCS = \[56, 60, 119\];' "$ui_js" || fail "claims_edit_ccs no longer means Undo/Copy/Delete"
+command grep -q 'Array.isArray(caps.claims_ccs)' "$ui_js" || fail "the general claims_ccs list is not read"
+command grep -q 'CC_CLAIM_VIEWS\[VIEWS.PARAM_PAGES\] = true' "$ui_js" \
+  || fail "the knob grid (PARAM_PAGES) cannot hold a claim -- it is the default param view"
+command grep -B3 'memset((void \*)shadow_control->claim_cc_bits, 0' "$shim" | command grep -q 'prev_display_mode && !shadow_display_mode' \
+  || fail "the shim does not drop the claims when the shadow display closes -- a crashed shadow_ui strands Move's buttons"
+echo "  ok  claims are reconciled from metadata in one place and dropped by the shim on display close"
+
+# ---- docs say what the code does ---------------------------------------------
+command grep -q '| `claims_ccs` |' "$docs" || fail "docs/MODULES.md capability table has no claims_ccs row"
+command grep -q '| `claims_edit_ccs` |' "$docs" || fail "docs/MODULES.md capability table has no claims_edit_ccs row"
+if command grep -q 'are delivered exclusively to the loaded module' "$docs"; then
+  fail "docs/MODULES.md still describes #154's unconditional block as current behaviour"
+fi
+echo "  ok  docs describe the opt-in"
+
+echo "PASS: test_claims_ccs"

--- a/tests/host/test_save_stems_contract.sh
+++ b/tests/host/test_save_stems_contract.sh
@@ -87,11 +87,18 @@ check(moveIdx === slots,
         const fields = [...body[1].matchAll(/volatile\s+\w+\s+(\w+)\s*(\[[^\]]*\])?\s*;/g)]
             .map(m => m[1]);
         check(fields.includes("save_stems"), "save_stems is not a field of shadow_control_t");
-        check(fields[fields.length - 1] === "save_stems",
-            "save_stems is not the LAST field of shadow_control_t (last is " +
-            JSON.stringify(fields[fields.length - 1]) + ") — appending is free, " +
-            "inserting moves every field behind it and schwung-manager reads one " +
-            "at a raw offset");
+        /* "Appended" means nothing was put in FRONT of it. It does not mean it
+         * stays last forever: the next register appended after it (the first
+         * was edit_cc_block) is exactly the discipline this pins, and a
+         * last-field check would fail on every correct append from here on. So
+         * the invariant is its PREDECESSOR -- the field it was appended after --
+         * which an insertion anywhere before it would change. */
+        const at = fields.indexOf("save_stems");
+        check(at > 0 && fields[at - 1] === "metronome_beats_per_bar",
+            "save_stems no longer directly follows metronome_beats_per_bar (preceded by " +
+            JSON.stringify(fields[at - 1]) + ") — a field was INSERTED before it, which " +
+            "moves every field behind it and schwung-manager reads one at a raw offset; " +
+            "new registers are APPENDED after the last field");
     }
 }
 


### PR DESCRIPTION
## In short

Adds a capability that lets a module take over specific Move buttons while its UI is on screen. Declare `claims_ccs: [cc, ...]` (or the `claims_edit_ccs` shorthand for Undo/Copy/Delete) and those buttons are delivered to the module instead of Move for as long as its screen is up, then handed straight back. Any module can use it to build gestures on hardware buttons that were previously unreachable; the controls the host itself depends on can't be claimed.

## For a drum module, concretely

On a hardware drum rack, Copy, Delete and Undo are pad tools: hold Copy and hit a pad to duplicate it, hold Delete to clear one, Undo to take it back. Today a module can't use those buttons at all, because every press also reaches Move and copies, deletes or undoes something in the set behind the screen. This lets a drum module say "while I'm on screen, these buttons are mine", and gives them back to Move the moment you leave.

## What

A module may claim buttons: `"capabilities": { "claims_ccs": [85, 58], "claims_edit_ccs": true }`. `claims_ccs` lists CC numbers; `claims_edit_ccs` is shorthand for the drum-rack trio, Undo (56), Copy (60) and Delete (119). While the module's UI is on screen (the knob grid, the hierarchy editor, the component edit/params screens, a `type:"canvas"` UI) a claimed button is withheld from Move firmware and forwarded to the shadow UI, so a module can build a gesture on it without the press also firing Move's own action behind the screen.

## Why this shape

#154 withheld Undo/Copy/Delete whenever the shadow display was up; #175 reverted it because Move's native Undo was gone during ordinary chain use. The revert named the acceptable shape: a capability opt-in. This is that, for any button. Modules that declare no claim are untouched, and Move keeps its own buttons everywhere else.

- **What cannot be claimed**, refused by the shim whatever the UI wrote: Shift, Menu and Back (how you leave a screen), the jog, the eight knobs and the master knob, the track buttons, Mute (Move-native Mute+Pad depends on it), and the jack detects. Everything else, transport included, is the module's to claim; a module that claims Play takes Move's transport button away while its UI is up, which is what a claim means.
- **Shift is the host's.** A press with Shift held is never claimed, so Shift+Copy / Shift+Delete remain the host's snapshot and recall over a claiming module.
- The claim is re-derived in one place, a tick-time reconcile against whatever is on screen (the knob grid's own slot and component there, since the list editor's identity is unset on the grid), so no path can forget to clear it; the shim also drops every claim on its own when the shadow display closes.
- Press and release are latched per button, so a claim changing mid-hold cannot leave Move or the module believing a button is held.
- `shadow_control_t.claim_cc_bits` (128 bits) is appended, per the struct's rule. `test_save_stems_contract.sh` pinned `save_stems` as the *last* field, which every correct append from here on would fail; it now pins the predecessor, the invariant its comment describes.
- `docs/MODULES.md` still described #154's unconditional block as current behaviour; corrected, and the capability documented under *Claiming buttons*.

## Tests

`tests/host/test_claims_ccs.sh` pins what a simplification would lose: filter gated on the claim rather than the display, the press/release latch, the Shift exemption, the shim-side denylist (and that it does not grow to cover the transport or the edit trio), the single reconcile site, the shorthand, and the shim-side drop. Each pin was mutation-checked. Full host suite green; ARM build clean; device-tested on a Move with a drum module (schwung-dr32 0.2.0) declaring `claims_edit_ccs`: Copy/Delete withheld only while its grid is up, Shift+Copy still snapshots, release pairs with press, Move's buttons back the moment the grid is left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwuEvvXACZX2yGvBuhbJFh
