### PR TITLE
Wake idle synth slots when MIDI FX timers emit

### DIFF
--- a/docs/CHAIN.md
+++ b/docs/CHAIN.md
@@ -108,6 +108,12 @@ Instrumenting only the first means `last_note` never updates at all with an arp
 in the slot, and the grid follows a pad nobody played. The same split already
 bit the MIDI trace, for the same reason.
 
+`tick()` also continues while an otherwise silent chain slot is parked by the
+audio idle gate. If it emits MIDI, that same block wakes and renders so the
+generated note reaches the synth immediately. The idle tick is marked as
+already advanced, preventing the wake-up render from advancing MIDI FX or LFO
+time a second time.
+
 Note-offs are ignored: a released pad is still the pad you are editing. The
 record is an int store on the SPI callback and nothing else — no allocation, no
 parsing, no logging.

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -67,6 +67,7 @@ void (*shadow_chain_set_inject_audio)(void *instance, int16_t *buf, int frames) 
 void (*shadow_chain_set_external_fx_mode)(void *instance, int mode) = NULL;
 void (*shadow_chain_process_fx)(void *instance, int16_t *buf, int frames) = NULL;
 int (*shadow_chain_fx_requires_continuous)(void *instance) = NULL;
+int (*shadow_chain_take_midi_tick_wake)(void *instance) = NULL;
 host_api_v1_t shadow_host_api;
 
 /* Look up the slot owning a chain plugin instance and return its live
@@ -1396,13 +1397,16 @@ int shadow_inprocess_load_chain(void) {
         dlsym(shadow_dsp_handle, "chain_process_fx");
     shadow_chain_fx_requires_continuous = (int (*)(void *))
         dlsym(shadow_dsp_handle, "chain_fx_requires_continuous");
+    shadow_chain_take_midi_tick_wake = (int (*)(void *))
+        dlsym(shadow_dsp_handle, "chain_take_midi_tick_wake");
 
-    unified_log("shim", LOG_LEVEL_INFO, "chain dlsym: inject=%p ext_fx_mode=%p process_fx=%p same_frame=%d keep_alive=%p",
+    unified_log("shim", LOG_LEVEL_INFO, "chain dlsym: inject=%p ext_fx_mode=%p process_fx=%p same_frame=%d keep_alive=%p midi_wake=%p",
             (void*)shadow_chain_set_inject_audio,
             (void*)shadow_chain_set_external_fx_mode,
             (void*)shadow_chain_process_fx,
             (shadow_chain_set_external_fx_mode && shadow_chain_process_fx) ? 1 : 0,
-            (void*)shadow_chain_fx_requires_continuous);
+            (void*)shadow_chain_fx_requires_continuous,
+            (void*)shadow_chain_take_midi_tick_wake);
 
     /* Set pages: read persisted page on boot */
     set_page_current = set_page_read_persisted();

--- a/src/host/shadow_chain_mgmt.h
+++ b/src/host/shadow_chain_mgmt.h
@@ -154,6 +154,8 @@ extern void (*shadow_chain_process_fx)(void *instance, int16_t *buf, int frames)
  * silence-skip via capabilities.requires_continuous_processing. NULL when the
  * loaded chain DSP is older than v0.3.12 — caller must null-check. */
 extern int (*shadow_chain_fx_requires_continuous)(void *instance);
+/* Optional one-shot wake after the idle path advances MIDI FX timers. */
+extern int (*shadow_chain_take_midi_tick_wake)(void *instance);
 extern host_api_v1_t shadow_host_api;
 extern int shadow_inprocess_ready;
 

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -758,7 +758,10 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
      * frame: no allocation, no logging, no file I/O on this path.
      */
     if (key && key[0] == 'm' && strcmp(key, "mod:tick") == 0) {
-        lfo_tick(inst, val ? atoi(val) : 128);
+        int frames = val ? atoi(val) : 128;
+        lfo_tick(inst, frames);
+        inst->midi_tick_wake = v2_tick_midi_fx(inst, frames);
+        inst->idle_tick_advanced = 1;
         return;
     }
 
@@ -2066,11 +2069,14 @@ static void v2_render_block(void *instance, int16_t *out_interleaved_lr, int fra
         }
     }
 
-    /* Tick LFOs — emit modulation before audio render */
-    lfo_tick(inst, frames);
-
-    /* Process MIDI FX tick (for arpeggiator timing) */
-    v2_tick_midi_fx(inst, frames);
+    /* A silent-slot mod:tick may already have advanced both timers and woken
+     * this exact block with a generated note. Never advance it twice. */
+    if (inst->idle_tick_advanced) {
+        inst->idle_tick_advanced = 0;
+    } else {
+        lfo_tick(inst, frames);
+        v2_tick_midi_fx(inst, frames);
+    }
 
     /* Always render so synth state advances (envelopes, LFOs, phases).
      * If bypassed, zero the buffer afterward — downstream FX still see
@@ -2203,4 +2209,19 @@ int chain_fx_requires_continuous(void *instance) {
         if (inst->fx_requires_continuous[i]) return 1;
     }
     return 0;
+}
+
+/* Called by the shim immediately after its silent-slot mod:tick. A true result
+ * means a timer-generated MIDI message has already reached the synth, so the
+ * current audio block must render instead of remaining parked. If no message
+ * was generated there will be no render, hence clear the double-tick guard
+ * here ready for the next block. */
+__attribute__((visibility("default")))
+int chain_take_midi_tick_wake(void *instance) {
+    chain_instance_t *inst = (chain_instance_t *)instance;
+    if (!inst) return 0;
+    int wake = inst->midi_tick_wake;
+    inst->midi_tick_wake = 0;
+    if (!wake) inst->idle_tick_advanced = 0;
+    return wake;
 }

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -398,6 +398,12 @@ typedef struct chain_instance {
      * events — not our own injection echoes — affect it. */
     uint8_t pre_pad_held[128];
 
+    /* The shim advances LFO/MIDI timers through "mod:tick" while an idle
+     * synth render is skipped. If a MIDI FX emits, it must wake that same
+     * block; idle_tick_advanced then prevents render_block ticking twice. */
+    int idle_tick_advanced;
+    int midi_tick_wake;
+
     /* Pre-mode inject-only record-align. Clock-driven generator output
      * (Beat Bank etc.) must reach Move's track AFTER the 0xF8 that advances
      * its step, or Move records it one 16th early. We can't delay the note
@@ -597,7 +603,7 @@ CHAIN_INTERNAL int chain_get_clock_status(void);
 CHAIN_INTERNAL int v2_load_midi_fx(chain_instance_t *inst, const char *fx_name);
 CHAIN_INTERNAL int v2_load_midi_fx_slot(chain_instance_t *inst, int slot, const char *fx_name);
 CHAIN_INTERNAL void v2_on_midi(void *instance, const uint8_t *msg, int len, int source);
-CHAIN_INTERNAL void v2_tick_midi_fx(chain_instance_t *inst, int frames);
+CHAIN_INTERNAL int v2_tick_midi_fx(chain_instance_t *inst, int frames);
 CHAIN_INTERNAL void v2_unload_all_midi_fx(chain_instance_t *inst);
 CHAIN_INTERNAL void v2_unload_midi_fx_slot(chain_instance_t *inst, int slot);
 

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -563,8 +563,9 @@ static int v2_run_midi_fx_from(chain_instance_t *inst, int from,
                                scratch, scratch_lens, MIDI_FX_MAX_OUT_MSGS);
 }
 
-void v2_tick_midi_fx(chain_instance_t *inst, int frames) {
-    if (!inst) return;
+int v2_tick_midi_fx(chain_instance_t *inst, int frames) {
+    if (!inst) return 0;
+    int emitted = 0;
 
     for (int fx = 0; fx < inst->midi_fx_count; fx++) {
         if (fx < MAX_MIDI_FX && inst->midi_fx_bypassed[fx]) continue;
@@ -582,6 +583,7 @@ void v2_tick_midi_fx(chain_instance_t *inst, int frames) {
          * ran in parallel off the same input instead of feeding each other.
          * Downstream only (fx + 1), so a stage can never feed itself. */
         count = v2_run_midi_fx_from(inst, fx + 1, out_msgs, out_lens, count);
+        if (count > 0) emitted = 1;
 
         /* Send generated messages to synth */
         for (int i = 0; i < count; i++) {
@@ -644,6 +646,7 @@ void v2_tick_midi_fx(chain_instance_t *inst, int frames) {
             }
         }
     }
+    return emitted;
 }
 
 /* ==========================================================================
@@ -1007,4 +1010,3 @@ void v2_on_midi(void *instance, const uint8_t *msg, int len, int source) {
 }
 
 /* V2 set_param handler */
-

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1943,8 +1943,15 @@ static void shadow_inprocess_render_to_buffer(void) {
                         shadow_plugin_v2->set_param(shadow_chain_slots[s].instance,
                                                     "mod:tick", "128");
                     }
-                    shadow_slot_deferred_valid[s] = 1;
-                    goto slot_run_deferred_fx;
+                    int midi_wake = shadow_chain_take_midi_tick_wake &&
+                        shadow_chain_take_midi_tick_wake(shadow_chain_slots[s].instance);
+                    if (midi_wake) {
+                        shadow_slot_idle[s] = 0;
+                        shadow_slot_silence_frames[s] = 0;
+                    } else {
+                        shadow_slot_deferred_valid[s] = 1;
+                        goto slot_run_deferred_fx;
+                    }
                 }
                 /* Probe frame: fall through to render and check output */
                 probe_burst_this_frame++;

--- a/tests/host/test_chain_host_file_split.sh
+++ b/tests/host/test_chain_host_file_split.sh
@@ -49,13 +49,14 @@ for f in chain_host.c chain_json.c chain_params.c chain_mod.c chain_midi.c chain
 done
 
 # 5. Exported-symbol invariant: dsp.so must export exactly the pre-split set
-#    (5 chain entry points + 6 unified_log fns). Cross-TU internals must be
+#    (6 chain entry points + 6 unified_log fns). Cross-TU internals must be
 #    hidden-visibility so dlopen'd sub-plugins can't collide with them.
 so="build/modules/chain/dsp.so"
 if [ -f "$so" ] && command -v nm >/dev/null 2>&1; then
   got=$(nm -D --defined-only "$so" 2>/dev/null | awk '{print $NF}' | sort)
   want=$(printf '%s\n' \
     chain_fx_requires_continuous chain_process_fx chain_set_external_fx_mode \
+    chain_take_midi_tick_wake \
     chain_set_inject_audio move_plugin_init_v2 \
     unified_log unified_log_crash unified_log_enabled unified_log_init \
     unified_log_shutdown unified_log_v | sort)

--- a/tests/host/test_chain_last_note.sh
+++ b/tests/host/test_chain_last_note.sh
@@ -69,7 +69,7 @@ printf '%s\n' "$BODY" | grep -Eq "malloc|calloc|free\(|fopen|fprintf|unified_log
 called_in() {
   printf '%s\n' "$STRIPPED" \
     | awk -v fn="$1" '
-        $0 ~ ("^(static )?void " fn "\\(") {on=1}
+        $0 ~ ("^(static )?(void|int) " fn "\\(") {on=1}
         on && /chain_record_synth_note\(inst,/ {found=1}
         on && /^}/ {exit}
         END {exit found ? 0 : 1}

--- a/tests/host/test_idle_midi_tick_wake.sh
+++ b/tests/host/test_idle_midi_tick_wake.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+MIDI=src/modules/chain/dsp/chain_midi.c
+HOST=src/modules/chain/dsp/chain_host.c
+SHIM=src/schwung_shim.c
+MGMT=src/host/shadow_chain_mgmt.c
+HDR=src/modules/chain/dsp/chain_internal.h
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+grep -q 'int v2_tick_midi_fx(chain_instance_t \*inst, int frames)' "$MIDI" \
+  || fail "MIDI FX tick does not report whether it emitted"
+grep -q 'if (count > 0) emitted = 1;' "$MIDI" \
+  || fail "generated MIDI does not mark the idle slot for wake-up"
+grep -q 'inst->midi_tick_wake = v2_tick_midi_fx(inst, frames);' "$HOST" \
+  || fail "mod:tick does not capture the MIDI wake result"
+grep -q 'inst->idle_tick_advanced = 1;' "$HOST" \
+  || fail "the idle tick is not guarded against double advancement"
+grep -q 'if (inst->idle_tick_advanced)' "$HOST" \
+  || fail "render_block does not consume the double-tick guard"
+grep -q 'int chain_take_midi_tick_wake(void \*instance)' "$HOST" \
+  || fail "chain DSP exports no one-shot MIDI wake result"
+grep -q 'shadow_chain_take_midi_tick_wake' "$MGMT" \
+  || fail "the shim loader does not resolve the wake export"
+grep -q 'if (midi_wake)' "$SHIM" \
+  || fail "the idle gate does not render a block when MIDI wakes it"
+grep -q 'int midi_tick_wake;' "$HDR" \
+  || fail "the chain instance has no wake state"
+
+echo "PASS: idle MIDI FX timers wake the synth without double ticking"


### PR DESCRIPTION
## Summary

- Advance MIDI FX timers alongside LFOs while a silent synth slot is parked by the idle gate.
- Wake and render the same audio block when a timer-generated MIDI message reaches the synth.
- Prevent the wake-up render from advancing MIDI FX and LFO time twice.
- Expose the one-shot wake result through the chain DSP/shim boundary.

## Why

Time-driven MIDI FX currently stop advancing when their synth slot becomes silent. Pixel Walkers made this visible as frozen physics followed by repeated or rewound animation, but the same path affects any MIDI FX whose tick function must generate the next note while the synth is idle.

## Verification

- make -C tests/host test
- bash tests/host/test_idle_midi_tick_wake.sh
- Exported-symbol contract updated and checked against the ARM build.
- Cross-compiled and tested on Ableton Move; generated notes continue after the synth enters idle, without double ticks or crashes.

Test module: https://github.com/mestela/schwung-pixel-walkers/releases/tag/v0.1.0

## AI assistance

Developed and tested with OpenAI Codex.