### PR TITLE
param pages: hold Copy or Delete, then pick an instance (copy, clear, undo for child levels)

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1512,6 +1512,41 @@ Without this, adding a child level to a module that already follows the played
 pad would *cost* that behaviour — the grid would sit on the instance the picker
 last chose. With it, the declaration is purely additive.
 
+#### Copying and clearing an instance — hold Copy or Delete, then pick
+
+A drum rack's oldest gesture: hold **Copy**, hit a pad, hit another, and the
+second now sounds like the first. The knob grid offers it to any child level,
+once the module has claimed the buttons (`capabilities.claims_edit_ccs`; Move
+keeps them otherwise):
+
+- **Hold Copy** on an instance's page: that instance is the source. Every
+  instance that becomes focused while Copy is held — a pad hit through
+  `child_index_param`, or a pick from the instance list — is pasted into.
+- **Hold Delete**: every instance that becomes focused is cleared.
+- **Undo** puts back the last instance overwritten (one level).
+
+What is copied is the level's **`child_copy_keys`**, in declared order (that
+is also the write order, so list the sample first), or the level's own params
+when none are declared. Declare the list: "what the page shows" is a weak
+default. A pad's level-affecting params with no cell — a gain, a velocity
+depth — would be skipped and the copy would be quieter than its source, and
+a key that is a *pointer* (a position within this pad's folder, an identity
+like its note) must not be copied at all.
+
+```json
+"pads": {
+  "child_prefix": "pad", "child_count": 32,
+  "child_index_param": "ui_current_pad",
+  "child_copy_keys": ["sample", "start", "end", "transpose", "gain", "volume", "pan"],
+  "knobs": ["start", "end", "transpose", "volume", "pan"]
+}
+```
+
+Clear writes each key's declared `default`; a key without one is left alone,
+and a filepath without one is written `""`. The focused instance itself is
+not touched by Delete going down — only the instances you pick while holding
+it — so a pad already on screen is cleared by picking another first.
+
 ### Declaring your performance surface
 
 A sequencer driving your module — movy is the live case — has to lay out Move's

--- a/src/shadow/shadow_ui_param_pages.mjs
+++ b/src/shadow/shadow_ui_param_pages.mjs
@@ -1128,6 +1128,16 @@ let _midiWindowStart = 0, _midiCount = 0, _knobTurnCount = 0;
 export function handleParamPagesMidi(data) {
     if (!controller) return false;
 
+    /* Undo / Copy / Delete reach the grid only for a module that claimed them
+     * (capabilities.claims_edit_ccs). They drive the instance copy/clear
+     * gesture -- hold Copy or Delete, then pick an instance -- and nothing
+     * else on the grid wants them. Not consumed on a page that has no
+     * instance to copy, so the event falls through as before. */
+    if (data && data.length >= 3 && (data[0] & 0xf0) === 0xb0 &&
+        (data[1] === 56 || data[1] === 60 || data[1] === 119)) {
+        return typeof controller.onEditCc === "function" && controller.onEditCc(data[1], data[2] > 0);
+    }
+
     const nowMsProbe = Date.now();
     _midiCount++;
     if (!_midiWindowStart) _midiWindowStart = nowMsProbe;

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -30,7 +30,7 @@
 import { planPages, pickMode, PAGE_KNOBS, PAGE_MENU, PAGE_PRESET, PAGE_ITEMS,
          buildTrailingPages, makeClaimer } from "./page_plan.mjs";
 import { resolveChildKey, childIndexParam, childIndexToWire, childIndexFromWire,
-         childName } from "./child_key.mjs";
+         childName, childLabel } from "./child_key.mjs";
 import { focusParamOf, voicesOf, voiceIndexFromLevel,
          voiceIndexFromWire, padLayoutOf, focusToken } from "./voices.mjs";
 import { buildMetaIndex, inferFromValue, isTurnable, flipsOnClick, enumIndexOf, KIND_ENUM, KIND_OPAQUE
@@ -670,6 +670,11 @@ export function createController(io = {}) {
          * Cheaper and more exact than polling: only these keys can change what
          * is visible, and we already read every key on the page. */
         conditionKeys: new Set(),
+        /* Instance copy / clear gesture (hold Copy or Delete, then pick an
+         * instance) -- see onEditCc. `editUndo` is the one-level undo. */
+        editGesture: null,
+        editUndo: null,
+        notice: null,
         /* Per-section memory of the sub-page you were last on. Naming a
          * section returns you to the page of it you were using, not to its
          * first page — a jump is a request for a PLACE, and the place you mean
@@ -1941,6 +1946,7 @@ export function createController(io = {}) {
         s.tickCount++;
         flushDueWrites();
         expireTurnClaim();
+        serviceEditGesture();
 
         /*
          * Re-try an unresolved contract BEFORE the page guards below: an
@@ -3648,6 +3654,135 @@ export function createController(io = {}) {
         return true;
     }
 
+    /* -------------------------------------------------- instance copy/clear */
+
+    /*
+     * HOLD COPY (or DELETE), THEN PICK AN INSTANCE.
+     *
+     * A drum rack's oldest gesture: hold Copy, hit a pad, hit another -- the
+     * second now sounds like the first. Generic here, for any child level: the
+     * SOURCE is the instance focused when Copy goes down; every instance that
+     * becomes focused while it is held is PASTED into (Delete: CLEARED). Focus
+     * moves however it moves for this module -- a pad hit through
+     * child_index_param, or the picker -- so the gesture never needs to know
+     * what a pad is. Undo (once) restores the last instance overwritten.
+     *
+     * WHAT IS COPIED. The level's `child_copy_keys` in declared order, else the
+     * level's own params. An explicit list exists because "what the page shows"
+     * is a weak default: a pad's level-affecting params with no cell (a gain, a
+     * velocity depth) would be silently skipped and the copy would be quieter
+     * than its source, and a key that is a POINTER (a position in this pad's
+     * folder) would be copied as a number and point somewhere else. Order is
+     * write order, so a module lists the sample first.
+     *
+     * CLEAR writes each key's declared `default`; a key with none is left
+     * alone, and a filepath with none is written "" (no file is its empty).
+     *
+     * The buttons reach the grid only for a module declaring
+     * capabilities.claims_edit_ccs -- Move keeps them otherwise -- so a module
+     * opts in to this exactly by opting in to those buttons.
+     */
+    function instanceLevel() {
+        const p = page();
+        return (p && p.childLevel && p.level) ? { name: p.level, def: p.childLevel } : null;
+    }
+    function copyKeysFor(def) {
+        const declared = Array.isArray(def.child_copy_keys) ? def.child_copy_keys : null;
+        const keys = declared || (def.params || []).map((p) => (typeof p === "string" ? p : (p && p.key)));
+        return keys.filter((k) => typeof k === "string" && k.length);
+    }
+    function wireFor(def, index, key) { return resolveChildKey(def, index, key) || key; }
+    function readInstance(def, index, keys) {
+        const snap = Object.create(null);
+        for (const k of keys) {
+            const v = getParam(`${s.prefix}:${wireFor(def, index, k)}`);
+            if (v !== null && v !== undefined) snap[k] = String(v);
+        }
+        return snap;
+    }
+    function writeInstance(def, index, snap) {
+        for (const k of Object.keys(snap)) setParam(`${s.prefix}:${wireFor(def, index, k)}`, snap[k]);
+    }
+    function clearedInstance(keys) {
+        const snap = Object.create(null);
+        for (const k of keys) {
+            const m = s.metaIndex ? s.metaIndex.getOrGuess(k) : null;
+            if (m && m.default !== undefined && m.default !== null) snap[k] = String(m.default);
+            else if (m && (m.type === "filepath" || m.type === "file")) snap[k] = "";
+        }
+        return snap;
+    }
+    function notice(text, ms) { s.notice = { text, until: now() + (ms || 1200) }; }
+
+    /** Copy (60) / Delete (119) / Undo (56). Returns whether the event was taken. */
+    function onEditCc(cc, down) {
+        if (cc === 56) {
+            if (!down) return true;
+            const u = s.editUndo;
+            if (!u) { notice("NOTHING TO UNDO"); return true; }
+            writeInstance(u.def, u.index, u.snap);
+            s.editUndo = null;
+            if (childIndexFor(u.level) === u.index) dropChildLevelCache(u.level);
+            notice("UNDONE " + childLabel(u.def, u.index).toUpperCase());
+            announce("undone");
+            return true;
+        }
+        if (cc !== 60 && cc !== 119) return false;
+        const kind = cc === 60 ? "copy" : "clear";
+        if (!down) {
+            if (s.editGesture && s.editGesture.kind === kind) { s.editGesture = null; s.notice = null; }
+            return true;
+        }
+        const lvl = instanceLevel();
+        if (!lvl) return false;                      /* not on an instance page: Move keeps it? no -- claimed; just inert */
+        const keys = copyKeysFor(lvl.def);
+        if (!keys.length) return false;
+        const from = childIndexFor(lvl.name);
+        s.editGesture = {
+            kind, level: lvl.name, def: lvl.def, keys, from, last: from,
+            snap: kind === "copy" ? readInstance(lvl.def, from, keys) : null,
+        };
+        const label = childLabel(lvl.def, from).toUpperCase();
+        notice(kind === "copy" ? `COPY ${label}: PICK A TARGET` : "CLEAR: PICK A TARGET", 4000);
+        announce(kind === "copy" ? `copy ${childLabel(lvl.def, from)}, pick a target` : "clear, pick a target");
+        return true;
+    }
+
+    /** Once per tick: a focus change while Copy/Delete is held applies the gesture. */
+    function serviceEditGesture() {
+        const g = s.editGesture;
+        if (!g) return;
+        const idx = childIndexFor(g.level);
+        if (idx === g.last) return;
+        g.last = idx;
+        if (g.kind === "copy" && idx === g.from) return;   /* pasting onto the source is a no-op */
+        const before = readInstance(g.def, idx, g.keys);
+        writeInstance(g.def, idx, g.kind === "copy" ? g.snap : clearedInstance(g.keys));
+        s.editUndo = { level: g.level, def: g.def, index: idx, snap: before };
+        dropChildLevelCache(g.level);               /* the grid is showing the instance just written */
+        const label = childLabel(g.def, idx).toUpperCase();
+        notice((g.kind === "copy" ? "PASTED " : "CLEARED ") + label, 4000);
+        announce((g.kind === "copy" ? "pasted " : "cleared ") + childLabel(g.def, idx));
+    }
+
+    /** A one-line floating notice, drawn over the page while it lasts. */
+    function drawNotice(ctx) {
+        const n = s.notice;
+        if (!n) return false;
+        if (now() >= n.until) { s.notice = null; return false; }
+        if (!ctx || typeof ctx.fillRect !== "function" || typeof ctx.print !== "function") return false;
+        const W = ctx.width || 128, H = ctx.height || 64;
+        const text = String(n.text);
+        const tw = (typeof ctx.textWidth === "function") ? ctx.textWidth(text) : text.length * 6;
+        const w = Math.min(W - 4, tw + 8), h = 13;
+        const x = Math.floor((W - w) / 2), y = Math.floor((H - h) / 2);
+        ctx.fillRect(x, y, w, h, 0);
+        ctx.fillRect(x, y, w, 1, 1); ctx.fillRect(x, y + h - 1, w, 1, 1);
+        ctx.fillRect(x, y, 1, h, 1); ctx.fillRect(x + w - 1, y, 1, h, 1);
+        ctx.print(x + 4, y + 3, text, 1);
+        return true;
+    }
+
     /* --------------------------------------------------------- presentation */
 
     /** Arm the first-run hint. Ignored once it has been shown and dismissed. */
@@ -4100,7 +4235,7 @@ export function createController(io = {}) {
      */
     function renderOverlays(ctx, { clearScreen } = {}) {
         const peek = enumPeek();
-        if (!peek) return drawDeclaredCard(ctx);
+        if (!peek) { const r = drawDeclaredCard(ctx); drawNotice(ctx); return r; }
         /*
          * No clear, no overlay. Drawing the list into a frame we may not blank
          * would leave it interleaved with the grid underneath -- two screens at
@@ -4488,6 +4623,10 @@ export function createController(io = {}) {
          *  hand-off needs it: without it the editor re-asks which child,
          *  when the grid already knows. */
         childIndexOf: (level) => childIndexFor(level),
+        /** Copy (CC 60) / Delete (CC 119) / Undo (CC 56) -- the instance
+         *  copy/clear gesture. See onEditCc. */
+        onEditCc,
+        get editGesture() { return s.editGesture; },
         get metaIndex() { return s.metaIndex; },
         /** True while `<prefix>:ui_hierarchy` could not be READ. The page set,
          *  if any, is the previous one — nothing here was planned from the

--- a/tests/host/test_child_copy_gesture.sh
+++ b/tests/host/test_child_copy_gesture.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# Hold Copy (or Delete), then pick an instance: the knob grid's instance
+# copy / clear gesture, with a one-level Undo. Driven through the real
+# controller against a fake device whose params are a plain map, so every
+# write the gesture makes is visible and every read it depends on is honest.
+#
+# Pinned:
+#   1. Copy down snapshots the FOCUSED instance; a focus change while held
+#      pastes the declared child_copy_keys, in declared order, into the new
+#      instance -- and nothing else is written
+#   2. Undo restores exactly what the paste overwrote
+#   3. Delete + pick writes declared defaults ("" for a filepath), nothing for
+#      a key with no default
+#   4. no gesture on a page with no instance, and no paste onto the source
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || fail "node is required"
+
+node -e '
+import("./src/shared/param_pages/page_controller.mjs").then((PC) => {
+  let bad = 0;
+  const fail = (m) => { console.log("FAIL: " + m); bad++; };
+
+  const PADS = {
+    label: "Pads", child_count: 4, child_label: "Pad", child_prefix: "pad",
+    child_index_param: "ui_current_pad",
+    child_copy_keys: ["sample", "vol", "gain"],
+    knobs: ["vol", "tune"],
+    params: [
+      { key: "sample", name: "Sample", type: "filepath" },
+      { key: "vol", name: "Vol", type: "float", min: 0, max: 1, default: 0.5 },
+      { key: "tune", name: "Tune", type: "float", min: -12, max: 12 },
+    ],
+  };
+  const HIER = { pad_layout: "drums", levels: {
+    root: { params: [{ level: "pads", label: "Pads" }, { level: "fx", label: "FX" }] },
+    pads: PADS,
+    fx: { name: "FX", knobs: ["verb"], params: [{ key: "verb", name: "Verb", type: "float", min: 0, max: 1 }] },
+  } };
+  const CP = [];
+  for (let i = 0; i < 4; i++) {
+    CP.push({ key: `pad${i}_sample`, name: "Sample", type: "filepath" });
+    CP.push({ key: `pad${i}_vol`, name: "Vol", type: "float", min: 0, max: 1, default: 0.5 });
+    CP.push({ key: `pad${i}_tune`, name: "Tune", type: "float", min: -12, max: 12 });
+    CP.push({ key: `pad${i}_gain`, name: "Gain", type: "float", min: 0, max: 2 });
+  }
+  CP.push({ key: "verb", name: "Verb", type: "float", min: 0, max: 1 });
+
+  const dev = {};
+  for (let i = 0; i < 4; i++) { dev[`pad${i}_sample`] = `/s/${i}.wav`; dev[`pad${i}_vol`] = String((i + 1) / 10); dev[`pad${i}_tune`] = String(i); dev[`pad${i}_gain`] = String(1 + i); }
+  dev.verb = "0.3"; dev.ui_current_pad = "0";
+  const writes = [];
+  const io = {
+    getParam: (k) => {
+      const key = k.replace(/^synth:/, "");
+      if (key === "ui_hierarchy") return JSON.stringify(HIER);
+      if (key === "chain_params") return JSON.stringify(CP);
+      if (key === "preset_name") return "";
+      if (key === "is_loading") return "0";
+      if (key === "module") return "dr32";
+      return key in dev ? dev[key] : null;
+    },
+    setParam: (k, v) => { const key = k.replace(/^synth:/, ""); dev[key] = String(v); writes.push([key, String(v)]); },
+    announce: () => {}, now: () => Date.now(),
+  };
+  const c = PC.createController(io);
+  c.load({ slot: 0, component: "synth", prefix: "synth" });
+  c.setLayout("movy");
+  const spin = (n) => { for (let i = 0; i < n; i++) c.tick(); };
+  spin(40);
+  const pageOf = (lvl) => c.pages.findIndex((p) => p.level === lvl && Array.isArray(p.keys) && p.keys.some(Boolean));
+  if (pageOf("pads") < 0 || pageOf("fx") < 0) fail("expected a knob page for pads and fx, got " + JSON.stringify(c.pages.map((p) => p.level)));
+  const onPads = () => { c.goToPage(pageOf("pads")); spin(5); };
+  onPads();
+  const focus = (i) => { dev.ui_current_pad = String(i); spin(30); };
+
+  /* ---- 1. copy pad 0 into pad 2 --------------------------------------- */
+  writes.length = 0;
+  if (!c.onEditCc(60, true)) fail("Copy down was not taken on a pad page");
+  if (!c.editGesture || c.editGesture.kind !== "copy" || c.editGesture.from !== 0) fail("no copy gesture armed from pad 0");
+  focus(2);
+  const pasted = writes.filter(([k]) => k.startsWith("pad2_"));
+  const want = [["pad2_sample", "/s/0.wav"], ["pad2_vol", "0.1"], ["pad2_gain", "1"]];
+  if (JSON.stringify(pasted) !== JSON.stringify(want))
+    fail("paste wrote " + JSON.stringify(pasted) + ", want " + JSON.stringify(want) + " (declared keys, declared order)");
+  if (writes.some(([k]) => k === "pad2_tune")) fail("a key outside child_copy_keys was written");
+  if (writes.some(([k]) => k.startsWith("pad0_") || k.startsWith("pad1_") || k.startsWith("pad3_"))) fail("a paste touched an instance that was not picked: " + JSON.stringify(writes));
+  c.onEditCc(60, false);
+  if (c.editGesture) fail("Copy release did not end the gesture");
+
+  /* ---- 2. undo puts pad 2 back ----------------------------------------- */
+  writes.length = 0;
+  c.onEditCc(56, true);
+  const undone = writes.filter(([k]) => k.startsWith("pad2_"));
+  const wantUndo = [["pad2_sample", "/s/2.wav"], ["pad2_vol", "0.3"], ["pad2_gain", "3"]];
+  if (JSON.stringify(undone) !== JSON.stringify(wantUndo)) fail("undo wrote " + JSON.stringify(undone) + ", want " + JSON.stringify(wantUndo));
+  writes.length = 0;
+  c.onEditCc(56, true);
+  if (writes.length) fail("a second Undo wrote again: " + JSON.stringify(writes));
+
+  /* ---- 3. clear pad 1 ---------------------------------------------------- */
+  writes.length = 0;
+  c.onEditCc(119, true);
+  focus(1);
+  const cleared = writes.filter(([k]) => k.startsWith("pad1_"));
+  const wantClear = [["pad1_sample", ""], ["pad1_vol", "0.5"]];
+  if (JSON.stringify(cleared) !== JSON.stringify(wantClear)) fail("clear wrote " + JSON.stringify(cleared) + ", want " + JSON.stringify(wantClear) + " (filepath -> \"\", declared default, no-default key untouched)");
+  c.onEditCc(119, false);
+
+  /* ---- 4. no instance, no gesture; no paste onto the source ------------- */
+  c.goToPage(pageOf("fx")); spin(5);
+  if (c.onEditCc(60, true)) fail("Copy was taken on a page with no instance");
+  if (c.editGesture) fail("a gesture was armed on a page with no instance");
+  onPads();
+  writes.length = 0;
+  c.onEditCc(60, true);
+  focus(3); focus(1);
+  if (writes.some(([k]) => k.startsWith("pad1_"))) fail("returning to the source pasted onto it");
+  c.onEditCc(60, false);
+
+  if (bad) process.exit(1);
+  console.log("  ok  copy pastes the declared keys in order into each picked instance; undo restores; clear writes defaults; nothing without an instance");
+}).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
+' || fail "controller half"
+
+pp="src/shadow/shadow_ui_param_pages.mjs"
+command grep -q 'controller.onEditCc(data\[1\], data\[2\] > 0)' "$pp" || fail "the host does not route CC 56/60/119 to the gesture"
+command grep -q '^#### Copying and clearing an instance' docs/MODULES.md || fail "the gesture is undocumented"
+echo "PASS: test_child_copy_gesture"


### PR DESCRIPTION
## In short

Adds a generic copy/clear/undo gesture for child levels on the knob grid. Hold Copy, pick instances, and each is pasted into from the one you started on; hold Delete to clear the ones you pick; Undo restores the last. A level declares which keys make up an instance. Works for any module with a child level that has claimed those buttons (#425), whether focus moves by pad hit (#426) or by the instance picker.

## For a drum module, concretely

Building a kit means a lot of "make this pad like that one, but tuned down", and "wipe this pad and start over". This is that gesture, done once in the host so any drum module gets it: hold Copy, hit pads to paste into them; hold Delete, hit pads to clear them; Undo puts the last one back.

## What

A drum rack's oldest gesture, offered by the knob grid to any child level: **hold Copy**, then pick instances (a pad hit through `child_index_param`, or the instance list) and each one is pasted into from the instance that was focused when Copy went down. **Hold Delete** to clear the instances you pick. **Undo** restores the last instance overwritten (one level). A floating one-line notice says what happened.

Builds on `capabilities.claims_edit_ccs` (the buttons reach the grid only for a module that claimed them, so a module opts in to the gesture exactly by opting in to the buttons) and on #411's `child_index_param` (focus moves however it moves for the module, so the gesture never needs to know what a pad is).

## What is copied

The level's **`child_copy_keys`** in declared order (also the write order, so a module lists its sample first), else the level's own params. An explicit list exists because "what the page shows" is a weak default: a pad's level-affecting params with no cell (a gain, a velocity depth) would be skipped and the copy would be quieter than its source, and a key that is a *pointer* (a position within this pad's folder) or an *identity* (its note) must not be copied at all. Clear writes each key's declared `default`, `""` for a filepath with none, and leaves a key with no default alone.

The focused instance itself is not touched by Delete going down, only the instances picked while holding it; a pad already on screen is cleared by picking another first. Documented under *Child Selectors* in `MODULES.md`.

## Tests

`tests/host/test_child_copy_gesture.sh` drives the real controller against a fake device: the declared keys in order into each picked instance and nothing else, undo restoring exactly what a paste overwrote, clear writing defaults, no gesture on a page without an instance, no paste onto the source. Full host suite green; device-tested with schwung-dr32 0.2.0 (copy, undo, clear, and Move's own Copy/Delete intact once the module's grid is left).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwuEvvXACZX2yGvBuhbJFh
