### PR TITLE
param pages: visible_if resolved against the list editor's slot, and failed open on the grid

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -275,7 +275,8 @@ import {
 import {
     paramPagesEnabled, enterParamPages, exitParamPages, paramPagesActive,
     tickParamPages, drawParamPages, handleParamPagesMidi, currentParamPage,
-    paramPagesComponent, paramPagesSlot, paramPagesChildIndex, clearParamPagesTouch,
+    paramPagesComponent, paramPagesSlot, paramPagesChildIndex, paramPagesLevelNameOf,
+    paramPagesCachedValue, clearParamPagesTouch,
     enumPickerFooterHints, CONTRACT_SETTLE_MS, LAYOUT_LIST,
     paramPagesRefreshTrailing, paramPagesExitMenu, paramPagesRevalue
 } from './shadow_ui_param_pages.mjs';
@@ -5047,13 +5048,13 @@ function compareConditionValue(actualRaw, expectedRaw) {
     return String(actualRaw) === String(expectedRaw);
 }
 
-function evaluateVisibilityConditionForContext(slot, componentPrefix, condition, levelDef, childIndex) {
+function evaluateVisibilityConditionForContext(slot, componentPrefix, condition, levelDef, childIndex, read) {
     if (!condition || typeof condition !== "object") return true;
     const conditionParam = condition.param || condition.key || condition.param_key;
     if (!conditionParam) return true;
 
     const fullKey = normalizeVisibilityConditionKey(componentPrefix, levelDef, childIndex, String(conditionParam));
-    const rawValue = getSlotParam(slot, fullKey);
+    const rawValue = (typeof read === "function") ? read(slot, fullKey) : getSlotParam(slot, fullKey);
     if (rawValue === null || rawValue === undefined) return true; // fail-open
 
     if (condition.equals !== undefined) {
@@ -5092,6 +5093,41 @@ function evaluateVisibilityConditionForContext(slot, componentPrefix, condition,
 }
 
 function evaluateVisibilityCondition(condition, levelDef) {
+    /*
+     * The knob grid is a caller too (page_controller's `visible` hook), and it
+     * keeps its OWN slot and component: enterParamPages never sets
+     * hierEditorSlot (see enterHierarchyEditorFromParamPages). So from the grid
+     * this read every condition against slot -1, got null, and FAILED OPEN --
+     * every visible_if on the grid was true, and a level meant to collapse to
+     * the armed type's cells (a send that is a reverb OR a delay) showed all of
+     * them, three pages deep. Reported from the device. On the grid, the
+     * grid's identity is the context.
+     */
+    if (view === VIEWS.PARAM_PAGES && paramPagesActive()) {
+        const comp = paramPagesComponent();
+        const slot = paramPagesSlot();
+        const lvlName = paramPagesLevelNameOf(levelDef);
+        /* Cache-first. A re-plan follows every detent of a gating knob and
+         * evaluates every condition on the level; a blocking read per
+         * condition (~2.8 ms each, forty on a gated send page) froze the OLED
+         * while the knob turned. The grid's own values answer first -- they
+         * carry every write it made and every key its cursor has read -- and
+         * the TTL cache answers a miss, so a plan costs IPC only for a key
+         * nothing has touched yet. */
+        const read = (s, k) => {
+            const held = paramPagesCachedValue(k);
+            if (held !== undefined) return held;
+            return getSlotParamCached(s, k, `grid:${s}:${comp}`);
+        };
+        return evaluateVisibilityConditionForContext(
+            slot,
+            getComponentParamPrefix(comp),
+            condition,
+            levelDef,
+            lvlName ? paramPagesChildIndex(lvlName) : -1,
+            read
+        );
+    }
     const prefix = getComponentParamPrefix(hierEditorComponent);
     return evaluateVisibilityConditionForContext(
         hierEditorSlot,

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -440,6 +440,41 @@ export function currentParamPage() {
  * module owns the answer through child_index_param anyway. Same defect as the
  * duplicate picker pages: a second control for a fact that already has one.
  */
+/**
+ * The NAME of a level the grid is showing, given its definition object; "" if
+ * the grid does not hold it. A visible_if condition arrives with the level's
+ * DEFINITION (the planner hands the object through), and resolving a
+ * per-instance condition key needs the instance index, which is filed by name.
+ */
+export function paramPagesLevelNameOf(levelDef) {
+    if (!controller || !levelDef) return "";
+    const hier = controller.state && controller.state.hierarchy;
+    const levels = (hier && hier.levels) || {};
+    for (const name of Object.keys(levels)) if (levels[name] === levelDef) return name;
+    return "";
+}
+
+/**
+ * A value the grid ALREADY HOLDS for `fullKey` ("<prefix>:<key>"), or undefined.
+ *
+ * The visibility evaluator asks for every condition key on every re-plan, and a
+ * re-plan follows every detent of a gating knob. Each miss is a blocking
+ * ~2.8 ms IPC read; a send level with twenty gated cells is forty of them per
+ * detent, which is the OLED standing still while a knob turns (reported from
+ * the device). The controller's own value cache is filled by the read cursor --
+ * condition keys included -- and by every write the grid makes, so it is the
+ * right first answer, and a fresh write is visible to the very next plan.
+ */
+export function paramPagesCachedValue(fullKey) {
+    if (!controller || typeof fullKey !== "string") return undefined;
+    const pre = `${currentPrefix}:`;
+    const key = fullKey.startsWith(pre) ? fullKey.slice(pre.length) : fullKey;
+    const vals = controller.state && controller.state.values;
+    if (!vals || !(key in vals)) return undefined;
+    const v = vals[key];
+    return (v === null || v === undefined) ? undefined : v;
+}
+
 export function paramPagesChildIndex(level) {
     if (!controller || !level) return -1;
     return (typeof controller.childIndexOf === "function")

--- a/tests/host/test_grid_visible_if_context.sh
+++ b/tests/host/test_grid_visible_if_context.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# visible_if on the knob grid read the WRONG slot and failed open.
+#
+# evaluateVisibilityCondition resolved its condition against hierEditorSlot /
+# hierEditorComponent -- the LIST editor's identity, which enterParamPages
+# never sets. From the grid that is slot -1: the read answers null, the
+# evaluator fails open, and every visible_if condition is true. A send level
+# meant to collapse to the armed type's cells showed all twenty, three pages
+# deep, with nothing logged. Reported from the device.
+#
+# Pinned: on PARAM_PAGES the evaluator takes the grid's own slot/component,
+# resolving a per-instance key through the grid's child index by level NAME.
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+ui="src/shadow/shadow_ui.js"
+pp="src/shadow/shadow_ui_param_pages.mjs"
+
+body=$(sed -n '/^function evaluateVisibilityCondition(condition, levelDef) {/,/^}/p' "$ui")
+[ -n "$body" ] || fail "evaluateVisibilityCondition is gone"
+echo "$body" | command grep -q 'paramPagesActive()' || fail "evaluateVisibilityCondition never asks whether the grid is up -- it reads the list editor's slot from the grid and fails open"
+echo "$body" | command grep -q 'paramPagesSlot()' || fail "on the grid the evaluator does not use the grid's slot"
+echo "$body" | command grep -q 'paramPagesComponent()' || fail "on the grid the evaluator does not use the grid's component"
+echo "$body" | command grep -q 'paramPagesLevelNameOf(levelDef)' || fail "a per-instance condition cannot find its instance: the level name is not resolved from its definition"
+command grep -q '^export function paramPagesLevelNameOf' "$pp" || fail "paramPagesLevelNameOf is not exported by $pp"
+command grep -q 'paramPagesLevelNameOf,' "$ui" || fail "shadow_ui.js does not import paramPagesLevelNameOf"
+# A re-plan follows every detent of a gating knob; a blocking read per condition froze the OLED.
+echo "$body" | command grep -q 'paramPagesCachedValue(k)' || fail "the grid evaluator does not consult the controller's own values first -- every re-plan pays a blocking read per condition"
+echo "$body" | command grep -q 'getSlotParamCached(' || fail "a cache miss on the grid goes to an uncached blocking read"
+if echo "$body" | command grep -q '[^a-zA-Z]getSlotParam(' ; then fail "the grid branch still reads through the uncached getSlotParam"; fi
+command grep -q '^export function paramPagesCachedValue' "$pp" || fail "paramPagesCachedValue is not exported by $pp"
+echo "  ok  visible_if on the knob grid resolves against the grid's own slot and component"
+echo "PASS: test_grid_visible_if_context"


### PR DESCRIPTION
## In short

Fixes a bug on `main`: `visible_if` conditions never took effect on the knob grid. The evaluator resolved them against the list editor's slot, which the grid doesn't set, so every condition failed open and gated cells were always shown. Every module using `visible_if` is affected. The fix reads the grid's own slot, and reads cache-first so a re-plan per knob detent stays cheap.

## For a drum module, concretely

A drum module's send page changes shape with the effect: a reverb has size and decay, a delay has time and feedback. `visible_if` is how a page hides the cells that don't apply. On the knob grid it silently never hid anything, so a send showed all twenty cells across three pages, most of them dead. With this fix the page collapses to the cells that matter.

## What

`evaluateVisibilityCondition` resolved every `visible_if` condition against `hierEditorSlot` / `hierEditorComponent`, the list editor's identity, which `enterParamPages` never sets (`enterHierarchyEditorFromParamPages` already records that). From the knob grid that is slot -1: the read answers null, the evaluator fails open, and every `visible_if` on the grid is true. A send level meant to collapse to the armed type's cells (a reverb *or* a delay, gated on a derived mode param) showed all twenty, three pages deep, with nothing logged. Found on the device with schwung-dr32 0.2.0.

## Fix

On `PARAM_PAGES` the evaluator takes the grid's own slot and component. A per-instance condition key still resolves through the level's child index, which the grid files by level *name*; the condition arrives with the level's *definition*, so a small `paramPagesLevelNameOf` maps one to the other.

**Cache-first**, because the first version of this froze the OLED: a re-plan follows every detent of a gating knob and evaluates every condition on the level, and each was a blocking ~2.8 ms read, forty per detent on a gated send page. The grid's own value cache answers first (it carries every write the grid made and every key its cursor has read, condition keys included, so a fresh write is seen by the very next plan), and the TTL'd slot-param cache answers a miss. A plan now costs IPC only for a key nothing has touched yet.

## Tests

`tests/host/test_grid_visible_if_context.sh`. Full host suite green; device-tested: send pages collapse per armed type, and turning the type knob through all eight options stays fluid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwuEvvXACZX2yGvBuhbJFh
