### PR TITLE
wave editor: read 24-bit WAV and AIFF, the formats the Core Library ships

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -15936,25 +15936,55 @@ function wavFindRiffOffset(bytes) {
     return -1;
 }
 
-function parseWavPositionPeaks(content, width) {
-    const bytes = wavContentToBytes(content);
-    if (!bytes || bytes.length < 44) return { error: "file too small", points: [] };
+function wavReadU16BE(bytes, idx) {
+    return (wavByteAt(bytes, idx) << 8) | wavByteAt(bytes, idx + 1);
+}
 
-    const riffOffset = wavFindRiffOffset(bytes);
-    if (riffOffset < 0) return { error: "not a wav file", points: [] };
+function wavReadU32BE(bytes, idx) {
+    return ((wavByteAt(bytes, idx) << 24) |
+        (wavByteAt(bytes, idx + 1) << 16) |
+        (wavByteAt(bytes, idx + 2) << 8) |
+        wavByteAt(bytes, idx + 3)) >>> 0;
+}
 
-    let fmtOffset = -1;
-    let dataOffset = -1;
-    let dataSize = 0;
+/*
+ * One sample as a float in -1..1, for every layout the peak reader accepts:
+ * PCM 8 (unsigned in WAV, signed in AIFF), 16 and 24 in either byte order,
+ * and 32-bit float (WAV only). Kept as a table of small readers rather than a
+ * bit-twiddling generic so each format's sign convention is stated once.
+ */
+function wavSampleReader(kind) {
+    switch (kind) {
+    case "pcm8u":   return (b, i) => (wavByteAt(b, i) - 128) / 128;
+    case "pcm8s":   return (b, i) => { const v = wavByteAt(b, i); return (v > 0x7f ? v - 0x100 : v) / 128; };
+    case "pcm16le": return (b, i) => wavReadS16LE(b, i) / 32768;
+    case "pcm16be": return (b, i) => { const v = wavReadU16BE(b, i); return (v > 0x7fff ? v - 0x10000 : v) / 32768; };
+    case "pcm24le": return (b, i) => {
+        const v = wavByteAt(b, i) | (wavByteAt(b, i + 1) << 8) | (wavByteAt(b, i + 2) << 16);
+        return (v > 0x7fffff ? v - 0x1000000 : v) / 8388608;
+    };
+    case "pcm24be": return (b, i) => {
+        const v = (wavByteAt(b, i) << 16) | (wavByteAt(b, i + 1) << 8) | wavByteAt(b, i + 2);
+        return (v > 0x7fffff ? v - 0x1000000 : v) / 8388608;
+    };
+    case "f32le":   return (b, i) => wavReadF32LE(b, i);
+    default:        return null;
+    }
+}
+
+/*
+ * Locate the sample data in a RIFF/WAVE file. Returns { kind, channels,
+ * blockAlign, dataOffset, dataSize } or { error }.
+ */
+function wavLocateRiff(bytes, riffOffset) {
+    let fmtOffset = -1, dataOffset = -1, dataSize = 0;
     let cursor = riffOffset + 12;
-
     while (cursor + 8 <= bytes.length) {
         const chunkId = wavReadChunkId(bytes, cursor);
         const chunkSize = wavReadU32LE(bytes, cursor + 4);
         const chunkData = cursor + 8;
         const chunkEnd = chunkData + chunkSize;
         const available = Math.max(0, bytes.length - chunkData);
-
         if (chunkId === "fmt " && available >= 16) {
             fmtOffset = chunkData;
         } else if (chunkId === "data") {
@@ -15962,29 +15992,82 @@ function parseWavPositionPeaks(content, width) {
             dataSize = Math.min(chunkSize, available);
             break;
         }
-
         if (chunkEnd <= chunkData || chunkEnd > bytes.length) break;
         cursor = chunkEnd + (chunkSize % 2);
     }
-
-    if (fmtOffset < 0 || dataOffset < 0 || dataSize <= 0) {
-        return { error: "missing wav chunks", points: [] };
-    }
-
+    if (fmtOffset < 0 || dataOffset < 0 || dataSize <= 0) return { error: "missing wav chunks" };
     const audioFmt = wavReadU16LE(bytes, fmtOffset);
     const channels = Math.max(1, wavReadU16LE(bytes, fmtOffset + 2));
-    const bits = wavReadU16LE(bytes, fmtOffset + 14);
     const blockAlign = Math.max(1, wavReadU16LE(bytes, fmtOffset + 12));
-    if (audioFmt !== 1 && audioFmt !== 3) return { error: "unsupported wav codec", points: [] };
-    if (!((audioFmt === 1 && (bits === 8 || bits === 16)) || (audioFmt === 3 && bits === 32))) {
-        return { error: "unsupported wav format", points: [] };
-    }
+    const bits = wavReadU16LE(bytes, fmtOffset + 14);
+    /* 0xFFFE is WAVE_FORMAT_EXTENSIBLE; its sub-format GUID's first two bytes
+     * name the real codec, and 24-bit files are very often written that way. */
+    let fmt = audioFmt;
+    if (audioFmt === 0xfffe && wavReadU16LE(bytes, fmtOffset + 16) >= 22) fmt = wavReadU16LE(bytes, fmtOffset + 24);
+    if (fmt !== 1 && fmt !== 3) return { error: "unsupported wav codec" };
+    const kind = fmt === 1 && bits === 8 ? "pcm8u"
+        : fmt === 1 && bits === 16 ? "pcm16le"
+        : fmt === 1 && bits === 24 ? "pcm24le"
+        : fmt === 3 && bits === 32 ? "f32le" : null;
+    if (!kind) return { error: "unsupported wav format" };
+    return { kind, channels, blockAlign, dataOffset, dataSize, bits };
+}
 
-    const sampleBytes = bits / 8;
-    const effectiveBlockAlign = blockAlign > 0 ? blockAlign : Math.max(1, channels * sampleBytes);
-    const frameCount = Math.max(1, Math.floor(dataSize / effectiveBlockAlign));
+/*
+ * Locate the sample data in a FORM/AIFF file (also AIFC with no compression),
+ * which is what much of Move's own Core Library ships as. Big-endian
+ * throughout; SSND carries its own offset before the first frame.
+ */
+function wavLocateAiff(bytes) {
+    const form = wavReadChunkId(bytes, 8);
+    if (wavReadChunkId(bytes, 0) !== "FORM" || (form !== "AIFF" && form !== "AIFC")) return { error: "not an aiff file" };
+    let channels = 0, bits = 0, compression = "NONE", dataOffset = -1, dataSize = 0;
+    let cursor = 12;
+    while (cursor + 8 <= bytes.length) {
+        const chunkId = wavReadChunkId(bytes, cursor);
+        const chunkSize = wavReadU32BE(bytes, cursor + 4);
+        const chunkData = cursor + 8;
+        const chunkEnd = chunkData + chunkSize;
+        const available = Math.max(0, bytes.length - chunkData);
+        if (chunkId === "COMM" && available >= 18) {
+            channels = Math.max(1, wavReadU16BE(bytes, chunkData));
+            bits = wavReadU16BE(bytes, chunkData + 6);
+            if (form === "AIFC" && available >= 22) compression = wavReadChunkId(bytes, chunkData + 18);
+        } else if (chunkId === "SSND" && available >= 8) {
+            const skip = wavReadU32BE(bytes, chunkData);
+            dataOffset = chunkData + 8 + skip;
+            dataSize = Math.max(0, Math.min(chunkSize, available) - 8 - skip);
+            break;
+        }
+        if (chunkEnd <= chunkData || chunkEnd > bytes.length) break;
+        cursor = chunkEnd + (chunkSize % 2);
+    }
+    if (!channels || !bits || dataOffset < 0 || dataSize <= 0) return { error: "missing aiff chunks" };
+    if (compression !== "NONE" && compression !== "sowt") return { error: "unsupported aiff codec" };
+    const le = compression === "sowt";
+    const kind = bits === 8 ? "pcm8s"
+        : bits === 16 ? (le ? "pcm16le" : "pcm16be")
+        : bits === 24 ? (le ? "pcm24le" : "pcm24be") : null;
+    if (!kind) return { error: "unsupported aiff format" };
+    return { kind, channels, blockAlign: channels * Math.ceil(bits / 8), dataOffset, dataSize, bits };
+}
+
+function parseWavPositionPeaks(content, width) {
+    const bytes = wavContentToBytes(content);
+    if (!bytes || bytes.length < 44) return { error: "file too small", points: [] };
+
+    const riffOffset = wavFindRiffOffset(bytes);
+    const located = riffOffset >= 0 ? wavLocateRiff(bytes, riffOffset) : wavLocateAiff(bytes);
+    if (located.error) return { error: located.error, points: [] };
+
+    const read = wavSampleReader(located.kind);
+    if (!read) return { error: "unsupported format", points: [] };
+    const sampleBytes = Math.ceil(located.bits / 8);
+    const effectiveBlockAlign = located.blockAlign > 0 ? located.blockAlign : Math.max(1, located.channels * sampleBytes);
+    const frameCount = Math.max(1, Math.floor(located.dataSize / effectiveBlockAlign));
     const points = new Array(width).fill(0);
-    const dataEnd = dataOffset + dataSize;
+    const dataOffset = located.dataOffset;
+    const dataEnd = dataOffset + located.dataSize;
 
     for (let x = 0; x < width; x++) {
         const start = Math.floor((x * frameCount) / width);
@@ -15996,15 +16079,7 @@ function parseWavPositionPeaks(content, width) {
         for (let frame = start; frame < end; frame += stride) {
             const base = dataOffset + frame * effectiveBlockAlign;
             if (base + sampleBytes > dataEnd) break;
-            let sample = 0;
-            if (audioFmt === 1 && bits === 16) {
-                sample = wavReadS16LE(bytes, base) / 32768;
-            } else if (audioFmt === 1 && bits === 8) {
-                sample = (wavByteAt(bytes, base) - 128) / 128;
-            } else if (audioFmt === 3 && bits === 32) {
-                sample = wavReadF32LE(bytes, base);
-            }
-            const abs = Math.abs(sample);
+            const abs = Math.abs(read(bytes, base));
             if (abs > maxAbs) maxAbs = abs;
         }
 

--- a/tests/host/test_wave_editor_formats.sh
+++ b/tests/host/test_wave_editor_formats.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# The fullscreen wave editor read RIFF/WAVE at 8 or 16 bits and nothing else.
+#
+# The sample CELL's peaks come from wav_peaks.mjs, which reads WAV 8/16/24,
+# float32 and AIFF -- so a Core Library kit (largely 24-bit WAV and AIFF)
+# drew its waveform in the cell and then answered "unsupported wav format"
+# the moment you clicked into the editor. Reported from the device. This
+# drives the editor's own parser, lifted out of shadow_ui.js by name, over
+# one synthesised file per layout and asserts the peak it finds.
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || fail "node is required"
+
+node -e '
+const fs = require("fs");
+const src = fs.readFileSync("src/shadow/shadow_ui.js", "utf8");
+const a = src.indexOf("function wavContentToBytes");
+const b = src.indexOf("function getWavPositionWaveformPreview");
+if (a < 0 || b < 0) { console.log("FAIL: parser functions not found"); process.exit(1); }
+const parse = new Function(src.slice(a, b) + "\nreturn parseWavPositionPeaks;")();
+
+const u16le = (v) => [v & 255, (v >> 8) & 255];
+const u32le = (v) => [v & 255, (v >> 8) & 255, (v >> 16) & 255, (v >>> 24) & 255];
+const u16be = (v) => [(v >> 8) & 255, v & 255];
+const u32be = (v) => [(v >>> 24) & 255, (v >> 16) & 255, (v >> 8) & 255, v & 255];
+const str = (s) => [...s].map((c) => c.charCodeAt(0));
+
+/* A ramp to +0.75 over 64 frames, one channel. */
+const N = 64, PEAK = 0.75;
+function samples(bits, be, signed8) {
+  const out = [];
+  for (let i = 0; i < N; i++) {
+    const v = (i / (N - 1)) * PEAK;
+    if (bits === 8) out.push(signed8 ? (Math.round(v * 127) & 255) : (128 + Math.round(v * 127)));
+    else if (bits === 16) { const s = Math.round(v * 32767); out.push(...(be ? u16be(s) : u16le(s))); }
+    else if (bits === 24) { const s = Math.round(v * 8388607); const le = [s & 255, (s >> 8) & 255, (s >> 16) & 255]; out.push(...(be ? le.reverse() : le)); }
+    else if (bits === 32) { const f = new Float32Array([v]); out.push(...new Uint8Array(f.buffer)); }
+  }
+  return out;
+}
+function wav(bits, fmt, extensible) {
+  const data = samples(bits, false);
+  const fmtBody = [...u16le(extensible ? 0xfffe : fmt), ...u16le(1), ...u32le(44100), ...u32le(44100 * bits / 8), ...u16le(bits / 8), ...u16le(bits)];
+  const ext = extensible ? [...u16le(22), ...u16le(bits), ...u32le(4), ...u16le(fmt), ...new Array(14).fill(0)] : [];
+  const fmtChunk = [...str("fmt "), ...u32le(fmtBody.length + ext.length), ...fmtBody, ...ext];
+  const junk = [...str("smpl"), ...u32le(4), 0, 0, 0, 0];
+  const dataChunk = [...str("data"), ...u32le(data.length), ...data];
+  const body = [...str("WAVE"), ...fmtChunk, ...junk, ...dataChunk];
+  return new Uint8Array([...str("RIFF"), ...u32le(body.length), ...body]);
+}
+function aiff(bits, form, comp) {
+  const data = samples(bits, comp !== "sowt", true);
+  const commBody = [...u16be(1), ...u32be(N), ...u16be(bits), 0x40, 0x0e, 0xac, 0x44, 0, 0, 0, 0, 0, 0];
+  if (form === "AIFC") commBody.push(...str(comp), 4, ...str("none"), 0);
+  const comm = [...str("COMM"), ...u32be(commBody.length), ...commBody];
+  const ssndBody = [...u32be(0), ...u32be(0), ...data];
+  const ssnd = [...str("SSND"), ...u32be(ssndBody.length), ...ssndBody];
+  const body = [...str(form), ...comm, ...ssnd];
+  return new Uint8Array([...str("FORM"), ...u32be(body.length), ...body]);
+}
+const cases = {
+  "wav pcm8": wav(8, 1), "wav pcm16": wav(16, 1), "wav pcm24": wav(24, 1),
+  "wav pcm24 extensible": wav(24, 1, true), "wav float32": wav(32, 3),
+  "aiff 16": aiff(16, "AIFF", "NONE"), "aiff 24": aiff(24, "AIFF", "NONE"), "aiff 8": aiff(8, "AIFF", "NONE"),
+  "aifc NONE 16": aiff(16, "AIFC", "NONE"), "aifc sowt 16": aiff(16, "AIFC", "sowt"),
+};
+let bad = 0;
+for (const [name, bytes] of Object.entries(cases)) {
+  const r = parse(bytes, 8);
+  const last = r.points.length ? r.points[r.points.length - 1] : -1;
+  if (r.error) { console.log(`FAIL: ${name}: ${r.error}`); bad++; continue; }
+  if (Math.abs(last - PEAK) > 0.03) { console.log(`FAIL: ${name}: peak ${last.toFixed(3)}, want ${PEAK}`); bad++; continue; }
+  if (r.points[0] > 0.15) { console.log(`FAIL: ${name}: first bin ${r.points[0].toFixed(3)} should be near silent -- byte order or sign is wrong`); bad++; continue; }
+}
+const bogus = parse(new Uint8Array(64).fill(65), 8);
+if (!bogus.error) { console.log("FAIL: 64 bytes of A parsed as audio"); bad++; }
+if (bad) process.exit(1);
+console.log("  ok  the wave editor reads WAV 8/16/24/float and AIFF 8/16/24, big- and little-endian");
+' || fail "parser"
+echo "PASS: test_wave_editor_formats"


### PR DESCRIPTION
## In short

Fixes a bug on `main`: the fullscreen wave editor could only read 8 and 16-bit WAV, while the sample cell beside it already reads 24-bit WAV, float and AIFF. Any `wav_position` parameter pointing at such a file drew in the cell and then failed in the editor. The editor now reads the same formats as the cell.

## For a drum module, concretely

Trimming a sample's start and end is basic drum editing, and the fullscreen wave editor is where you do it. Move's own Core Library kits are mostly AIFF and 24-bit files, and the editor refused every one of them with "unsupported waveform". Now it opens them.

## What

The fullscreen `wav_position` editor parsed RIFF/WAVE at 8 or 16 bits and nothing else. The sample **cell** beside it uses `wav_peaks.mjs`, which reads WAV 8/16/24, float32 and AIFF, so a Core Library kit (largely 24-bit WAV and AIFF) drew its waveform in the cell and then answered "unsupported wav format" the moment you clicked into the editor. Found on the device with a stock drum kit.

## Fix

The parser now locates sample data in either container: RIFF (including `WAVE_FORMAT_EXTENSIBLE`, which is how 24-bit files are usually written) or FORM/AIFF and AIFC with no compression or `sowt`, and reads each layout through one small sample reader per format, so every sign and byte-order convention is stated once. Chunk walking, the peak sweep and the cache are unchanged.

## Tests

`tests/host/test_wave_editor_formats.sh` lifts the parser out of `shadow_ui.js` by name and drives it over one synthesised file per layout, asserting the peak it finds and that the first bin is near silent (a wrong byte order or sign shows up there before anywhere else). Full host suite green; device-tested on AIFF kit samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwuEvvXACZX2yGvBuhbJFh
