### PR TITLE
install.sh: a payload older than the selector is a downgrade, not a corrupt tarball

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -967,6 +967,49 @@ fi
 # ═══════════════════════════════════════════════════════════════════════════════
 # Re-enable mode: root partition operations only (after firmware update)
 # ═══════════════════════════════════════════════════════════════════════════════
+boot_selector_state=""   # set by the rule below; read under `set -u`
+
+# ---- Boot-selector payload rule (BOOT_SELECTOR_PAYLOAD_RULE) --------------
+#
+# The boot selector adds three files to the payload. Asserting all three
+# unconditionally made this installer unable to install ANY release older than
+# the selector: install.sh on a v1.2.0 tarball died with
+# "Payload missing: schwung-entry.sh" -- and died AFTER extraction, so it left
+# a half-installed tree whose /opt/move/Move was still the newer selector with
+# no boot_target_lib.sh under /data, i.e. the lib-missing fallback: Schwung up,
+# no sidecars, no manager on :7700. Rolling back to a known-good release is
+# exactly what you want an installer for when a release goes bad.
+#
+# A pre-selector tarball legitimately has NONE of the three and brings its own
+# shim-entrypoint.sh, which is the launcher of its era and self-consistent. So
+# the rule is all-or-nothing: none = an older payload, install it; all = a
+# selector payload; SOME = genuinely corrupt, and that is the case worth
+# failing on. The state is computed from the TARBALL LISTING and checked
+# BEFORE extraction, so a bad payload never lands half-written.
+BOOT_SELECTOR_FILES="schwung-entry.sh host/boot_target_lib.sh bin/boot-select"
+
+# boot_selector_payload_state <present-path>... -> "full" | "none" | "partial <missing>..."
+# Paths are relative to the tarball's schwung/ root (or to /data/UserData/schwung).
+boot_selector_payload_state() {
+  bsp_present=" $* "
+  bsp_missing=""
+  bsp_found=0
+  for bsp_f in $BOOT_SELECTOR_FILES; do
+    case "$bsp_present" in
+      *" $bsp_f "*) bsp_found=$((bsp_found + 1)) ;;
+      *) bsp_missing="$bsp_missing $bsp_f" ;;
+    esac
+  done
+  if [ "$bsp_found" -eq 0 ]; then
+    echo "none"
+  elif [ -z "$bsp_missing" ]; then
+    echo "full"
+  else
+    echo "partial$bsp_missing"
+  fi
+}
+# ---- end BOOT_SELECTOR_PAYLOAD_RULE ---------------------------------------
+
 if [ "$use_reenable" = true ]; then
   echo
   echo "Re-enable mode: restoring root partition hooks..."
@@ -979,15 +1022,23 @@ if [ "$use_reenable" = true ]; then
   if ! $ssh_ableton "test -f /data/UserData/schwung/shim-entrypoint.sh" 2>/dev/null; then
     fail "Entrypoint not found on data partition. Run a full install instead."
   fi
-  if ! $ssh_ableton "test -f /data/UserData/schwung/schwung-entry.sh" 2>/dev/null; then
-    fail "schwung-entry.sh not found on data partition. Run a full install instead."
-  fi
-  if ! $ssh_ableton "test -f /data/UserData/schwung/host/boot_target_lib.sh" 2>/dev/null; then
-    fail "host/boot_target_lib.sh not found on data partition. Run a full install instead."
-  fi
-  if ! $ssh_ableton "test -f /data/UserData/schwung/bin/boot-select" 2>/dev/null; then
-    fail "bin/boot-select not found on data partition. Run a full install instead."
-  fi
+  # Boot-selector trio: all three, or none (a pre-selector payload on disk).
+  # Some-but-not-all is the corrupt case. See BOOT_SELECTOR_PAYLOAD_RULE.
+  reenable_present=""
+  for f in $BOOT_SELECTOR_FILES; do
+    if $ssh_ableton "test -f /data/UserData/schwung/$f" 2>/dev/null; then
+      reenable_present="$reenable_present $f"
+    fi
+  done
+  boot_selector_state=$(boot_selector_payload_state $reenable_present)
+  case "$boot_selector_state" in
+    partial*)
+      fail "Incomplete boot-selector payload on data partition (missing:${boot_selector_state#partial}). Run a full install instead."
+      ;;
+    none)
+      iecho "No boot-selector payload on the data partition — re-enabling the pre-selector entrypoint it shipped with."
+      ;;
+  esac
 
   # Clean stale ld.so.preload entries
   ssh_root_with_retry "if [ -f /etc/ld.so.preload ] && grep -q 'schwung-shim.so' /etc/ld.so.preload; then ts=\$(date +%Y%m%d-%H%M%S); cp /etc/ld.so.preload /etc/ld.so.preload.bak-schwung-\$ts; grep -v 'schwung-shim.so' /etc/ld.so.preload > /tmp/ld.so.preload.new || true; if [ -s /tmp/ld.so.preload.new ]; then cat /tmp/ld.so.preload.new > /etc/ld.so.preload; else rm -f /etc/ld.so.preload; fi; rm -f /tmp/ld.so.preload.new; fi" || true
@@ -1012,7 +1063,9 @@ if [ "$use_reenable" = true ]; then
 
   # Ensure entrypoint is executable
   ssh_root_with_retry "chmod +x /data/UserData/schwung/shim-entrypoint.sh" || fail "Failed to set entrypoint permissions"
+  if [ "$boot_selector_state" = "full" ]; then
   ssh_root_with_retry "chmod +x /data/UserData/schwung/schwung-entry.sh" || fail "Failed to set entry permissions"
+fi
 
   # Install schwung-heal as setuid root (re-enable path mirror of full
   # install). Without this the entrypoint's boot-time heal silently
@@ -1116,6 +1169,22 @@ ssh_ableton_with_retry "tar -tzf ./$remote_filename | grep -qx 'schwung/schwung-
 # the raw (mangled) names, so this catches what host-side bsdtar hides.
 ssh_ableton_with_retry "! tar -tzf ./$remote_filename | grep -q 'GNUSparseFile'" || \
     fail "Invalid tar payload: contains GNU sparse entries BusyBox cannot extract (repackage with sparse-safe tar)"
+# Boot-selector trio, judged from the tarball and BEFORE extraction so a
+# corrupt payload never half-lands. See BOOT_SELECTOR_PAYLOAD_RULE.
+# `|| true`: a pre-selector tarball makes grep exit 1, and under `set -e` a
+# failing command substitution in an assignment aborts the script -- which
+# would kill the installer on precisely the payload this rule exists to accept.
+tarball_present=$($ssh_ableton "tar -tzf ./$remote_filename | sed -n 's|^schwung/||p' | grep -x -e schwung-entry.sh -e host/boot_target_lib.sh -e bin/boot-select" 2>/dev/null | tr '\n' ' ' || true)
+boot_selector_state=$(boot_selector_payload_state $tarball_present)
+case "$boot_selector_state" in
+  partial*)
+    fail "Invalid tar payload: incomplete boot-selector payload (missing:${boot_selector_state#partial})"
+    ;;
+  none)
+    iecho "This payload predates the boot selector — installing it as-is (its own shim-entrypoint.sh becomes /opt/move/Move)."
+    ;;
+esac
+
 # Use verbose tar only in non-quiet mode (screen reader friendly)
 if [ "$quiet_mode" = true ]; then
     ssh_ableton_with_retry "tar -xzof ./$remote_filename" || fail "Failed to extract tarball"
@@ -1126,9 +1195,11 @@ fi
 # Verify expected payload exists before making system changes
 ssh_ableton_with_retry "test -f /data/UserData/schwung/schwung-shim.so" || fail "Payload missing: schwung-shim.so"
 ssh_ableton_with_retry "test -f /data/UserData/schwung/shim-entrypoint.sh" || fail "Payload missing: shim-entrypoint.sh"
-ssh_ableton_with_retry "test -f /data/UserData/schwung/schwung-entry.sh" || fail "Payload missing: schwung-entry.sh"
-ssh_ableton_with_retry "test -f /data/UserData/schwung/host/boot_target_lib.sh" || fail "Payload missing: host/boot_target_lib.sh"
-ssh_ableton_with_retry "test -f /data/UserData/schwung/bin/boot-select" || fail "Payload missing: bin/boot-select"
+if [ "$boot_selector_state" = "full" ]; then
+  ssh_ableton_with_retry "test -f /data/UserData/schwung/schwung-entry.sh" || fail "Payload missing: schwung-entry.sh"
+  ssh_ableton_with_retry "test -f /data/UserData/schwung/host/boot_target_lib.sh" || fail "Payload missing: host/boot_target_lib.sh"
+  ssh_ableton_with_retry "test -f /data/UserData/schwung/bin/boot-select" || fail "Payload missing: bin/boot-select"
+fi
 
 # Verify modules directory exists
 if ssh_ableton_with_retry "test -d /data/UserData/schwung/modules"; then
@@ -1213,7 +1284,9 @@ fi
 
 # Ensure the replacement Move script exists and is executable
 ssh_root_with_retry "chmod +x /data/UserData/schwung/shim-entrypoint.sh" || fail "Failed to set entrypoint permissions"
-ssh_root_with_retry "chmod +x /data/UserData/schwung/schwung-entry.sh" || fail "Failed to set entry permissions"
+if [ "$boot_selector_state" = "full" ]; then
+  ssh_root_with_retry "chmod +x /data/UserData/schwung/schwung-entry.sh" || fail "Failed to set entry permissions"
+fi
 
 # Install schwung-heal as setuid root. This is the only privileged code
 # path on the device for ableton-context callers (entrypoint, schwung-

--- a/tests/host/test_install_boot_selector_payload.sh
+++ b/tests/host/test_install_boot_selector_payload.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# install.sh asserted the boot selector's three payload files unconditionally,
+# which made it unable to install ANY release older than the selector: a
+# rollback to v1.2.0 died with "Payload missing: schwung-entry.sh". Worse, it
+# died AFTER extraction, leaving a half-installed tree whose /opt/move/Move was
+# still the newer selector with no boot_target_lib.sh under /data — the
+# lib-missing fallback, i.e. Schwung up with no sidecars and no manager on
+# :7700. Rolling back is what you want an installer for when a release is bad.
+#
+# The rule is all-or-nothing: none = an older payload (install it), all = a
+# selector payload, SOME = corrupt (fail, and fail before extraction).
+#
+# The function is LIFTED from install.sh, not restated here: a copy would drift
+# from the shipped one and go on passing.
+
+fails=0
+say_fail() { echo "FAIL: $*"; fails=$((fails + 1)); }
+say_pass() { echo "PASS: $*"; }
+
+# awk, not `grep -n | head -1`: head exits after the first line, grep takes
+# SIGPIPE and pipefail turns that into a failed assignment.
+first_line_matching() {
+    awk -v pat="$1" '!n && index($0, pat) == 1 { n = NR } END { if (n) print n }' "$2"
+}
+start=$(first_line_matching 'BOOT_SELECTOR_FILES=' scripts/install.sh)
+end=$(first_line_matching '# ---- end BOOT_SELECTOR_PAYLOAD_RULE' scripts/install.sh)
+if [ -z "$start" ] || [ -z "$end" ] || [ "$start" -ge "$end" ]; then
+    echo "FAIL: could not slice BOOT_SELECTOR_PAYLOAD_RULE out of scripts/install.sh"
+    exit 1
+fi
+eval "$(sed -n "${start},$((end - 1))p" scripts/install.sh)"
+
+check() { # check <expected> <label> <present...>
+    expected="$1"; label="$2"; shift 2
+    got=$(boot_selector_payload_state "$@")
+    if [ "$got" = "$expected" ]; then
+        say_pass "$label -> $got"
+    else
+        say_fail "$label -> [$got], expected [$expected]"
+    fi
+}
+
+# ---- 1. a current payload: all three --------------------------------------
+check full "all three present" schwung-entry.sh host/boot_target_lib.sh bin/boot-select
+
+# ---- 2. a pre-selector payload: none of them ------------------------------
+# This is the v1.2.0 tarball, and it MUST be installable.
+check none "pre-selector payload (none present)"
+
+# ---- 3. corrupt payloads: some but not all -------------------------------
+check "partial host/boot_target_lib.sh bin/boot-select" \
+    "only the entry script" schwung-entry.sh
+check "partial bin/boot-select" \
+    "entry + lib, no boot-select" schwung-entry.sh host/boot_target_lib.sh
+check "partial schwung-entry.sh" \
+    "lib + boot-select, no entry script" host/boot_target_lib.sh bin/boot-select
+
+# ---- 4. order does not matter --------------------------------------------
+check full "all three, reversed" bin/boot-select host/boot_target_lib.sh schwung-entry.sh
+
+# ---- 5. a near-miss name is not a match ----------------------------------
+# Substring matching would let bin/boot-selector or schwung-entry.sh.bak stand
+# in for the real file; the rule pads with spaces and matches whole words.
+check "partial bin/boot-select" "bin/boot-selector is not bin/boot-select" \
+    schwung-entry.sh host/boot_target_lib.sh bin/boot-selector
+
+# ---- 6. the shipped script actually USES the rule -------------------------
+# The function existing is not the fix; the three call sites are. Assert the
+# post-extraction asserts and the entry chmod are gated on it, and that the
+# tarball check happens BEFORE extraction (that is the half-install half of
+# the bug).
+if awk '/^tarball_present=/ { t = NR } /tar -xzo?vf|tar -xzof|tar -xzvof/ { if (!x) x = NR } END { exit !(t && x && t < x) }' scripts/install.sh; then
+    say_pass "the tarball is judged before it is extracted"
+else
+    say_fail "the boot-selector payload check does not precede extraction"
+fi
+
+if grep -q 'if \[ "\$boot_selector_state" = "full" \]; then' scripts/install.sh; then
+    say_pass "call sites are gated on the computed state"
+else
+    say_fail "no call site gates on boot_selector_state"
+fi
+
+# An unguarded assert would re-break rollback. There must be none outside a gate.
+# index(), not a regex: awk eats the backslash in \$ inside a regex literal,
+# turning it into an end-anchor, and the gate then never matches — the check
+# passes by never seeing the gate rather than by the gate being there.
+if awk '
+    /^[ \t]*#/ { next }          # the rule\047s own comment quotes the old message
+    index($0, "boot_selector_state") && index($0, "full") { gate = 1 }
+    $0 == "fi" { gate = 0 }
+    index($0, "Payload missing: schwung-entry") && !gate { bad = 1 }
+    index($0, "Payload missing: host/boot_target_lib") && !gate { bad = 1 }
+    index($0, "Payload missing: bin/boot-select") && !gate { bad = 1 }
+    END { exit bad }
+' scripts/install.sh; then
+    say_pass "no ungated boot-selector payload assert remains"
+else
+    say_fail "an ungated 'Payload missing' assert for the selector trio is back"
+fi
+
+if [ "$fails" -eq 0 ]; then
+    echo "PASS: all install.sh boot-selector payload checks passed"
+    exit 0
+fi
+echo "$fails check(s) failed"
+exit 1


### PR DESCRIPTION
`./scripts/install.sh` with no `local` downloads the **latest GitHub release** (`install.sh:687-697`) while running *main's* installer. Since the boot selector landed, main's installer asserts three payload files the v1.2.0 tarball does not have — so the plain documented install command fails from any checkout until the next release is cut. Hit for real while setting up the web-update test.

It also failed **after** extraction, leaving a half-installed tree: `/opt/move/Move` still the newer selector with no `boot_target_lib.sh` under `/data`, which takes the lib-missing fallback — Schwung boots, no sidecars, no manager on :7700. That is the part worth fixing regardless of the selector: a payload check that runs after the payload has landed turns "wrong tarball" into a confusing device state.

## The rule

All-or-nothing, computed from the tarball listing **before** extraction:

- **none** — a pre-selector payload. Install it; it brings its own `shim-entrypoint.sh`, the launcher of its era, which is self-consistent.
- **all** — a selector payload, as today.
- **some** — genuinely corrupt. Fail, and fail before anything lands.

Re-enable mode applies the same rule against what is on disk.

## Test

`tests/host/test_install_boot_selector_payload.sh` **lifts** the function out of `install.sh` rather than restating it (a copy would drift and go on passing). It pins full/none/partial, that `bin/boot-selector` is not `bin/boot-select`, that the check precedes extraction, and that no ungated `Payload missing` assert returns. Both mutations — the rule rejecting an old payload, and an ungated assert coming back — were confirmed to fail it.

## Two `set -euo pipefail` traps caught in my own first draft

- The `grep` that finds nothing on a pre-selector tarball exits 1, and a failing command substitution in an assignment aborts under `set -e` — on exactly the payload this change exists to accept.
- `boot_selector_state` is read under `set -u` on paths that may not have set it; it is initialised at declaration.

## Verification

`tests/host` 0 failures, `make -C tests/host test` ALL PASS, `bash -n scripts/install.sh` clean. **Not exercised end-to-end on hardware** — that would mean two full install cycles (roll back to v1.2.0, roll forward), and the value did not seem worth the device time.