### PR TITLE
sampler: the preroll trim never ran — the WAV was opened write-only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -832,6 +832,15 @@ Mute (CC 88) is passed through to Move firmware (even while shadow UI is shown) 
 
 Shift+Sample. Source: resample (incl. Schwung synths) or Move Input. Duration in bars (or until stopped); uses MIDI clock, falls back to project tempo. Starts on note event or play. Saved to `Samples/Schwung/Resampler/YYYY-MM-DD/`.
 
+**The take is recorded THROUGH the preroll and trimmed afterwards** — starting
+on the count-in is what makes it sample-accurate to the downbeat. That trim was
+a no-op from 2026-04 to 1.2: the WAV was opened `"wb"`, so its `fread` returned
+0, the copy broke on the first pass and the `ftruncate` ran anyway — leaving the
+COUNT-IN on the card at exactly the right duration with the tail cut, which
+reads as a sampler that ignores preroll rather than as a file never rewritten.
+It logged success. **A short read must never become a truncation, and a length
+assertion would have passed the whole time** — see `docs/SHADOW_UI.md`.
+
 ### Feedback Protection
 
 Loading a chain module / tool that consumes line-in shows "Speaker Feedback Risk" warning if speakers active AND no line-in cable. Jog-click proceeds, Back aborts.

--- a/docs/SHADOW_UI.md
+++ b/docs/SHADOW_UI.md
@@ -896,6 +896,42 @@ pulse error, a latency, or any mix; it took a second tempo to solve for both.
 and has no announcement to key off. Record + transport is not a sufficient
 signal. Not covered.
 
+### The preroll trim was a no-op for five months, and looked like bad timing
+
+The quantized sampler records **through** its preroll — starting on the count-in
+rather than on the tick that ends it is what makes the take sample-accurate to
+the downbeat (`b76cdfed`, 2026-04-01, which measured the offset down from
+15–45 ms to <1.5 ms). The count-in bars are then cut off the front of the WAV on
+stop, by `sampler_wav_trim_front`.
+
+**That cut never happened.** The take and its five stems were opened `"wb"`, and
+`fread` on a write-only stream returns 0 — so the copy loop broke on its first
+pass, before anything moved. The `ftruncate` after it ran anyway, cutting the
+preroll's worth of bytes off the **END** of a file whose front was untouched. So
+what landed on the card was the **count-in**, at exactly the right duration, with
+the take's tail missing. Every visible signal agreed it had worked: the length
+was right, the file was there, and `"trimmed N preroll frames"` was logged —
+because the caller printed it on a return value of 1, which the function returned
+whether or not it had copied a byte.
+
+Two things follow, and they are the general ones:
+
+- **A short read must not become a truncation.** `sampler_wav_trim_front_impl`
+  returns 0 and leaves the file **whole** if the copy did not complete. A take
+  that kept its preroll can be trimmed by hand; one truncated around unmoved
+  audio has lost the end of the performance for good. Same rule as the
+  three-answer param read: a failed read may not produce a result.
+- **A length assertion would have passed the entire time.** The failing
+  implementation gets the frame count exactly right and the audio entirely
+  wrong. `tests/host/test_sampler_wav_trim.c` asserts the file **begins** on the
+  first post-preroll frame and **ends** on the last recorded one, against a file
+  whose every frame is stamped with its own index; and it runs the trim against
+  a write-only stream to pin the recovery. The body lives in
+  `src/host/sampler_wav_trim.h` so it can be run on the dev machine at all —
+  five months on hardware never caught it, and one host test does.
+  `tests/host/test_sampler_wav_open_mode.sh` pins the two call sites, because
+  the arithmetic was never what was wrong.
+
 ### Save Stems: a stem is a SLOT, and that is forced by the FX chain
 
 **Global Settings → Audio → Save** (`save_stems` in `features.json`, mirrored

--- a/src/host/sampler_wav_trim.h
+++ b/src/host/sampler_wav_trim.h
@@ -1,0 +1,95 @@
+/* sampler_wav_trim.h - dropping the preroll off the front of an open WAV.
+ *
+ * A header, and a static inline, for the same reason sampler_stem_path.h is:
+ * the take and each of its five stems go through this, and a second copy of
+ * it is how the two halves drift. It is here rather than in shadow_sampler.c
+ * so tests/host can run it against a real file on the dev machine — which is
+ * the only thing that would have caught what it did for five months.
+ *
+ * WHAT IT DID: `f` must be open for READING as well as writing ("w+b"). Both
+ * callers opened it "wb". The fread below then returned 0 on the very first
+ * pass, the copy loop broke immediately — and the ftruncate ran anyway,
+ * cutting `preroll_frames` off the END of a file whose front had never moved.
+ * The saved take was the PREROLL, at exactly the right duration, so it read as
+ * a recording that started early rather than as a trim that never happened.
+ * Nothing failed loudly: the caller's "trimmed N preroll frames" log line was
+ * printed on the strength of a return value of 1.
+ *
+ * So the truncate is conditional on the copy now. A short read leaves the file
+ * WHOLE and reports it: a take that kept its preroll can be trimmed by hand,
+ * one that has been truncated has lost the audio for good.
+ *
+ * Header is NOT rewritten here — the caller stamps the final size. Returns 1
+ * if the audio moved and *frames was updated.
+ *
+ * Runs on the shim worker (SCHED_OTHER). The malloc, the seeks and the paced
+ * writer are the reason this is not on the RT path. */
+
+#ifndef SAMPLER_WAV_TRIM_H
+#define SAMPLER_WAV_TRIM_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/* Writes `bytes` from `buf` at the stream's current position, returning the
+ * count written. The shim passes its paced writer (the trim rewrites the whole
+ * file, once per stem — six unpaced rewrites at stop is the burst the skipback
+ * save was); a test passes plain fwrite. */
+typedef size_t (*sampler_trim_write_fn)(FILE *f, const void *buf, size_t bytes);
+
+/* Optional. NULL is allowed so the unit test can run without a host. */
+typedef void (*sampler_trim_log_fn)(const char *msg);
+
+#define SAMPLER_TRIM_CHUNK_BYTES (44100u * 2u * 2u)  /* ~1 second, stereo s16 */
+
+static inline int sampler_wav_trim_front_impl(FILE *f,
+                                              size_t header_size,
+                                              unsigned bytes_per_frame,
+                                              unsigned preroll_frames,
+                                              unsigned *frames,
+                                              sampler_trim_write_fn write_fn,
+                                              sampler_trim_log_fn log_fn) {
+    if (!f || !write_fn || preroll_frames == 0 || !frames) return 0;
+    unsigned preroll_bytes = preroll_frames * bytes_per_frame;
+    unsigned total_bytes = *frames * bytes_per_frame;
+    if (preroll_bytes >= total_bytes) return 0;
+
+    unsigned keep_bytes = total_bytes - preroll_bytes;
+    unsigned keep_frames = *frames - preroll_frames;
+
+    unsigned char *chunk = (unsigned char *)malloc(SAMPLER_TRIM_CHUNK_BYTES);
+    if (!chunk) return 0;
+    unsigned remaining = keep_bytes;
+    unsigned read_offset = (unsigned)header_size + preroll_bytes;
+    unsigned write_offset = (unsigned)header_size;
+    int short_read = 0;
+    while (remaining > 0) {
+        unsigned to_copy = remaining < SAMPLER_TRIM_CHUNK_BYTES
+                         ? remaining : SAMPLER_TRIM_CHUNK_BYTES;
+        fseek(f, (long)read_offset, SEEK_SET);
+        size_t got = fread(chunk, 1, to_copy, f);
+        if (got == 0) { short_read = 1; break; }
+        fseek(f, (long)write_offset, SEEK_SET);
+        if (write_fn(f, chunk, got) != got) { short_read = 1; break; }
+        read_offset += (unsigned)got;
+        write_offset += (unsigned)got;
+        remaining -= (unsigned)got;
+    }
+    free(chunk);
+
+    if (short_read) {
+        fflush(f);
+        if (log_fn)
+            log_fn("Sampler: preroll trim could not read the take back — "
+                   "file kept whole, preroll NOT removed");
+        return 0;
+    }
+
+    fflush(f);
+    ftruncate(fileno(f), (off_t)(header_size + keep_bytes));
+    *frames = keep_frames;
+    return 1;
+}
+
+#endif /* SAMPLER_WAV_TRIM_H */

--- a/src/host/sampler_wav_trim.h
+++ b/src/host/sampler_wav_trim.h
@@ -28,8 +28,18 @@
 #ifndef SAMPLER_WAV_TRIM_H
 #define SAMPLER_WAV_TRIM_H
 
+/* ftruncate/fileno and off_t are POSIX, and glibc hides them under a strict
+ * -std=c11 unless the TU asks. shadow_sampler.c defines _GNU_SOURCE; a caller
+ * that does not (tests/host builds with -std=c11) must say so before including
+ * this. macOS declares them regardless, which is why a build that is fine on
+ * the dev machine fails on CI and on the device toolchain. */
+#if !defined(_GNU_SOURCE) && !defined(_POSIX_C_SOURCE) && !defined(__APPLE__)
+#error "sampler_wav_trim.h needs POSIX: define _POSIX_C_SOURCE 200809L (or _GNU_SOURCE) before including it"
+#endif
+
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 /* Writes `bytes` from `buf` at the stream's current position, returning the

--- a/src/host/shadow_sampler.c
+++ b/src/host/shadow_sampler.c
@@ -13,6 +13,7 @@
 #include "shim_worker.h"
 #include "shadow_constants.h"
 #include "sampler_stem_path.h"
+#include "sampler_wav_trim.h"
 #include <semaphore.h>
 
 #include <stdlib.h>
@@ -406,53 +407,20 @@ static void sampler_write_wav_header(FILE *f, uint32_t data_size) {
     fwrite(&header, sizeof(header), 1, f);
 }
 
-/* Drop `preroll_frames` from the FRONT of an open WAV, in place: copy the
- * tail down over the head, truncate, and update *frames to what is left.
- * Header is NOT rewritten here — the caller stamps the final size.
+/* Drop `preroll_frames` from the FRONT of an open WAV, in place.
  *
- * Extracted from sampler_worker_finalize so the stems get the identical trim
- * rather than a second implementation of it. Returns 1 if anything moved.
- *
- * Runs on the shim worker (SCHED_OTHER). The malloc and the seeks are the
- * reason this is not on the RT path. */
+ * The body lives in sampler_wav_trim.h so tests/host can run it against a real
+ * file — including the case that made this whole feature a no-op for five
+ * months, which was the FILE MODE and not the arithmetic. Read the header. */
 static int sampler_wav_trim_front(FILE *f, uint32_t preroll_frames, uint32_t *frames) {
-    if (!f || preroll_frames == 0 || !frames) return 0;
-    uint32_t bytes_per_frame = SAMPLER_NUM_CHANNELS * (SAMPLER_BITS_PER_SAMPLE / 8);
-    uint32_t preroll_bytes = preroll_frames * bytes_per_frame;
-    uint32_t total_bytes = *frames * bytes_per_frame;
-    if (preroll_bytes >= total_bytes) return 0;
-
-    uint32_t keep_bytes = total_bytes - preroll_bytes;
-    uint32_t keep_frames = *frames - preroll_frames;
-    size_t header_size = sizeof(sampler_wav_header_t);
-
-    /* Process in chunks to limit memory usage */
-    #define TRIM_CHUNK_SIZE (44100 * 2 * 2)  /* ~1 second */
-    int16_t *chunk = malloc(TRIM_CHUNK_SIZE);
-    if (!chunk) return 0;
-    uint32_t remaining = keep_bytes;
-    uint32_t read_offset = (uint32_t)header_size + preroll_bytes;
-    uint32_t write_offset = (uint32_t)header_size;
-    while (remaining > 0) {
-        uint32_t to_copy = remaining < TRIM_CHUNK_SIZE ? remaining : TRIM_CHUNK_SIZE;
-        fseek(f, read_offset, SEEK_SET);
-        size_t got = fread(chunk, 1, to_copy, f);
-        if (got == 0) break;
-        fseek(f, write_offset, SEEK_SET);
-        /* Paced: the trim rewrites the WHOLE file, and finalize runs it once per
-         * stem. Six unpaced rewrites at stop is the same burst the skipback save
-         * was. */
-        sampler_write_paced(f, chunk, got);
-        read_offset += (uint32_t)got;
-        write_offset += (uint32_t)got;
-        remaining -= (uint32_t)got;
-    }
-    free(chunk);
-    #undef TRIM_CHUNK_SIZE
-
-    ftruncate(fileno(f), (off_t)(header_size + keep_bytes));
-    *frames = keep_frames;
-    return 1;
+    unsigned n = frames ? (unsigned)*frames : 0;
+    int moved = sampler_wav_trim_front_impl(
+        f, sizeof(sampler_wav_header_t),
+        SAMPLER_NUM_CHANNELS * (SAMPLER_BITS_PER_SAMPLE / 8),
+        (unsigned)preroll_frames, &n,
+        sampler_write_paced, s_host.log);
+    if (frames) *frames = (uint32_t)n;
+    return moved;
 }
 
 static size_t sampler_ring_available_write(void) {
@@ -900,7 +868,8 @@ static int sampler_worker_open_stems(void) {
         sampler_stem_t *st = &sampler_stems[i];
         sampler_stem_path_build(st->path, sizeof(st->path),
                                 sampler_current_recording, sampler_stem_names[i]);
-        st->file = fopen(st->path, "wb");
+        /* "w+b" — the preroll trim reads this back. See sampler_wav_trim_front. */
+        st->file = fopen(st->path, "w+b");
         if (!st->file) {
             char msg[380];
             snprintf(msg, sizeof(msg), "Sampler: failed to open stem file: %s", st->path);
@@ -1033,7 +1002,10 @@ void sampler_worker_prepare(void) {
         s_host.log("Sampler: source is Move Input — stems not available, recording master");
 
     if (SAVE_STEMS_WANTS_MASTER(sampler_take_stem_mode)) {
-        sampler_wav_file = fopen(sampler_current_recording, "wb");
+        /* "w+b", not "wb": sampler_wav_trim_front() READS this file back to
+         * copy the tail down over the preroll. A write-only stream fails that
+         * fread, which is the whole preroll bug — see the comment there. */
+        sampler_wav_file = fopen(sampler_current_recording, "w+b");
         if (!sampler_wav_file) {
             char msg[300];
             snprintf(msg, sizeof(msg), "Sampler: failed to open WAV file: %s",

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -52,6 +52,7 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_metronome_announce \
 	$(BUILD_DIR)/test_shadow_metronome \
 	$(BUILD_DIR)/test_sampler_stem_path \
+	$(BUILD_DIR)/test_sampler_wav_trim \
 	$(BUILD_DIR)/test_perf_snapshot_size \
 	$(BUILD_DIR)/test_relative_cc \
 	$(BUILD_DIR)/test_link_audio_backlog_trim
@@ -127,6 +128,9 @@ $(BUILD_DIR)/test_metronome_announce: test_metronome_announce.c ../../src/host/m
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_sampler_stem_path: test_sampler_stem_path.c ../../src/host/sampler_stem_path.h | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
+
+$(BUILD_DIR)/test_sampler_wav_trim: test_sampler_wav_trim.c ../../src/host/sampler_wav_trim.h | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $< -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_shadow_metronome: test_shadow_metronome.c ../../src/host/shadow_metronome.c ../../src/host/metronome_click.h | $(BUILD_DIR)

--- a/tests/host/test_sampler_wav_open_mode.sh
+++ b/tests/host/test_sampler_wav_open_mode.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Every WAV the preroll trim has to read back must be opened readable.
+#
+# test_sampler_wav_trim.c pins the trim itself, and would stay green through
+# this bug: the defect was never in the arithmetic, it was that both callers
+# handed it a stream opened "wb". fread on a write-only stream returns 0, the
+# copy loop breaks on the first pass, and what lands on the card is the
+# preroll at exactly the right duration. Only the CALL SITE can show that.
+#
+# The two files are the sampler's master take and each of its five stems.
+
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+
+SRC=src/host/shadow_sampler.c
+fails=0
+
+fail() { echo "FAIL: $1"; fails=$((fails + 1)); }
+
+# The master take.
+if ! grep -q 'sampler_wav_file = fopen(sampler_current_recording, "w+b")' "$SRC"; then
+    fail "master take is not opened \"w+b\" — the preroll trim cannot read it back"
+fi
+
+# The stems, opened in sampler_worker_open_stems.
+if ! grep -q 'st->file = fopen(st->path, "w+b")' "$SRC"; then
+    fail "stem files are not opened \"w+b\" — their preroll trim cannot read them back"
+fi
+
+# And nothing may quietly reintroduce a write-only open for either of them.
+if grep -n 'fopen(sampler_current_recording, "wb")\|fopen(st->path, "wb")' "$SRC"; then
+    fail "a sampler WAV is opened write-only above"
+fi
+
+if [ "$fails" -eq 0 ]; then
+    echo "test_sampler_wav_open_mode: all checks passed"
+    exit 0
+fi
+exit 1

--- a/tests/host/test_sampler_wav_trim.c
+++ b/tests/host/test_sampler_wav_trim.c
@@ -12,6 +12,10 @@
  * AUDIO wrong, so a test that only counted frames would have passed for the
  * whole time this was broken. */
 
+/* Before every include: the trim calls ftruncate/fileno and this file calls
+ * fdopen, all POSIX, all hidden by glibc under the suite's -std=c11. */
+#define _POSIX_C_SOURCE 200809L
+
 #include "../../src/host/sampler_wav_trim.h"
 #include <stdio.h>
 #include <string.h>

--- a/tests/host/test_sampler_wav_trim.c
+++ b/tests/host/test_sampler_wav_trim.c
@@ -1,0 +1,147 @@
+/* The quantized sampler's preroll trim, run against a real file.
+ *
+ * The take is recorded THROUGH the preroll — that is what makes it
+ * sample-accurate to the downbeat — and the preroll frames are then cut off
+ * the front on stop. When that cut silently does nothing, what lands on the
+ * card is the preroll, at exactly the right length, and the user reports it as
+ * "the sampler is ignoring my preroll" rather than as a file that was never
+ * rewritten. That is the shape this test exists to fail on.
+ *
+ * The content assertions matter more than the length one: a wrong
+ * implementation that truncates without copying gets the LENGTH right and the
+ * AUDIO wrong, so a test that only counted frames would have passed for the
+ * whole time this was broken. */
+
+#include "../../src/host/sampler_wav_trim.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+static int fails = 0;
+static char last_log[256];
+
+static size_t plain_write(FILE *f, const void *buf, size_t bytes) {
+    return fwrite(buf, 1, bytes, f);
+}
+static void capture_log(const char *msg) {
+    snprintf(last_log, sizeof(last_log), "%s", msg);
+}
+
+#define HDR 44u
+#define BPF 4u   /* stereo s16 */
+
+/* Byte i of frame n is (n & 0xff) — so the content of any frame identifies
+ * which frame of the ORIGINAL recording it is. */
+static void fill(unsigned char *p, unsigned frames) {
+    for (unsigned n = 0; n < frames; n++)
+        for (unsigned b = 0; b < BPF; b++)
+            p[n * BPF + b] = (unsigned char)(n & 0xff);
+}
+
+/* Write a header + `frames` of identifiable audio, then hand back a stream.
+ * `writable_only` reopens it O_WRONLY — the mode both callers used, and the
+ * one fopen cannot express without also truncating what we just wrote. */
+static FILE *make_file(const char *path, int writable_only, unsigned frames) {
+    FILE *w = fopen(path, "wb");
+    unsigned char hdr[HDR];
+    memset(hdr, 'H', HDR);
+    fwrite(hdr, 1, HDR, w);
+    unsigned char *audio = malloc(frames * BPF);
+    fill(audio, frames);
+    fwrite(audio, 1, frames * BPF, w);
+    free(audio);
+    fclose(w);
+    if (writable_only) {
+        int fd = open(path, O_WRONLY);
+        return fd < 0 ? NULL : fdopen(fd, "wb");
+    }
+    return fopen(path, "r+b");
+}
+
+static long file_size(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    fseek(f, 0, SEEK_END);
+    long n = ftell(f);
+    fclose(f);
+    return n;
+}
+
+static void expect(int cond, const char *what) {
+    if (!cond) { printf("FAIL: %s\n", what); fails++; }
+}
+
+int main(void) {
+    const char *path = "/tmp/schwung_test_trim.wav";
+
+    /* 1. The ordinary trim, on a file opened the way the sampler opens it.
+     *    Two chunks' worth so the copy loop runs more than once. */
+    {
+        unsigned frames = (SAMPLER_TRIM_CHUNK_BYTES / BPF) * 2 + 777;
+        unsigned preroll = 5000;
+        FILE *f = make_file(path, 0, frames);
+        unsigned n = frames;
+        int moved = sampler_wav_trim_front_impl(f, HDR, BPF, preroll, &n,
+                                                plain_write, capture_log);
+        fflush(f);
+        expect(moved == 1, "trim reports that it moved the audio");
+        expect(n == frames - preroll, "frame count drops by the preroll");
+        expect(file_size(path) == (long)(HDR + (frames - preroll) * BPF),
+               "file is header + kept audio");
+
+        /* The kept audio must START at original frame `preroll` and run to the
+         * end of the take. A truncate-without-copy passes the two assertions
+         * above and fails both of these. */
+        fseek(f, HDR, SEEK_SET);
+        unsigned char first[BPF], last[BPF];
+        expect(fread(first, 1, BPF, f) == BPF, "first kept frame is readable");
+        expect(first[0] == (unsigned char)(preroll & 0xff),
+               "file now BEGINS at the first post-preroll frame");
+        fseek(f, (long)(HDR + (n - 1) * BPF), SEEK_SET);
+        expect(fread(last, 1, BPF, f) == BPF, "last kept frame is readable");
+        expect(last[0] == (unsigned char)((frames - 1) & 0xff),
+               "file still ENDS on the last recorded frame");
+        fclose(f);
+    }
+
+    /* 2. The regression itself: a WRITE-ONLY stream, which is what both
+     *    callers passed for five months. The read fails, so nothing can be
+     *    copied — and the file must come back WHOLE rather than truncated to
+     *    the right length around the wrong audio. */
+    {
+        unsigned frames = 20000, preroll = 5000;
+        FILE *f = make_file(path, 1, frames);   /* write-only, as both callers were */
+        unsigned n = frames;
+        last_log[0] = '\0';
+        int moved = sampler_wav_trim_front_impl(f, HDR, BPF, preroll, &n,
+                                                plain_write, capture_log);
+        fclose(f);
+        expect(moved == 0, "a trim that could not read reports FAILURE");
+        expect(n == frames, "frame count is left alone when nothing moved");
+        expect(file_size(path) == (long)(HDR + frames * BPF),
+               "the take is kept WHOLE — never truncated around unmoved audio");
+        expect(last_log[0] != '\0', "the failure is logged, not silent");
+    }
+
+    /* 3. Degenerate inputs the caller can produce: a take shorter than its own
+     *    preroll (stopped during the count-in) and a take with no preroll. */
+    {
+        unsigned frames = 100, preroll = 500;
+        FILE *f = make_file(path, 0, frames);
+        unsigned n = frames;
+        expect(sampler_wav_trim_front_impl(f, HDR, BPF, preroll, &n,
+                                           plain_write, capture_log) == 0,
+               "preroll >= take is a no-op");
+        expect(n == frames, "no-op leaves the frame count alone");
+        expect(sampler_wav_trim_front_impl(f, HDR, BPF, 0, &n,
+                                           plain_write, capture_log) == 0,
+               "zero preroll is a no-op");
+        fclose(f);
+    }
+
+    remove(path);
+    if (fails == 0) printf("test_sampler_wav_trim: all checks passed\n");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
A user on 1.2 reports the quantized sampler ignoring preroll: "the sample is missing the tail at the beginning, like it sampled the 1st bars and not after the preroll."

## What it is

The sampler records **through** the preroll — that is what makes the take sample-accurate to the downbeat — and cuts the count-in off the front of the WAV on stop. **That cut has never happened.**

Both the master take and the five stems were opened `"wb"`. `fread` on a write-only stream returns 0, so the copy loop in `sampler_wav_trim_front` broke on its first pass, before a byte moved — and the `ftruncate` after it ran anyway, cutting the preroll's worth of bytes off the **END** of a file whose front was untouched.

So the file is the **count-in**, at exactly the right duration, with the performance's tail missing. Exactly the report.

Nothing failed loudly. Right length, file present, and `"trimmed N preroll frames"` in the log — the caller printed that on a return value of `1`, which the function returned whether or not it copied anything.

Broken since b76cdfed (2026-04-01), the commit that introduced the record-through-preroll design. It measured the onset offset (15–45 ms → <1.5 ms) and never opened the resulting file.

## The fix

- Open the take and the stems `"w+b"`.
- **A short read no longer truncates.** The file is kept whole and the failure is logged. A take that kept its preroll can be trimmed by hand; one truncated around unmoved audio has lost the end of the performance for good.
- Body moves to `src/host/sampler_wav_trim.h` so `tests/host` can run it on the dev machine — which is what five months on hardware did not.

## Tests

- `test_sampler_wav_trim.c` — every frame is stamped with its own index, and the assertions are that the file **begins** on the first post-preroll frame and **ends** on the last recorded one. A length-only assertion passes the broken implementation exactly, which is why this was invisible. Also runs the trim against a write-only stream to pin the recovery, and covers preroll ≥ take (stopped during the count-in) and preroll = 0. Mutation-checked: disabling the short-read guard fails 4 assertions.
- `test_sampler_wav_open_mode.sh` — pins both call sites. The arithmetic was never what was wrong.

`make -C tests/host test` green, all 266 `tests/host/*.sh` green, ARM cross-compile clean.

## Not verified on hardware

Host-only so far — the trim is exercised against real files by the new unit test, but no take has been recorded on a device with this build. Worth one Shift+Sample with preroll on before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NRtu3wsqjivHfz41o6NFus