### PR TITLE
Let custom pages read hidden canvas state

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2277,6 +2277,18 @@ carrying that level's own knobs:
   "canvas_script": "canvas.js", "as_page": true, "show_value": false }
 ```
 
+If the drawing needs a read-only value that is not one of the level's knobs,
+declare it with `extra_keys`. Those values are added to the page's staggered
+read rotation without becoming visible or turnable cells:
+
+```json
+{ "key": "activity", "name": "Activity", "type": "string",
+  "access": "read", "hidden": true }
+{ "key": "face", "name": "Face", "type": "canvas",
+  "canvas_script": "canvas.js", "as_page": true,
+  "show_value": false, "extra_keys": ["activity"] }
+```
+
 ```javascript
 globalThis.canvas_overlay = {
     drawPage(ctx, { values, base, keys, touched, nowMs, preset }) {
@@ -2298,6 +2310,8 @@ globalThis.canvas_overlay = {
   and you should not draw any of your own.
 - `values` carries live values merged over the base; `base` is the knob
   positions, for a page that wants to show both.
+- `extra_keys` is capped by the same bounded read rotation as other visual
+  dependencies. Use it for compact state snapshots, not high-volume data.
 - **One strike**, as everywhere else: a `drawPage` that throws is retired for
   the session and the body is left empty under a normal page.
 

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1563,6 +1563,12 @@ turned by the encoders, redrawn every tick so it can animate, and wearing the
 host's own header and footer. `preset_browser` goes further and makes it the
 level's browser, so a face per character replaces a row of text.
 
+An authored canvas page can declare `extra_keys` on its canvas parameter.
+They travel as `canvas.extraKeys` and join the controller's bounded value-read
+rotation only while that page is current. They never join `page.keys`, so an
+animation snapshot can reach `drawPage({ values })` without consuming a cell
+or encoder.
+
 **IT IS A PAGE_KNOBS PAGE WITH A DRAWER, NOT A NEW KIND**, and that is the whole
 reason it works. Twenty-two places in `page_controller` branch on PAGE_KNOBS:
 reads, knob turns, touch, the touch strip, announce, dive targets, the list

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -2059,6 +2059,14 @@ export function createController(io = {}) {
          * takes.
          */
         const extraKeys = vizEnabled ? vizExtraKeys() : [];
+        /* A module-drawn page can depend on read-only state that is not one of
+         * its encoder keys (animation snapshots are the motivating case).
+         * Read it on this same bounded rotation; never synchronously in draw. */
+        if (p.canvas && Array.isArray(p.canvas.extraKeys)) {
+            for (const k of p.canvas.extraKeys) {
+                if (k && extraKeys.indexOf(k) < 0) extraKeys.push(k);
+            }
+        }
         /*
          * THE NEIGHBOUR LANE — why the incoming page arrives populated.
          *

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -440,6 +440,14 @@ function canvasPageParams(chainParams) {
             script: typeof p.canvas_script === "string" ? p.canvas_script : "canvas.js",
             overlay: typeof p.canvas_overlay === "string" ? p.canvas_overlay
                    : (typeof p.overlay === "string" ? p.overlay : ""),
+            /* Read-only values the picture needs but which must not become
+             * visible/turnable cells on the level grid. They join the normal
+             * staggered read rotation, never the draw path. */
+            extraKeys: Array.isArray(p.extra_keys)
+                ? p.extra_keys.filter((k) => typeof k === "string" && k)
+                : (Array.isArray(p.extraKeys)
+                    ? p.extraKeys.filter((k) => typeof k === "string" && k)
+                    : []),
             name: p.name || p.short_name || p.key,
         });
     }
@@ -807,7 +815,8 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
                 nameParam: lvl.name_param || "preset_name",
                 ...(browserCanvas ? {
                     canvas: { key: browserCanvas.key, script: browserCanvas.script,
-                              overlay: browserCanvas.overlay },
+                              overlay: browserCanvas.overlay,
+                              extraKeys: browserCanvas.extraKeys },
                     keys: knobKeys(lvl).filter(
                         (k) => !isHiddenParam(lvl, k, isVisible) && !selectorKeys.has(k))
                         .slice(0, perPage === Infinity ? undefined : perPage),
@@ -1068,7 +1077,8 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
                 authored: true,
                 /* What makes it custom. render_page hands the module this and
                  * the body band; everything else about the page is ordinary. */
-                canvas: { key: cp.key, script: cp.script, overlay: cp.overlay },
+                canvas: { key: cp.key, script: cp.script, overlay: cp.overlay,
+                          extraKeys: cp.extraKeys },
             });
         }
 

--- a/tests/host/test_canvas_page.sh
+++ b/tests/host/test_canvas_page.sh
@@ -57,7 +57,7 @@ const CP = [
   { key: "b", name: "B", type: "float", min: 0, max: 1, step: 0.01 },
   { key: "c", name: "C", type: "float", min: 0, max: 1, step: 0.01 },
   { key: "face", name: "Face", type: "canvas", canvas_script: "canvas.js",
-    canvas_overlay: "face_page", as_page: true },
+    canvas_overlay: "face_page", as_page: true, extra_keys: ["activity"] },
 ];
 
 /* ---- planning ---- */
@@ -72,6 +72,8 @@ ok(cp && JSON.stringify(cp.keys) === JSON.stringify(["a", "b", "c"]),
    "it carries the levels own knobs, so the encoders do what they do on the grid");
 ok(cp && cp.canvas.script === "canvas.js" && cp.canvas.overlay === "face_page",
    "the script and overlay travel with the page");
+ok(cp && JSON.stringify(cp.canvas.extraKeys) === JSON.stringify(["activity"]),
+   "read-only canvas dependencies travel with the page without becoming cells");
 
 /* The canvas key must NOT also be a cell anywhere. */
 const celled = plan.pages.some((p) => (p.keys || []).indexOf("face") >= 0);
@@ -117,7 +119,7 @@ ok(plan2.pages.some((p) => (p.keys || []).indexOf("face") >= 0),
 /* ---- the controller reaches it, and knobs still work ---- */
 {
   const store = { ui_hierarchy: JSON.stringify(HIER), chain_params: JSON.stringify(CP),
-                  a: "0.25", b: "0.5", c: "0.75" };
+                  a: "0.25", b: "0.5", c: "0.75", activity: "frame-1" };
   const writes = [];
   let t = 0;
   const ctrl = createController({
@@ -142,9 +144,16 @@ ok(plan2.pages.some((p) => (p.keys || []).indexOf("face") >= 0),
 
   /* Turning knob 0 on the custom page must write the levels first knob. */
   for (let i = 0; i < 10; i++) ctrl.tick();
+  ctrl.render(drawContext(createFramebuffer(128, 64)), {
+    title: "M", footer: null,
+  });
   ctrl.onKnobTurn(0, 1);
   ok(writes.some((w) => w[0] === "a"),
      "an encoder on the custom page writes the levels own param");
+  /* It is fetched only while the custom page is current and never appears in
+   * cp.keys, so it does not consume a knob/cell. */
+  ok(ctrl.state.values.activity === "frame-1",
+     "the canvas extra key is fetched by the staggered value rotation");
 }
 
 /* ---- a thrower is retired, not fatal ---- */


### PR DESCRIPTION
## Summary

- Allow an as_page canvas parameter to declare extra_keys.
- Carry those keys into the custom page plan without turning them into cells or encoder assignments.
- Fetch them through the existing bounded, staggered value rotation only while the custom page is active.
- Document the contract and extend the custom-page controller test.

## Why

Animated module pages sometimes need compact read-only state that is not a user control. Without this, a module must expose an internal Activity-style parameter as a knob merely to get its value into drawPage. Pixel Walkers uses this for an immutable physics snapshot while keeping its six actual controls on Main.

## Verification

- bash tests/host/test_canvas_page.sh
- bash tests/host/test_viz_extra_keys.sh
- Tested on Ableton Move with the Pixel Walkers canvas updating continuously and no internal Activity control visible.

Test module: https://github.com/mestela/schwung-pixel-walkers/releases/tag/v0.1.0

## AI assistance

Developed and tested with OpenAI Codex.