### PR TITLE
chain: an idle-slot wake follows DELIVERY to the synth, not emission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,21 @@ jobs:
           file build/link-subscriber | grep -q 'aarch64' || \
             { echo "WRONG ARCH"; file build/link-subscriber; exit 1; }
           echo "ok"
+      - name: Install ripgrep
+        # test_chain_host_file_split.sh uses rg. host-tests installs it in its
+        # own job; this one runs the same script on the runner, not in the
+        # builder container, so it needs its own copy.
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Chain dsp.so exported-symbol invariant
+        # test_chain_host_file_split.sh step 5 asserts dsp.so exports exactly
+        # the chain entry points plus the unified_log set — cross-TU internals
+        # must stay hidden or a dlopen'd sub-plugin can collide with them. That
+        # check is gated on `[ -f build/modules/chain/dsp.so ]`, and the
+        # host-tests job never builds one, so the invariant has been SKIPPING
+        # in CI since it was written: the ABI it guards was only ever checked
+        # by whoever happened to have a local ARM build. This job has the .so.
+        # GNU nm reads aarch64 ELF fine on the runner.
+        run: bash tests/host/test_chain_host_file_split.sh
       - name: Verify packaged tarball
         run: |
           test -f schwung.tar.gz

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,6 +502,18 @@ layout, and the shape-edit verbs. Read it before touching `modules/chain/dsp/`.
   slot. It reports a NOTE, not a voice index — the canonical voice order lives
   in `voices.mjs` and a C copy of it would fail silently as "the grid follows
   the wrong pad".
+- **A MIDI FX `tick()` runs on IDLE frames too, and what wakes the slot is
+  DELIVERY, not emission.** The shim skips `render_block` on a silent slot
+  (one frame in 172), which used to freeze every time-driven MIDI FX with it —
+  the generator stopped, then replayed. `mod:tick` now runs the MIDI FX tick
+  beside the LFOs, and a message that reaches the synth un-parks that same
+  block. Waking on "a MIDI FX emitted" instead would switch the idle gate off
+  permanently for a slot with **no synth** (Pre mode driving Move's own
+  instrument): silent by construction, so idle forever, so woken on every
+  generating frame to render nothing. The handshake is order-dependent —
+  tick, then ONE `chain_take_midi_tick_wake`, then the render — because `take`
+  is one-shot and a "no" is what clears the double-tick guard. Transitions in
+  `chain_idle_tick.h` so `tests/host` can drive them.
 
 ### The knob grid / param pages — `docs/PARAM_PAGES.md`
 

--- a/docs/CHAIN.md
+++ b/docs/CHAIN.md
@@ -109,10 +109,27 @@ in the slot, and the grid follows a pad nobody played. The same split already
 bit the MIDI trace, for the same reason.
 
 `tick()` also continues while an otherwise silent chain slot is parked by the
-audio idle gate. If it emits MIDI, that same block wakes and renders so the
-generated note reaches the synth immediately. The idle tick is marked as
-already advanced, preventing the wake-up render from advancing MIDI FX or LFO
-time a second time.
+audio idle gate: the shim's `mod:tick` runs it alongside the LFOs, so a
+time-driven MIDI FX keeps generating with no audio render behind it. If it
+**delivers a message to the synth**, that same block wakes and renders, so the
+generated note is heard now rather than on the next idle probe up to ~0.5 s
+later. The tick is marked as already advanced, so the wake-up render does not
+advance MIDI FX or LFO time a second time.
+
+Delivery, not emission, is the trigger — and the distinction is not academic.
+A slot carrying MIDI FX with **no synth loaded** (Pre mode, driving Move's own
+track instrument) is silent by construction and therefore permanently idle, so
+waking it on "a MIDI FX emitted" would un-park it on every generating frame to
+render a synth that is not there: the idle gate switched off for exactly the
+slot that can never need it.
+
+The handshake is three calls and it is order-dependent — `mod:tick`, then one
+`chain_take_midi_tick_wake`, then the render. `take` is one-shot and clears the
+double-tick guard when the answer is no, because in that case no render is
+coming to consume it; ask twice and the second answer erases the first. The
+transitions are pure and live in `chain_idle_tick.h` so `tests/host` can drive
+them (`test_chain_idle_tick.c`); the wiring is pinned by
+`test_idle_midi_tick_wake.sh`.
 
 Note-offs are ignored: a released pad is still the pad you are editing. The
 record is an int store on the SPI callback and nothing else — no allocation, no

--- a/src/host/shadow_chain_mgmt.h
+++ b/src/host/shadow_chain_mgmt.h
@@ -154,7 +154,12 @@ extern void (*shadow_chain_process_fx)(void *instance, int16_t *buf, int frames)
  * silence-skip via capabilities.requires_continuous_processing. NULL when the
  * loaded chain DSP is older than v0.3.12 — caller must null-check. */
 extern int (*shadow_chain_fx_requires_continuous)(void *instance);
-/* Optional one-shot wake after the idle path advances MIDI FX timers. */
+/* Optional: one-shot, asked EXACTLY ONCE per silent frame and immediately
+ * after the "mod:tick" that advances the timers. Returns 1 if a MIDI FX
+ * delivered a generated message to the synth, meaning this block must render
+ * rather than stay parked. Asking twice loses the wake, and asking before the
+ * tick answers about the previous frame. NULL when the loaded chain DSP is
+ * older than v1.2.1 — caller must null-check. */
 extern int (*shadow_chain_take_midi_tick_wake)(void *instance);
 extern host_api_v1_t shadow_host_api;
 extern int shadow_inprocess_ready;

--- a/src/modules/chain/dsp/chain_host.c
+++ b/src/modules/chain/dsp/chain_host.c
@@ -753,15 +753,21 @@ static void v2_set_param(void *instance, const char *key, const char *val) {
      * against the current header, and appending to it would have the host read
      * past the end of theirs. A string key costs one strcmp.
      *
+     * It also runs the MIDI FX tick, so a time-driven FX keeps generating
+     * while its synth is parked, and reports back whether anything reached
+     * the synth — the shim renders this same block if so (chain_idle_tick.h).
+     *
      * FIRST statement in the function, before the debug log and every other
      * route, because this is called from the SPI callback on every silent
-     * frame: no allocation, no logging, no file I/O on this path.
+     * frame. Nothing on OUR side of it allocates, logs or touches a file. It
+     * does call into third-party MIDI FX tick() and, when the MIDI trace is
+     * armed, chain_midi_trace() — the same code render_block has always run
+     * here, now also on the frames render_block skips.
      */
     if (key && key[0] == 'm' && strcmp(key, "mod:tick") == 0) {
         int frames = val ? atoi(val) : 128;
         lfo_tick(inst, frames);
-        inst->midi_tick_wake = v2_tick_midi_fx(inst, frames);
-        inst->idle_tick_advanced = 1;
+        chain_idle_tick_mark(&inst->idle_tick, v2_tick_midi_fx(inst, frames));
         return;
     }
 
@@ -2071,9 +2077,7 @@ static void v2_render_block(void *instance, int16_t *out_interleaved_lr, int fra
 
     /* A silent-slot mod:tick may already have advanced both timers and woken
      * this exact block with a generated note. Never advance it twice. */
-    if (inst->idle_tick_advanced) {
-        inst->idle_tick_advanced = 0;
-    } else {
+    if (chain_idle_tick_consume(&inst->idle_tick)) {
         lfo_tick(inst, frames);
         v2_tick_midi_fx(inst, frames);
     }
@@ -2213,15 +2217,11 @@ int chain_fx_requires_continuous(void *instance) {
 
 /* Called by the shim immediately after its silent-slot mod:tick. A true result
  * means a timer-generated MIDI message has already reached the synth, so the
- * current audio block must render instead of remaining parked. If no message
- * was generated there will be no render, hence clear the double-tick guard
- * here ready for the next block. */
+ * current audio block must render instead of remaining parked. One-shot; see
+ * chain_idle_tick.h for why a "no" clears the double-tick guard here. */
 __attribute__((visibility("default")))
 int chain_take_midi_tick_wake(void *instance) {
     chain_instance_t *inst = (chain_instance_t *)instance;
     if (!inst) return 0;
-    int wake = inst->midi_tick_wake;
-    inst->midi_tick_wake = 0;
-    if (!wake) inst->idle_tick_advanced = 0;
-    return wake;
+    return chain_idle_tick_take(&inst->idle_tick);
 }

--- a/src/modules/chain/dsp/chain_idle_tick.h
+++ b/src/modules/chain/dsp/chain_idle_tick.h
@@ -1,0 +1,64 @@
+/* The idle-tick handshake between the shim's idle gate and the chain host.
+ *
+ * Extracted from chain_host.c so the transitions are unit-testable host-side
+ * without the full chain host. No side effects, no allocation — this runs on
+ * the SPI callback.
+ *
+ * The shim skips render_block on a silent slot (one probe frame in 172, see
+ * schwung_shim.c) and calls "mod:tick" instead, so LFO and MIDI FX timers keep
+ * advancing. If a MIDI FX emits a message to the synth on such a frame, that
+ * same block must render — otherwise the note reaches a slot that will not be
+ * heard until the next probe, up to half a second later. Three facts have to
+ * survive between the two calls the shim makes:
+ *
+ *   mark()    mod:tick advanced both timers this frame, and whether a MIDI FX
+ *             delivered anything to the synth.
+ *   take()    the shim asks, once, whether to un-park the slot. A one-shot: if
+ *             the answer is no there will be no render, so the double-tick
+ *             guard is cleared here rather than left standing for whichever
+ *             frame renders next.
+ *   consume() render_block asks whether it still owes a tick. After a wake the
+ *             answer is no — mod:tick already did it, and ticking twice is a
+ *             doubled LFO rate and a doubled arp.
+ *
+ * take() is what makes the pair self-clearing, so a shim that never calls it
+ * (an older build with no dlsym for the export) costs at most one skipped tick
+ * on the next render rather than leaving the guard latched forever.
+ */
+#ifndef CHAIN_IDLE_TICK_H
+#define CHAIN_IDLE_TICK_H
+
+typedef struct chain_idle_tick {
+    int advanced;  /* mod:tick ran this frame; render_block must not re-tick */
+    int wake;      /* a MIDI FX delivered to the synth; render this block */
+} chain_idle_tick_t;
+
+/* Record that the idle path advanced the timers. `delivered` is non-zero only
+ * when a generated message actually reached the synth — a MIDI FX emitting
+ * into a slot with no synth loaded has nothing to wake. */
+static inline void chain_idle_tick_mark(chain_idle_tick_t *st, int delivered) {
+    if (!st) return;
+    st->wake = delivered ? 1 : 0;
+    st->advanced = 1;
+}
+
+/* One-shot read of the wake result. Clears the double-tick guard when the
+ * answer is no, because no render will come to consume it. */
+static inline int chain_idle_tick_take(chain_idle_tick_t *st) {
+    if (!st) return 0;
+    int wake = st->wake;
+    st->wake = 0;
+    if (!wake) st->advanced = 0;
+    return wake;
+}
+
+/* Returns 1 if render_block still owes a tick, 0 if the idle path already ran
+ * it. Consumes the guard either way. */
+static inline int chain_idle_tick_consume(chain_idle_tick_t *st) {
+    if (!st) return 1;
+    if (!st->advanced) return 1;
+    st->advanced = 0;
+    return 0;
+}
+
+#endif /* CHAIN_IDLE_TICK_H */

--- a/src/modules/chain/dsp/chain_internal.h
+++ b/src/modules/chain/dsp/chain_internal.h
@@ -25,6 +25,8 @@
 #include <pwd.h>
 #include <malloc.h>
 
+#include "chain_idle_tick.h"
+
 /* Sentinel for "channel field not present in patch file".
  * Distinguishes genuine absence from the legal 0 values used by
  * receive_channel (0=All) and forward_channel (0=ch 1 internal). */
@@ -399,10 +401,11 @@ typedef struct chain_instance {
     uint8_t pre_pad_held[128];
 
     /* The shim advances LFO/MIDI timers through "mod:tick" while an idle
-     * synth render is skipped. If a MIDI FX emits, it must wake that same
-     * block; idle_tick_advanced then prevents render_block ticking twice. */
-    int idle_tick_advanced;
-    int midi_tick_wake;
+     * synth render is skipped. If a MIDI FX delivers to the synth, it must
+     * wake that same block without render_block ticking a second time. The
+     * transitions are pure and live in chain_idle_tick.h so tests/host can
+     * run them; this is only where the state is kept. */
+    chain_idle_tick_t idle_tick;
 
     /* Pre-mode inject-only record-align. Clock-driven generator output
      * (Beat Bank etc.) must reach Move's track AFTER the 0xF8 that advances

--- a/src/modules/chain/dsp/chain_midi.c
+++ b/src/modules/chain/dsp/chain_midi.c
@@ -563,9 +563,16 @@ static int v2_run_midi_fx_from(chain_instance_t *inst, int from,
                                scratch, scratch_lens, MIDI_FX_MAX_OUT_MSGS);
 }
 
+/* Returns 1 if a generated message was DELIVERED to the synth this tick —
+ * the shim's idle gate uses it to un-park a silent slot for this same block.
+ * Deliberately not "a MIDI FX emitted": a slot carrying MIDI FX with no synth
+ * loaded (Pre mode driving Move's native instrument) is silent by
+ * construction, so counting its output would wake it on every emitting frame
+ * to render a synth that isn't there — the idle gate switched off for exactly
+ * the slot that can never need it. */
 int v2_tick_midi_fx(chain_instance_t *inst, int frames) {
     if (!inst) return 0;
-    int emitted = 0;
+    int delivered = 0;
 
     for (int fx = 0; fx < inst->midi_fx_count; fx++) {
         if (fx < MAX_MIDI_FX && inst->midi_fx_bypassed[fx]) continue;
@@ -583,7 +590,6 @@ int v2_tick_midi_fx(chain_instance_t *inst, int frames) {
          * ran in parallel off the same input instead of feeding each other.
          * Downstream only (fx + 1), so a stage can never feed itself. */
         count = v2_run_midi_fx_from(inst, fx + 1, out_msgs, out_lens, count);
-        if (count > 0) emitted = 1;
 
         /* Send generated messages to synth */
         for (int i = 0; i < count; i++) {
@@ -596,6 +602,7 @@ int v2_tick_midi_fx(chain_instance_t *inst, int frames) {
                     chain_midi_trace(inst, "  ~> synth(tick)", out_msgs[i], out_lens[i], -1, 0);
                 chain_record_synth_note(inst, out_msgs[i], out_lens[i]);
                 inst->synth_plugin_v2->on_midi(inst->synth_instance, out_msgs[i], out_lens[i], 0);
+                delivered = 1;
             }
         }
 
@@ -646,7 +653,7 @@ int v2_tick_midi_fx(chain_instance_t *inst, int frames) {
             }
         }
     }
-    return emitted;
+    return delivered;
 }
 
 /* ==========================================================================

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -1969,16 +1969,23 @@ static void shadow_inprocess_render_to_buffer(void) {
                     }
                     int midi_wake = shadow_chain_take_midi_tick_wake &&
                         shadow_chain_take_midi_tick_wake(shadow_chain_slots[s].instance);
-                    if (midi_wake) {
-                        shadow_slot_idle[s] = 0;
-                        shadow_slot_silence_frames[s] = 0;
-                    } else {
+                    if (!midi_wake) {
                         shadow_slot_deferred_valid[s] = 1;
                         goto slot_run_deferred_fx;
                     }
+                    /* A MIDI FX delivered a generated message to the synth on
+                     * this frame, so render it here rather than leaving it
+                     * parked until the next probe (up to ~0.5s away). NOT
+                     * counted as a probe below: probe_burst_this_frame is the
+                     * stagger-alignment detector, and a MIDI-driven wake is
+                     * not a probe — counting it reports a spike the stagger
+                     * cannot fix. */
+                    shadow_slot_idle[s] = 0;
+                    shadow_slot_silence_frames[s] = 0;
+                } else {
+                    /* Probe frame: fall through to render and check output */
+                    probe_burst_this_frame++;
                 }
-                /* Probe frame: fall through to render and check output */
-                probe_burst_this_frame++;
             }
 
             if (same_frame_fx) {

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -56,7 +56,8 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_perf_snapshot_size \
 	$(BUILD_DIR)/test_relative_cc \
 	$(BUILD_DIR)/test_link_audio_backlog_trim \
-	$(BUILD_DIR)/test_boot_select_core
+	$(BUILD_DIR)/test_boot_select_core \
+	$(BUILD_DIR)/test_chain_idle_tick
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
 # the routing test covers whatever range Master FX actually runs with. Raising
@@ -148,6 +149,11 @@ $(BUILD_DIR)/test_master_fx_slot_routing: test_master_fx_slot_routing.c ../../sr
 
 $(BUILD_DIR)/test_boot_select_core: test_boot_select_core.c ../../src/host/boot_select_core.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $(filter %.c,$^) -o $@ $(LDFLAGS)
+
+# Same as relative_cc above: chain_idle_tick.h lives with the chain DSP and is
+# standalone by construction (no chain_internal.h).
+$(BUILD_DIR)/test_chain_idle_tick: test_chain_idle_tick.c ../../src/modules/chain/dsp/chain_idle_tick.h | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(DEPFLAGS) -I../../src/modules/chain/dsp $< -o $@ $(LDFLAGS)
 
 test: $(TARGETS)
 	@for t in $(TARGETS); do \

--- a/tests/host/test_chain_idle_tick.c
+++ b/tests/host/test_chain_idle_tick.c
@@ -1,0 +1,81 @@
+/*
+ * The idle-tick handshake between the shim's idle gate and the chain host.
+ *
+ * The interesting failure is not a compile error, it is a LEAK: if the
+ * `advanced` guard is ever left standing after a frame that does not render,
+ * the next render silently skips one LFO and MIDI FX tick — forever, with no
+ * symptom anyone can attribute. The original change was pinned by a shell
+ * script grepping for nine exact source lines, which cannot see that at all.
+ * The transitions live in a header so this can drive them.
+ */
+#include <assert.h>
+#include <stdio.h>
+#include "chain_idle_tick.h"
+
+/* One idle, non-probe frame: the shim ticks, then asks once whether to wake. */
+static int idle_frame(chain_idle_tick_t *st, int delivered) {
+    chain_idle_tick_mark(st, delivered);
+    return chain_idle_tick_take(st);
+}
+
+int main(void) {
+    chain_idle_tick_t st = {0, 0};
+
+    /* ---- a rendering frame owes its own tick ---------------------------- */
+    assert(chain_idle_tick_consume(&st) == 1);
+    assert(chain_idle_tick_consume(&st) == 1);   /* and stays that way */
+
+    /* ---- idle frame, nothing delivered: no wake, no residue -------------
+     * There will be no render to consume the guard, so take() must clear it.
+     * Left standing, the NEXT render (a probe frame, or a note-on) would skip
+     * its tick — the doubled-arp bug's mirror image, and much harder to see. */
+    assert(idle_frame(&st, 0) == 0);
+    assert(st.advanced == 0);
+    assert(st.wake == 0);
+    assert(chain_idle_tick_consume(&st) == 1);   /* probe frame still ticks */
+
+    /* ---- idle frame, delivered: wake, and the render must NOT re-tick ---- */
+    assert(idle_frame(&st, 1) == 1);
+    assert(st.advanced == 1);                    /* survives take() */
+    assert(chain_idle_tick_consume(&st) == 0);   /* mod:tick already did it */
+    assert(st.advanced == 0);
+    assert(chain_idle_tick_consume(&st) == 1);   /* one block only */
+
+    /* ---- take() is ONE-SHOT ---------------------------------------------
+     * The shim asks once per frame. A second ask must not wake a second
+     * block, or a single generated note holds the slot out of idle. */
+    chain_idle_tick_mark(&st, 1);
+    assert(chain_idle_tick_take(&st) == 1);
+    assert(chain_idle_tick_take(&st) == 0);
+    /* …and the repeat ask, seeing no wake, clears the guard the first ask
+     * left for the render. That is a real ordering constraint on the shim:
+     * take() exactly once, before render_block. */
+    assert(st.advanced == 0);
+
+    /* ---- a shim too old to dlsym the export -----------------------------
+     * chain_take_midi_tick_wake is NULL-checked at the call site, so mark()
+     * can run with no take() at all. The cost must be bounded at one skipped
+     * tick on the next render, never a latched guard. */
+    st.advanced = 0; st.wake = 0;
+    chain_idle_tick_mark(&st, 1);
+    chain_idle_tick_mark(&st, 1);
+    chain_idle_tick_mark(&st, 0);
+    assert(chain_idle_tick_consume(&st) == 0);   /* the one skipped tick */
+    assert(chain_idle_tick_consume(&st) == 1);   /* recovered */
+
+    /* ---- mark() overwrites, never accumulates ---------------------------
+     * A delivered frame followed by an empty one must not stay woken. */
+    chain_idle_tick_mark(&st, 1);
+    chain_idle_tick_mark(&st, 0);
+    assert(chain_idle_tick_take(&st) == 0);
+
+    /* ---- NULL instance ---------------------------------------------------
+     * consume() answers 1: a caller with no state owes its tick, because
+     * skipping is the outcome that freezes an LFO. */
+    assert(chain_idle_tick_consume(NULL) == 1);
+    assert(chain_idle_tick_take(NULL) == 0);
+    chain_idle_tick_mark(NULL, 1);
+
+    printf("PASS: chain idle-tick handshake\n");
+    return 0;
+}

--- a/tests/host/test_idle_midi_tick_wake.sh
+++ b/tests/host/test_idle_midi_tick_wake.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# The WIRING of the idle-tick wake. The transitions themselves are driven by
+# tests/host/test_chain_idle_tick.c against chain_idle_tick.h — this pins only
+# what a unit test cannot see: that the three call sites exist, in the right
+# files, and in the one order the handshake depends on.
+#
+# It deliberately does NOT grep for the body of the state machine. The first
+# version of this file pinned nine exact source lines, which broke on any
+# reformat and proved nothing about behaviour.
 set -euo pipefail
 
 cd "$(dirname "$0")/../.."
@@ -6,28 +14,59 @@ cd "$(dirname "$0")/../.."
 MIDI=src/modules/chain/dsp/chain_midi.c
 HOST=src/modules/chain/dsp/chain_host.c
 SHIM=src/schwung_shim.c
-MGMT=src/host/shadow_chain_mgmt.c
-HDR=src/modules/chain/dsp/chain_internal.h
+HDR=src/modules/chain/dsp/chain_idle_tick.h
 
 fail() { echo "FAIL: $1"; exit 1; }
 
+[ -f "$HDR" ] || fail "the idle-tick transitions are not in a header tests/host can run"
+
+# 1. The tick reports delivery, and reports it from INSIDE the synth-delivery
+#    guard. A MIDI FX slot with no synth is silent by construction, so waking
+#    on "a message was emitted" switches the idle gate off for the one slot
+#    that can never need it.
 grep -q 'int v2_tick_midi_fx(chain_instance_t \*inst, int frames)' "$MIDI" \
-  || fail "MIDI FX tick does not report whether it emitted"
-grep -q 'if (count > 0) emitted = 1;' "$MIDI" \
-  || fail "generated MIDI does not mark the idle slot for wake-up"
-grep -q 'inst->midi_tick_wake = v2_tick_midi_fx(inst, frames);' "$HOST" \
-  || fail "mod:tick does not capture the MIDI wake result"
-grep -q 'inst->idle_tick_advanced = 1;' "$HOST" \
-  || fail "the idle tick is not guarded against double advancement"
-grep -q 'if (inst->idle_tick_advanced)' "$HOST" \
+  || fail "MIDI FX tick does not report whether it delivered"
+awk '
+  /^int v2_tick_midi_fx/ {fn=1}
+  fn && /synth_plugin_v2->on_midi\(inst->synth_instance/ {guard=1}
+  fn && guard && /delivered = 1;/ {found=1}
+  fn && /^}/ {exit}
+  END {exit found ? 0 : 1}
+' "$MIDI" || fail "the wake flag is not set inside the synth-delivery guard"
+
+# 2. mod:tick marks, and does so with the tick result — not unconditionally.
+grep -q 'chain_idle_tick_mark(&inst->idle_tick, v2_tick_midi_fx(' "$HOST" \
+  || fail "mod:tick does not record the MIDI tick result"
+
+# 3. render_block asks before ticking, so a woken block never ticks twice.
+grep -q 'if (chain_idle_tick_consume(&inst->idle_tick))' "$HOST" \
   || fail "render_block does not consume the double-tick guard"
+
+# 4. The export the shim resolves by dlsym.
 grep -q 'int chain_take_midi_tick_wake(void \*instance)' "$HOST" \
   || fail "chain DSP exports no one-shot MIDI wake result"
-grep -q 'shadow_chain_take_midi_tick_wake' "$MGMT" \
+grep -q 'chain_take_midi_tick_wake' src/host/shadow_chain_mgmt.c \
   || fail "the shim loader does not resolve the wake export"
-grep -q 'if (midi_wake)' "$SHIM" \
-  || fail "the idle gate does not render a block when MIDI wakes it"
-grep -q 'int midi_tick_wake;' "$HDR" \
-  || fail "the chain instance has no wake state"
+
+# 5. ORDER, in the shim: mod:tick, THEN take, THEN the idle bail-out. take() is
+#    one-shot and clears the guard when the answer is no, so asking before the
+#    tick, or twice, silently loses the wake.
+awk '
+  /"mod:tick"/ {tick=NR}
+  tick && /shadow_chain_take_midi_tick_wake\(shadow_chain_slots/ {take=NR}
+  take && /goto slot_run_deferred_fx;/ {bail=NR; exit}
+  END {exit (tick && take && bail && tick < take && take < bail) ? 0 : 1}
+' "$SHIM" || fail "the shim does not tick, then take, then bail — in that order"
+
+# 6. A MIDI wake is not a probe. probe_burst_this_frame is the stagger-
+#    alignment detector, so the increment must sit in the ELSE arm (the real
+#    probe frame). On the wake path it reports a spike the stagger cannot fix.
+awk '
+  /shadow_chain_take_midi_tick_wake\(shadow_chain_slots/ {take=1; next}
+  take && !els && /probe_burst_this_frame\+\+/ {bad=1; exit}
+  take && !els && /^                \} else \{/ {els=1; next}
+  els && /probe_burst_this_frame\+\+/ {inc=1; exit}
+  END {exit (!bad && els && inc) ? 0 : 1}
+' "$SHIM" || fail "a MIDI-driven wake is counted as an idle probe"
 
 echo "PASS: idle MIDI FX timers wake the synth without double ticking"


### PR DESCRIPTION
Follow-up to #432 (merged as 4c874ad4). The design there is right — I traced every path of the `advanced`/`wake` pair and found no leak — these are the four things the review turned up.

## 1. The wake condition was too broad (the actual bug)

`v2_tick_midi_fx` set its return from `count > 0`, **outside** the loop that delivers to the synth. A slot carrying MIDI FX with **no synth loaded** — Pre mode, driving Move's own track instrument — is silent by construction and therefore permanently idle, so it was un-parked on every generating frame to render a synth that is not there: the idle gate switched off for exactly the slot that can never need it. Note-offs and CCs also woke a silent synth that cannot make sound from either.

The flag now sets inside the delivery guard, where it means what its name says. I deliberately did **not** narrow further to note-on-only, which would preserve the gate against a CC-spewing MIDI FX: the miss case (a synth whose sound is triggered by a CC or program change) is a half-second of dead slot that is very hard to attribute, and this codebase has a long history of clever gates that silently swallow things. Never-misses wins over the small CPU saving.

## 2. A MIDI wake was counted as an idle probe

`probe_burst_this_frame++` sits after the inner branch, so the wake path fell through it. `spi_slot_probe_burst_max` is the probe-*stagger* alignment detector; a MIDI-driven wake inflating it reports a spike the stagger cannot fix. Moved into the else arm that is the actual probe frame.

(Left alone deliberately: resetting `silence_frames` on a wake re-aligns the `(frames + s*43) % 172` stagger. The existing fade-wake does the same, so it is the house pattern.)

## 3. The pin could not see the failure it exists for

The transitions move to `chain_idle_tick.h` — the `chain_pre_inject.h` / `recall_quantize.h` pattern — and are driven by `tests/host/test_chain_idle_tick.c`.

The interesting failure is not a compile error, it is a **leak**: an `advanced` guard left standing after a frame that does not render makes the *next* render silently skip one LFO and MIDI FX tick, forever, with no symptom to attribute it to. The original `test_idle_midi_tick_wake.sh` grepped for nine exact source lines, which breaks on any reformat and cannot see that at all. Both mutations of the handshake (`take` not clearing on "no", `consume` not clearing) now abort the unit.

`test_idle_midi_tick_wake.sh` keeps only what a unit cannot see: that the three call sites exist, and that the shim ticks → takes → bails **in that order**, because `take` is one-shot and asking early or twice loses the wake. Both probe-accounting mutations fail it.

## 4. The ABI pin #432 updated does not run in CI

`test_chain_host_file_split.sh` step 5 asserts dsp.so's exported-symbol surface, and #432 correctly added `chain_take_midi_tick_wake` to it — but the check is gated on `[ -f build/modules/chain/dsp.so ]` and the `host-tests` job never builds one. It has been **skipping in CI since it was written**; the ABI was only ever checked by whoever happened to have a local ARM build.

It now runs in `cross-compile`, which has the real .so. Verified that x86 GNU nm reads the aarch64 object and the test passes against it (plain `ubuntu:24.04` + binutils, against this branch's ARM build).

## Verification

- `make -C tests/host test` + all `tests/host/*.sh` — green
- ARM cross-compile (`./scripts/build.sh`) — green
- Mutation checks: 2/2 handshake mutations abort the unit, 2/2 probe-accounting mutations fail the wiring test
- Symbol invariant run against the real aarch64 dsp.so under x86 Linux binutils — passes
- **Not yet on hardware.** #432 was verified on-device; the behaviour change here is the no-synth slot and the diagnostic, neither of which #432's Pixel Walkers repro exercises.

Docs: `docs/CHAIN.md` gains the delivery-vs-emission rule and the ordering contract; `CLAUDE.md` gains the hook bullet the release checklist asks for; `shadow_chain_mgmt.h` names the version the export is NULL before, as its neighbour does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFzFmChozNt32J6t6d9Apw