### PR TITLE
schwung-heal: install a standalone tool's staged helper (#419, with follow-ups)

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -120,12 +120,22 @@ service to pause. They cannot reuse `schwung-heal`: its paths are compile-time
 constants on purpose. Instead a tool stages **its own** helper and lets
 `schwung-heal` install it:
 
-- stage the helper at `modules/tools/<id>/bin/heal.new` (a regular file, not a
-  symlink; `<id>` limited to `[A-Za-z0-9_.-]`);
+- stage the helper at `modules/tools/<id>/bin/heal.new` (a regular file;
+  `<id>` limited to `[A-Za-z0-9_.-]` and never leading-dot);
 - run `/data/UserData/schwung/bin/schwung-heal` (it is setuid; the tool may run
   it as `ableton`);
 - heal installs the stage beside itself as `bin/heal`, root-owned `04755`, and
   removes the stage — exactly the way it installs its own `schwung-heal.new`.
+
+`<id>`, `bin/` and the stage itself are ableton-writable names, so heal resolves
+every one of them with `O_NOFOLLOW` and copies through descriptors: **a symlink
+at any component is refused, not followed.** Nothing here may be a symlink, and
+the stage must be a regular file — a directory or a FIFO is ignored with a
+message rather than blocking heal, which runs at every boot.
+
+A tool's failure is reported but never changes heal's exit code, because that
+code gates `--reboot` and the reboot belongs to heal's own mirror. A broken
+stage cannot turn a repair into "shim mirrored, device never rebooted".
 
 The trust model is unchanged: `ableton` can already stage `schwung-heal.new`
 itself, so a staged helper adds convenience, not capability, and a device with

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -98,6 +98,7 @@ for keys anywhere in `module.json`).
 | `suspend_keeps_js` | Tool/overtake modules: pressing Back suspends the UI but the DSP keeps ticking; full exit requires Shift+Back. Useful for sequencers that should keep playing while you browse Move. |
 | `component_type` | Module category: `sound_generator`, `audio_fx`, `midi_fx`, `utility`, `system`, `featured`, `overtake`, or `tool` |
 | `forks_processes` | Module creates child **processes** (not threads) to do its DSP, as JE-8086 does. See below. |
+| `standalone` | A **tool** that is a whole program: selecting it runs `<module dir>/standalone` through `launch-standalone.sh`, which restarts Move when the program exits. See below. |
 
 > **Where these are read.** `src/host/module_manager.c` (used by the
 > standalone host runtime) currently parses only `claims_master_knob`,
@@ -105,6 +106,31 @@ for keys anywhere in `module.json`).
 > shim and shadow UI code paths that actually run on device — search
 > for the flag name in `src/schwung_shim.c`, `src/shadow/shadow_ui.{c,js}`,
 > and `src/modules/chain/dsp/chain_host.c` to find the consumer.
+
+### `standalone` tools, and a privileged helper of their own
+
+A tool with `"standalone": true` carries an executable named `standalone` in its
+module directory; the Tools menu runs it via `launch-standalone.sh` and Move is
+restarted when it exits. Everything such a tool installs lives under its own
+`modules/tools/<id>/` — ableton-owned, like every module.
+
+Some standalone tools need one privileged step of their own — a shim of their own
+that must reach `/usr/lib` setuid for glibc's AT_SECURE `LD_PRELOAD` check, or a
+service to pause. They cannot reuse `schwung-heal`: its paths are compile-time
+constants on purpose. Instead a tool stages **its own** helper and lets
+`schwung-heal` install it:
+
+- stage the helper at `modules/tools/<id>/bin/heal.new` (a regular file, not a
+  symlink; `<id>` limited to `[A-Za-z0-9_.-]`);
+- run `/data/UserData/schwung/bin/schwung-heal` (it is setuid; the tool may run
+  it as `ableton`);
+- heal installs the stage beside itself as `bin/heal`, root-owned `04755`, and
+  removes the stage — exactly the way it installs its own `schwung-heal.new`.
+
+The trust model is unchanged: `ableton` can already stage `schwung-heal.new`
+itself, so a staged helper adds convenience, not capability, and a device with
+nothing staged never enters the path. Heal's own duties (the shim and entrypoint
+mirror) run on the same invocation, idempotently.
 
 ### `forks_processes`
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -826,7 +826,9 @@ fi
 # and entrypoint to /usr/lib + /opt/move). Needed because everything from
 # MoveLauncher down runs as ableton; this is the only way ableton-context
 # code (entrypoint, schwung-manager) can refresh the live shim.
-if needs_rebuild build/bin/schwung-heal src/schwung-heal.c; then
+# Header dep is tracked too: heal_tool_id.h carries the tool-id filter, and
+# without it here an edit to the header leaves a stale binary on the device.
+if needs_rebuild build/bin/schwung-heal src/schwung-heal.c src/host/heal_tool_id.h; then
     echo "Building schwung-heal..."
     "${CROSS_PREFIX}gcc" -g -O2 -static \
         src/schwung-heal.c \

--- a/src/host/heal_tool_id.h
+++ b/src/host/heal_tool_id.h
@@ -1,0 +1,32 @@
+/*
+ * heal_tool_id.h — which directory names schwung-heal will treat as a tool id.
+ *
+ * Split out from schwung-heal.c so tests/host can run the predicate. The
+ * binary itself calls setuid(0) at startup and refuses to run unprivileged,
+ * so this policy is only testable while it lives apart from the binary.
+ *
+ * The names come from a directory scan of
+ * /data/UserData/schwung/modules/tools — never from argv — and are used to
+ * resolve a root-owned 04755 install, so the filter is deliberately narrow:
+ * [A-Za-z0-9_.-], and never a leading dot, which excludes "." and ".." along
+ * with hidden directories. Everything else is skipped silently.
+ *
+ * The filter is a first cut, not the safety property: schwung-heal resolves
+ * every component of the path with O_NOFOLLOW and operates on descriptors, so
+ * a name that gets past this cannot steer a write out of the tool's own
+ * directory. See install_one_tool_helper() in src/schwung-heal.c.
+ */
+#ifndef HEAL_TOOL_ID_H
+#define HEAL_TOOL_ID_H
+
+static inline int heal_tool_id_is_safe(const char *id) {
+    if (!id || id[0] == '\0' || id[0] == '.') return 0;
+    for (const char *c = id; *c; c++) {
+        if (!((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z') ||
+              (*c >= '0' && *c <= '9') || *c == '_' || *c == '-' || *c == '.'))
+            return 0;
+    }
+    return 1;
+}
+
+#endif /* HEAL_TOOL_ID_H */

--- a/src/schwung-heal.c
+++ b/src/schwung-heal.c
@@ -35,8 +35,21 @@
  * here as root-owned 04755 before doing its other work. Hardcoded path only,
  * so the audit story holds: ableton already controls /data and we already
  * mirror /data's shim to /usr/lib setuid-root.
+ *
+ * Standalone tools: a tool module that relaunches Move under its own build
+ * ("standalone": true) needs a privileged helper of its own for the same
+ * reason we do — its shim has to reach /usr/lib setuid. Rather than grow
+ * this binary a flag per tool, the tool stages its helper at the hardcoded
+ * pattern /data/UserData/schwung/modules/tools/<id>/bin/heal.new and this
+ * heal installs it beside the stage as bin/heal, root-owned 04755, exactly
+ * like its own self-update. Same trust as schwung-heal.new: ableton can
+ * already stage anything at that path. <id> is the directory name, taken
+ * from a directory scan (never argv) and limited to [A-Za-z0-9_.-].
+ * Nothing is installed unless a tool has staged something; stock devices
+ * never hit this path.
  */
 
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
@@ -162,6 +175,52 @@ static int needs_copy(const char *src, const char *dst) {
     return contents_differ(src, dst);             /* same size → verify bytes */
 }
 
+/* Install every staged standalone-tool helper (see the file header). One
+ * failure does not stop the others; returns nonzero if any failed. */
+static int install_tool_helpers(void) {
+    static const char *tools_dir = "/data/UserData/schwung/modules/tools";
+    DIR *d = opendir(tools_dir);
+    if (!d) return 0;                              /* no tools dir → nothing to do */
+
+    int rc = 0;
+    struct dirent *e;
+    while ((e = readdir(d)) != NULL) {
+        const char *id = e->d_name;
+        if (id[0] == '.') continue;
+        int ok = 1;
+        for (const char *c = id; *c; c++) {
+            if (!((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z') ||
+                  (*c >= '0' && *c <= '9') || *c == '_' || *c == '-' || *c == '.')) {
+                ok = 0;
+                break;
+            }
+        }
+        if (!ok) continue;
+
+        char staged[512], dst[512];
+        int n1 = snprintf(staged, sizeof(staged), "%s/%s/bin/heal.new", tools_dir, id);
+        int n2 = snprintf(dst, sizeof(dst), "%s/%s/bin/heal", tools_dir, id);
+        if (n1 < 0 || (size_t)n1 >= sizeof(staged) ||
+            n2 < 0 || (size_t)n2 >= sizeof(dst)) continue;
+
+        struct stat st;
+        if (lstat(staged, &st) < 0) continue;      /* nothing staged for this tool */
+        if (!S_ISREG(st.st_mode)) {                /* a symlink or dir is not a stage */
+            fprintf(stderr, "schwung-heal: %s: not a regular file, ignored\n", staged);
+            continue;
+        }
+
+        if (copy_atomic(staged, dst, 04755) == 0) {
+            unlink(staged);
+            fprintf(stderr, "schwung-heal: installed tool helper %s\n", dst);
+        } else {
+            rc = 2;
+        }
+    }
+    closedir(d);
+    return rc;
+}
+
 int main(int argc, char **argv) {
     /* Setuid bit on the binary should give us euid=0; some kernels also
      * keep ruid=ableton. Force ruid=0 too so child processes (rename,
@@ -213,6 +272,9 @@ int main(int argc, char **argv) {
             }
         }
     }
+
+    /* Standalone tools' staged helpers (see the file header). */
+    if (install_tool_helpers() != 0) rc = 2;
 
     /* Shim — perms 04755 (-rwsr-xr-x). The setuid bit on the .so is
      * required for glibc 2.35+ AT_SECURE on devices where MoveOriginal

--- a/src/schwung-heal.c
+++ b/src/schwung-heal.c
@@ -44,9 +44,15 @@
  * heal installs it beside the stage as bin/heal, root-owned 04755, exactly
  * like its own self-update. Same trust as schwung-heal.new: ableton can
  * already stage anything at that path. <id> is the directory name, taken
- * from a directory scan (never argv) and limited to [A-Za-z0-9_.-].
- * Nothing is installed unless a tool has staged something; stock devices
- * never hit this path.
+ * from a directory scan (never argv) and limited to [A-Za-z0-9_.-] by
+ * heal_tool_id_is_safe() in host/heal_tool_id.h. Nothing is installed
+ * unless a tool has staged something; stock devices never hit this path.
+ *
+ * That path is the one place this binary works on names it did not compile
+ * in, so it resolves every component with O_NOFOLLOW and copies through
+ * descriptors — see install_one_tool_helper(). And a tool's failure there is
+ * reported but never folded into the exit code, because the exit code gates
+ * --reboot and that reboot belongs to the mirrors below.
  */
 
 #include <dirent.h>
@@ -59,6 +65,34 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include "host/heal_tool_id.h"
+
+/* Stream sfd -> dfd. Returns 0 on success, -1 on error (message printed).
+ * Closes nothing and unlinks nothing: the caller owns both descriptors and
+ * whatever cleanup its own failure path needs. The labels are for messages
+ * only, so a descriptor-based caller can name a path it never opened by name. */
+static int copy_body(int sfd, int dfd, const char *src_label, const char *dst_label) {
+    char buf[65536];
+    ssize_t r;
+    while ((r = read(sfd, buf, sizeof(buf))) > 0) {
+        ssize_t off = 0;
+        while (off < r) {
+            ssize_t w = write(dfd, buf + off, r - off);
+            if (w < 0) {
+                if (errno == EINTR) continue;
+                fprintf(stderr, "schwung-heal: write %s: %s\n", dst_label, strerror(errno));
+                return -1;
+            }
+            off += w;
+        }
+    }
+    if (r < 0) {
+        fprintf(stderr, "schwung-heal: read %s: %s\n", src_label, strerror(errno));
+        return -1;
+    }
+    return 0;
+}
 
 static int copy_atomic(const char *src, const char *dst, mode_t perms) {
     int sfd = open(src, O_RDONLY);
@@ -90,23 +124,7 @@ static int copy_atomic(const char *src, const char *dst, mode_t perms) {
         return -1;
     }
 
-    char buf[65536];
-    ssize_t r;
-    while ((r = read(sfd, buf, sizeof(buf))) > 0) {
-        ssize_t off = 0;
-        while (off < r) {
-            ssize_t w = write(dfd, buf + off, r - off);
-            if (w < 0) {
-                if (errno == EINTR) continue;
-                fprintf(stderr, "schwung-heal: write %s: %s\n", tmp, strerror(errno));
-                close(sfd); close(dfd); unlink(tmp);
-                return -1;
-            }
-            off += w;
-        }
-    }
-    if (r < 0) {
-        fprintf(stderr, "schwung-heal: read %s: %s\n", src, strerror(errno));
+    if (copy_body(sfd, dfd, src, tmp) < 0) {
         close(sfd); close(dfd); unlink(tmp);
         return -1;
     }
@@ -175,50 +193,110 @@ static int needs_copy(const char *src, const char *dst) {
     return contents_differ(src, dst);             /* same size → verify bytes */
 }
 
-/* Install every staged standalone-tool helper (see the file header). One
- * failure does not stop the others; returns nonzero if any failed. */
-static int install_tool_helpers(void) {
-    static const char *tools_dir = "/data/UserData/schwung/modules/tools";
-    DIR *d = opendir(tools_dir);
-    if (!d) return 0;                              /* no tools dir → nothing to do */
+/* Install one tool's staged helper, working entirely through a descriptor for
+ * that tool's bin/ directory.
+ *
+ * Every open here is O_NOFOLLOW and every subsequent operation is *at()-
+ * relative, because unlike the mirrors above NONE of this path is hardcoded:
+ * <id> and bin/ are ableton-writable directory names. A path-based copy would
+ * follow a symlink planted at any component and steer a root-owned 04755 write
+ * anywhere on the filesystem, and an lstat-then-open check would still lose the
+ * race between the two calls. Resolving once and then working from the
+ * descriptor closes both. (This is not an escalation under the threat model in
+ * the file header — ableton can already stage schwung-heal.new — but the audit
+ * story for this binary is "it can only ever do what is hardcoded", and a
+ * directory scan is where that stops being true for free.)
+ *
+ * O_NONBLOCK on the stage matters: without it a FIFO left at heal.new would
+ * block the open forever, and shim-entrypoint.sh runs heal at every boot
+ * before the LD_PRELOAD exec. The fstat below rejects it a moment later.
+ *
+ * Returns 0 on success or when nothing is staged, -1 on failure. */
+static int install_one_tool_helper(int tools_fd, const char *id) {
+    int idfd = openat(tools_fd, id, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    if (idfd < 0) return 0;                    /* not a real directory -> skip */
+    int bfd = openat(idfd, "bin", O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+    close(idfd);
+    if (bfd < 0) return 0;                     /* no bin/ -> nothing staged */
+
+    int sfd = openat(bfd, "heal.new", O_RDONLY | O_NOFOLLOW | O_NONBLOCK);
+    if (sfd < 0) {
+        if (errno == ELOOP)                    /* a symlink is not a stage */
+            fprintf(stderr, "schwung-heal: %s/bin/heal.new: symlink, ignored\n", id);
+        close(bfd);
+        return 0;                              /* usually: nothing staged */
+    }
+
+    struct stat sst;
+    if (fstat(sfd, &sst) < 0 || !S_ISREG(sst.st_mode)) {
+        fprintf(stderr, "schwung-heal: %s/bin/heal.new: not a regular file, ignored\n", id);
+        close(sfd); close(bfd);
+        return 0;
+    }
+
+    /* Fresh tmp beside the stage: drop any leftover from a killed run, then
+     * O_EXCL so we can never write through something planted in between. */
+    unlinkat(bfd, "heal.heal-tmp", 0);
+    int dfd = openat(bfd, "heal.heal-tmp",
+                     O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0600);
+    if (dfd < 0) {
+        fprintf(stderr, "schwung-heal: open %s/bin/heal.heal-tmp: %s\n",
+                id, strerror(errno));
+        close(sfd); close(bfd);
+        return -1;
+    }
 
     int rc = 0;
+    if (copy_body(sfd, dfd, "tool heal.new", "tool heal.heal-tmp") < 0) rc = -1;
+    close(sfd);
+
+    /* fchmod AFTER the write and never fchown after it — Linux clears the suid
+     * bit on chown. setuid(0)/setgid(0) at startup already made this root:root. */
+    if (rc == 0 && fchmod(dfd, 04755) < 0) {
+        fprintf(stderr, "schwung-heal: fchmod %s/bin/heal.heal-tmp: %s\n",
+                id, strerror(errno));
+        rc = -1;
+    }
+    if (rc == 0) { if (fsync(dfd) < 0) { /* non-fatal; rename is the durability point */ } }
+    if (close(dfd) < 0 && rc == 0) {
+        fprintf(stderr, "schwung-heal: close %s/bin/heal.heal-tmp: %s\n",
+                id, strerror(errno));
+        rc = -1;
+    }
+
+    if (rc == 0 && renameat(bfd, "heal.heal-tmp", bfd, "heal") < 0) {
+        fprintf(stderr, "schwung-heal: rename %s/bin/heal: %s\n", id, strerror(errno));
+        rc = -1;
+    }
+
+    if (rc != 0) {
+        unlinkat(bfd, "heal.heal-tmp", 0);
+    } else {
+        unlinkat(bfd, "heal.new", 0);
+        fprintf(stderr, "schwung-heal: installed tool helper %s/bin/heal\n", id);
+    }
+    close(bfd);
+    return rc;
+}
+
+/* Install every staged standalone-tool helper (see the file header). One
+ * failure does not stop the others; returns how many failed. A device with
+ * nothing staged never opens anything past the tools directory itself. */
+static int install_tool_helpers(void) {
+    static const char *tools_dir = "/data/UserData/schwung/modules/tools";
+    int tools_fd = open(tools_dir, O_RDONLY | O_DIRECTORY);
+    if (tools_fd < 0) return 0;                /* no tools dir -> nothing to do */
+    DIR *d = fdopendir(tools_fd);
+    if (!d) { close(tools_fd); return 0; }
+
+    int failures = 0;
     struct dirent *e;
     while ((e = readdir(d)) != NULL) {
-        const char *id = e->d_name;
-        if (id[0] == '.') continue;
-        int ok = 1;
-        for (const char *c = id; *c; c++) {
-            if (!((*c >= 'a' && *c <= 'z') || (*c >= 'A' && *c <= 'Z') ||
-                  (*c >= '0' && *c <= '9') || *c == '_' || *c == '-' || *c == '.')) {
-                ok = 0;
-                break;
-            }
-        }
-        if (!ok) continue;
-
-        char staged[512], dst[512];
-        int n1 = snprintf(staged, sizeof(staged), "%s/%s/bin/heal.new", tools_dir, id);
-        int n2 = snprintf(dst, sizeof(dst), "%s/%s/bin/heal", tools_dir, id);
-        if (n1 < 0 || (size_t)n1 >= sizeof(staged) ||
-            n2 < 0 || (size_t)n2 >= sizeof(dst)) continue;
-
-        struct stat st;
-        if (lstat(staged, &st) < 0) continue;      /* nothing staged for this tool */
-        if (!S_ISREG(st.st_mode)) {                /* a symlink or dir is not a stage */
-            fprintf(stderr, "schwung-heal: %s: not a regular file, ignored\n", staged);
-            continue;
-        }
-
-        if (copy_atomic(staged, dst, 04755) == 0) {
-            unlink(staged);
-            fprintf(stderr, "schwung-heal: installed tool helper %s\n", dst);
-        } else {
-            rc = 2;
-        }
+        if (!heal_tool_id_is_safe(e->d_name)) continue;
+        if (install_one_tool_helper(tools_fd, e->d_name) != 0) failures++;
     }
-    closedir(d);
-    return rc;
+    closedir(d);                               /* also closes tools_fd */
+    return failures;
 }
 
 int main(int argc, char **argv) {
@@ -273,8 +351,18 @@ int main(int argc, char **argv) {
         }
     }
 
-    /* Standalone tools' staged helpers (see the file header). */
-    if (install_tool_helpers() != 0) rc = 2;
+    /* Standalone tools' staged helpers (see the file header). A tool's failure
+     * is reported but deliberately does NOT feed `rc`: rc gates --reboot, and
+     * that reboot exists for OUR mirror (post-update.sh, the manager's
+     * /system/repair). A third-party tool leaving an unreadable stage must not
+     * be able to turn a repair into "shim mirrored, device never rebooted" —
+     * the silent, self-concealing shape that flow was built to avoid. */
+    {
+        int helper_failures = install_tool_helpers();
+        if (helper_failures > 0)
+            fprintf(stderr, "schwung-heal: %d tool helper(s) failed to install\n",
+                    helper_failures);
+    }
 
     /* Shim — perms 04755 (-rwsr-xr-x). The setuid bit on the .so is
      * required for glibc 2.35+ AT_SECURE on devices where MoveOriginal

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -57,7 +57,8 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_relative_cc \
 	$(BUILD_DIR)/test_link_audio_backlog_trim \
 	$(BUILD_DIR)/test_boot_select_core \
-	$(BUILD_DIR)/test_chain_idle_tick
+	$(BUILD_DIR)/test_chain_idle_tick \
+	$(BUILD_DIR)/test_heal_tool_id
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
 # the routing test covers whatever range Master FX actually runs with. Raising
@@ -108,6 +109,12 @@ $(BUILD_DIR)/test_spi_tally: test_spi_tally.c ../../src/host/spi_tally.c | $(BUI
 # Header-only unit: link_audio_in_trim_pos lives in link_audio.h, so the
 # DEPFLAGS header tracking above is what keeps this honest when it changes.
 $(BUILD_DIR)/test_link_audio_backlog_trim: test_link_audio_backlog_trim.c | $(BUILD_DIR)
+	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $(filter %.c,$^) -o $@ $(LDFLAGS)
+
+# Header-only unit: heal_tool_id_is_safe lives in heal_tool_id.h. schwung-heal
+# itself cannot be exercised here (it setuid(0)s and bails when not root), so
+# the filter is only testable as long as it stays out of the binary.
+$(BUILD_DIR)/test_heal_tool_id: test_heal_tool_id.c | $(BUILD_DIR)
 	$(CC) $(CFLAGS) $(DEPFLAGS) $(INCLUDES) $(filter %.c,$^) -o $@ $(LDFLAGS)
 
 $(BUILD_DIR)/test_align_capture: test_align_capture.c ../../src/host/align_capture.c | $(BUILD_DIR)

--- a/tests/host/test_heal_tool_helper_invariants.sh
+++ b/tests/host/test_heal_tool_helper_invariants.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Source invariants for schwung-heal's standalone-tool helper install.
+#
+# This is a setuid-root binary that cannot be exercised here (it setuid(0)s and
+# bails when it is not root), and the two properties below are structural
+# rather than computational, so a unit cannot reach them:
+#
+#   1. A tool's failure must not feed the exit code, because the exit code
+#      gates --reboot and that reboot belongs to OUR shim/entrypoint mirror.
+#      Folding them together lets a third-party tool's bad stage turn a
+#      /system/repair into "shim mirrored, device never rebooted".
+#
+#   2. The tool path is the one place this binary works on names it did not
+#      compile in — <id> and bin/ are ableton-writable — so every component is
+#      resolved O_NOFOLLOW and every write goes through a descriptor. A
+#      path-based copy would follow a planted symlink and steer a root-owned
+#      04755 write anywhere on the filesystem.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="$ROOT/src/schwung-heal.c"
+HDR="$ROOT/src/host/heal_tool_id.h"
+fail=0
+
+note() { echo "  ok:  $1"; }
+bad()  { echo "  FAIL: $1"; fail=1; }
+
+[ -f "$SRC" ] || { echo "missing $SRC"; exit 1; }
+[ -f "$HDR" ] || { echo "missing $HDR"; exit 1; }
+
+# --- 1. the reboot gate -----------------------------------------------------
+# Any line that calls install_tool_helpers and also mentions rc is the
+# regression: `if (install_tool_helpers() != 0) rc = 2;` and friends.
+if grep -n 'install_tool_helpers' "$SRC" | grep -q '\brc\b'; then
+    bad "install_tool_helpers() result feeds rc — that gates --reboot"
+else
+    note "a tool helper failure does not feed rc (so it cannot suppress --reboot)"
+fi
+
+if grep -q 'helper_failures' "$SRC"; then
+    note "helper failures are counted and reported separately"
+else
+    bad "expected a separate helper failure count that is reported, not returned"
+fi
+
+# The gate itself must still exist for our own mirrors.
+if grep -q 'do_reboot && rc == 0' "$SRC"; then
+    note "--reboot is still gated on rc for the shim/entrypoint mirror"
+else
+    bad "the do_reboot/rc gate moved — re-check what can now suppress a reboot"
+fi
+
+# --- 2. symlink-proof resolution -------------------------------------------
+helper="$(awk '/^static int install_one_tool_helper/,/^}/' "$SRC")"
+[ -n "$helper" ] || { echo "  FAIL: install_one_tool_helper not found"; exit 1; }
+
+nofollow_opens=$(printf '%s\n' "$helper" | grep -c 'O_NOFOLLOW')
+if [ "$nofollow_opens" -ge 4 ]; then
+    note "every component is opened O_NOFOLLOW ($nofollow_opens opens)"
+else
+    bad "expected >=4 O_NOFOLLOW opens (<id>, bin, the stage, the tmp), found $nofollow_opens"
+fi
+
+for want in 'openat' 'renameat' 'unlinkat' 'O_EXCL' 'O_DIRECTORY' 'O_NONBLOCK' 'fchmod'; do
+    if printf '%s\n' "$helper" | grep -q "$want"; then
+        note "uses $want"
+    else
+        bad "install_one_tool_helper no longer uses $want"
+    fi
+done
+
+# A path-based rename/unlink inside the helper means a component is being
+# re-resolved by name, which is exactly what the descriptors are avoiding.
+if printf '%s\n' "$helper" | grep -Eq '[^a-z_](rename|unlink)[[:space:]]*\('; then
+    bad "path-based rename()/unlink() in the helper — use renameat/unlinkat"
+else
+    note "no path-based rename()/unlink() re-resolves a component by name"
+fi
+
+# O_NONBLOCK is what keeps a FIFO left at heal.new from wedging boot:
+# shim-entrypoint.sh runs heal before the LD_PRELOAD exec.
+if printf '%s\n' "$helper" | grep -q 'S_ISREG'; then
+    note "the stage is still required to be a regular file"
+else
+    bad "the S_ISREG check on the stage is gone"
+fi
+
+# --- 3. the id filter lives in the header, once ----------------------------
+if grep -q 'heal_tool_id_is_safe' "$SRC"; then
+    note "the id filter is called from the shared header"
+else
+    bad "schwung-heal.c no longer uses heal_tool_id_is_safe()"
+fi
+
+# A restated character class in the .c is a second copy of the policy that
+# tests/host cannot see.
+if awk '/^static int install_tool_helpers/,/^}/' "$SRC" | grep -q "'z'"; then
+    bad "the id character class is restated in schwung-heal.c — keep it in the header"
+else
+    note "the character class is not restated in the .c"
+fi
+
+if [ "$fail" -eq 0 ]; then
+    echo "PASS: schwung-heal tool helper invariants"
+else
+    echo "FAIL: schwung-heal tool helper invariants"
+    exit 1
+fi

--- a/tests/host/test_heal_tool_id.c
+++ b/tests/host/test_heal_tool_id.c
@@ -1,0 +1,62 @@
+/*
+ * test_heal_tool_id — the directory-name filter schwung-heal applies before it
+ * will install a standalone tool's staged helper as root-owned 04755.
+ *
+ * Worth a unit of its own because the binary is untestable end-to-end here: it
+ * calls setuid(0) at startup and bails when it is not root, so the policy is
+ * only reachable while it lives in a header. The names it screens come from a
+ * directory scan of an ableton-writable tree.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "heal_tool_id.h"
+
+static int failures = 0;
+
+static void expect(const char *id, int want, const char *why) {
+    int got = heal_tool_id_is_safe(id);
+    if (got != want) {
+        printf("FAIL: heal_tool_id_is_safe(\"%s\") = %d, want %d (%s)\n",
+               id ? id : "(null)", got, want, why);
+        failures++;
+    }
+}
+
+int main(void) {
+    /* Ordinary module ids in the catalog's shape. */
+    expect("davebox-sa", 1, "hyphen is a normal module id");
+    expect("seq-test", 1, "hyphen is a normal module id");
+    expect("m8", 1, "short alphanumeric");
+    expect("rnbo_runner", 1, "underscore");
+    expect("tool.v2", 1, "interior dot");
+    expect("ABC123", 1, "uppercase and digits");
+
+    /* Leading dot: excludes "." and ".." along with hidden dirs, which is what
+     * keeps a scan from walking up out of the tools directory. */
+    expect(".", 0, "self");
+    expect("..", 0, "parent");
+    expect(".hidden", 0, "hidden dir");
+
+    /* Anything that could be read as more than a name. A slash is the one that
+     * matters most: the id is pasted into a path. */
+    expect("a/b", 0, "slash");
+    expect("../evil", 0, "traversal");
+    expect("$(id)", 0, "command substitution");
+    expect("a b", 0, "space");
+    expect("a\nb", 0, "newline");
+    expect("a;b", 0, "semicolon");
+    expect("a*", 0, "glob");
+    expect("a'b", 0, "quote");
+
+    /* Degenerate input. */
+    expect("", 0, "empty");
+    expect(NULL, 0, "null");
+
+    if (failures) {
+        printf("test_heal_tool_id: %d failure(s)\n", failures);
+        return 1;
+    }
+    printf("test_heal_tool_id: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
Lands **#419** by @legsmechanical, plus two follow-up fixes. Opened here because CI cannot run on the fork branch without a manual "Approve and run", and `main`'s three checks are required — the commits are unchanged from #419 and ElMech's authorship is preserved. Merging with rebase so both commits keep their authors. Closes #419.

## What (from #419)

`schwung-heal` gains one more hardcoded pattern: for each `modules/tools/<id>/bin/heal.new` it installs the stage beside itself as `bin/heal`, root-owned `04755`, and unlinks the stage — the same shape as its own `schwung-heal.new` self-update. A tool with `"standalone": true` relaunches Move under a program of its own, and some need one privileged step for the same reason `schwung-heal` exists: a shim that must reach `/usr/lib` setuid to survive glibc's `AT_SECURE` `LD_PRELOAD` check. They cannot reuse `schwung-heal` — its paths are compile-time constants, which is its whole security property — so today the only way is an SSH session as root, once per device. dAVEBOx SA is the tool that needs this; the mechanism is generic and off by default.

`docs/MODULES.md` documents it beside the `standalone` flag, which the flag table did not list before.

Trust is unchanged: `ableton` already controls `/data` and can already stage `schwung-heal.new` itself. A staged tool helper adds convenience, not capability.

## Follow-ups in the second commit

**A tool's failure no longer feeds `rc`.** `rc` gates `--reboot`, and that reboot belongs to heal's *own* mirror — `post-update.sh` and the manager's `/system/repair`. Folding a third-party tool's unreadable stage into it let that tool turn a repair into "shim mirrored, device never rebooted", the silent self-concealing shape that flow exists to avoid. Failures are counted and printed; the gate stays for the shim/entrypoint mirror.

**Every component is resolved `O_NOFOLLOW`, through descriptors.** The `lstat` + `S_ISREG` check covered only the source and lost the race to the `open` after it; nothing covered the destination, and `<id>`, `bin/` and the tmp are all ableton-writable names. Built on Linux and run as root, two scenarios reproduced against the original commit:

- a symlinked `bin/` steered the root-owned `04755` write outside the tool's directory and consumed the stage;
- a symlink at `bin/heal.heal-tmp` was **followed, truncated, written through and `fchmod 04755`'d as root** before the `rename` replaced the link — an arbitrary path left holding the payload with the setuid bit.

Not an escalation under the threat model above, but this binary's audit story is "it can only ever do what is hardcoded", and a directory scan is where that stops holding for free. Now `openat`/`renameat`/`unlinkat` with `O_NOFOLLOW` throughout and `O_EXCL` on a freshly-unlinked tmp.

The hardcoded mirrors are deliberately untouched: `/usr/lib/schwung-shim.so` is legitimately a symlink on devices that took `install.sh`'s `cp` fallback (`install.sh:990`), so `copy_atomic` must keep following there. Its copy loop is now shared with the descriptor path rather than duplicated.

`O_NONBLOCK` on the stage comes with the descriptor rewrite: an `lstat`-first version was safe from a FIFO, this one is not, and `shim-entrypoint.sh` runs heal at every boot before the LD_PRELOAD exec.

## Tests

The id filter moved to `src/host/heal_tool_id.h` so `tests/host` can reach it at all — the binary `setuid(0)`s and bails when unprivileged, so the policy is only testable outside it.

- `test_heal_tool_id.c` — catalog id shapes, `.`/`..`, separators, shell metacharacters.
- `test_heal_tool_helper_invariants.sh` — the two structural facts a unit cannot see: the helper result never reaches `rc`, and every component is opened `O_NOFOLLOW` through a descriptor.

Both mutation-checked (each fails when the fix is reverted). `build.sh` tracks the new header so editing it cannot leave a stale binary on the device.

## Verified

- Full `tests/host` suite green — `make -C tests/host test` and every `tests/host/*.sh`.
- ARM64 static cross-compile clean under `-Wall -Wextra`.
- 11 functional scenarios as root on Linux: normal stage installs `4755` root:root with bytes intact and no tmp left; nothing staged is silent and rc 0; symlink stage, directory stage and FIFO stage each refused with a message and no hang; a `$`-named id skipped with its stage untouched; both attack scenarios above blocked; one bad tool does not stop another; and heal's own shim mirror still runs on the same invocation.
- ElMech's original 11 manual on-device scenarios all still hold on this build.

Not hardware-verified — the new path is unreachable until a tool stages a helper, and nothing shipped does yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EsJhkcoQYDruL3dbbKNh43