### PR TITLE
claims_ccs: a held button survives the display close, and a failed read claims nothing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -328,7 +328,14 @@ any hand-rolled hardware-mailbox zeroing.
 **Swallowing a button needs BOTH EDGES, latched.** Press-only leaves Move a lone
 button-up for a key it never saw go down, and Move acts on it. The release
 cannot be gated on `shadow_shift_held` either — Shift is usually let go *before*
-the button.
+the button. **Nor on the screen still being up:** `capabilities.claims_ccs`
+withholds a claimed press inside the `shadow_display_mode` block, so dropping
+the latch when the display closes hands Move the orphan release directly — hold
+Copy on a claiming module's grid, dismiss, let go. The latch is a TRI-state
+(`CLAIM_LATCH_HELD` vs `RELEASED`) precisely because it deliberately outlives
+the release, so "non-zero" cannot answer "is a release still owed?"; a held
+button keeps its latch across the close and a drain in the unconditional
+post-ioctl scan swallows what is owed.
 
 `shadow_midi_in_compact()` (`src/host/shadow_midi_filter.c`) closes the gaps and
 runs **last** in `shim_post_transfer` — the blocking sites above it pair `sh[j]`

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -6933,7 +6933,18 @@ static inline void midi_in_swallow(uint8_t *shadow_midi_in, uint8_t *hw_midi_in,
  * receives its RELEASE even if the claim (capabilities.claims_ccs) changes
  * mid-hold. Read by both the Move-firmware filter and the forward-to-shadow_ui
  * site; the filter runs first in the frame, so the forward site sees this
- * frame's decision. Touched only from the SPI callback -- no locking. */
+ * frame's decision. Touched only from the SPI callback -- no locking.
+ *
+ * THREE states, not two, and the third is what makes the display-close edge
+ * safe. Both non-zero values mean "this button's press was claimed" -- which
+ * is all the forward site asks -- but only HELD means the button is still
+ * down. The distinction exists because the latch is deliberately NOT cleared
+ * on release (the forward site runs later in the same frame and must route the
+ * release the way the press went), so "non-zero" outlives the hold and cannot
+ * by itself answer "is a release still owed?". */
+#define CLAIM_LATCH_NONE     0
+#define CLAIM_LATCH_RELEASED 1   /* last press was claimed; button is up */
+#define CLAIM_LATCH_HELD     2   /* claimed press delivered, release still owed */
 static uint8_t claim_press_blocked[128];
 
 /* Controls the host owns and a module may NEVER claim: how you leave the
@@ -7221,15 +7232,26 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
      * exited (or crashed) before reconciling it to 0 would otherwise leave
      * Move's Undo / Copy / Delete captured with nothing left to deliver them
      * to. Same reasoning as the runtime-claim drops on overtake exit above:
-     * this edge covers EVERY exit path. Also disarms the press latch so a
-     * release arriving after the display closed is routed to Move, matching
-     * where its press went. Runs unconditionally -- the filter itself is inside
-     * the shadow_display_mode branch below, so this must not be. */
+     * this edge covers EVERY exit path. Runs unconditionally -- the filter
+     * itself is inside the shadow_display_mode branch below, so this must not
+     * be.
+     *
+     * A BUTTON STILL HELD KEEPS ITS LATCH. Clearing the whole array here
+     * looks like the tidy thing and is a stuck-button bug: that press was
+     * withheld from Move, so releasing the latch hands Move a lone button-up
+     * for a key it never saw go down, and Move acts on it -- Delete being the
+     * member of the trio that acts destructively. Hold Copy on a claiming
+     * module's grid, dismiss the shadow UI, let go: that is the whole repro.
+     * The owed releases are drained below (see the claim-latch drain in the
+     * post-ioctl scan), which is also the only thing that retires a HELD
+     * latch once the filter has stopped running. */
     {
         static int prev_display_mode = 0;
         if (prev_display_mode && !shadow_display_mode) {
             if (shadow_control) memset((void *)shadow_control->claim_cc_bits, 0, sizeof(shadow_control->claim_cc_bits));
-            memset(claim_press_blocked, 0, sizeof(claim_press_blocked));
+            for (int c = 0; c < 128; c++) {
+                if (claim_press_blocked[c] != CLAIM_LATCH_HELD) claim_press_blocked[c] = CLAIM_LATCH_NONE;
+            }
         }
         prev_display_mode = shadow_display_mode;
     }
@@ -7429,9 +7451,18 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
                                  * loop). A press with Shift held is never claimed:
                                  * the module gets the BARE buttons only. */
                                 claim_press_blocked[d1] =
-                                    (claim_cc_set(d1) && !claim_denied_cc(d1) && !shadow_shift_held) ? 1 : 0;
+                                    (claim_cc_set(d1) && !claim_denied_cc(d1) && !shadow_shift_held)
+                                        ? CLAIM_LATCH_HELD : CLAIM_LATCH_NONE;
                             }
                             if (claim_press_blocked[d1]) filter = 1;
+                            /* The hold ends here. Demoted rather than cleared:
+                             * the forward site below still needs a non-zero
+                             * latch this frame to route the release to the
+                             * module, but the button is no longer down, so the
+                             * display-close edge must not keep swallowing it. */
+                            if (d2 == 0 && claim_press_blocked[d1] == CLAIM_LATCH_HELD) {
+                                claim_press_blocked[d1] = CLAIM_LATCH_RELEASED;
+                            }
                             /* Deliberately NOT cleared on release: the latch is
                              * re-armed by the next press, which keeps it valid
                              * for the forward-to-shadow_ui site that runs LATER
@@ -8721,6 +8752,30 @@ static void shim_post_transfer(void *ctx, uint8_t *shadow, const uint8_t *hw, in
 
                 if (forward_to_shadow && shadow_ui_midi_shm) {
                     shadow_ui_midi_publish(0x0B, status, d1, d2);
+                }
+
+                /* CLAIM-LATCH DRAIN. A claimed press withheld from Move while
+                 * the display was up owes Move nothing but silence on its
+                 * release -- and the filter that would have supplied that
+                 * silence lives inside the shadow_display_mode block, which
+                 * has stopped running. So swallow the owed events here, where
+                 * the walk is unconditional, and retire the latch on the
+                 * release that closes the hold.
+                 *
+                 * Gated on HELD, never on "non-zero": the latch survives a
+                 * release on purpose, and swallowing on that would eat the
+                 * button's NEXT press with the display closed and the claim
+                 * long gone.
+                 *
+                 * midi_in_swallow, not a hand-rolled zero of the hardware
+                 * mailbox -- Move reads the shadow buffer, and a zeroed slot
+                 * is a terminator. Sits after the forward above so a shadow_ui
+                 * still alive pairs the release, and before
+                 * shadow_midi_in_compact(), which must stay last. */
+                if (!shadow_display_mode && d1 < 128 &&
+                    claim_press_blocked[d1] == CLAIM_LATCH_HELD) {
+                    midi_in_swallow(shadow + MIDI_IN_OFFSET, src, j);
+                    if (d2 == 0) claim_press_blocked[d1] = CLAIM_LATCH_NONE;
                 }
 
                 /* Mute (CC 88) is passed through to Move firmware unconditionally,

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16449,15 +16449,24 @@ function moduleFileExists(path) {
     }
 }
 
-function getHierarchyActiveModuleId() {
+/* The same lookup, with the tri-state INTACT: null = the read did not complete.
+ * getHierarchyActiveModuleId below is the `|| ""` view of it, which is what
+ * every caller that only wants a name should use. reconcileCcClaim wants the
+ * third answer, because "the read failed" and "there is no module" lead to
+ * opposite decisions there. */
+function hierarchyActiveModuleIdRaw() {
     if (hierEditorSlot < 0 || !hierEditorComponent) return "";
     if (hierEditorIsMasterFx) {
-        return getSlotParam(0, `${hierEditorComponent}:module`) || "";
+        return getSlotParam(0, `${hierEditorComponent}:module`);
     }
 
     const prefix = getComponentParamPrefix(hierEditorComponent);
     if (!prefix) return "";
-    return getSlotParam(hierEditorSlot, `${prefix}_module`) || "";
+    return getSlotParam(hierEditorSlot, `${prefix}_module`);
+}
+
+function getHierarchyActiveModuleId() {
+    return hierarchyActiveModuleIdRaw() || "";
 }
 
 /* Module id whose in-grid widgets are currently registered. "" = none. */
@@ -16701,7 +16710,15 @@ function moduleClaimedCcs(moduleId) {
         if (typeof host_get_module_metadata === "function") {
             meta = host_get_module_metadata(moduleId);
         }
-    } catch (e) { meta = null; }
+    } catch (e) {
+        /* The read threw -- that is news about the CHANNEL, not about the
+         * module. Answer "no claim" for this tick and leave the cache empty so
+         * the next reconcile asks again; caching it would make one bad read
+         * permanent for the session. A metadata object that simply declares no
+         * capability is a real answer and IS cached below. */
+        debugLog(`claims_ccs: metadata read for ${moduleId} failed (${e}) -- not cached`);
+        return "";
+    }
     const caps = (meta && meta.capabilities) || {};
     const want = new Set();
     if (caps.claims_edit_ccs) for (const cc of EDIT_CCS) want.add(cc);
@@ -16739,14 +16756,31 @@ function reconcileCcClaim() {
         ? (view + "|" + coRunView + "|" + slot + "|" + comp)
         : "";
     if (key === ccClaimKey) return;
-    ccClaimKey = key;
+    /* THE READ COMES FIRST, AND null IS NOT AN ANSWER.
+     *
+     * getSlotParam is the tri-state: null means the read did not complete (the
+     * claim was refused, or the response timed out), "" means served-but-empty.
+     * Collapsing them with `|| ""` reads as "this component has no module", so
+     * the claim is dropped -- and latching ccClaimKey before the read made that
+     * verdict permanent for the whole visit to the screen, with Delete going
+     * back to Move. That is the failure the capability exists to prevent.
+     *
+     * So the key is latched only once an answer is in hand; a failed read
+     * leaves it alone and the next tick asks again. */
     let moduleId = "";
     if (onScreen && onGrid) {
         const prefix = getComponentParamPrefix(comp);
-        moduleId = prefix ? (getSlotParam(slot, `${prefix}_module`) || "") : "";
+        if (prefix) {
+            const raw = getSlotParam(slot, `${prefix}_module`);
+            if (raw === null || raw === undefined) return;   /* retry next tick */
+            moduleId = raw;
+        }
     } else if (onScreen) {
-        moduleId = getHierarchyActiveModuleId();
+        const raw = hierarchyActiveModuleIdRaw();
+        if (raw === null || raw === undefined) return;       /* retry next tick */
+        moduleId = raw;
     }
+    ccClaimKey = key;
     const claim = onScreen ? moduleClaimedCcs(moduleId) : "";
     if (claim === ccClaimed) return;
     ccClaimed = claim;

--- a/tests/host/test_claims_ccs.sh
+++ b/tests/host/test_claims_ccs.sh
@@ -50,7 +50,15 @@ command grep -q 'claim_press_blocked\[d1\] =' "$shim" \
   || fail "the per-button press latch is gone from the firmware filter"
 command grep -A1 'claim_press_blocked\[d1\] =' "$shim" | command grep -q 'claim_cc_set(d1)' \
   || fail "the press latch is not derived from the claim bitmap -- that is #154 again"
-if command grep -B2 -A2 'claim_press_blocked\[d1\] =' "$shim" | command grep -q 'shadow_display_mode'; then
+# Scoped to the firmware-filter block rather than to a +-2 line window around
+# the assignment: the drain added later legitimately reads shadow_display_mode,
+# and a window pin cannot tell the two sites apart (it also matched `==` on the
+# `[d1] =` prefix, so it failed on a correct tree).
+press_block=$(sed -n '/A CLAIMED button: withheld from Move firmware ONLY while/,/Filter Menu unless long-press mode/p' "$shim")
+[ -n "$press_block" ] || fail "the firmware-filter claim block is gone"
+echo "$press_block" | command grep -q 'claim_press_blocked\[d1\] =' \
+  || fail "the firmware-filter claim block no longer sets the press latch"
+if echo "$press_block" | command grep -q 'shadow_display_mode'; then
   fail "the claim site tests the display, not the claim -- the #175 revert exists because of exactly this"
 fi
 echo "  ok  the firmware filter withholds a button only under the runtime claim"
@@ -96,6 +104,65 @@ command grep -q 'CC_CLAIM_VIEWS\[VIEWS.PARAM_PAGES\] = true' "$ui_js" \
 command grep -B3 'memset((void \*)shadow_control->claim_cc_bits, 0' "$shim" | command grep -q 'prev_display_mode && !shadow_display_mode' \
   || fail "the shim does not drop the claims when the shadow display closes -- a crashed shadow_ui strands Move's buttons"
 echo "  ok  claims are reconciled from metadata in one place and dropped by the shim on display close"
+
+# ---- 6. a HELD button keeps its latch across the display close ---------------
+# Clearing the whole latch array on that edge hands Move a lone button-up for a
+# key it never saw go down -- the shape that deleted a clip once already.
+close_edge=$(sed -n '/prev_display_mode && !shadow_display_mode/,/prev_display_mode = shadow_display_mode;/p' "$shim")
+[ -n "$close_edge" ] || fail "the display-close edge is gone"
+if echo "$close_edge" | command grep -q 'memset(claim_press_blocked'; then
+  fail "the display-close edge blanket-clears the press latch -- a button held across it hands Move an orphan release"
+fi
+echo "$close_edge" | command grep -q 'CLAIM_LATCH_HELD' \
+  || fail "the display-close edge does not spare the buttons still HELD"
+echo "  ok  a button held across the display close keeps its latch"
+
+# ---- 7. ...and the owed release is drained, not leaked ------------------------
+drain=$(sed -n '/CLAIM-LATCH DRAIN/,/^                }$/p' "$shim")
+[ -n "$drain" ] || fail "the claim-latch drain is gone -- a HELD latch kept past the display close is never retired"
+echo "$drain" | command grep -q 'claim_press_blocked\[d1\] == CLAIM_LATCH_HELD' \
+  || fail "the drain is not gated on HELD -- gated on non-zero it eats the button's NEXT press"
+echo "$drain" | command grep -q 'midi_in_swallow(shadow + MIDI_IN_OFFSET, src, j)' \
+  || fail "the drain does not use midi_in_swallow -- Move reads the SHADOW buffer, and a zeroed hw slot is a terminator"
+echo "$drain" | command grep -q 'if (d2 == 0) claim_press_blocked\[d1\] = CLAIM_LATCH_NONE;' \
+  || fail "the drain never retires the latch, so the button stays swallowed forever"
+# It must run BEFORE compaction, which is required to be last.
+drain_line=$(command grep -n 'CLAIM-LATCH DRAIN' "$shim" | head -1 | cut -d: -f1)
+compact_line=$(command grep -n 'shadow_midi_in_compact(global_mmap_addr' "$shim" | head -1 | cut -d: -f1)
+[ -n "$drain_line" ] && [ -n "$compact_line" ] && [ "$drain_line" -lt "$compact_line" ] \
+  || fail "the drain runs after shadow_midi_in_compact() -- nothing may zero a slot once the gaps are closed"
+echo "  ok  the owed release is swallowed in both buffers and the latch retired"
+
+# ---- 8. a FAILED module-id read plans nothing and latches nothing -------------
+# null from getSlotParam is "the read did not complete", not "no module here".
+# Collapsed with || "" it reads as "nothing claims anything" -- and latching the
+# key before the read made that verdict stick for the whole visit, with Delete
+# going back to Move.
+rec=$(sed -n '/^function reconcileCcClaim()/,/^}/p' "$ui_js")
+[ -n "$rec" ] || fail "reconcileCcClaim is gone"
+if echo "$rec" | command grep -q '_module`) || ""'; then
+  fail "reconcileCcClaim collapses a failed module-id read into \"\" -- a timed-out read then reads as \"no claim\""
+fi
+# BOTH branches, counted. reconcileCcClaim reads a module id two ways -- the
+# grid's own slot/component, and the list editor's -- and guarding one of them
+# is indistinguishable from guarding both unless the count is the assertion.
+raws=$(echo "$rec" | command grep -c 'const raw = ' || true)
+guards=$(echo "$rec" | command grep -c 'raw === null || raw === undefined) return;' || true)
+[ "$raws" -eq 2 ] || fail "reconcileCcClaim no longer makes exactly 2 raw module-id reads (found $raws) -- update the guard count with them"
+[ "$guards" -eq "$raws" ] \
+  || fail "$((raws - guards)) of $raws raw module-id reads in reconcileCcClaim are unguarded -- an unguarded one turns a timed-out read into \"no claim\""
+key_line=$(echo "$rec" | command grep -n 'ccClaimKey = key;' | head -1 | cut -d: -f1)
+raw_line=$(echo "$rec" | command grep -n 'raw === null' | head -1 | cut -d: -f1)
+[ -n "$key_line" ] && [ -n "$raw_line" ] && [ "$raw_line" -lt "$key_line" ] \
+  || fail "ccClaimKey is latched BEFORE the read -- a failed read is then never retried for this screen"
+echo "$rec" | command grep -q 'hierarchyActiveModuleIdRaw()' \
+  || fail "the hierarchy branch reads through the || \"\" helper, which has already thrown the third answer away"
+command grep -q 'function hierarchyActiveModuleIdRaw' "$ui_js" \
+  || fail "hierarchyActiveModuleIdRaw is gone"
+mcc=$(sed -n '/^function moduleClaimedCcs(/,/^}/p' "$ui_js")
+echo "$mcc" | command grep -q 'not cached' \
+  || fail "a THROWN metadata read is cached -- one bad read then answers \"no claim\" for the rest of the session"
+echo "  ok  a read that did not answer produces no claim, no cache entry and no latch"
 
 # ---- docs say what the code does ---------------------------------------------
 command grep -q '| `claims_ccs` |' "$docs" || fail "docs/MODULES.md capability table has no claims_ccs row"


### PR DESCRIPTION
## In short

Two follow-up fixes to #425, one on each side of the SHM. Both re-broke a rule this repo already had written down.

## The shim: an orphan release

The display-close edge memset the whole press latch, with a comment saying that routed a late release *"to Move, matching where its press went"*. Its press went to the **module** — it was withheld from Move by the filter. So Move got a button-up for a key it never saw go down: the shape `CLAUDE.md` records under *Swallowing a button needs BOTH EDGES, latched*, the one that deleted a clip.

Repro: hold Copy on a claiming module's grid, dismiss the shadow UI, let go. Delete is the destructive member of the trio.

Keeping the latch is not enough by itself. The latch **deliberately outlives the release** — the forward-to-shadow_ui site runs later in the same frame and must route the release the way the press went — so "non-zero" cannot answer *is a release still owed?*, and a latch kept on that basis would eat the button's NEXT press with the claim long gone. Hence three states: `HELD` is spared at the close, `RELEASED` is not, and a drain in the unconditional post-ioctl scan swallows what is owed and retires the latch. It uses `midi_in_swallow` (both buffers — a zeroed hw slot is a terminator), sits after the forward, and before `shadow_midi_in_compact()`, which stays last.

## The JS: a failed read that claimed nothing, permanently

`reconcileCcClaim` latched `ccClaimKey` **before** reading the module id, then collapsed the read with `|| ""`. `null` is the third answer — the read did not complete. Collapsed, it reads as "no module here", so no claim is written; and the latch made that verdict permanent for the whole visit to the screen, with Delete going back to Move. Exactly the failure the capability exists to prevent, and exactly *A param read has THREE answers*.

The key is now latched only once an answer is in hand; a failed read retries next tick. `hierarchyActiveModuleIdRaw()` is the null-preserving lookup, with `getHierarchyActiveModuleId()` as its `|| ""` view for every caller that only wants a name. A metadata read that **threw** is no longer cached either — one bad read answered "no claim" for the rest of the session.

## Tests

Five new pins in `test_claims_ccs.sh`, each mutation-checked: the blanket clear, the drain's `HELD` gate, its use of `midi_in_swallow`, its position before compaction, **both** raw reads guarded (counted — guarding one of two is otherwise invisible), and the thrown-read cache.

The inherited "gated on the claim, not the display" pin is scoped to the filter block rather than a ±2 line window: that window also matched `==` on the `[d1] =` prefix, so it failed on a correct tree once the drain existed.

Full `tests/host` suite green (shell + `make test`); ARM cross-compile clean. Not yet hardware-verified.

## Not in scope

`docs/MODULES.md` still describes the knob-grid Copy/Delete gesture in the present tense; that gesture is #429, which is open. Left alone deliberately — editing it would conflict with the PR that makes it true.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmPQneXbyDpwQ6tv2cicbS