### PR TITLE
param pages: the copy gesture READS the focus, and a failed read voids the copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -652,6 +652,15 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   your hand. A map matching the page order would be a second bank bar. Move's
   rack counts up from the BOTTOM-LEFT; off-rack draws the empty box rather than
   the nearest cell.
+- **Hold Copy or Delete, then pick an instance** — copy, clear and one-level
+  undo for any child level, opted into by `capabilities.claims_edit_ccs`. It
+  is the one thing on the grid that reads `child_index_param` **itself, every
+  tick, while a button is held**: the rotation refreshes that focus once every
+  `keys.length + 1` ticks, which made the SOURCE the pad before the one you
+  hit and made a second tap inside the window invisible — four pads tapped,
+  one pasted, silently. And a failed read voids the whole snapshot rather than
+  dropping a key, or a pad is copied without its sample and still reported as
+  `PASTED`.
 - **The voice-follow path writes no pad LEDs.** Move owns the pads while the
   shadow UI is up; `tests/host/test_voice_follow_no_leds.sh` fails on a MIDI or
   LED write in `syncVoiceFromModule` or `voices.mjs`.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1587,7 +1587,10 @@ like its note) must not be copied at all.
 ```
 
 Clear writes each key's declared `default`; a key without one is left alone,
-and a filepath without one is written `""`. The focused instance itself is
+and a filepath without one is written `""`. A key whose read does not complete
+cancels the whole operation — a copy missing one key would leave the target's
+own value in place and still report a paste — so declare keys the module
+actually serves. The focused instance itself is
 not touched by Delete going down — only the instances you pick while holding
 it — so a pad already on screen is cleared by picking another first.
 

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -448,6 +448,52 @@ again. Without the count, hit kick → jog to Reverb → hit kick leaves you on
 Reverb, because the answer never changed. 9W9 shipped a counter for this before
 the contract existed; see `focusToken` in `voices.mjs`.
 
+### Hold Copy or Delete, then pick an instance — and the POLL is the hard part
+
+A drum rack's oldest gesture, offered by the grid to any child level: the
+instance focused when **Copy** goes down is the source, every instance focused
+while it is held is pasted into, **Delete** clears them instead, and **Undo**
+restores the last one overwritten (one level). `onEditCc` /
+`serviceEditGesture` in `page_controller.mjs`; the buttons reach the grid only
+for a module declaring `capabilities.claims_edit_ccs`, so opting in to the
+buttons IS opting in to the gesture. What is copied is `child_copy_keys` in
+declared order — see `docs/MODULES.md`, which is where a module author looks.
+
+**The gesture reads `child_index_param` ITSELF, once per tick, while a button
+is held.** Everything else on the grid takes the focus from `s.childIndex`,
+which `syncChildIndexFromModule` refreshes on **one stop of the read rotation**
+— every `keys.length + 1` ticks, ~150 ms on an eight-key drum page. That
+cadence is exactly right for following a played pad onto the page and wrong for
+this gesture in two ways at once, both reproduced against the controller before
+they were fixed:
+
+- the SOURCE was the pad focused *before* the one you just hit, because Copy
+  went down inside the window — hit a pad, hold Copy, copy the wrong pad, no
+  indication;
+- a second pad tapped inside the same window was **invisible**, because the
+  poll only ever sees where the focus ended up. "Hold Copy and tap four pads"
+  pasted into the fourth one only, silently. `test_child_copy_gesture.sh` taps
+  one tick apart and asserts all three targets.
+
+The extra read costs a round-trip per tick *for the duration of a hold* and
+nothing at all otherwise — the poll returns on `!s.editGesture` first. The
+answer is adopted into `s.childIndex` rather than kept beside it: without that,
+`dropChildLevelCache` re-warms the instance the cache still believed in and
+paints the wrong pad's values over the write just made.
+
+**A read that did not complete voids the whole snapshot** — the tri-state, and
+it bites harder here than anywhere. Dropping a failed key left the target's own
+value in place: a pad copied without its sample, reported as `PASTED`. So a
+source that cannot be read arms nothing, and an undo snapshot that cannot be
+read skips that instance rather than overwriting something it cannot put back.
+`""` stays a value (a filepath with no file); only `null` is a failure.
+
+The notice is a `prompt` (dropped when the button comes up) or a RESULT (not).
+Clearing every notice on the release meant `PASTED PAD 2` was only ever visible
+while you kept holding the button — and the release is how the gesture ends. It
+is centred in `s.frameRect`, the same rect a floating card is centred in, so an
+embedded consumer does not get it on its own chrome.
+
 ### The header pad minimap
 
 A component declaring `pad_layout: "drums"` gets a 6px box in the header with

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -3774,11 +3774,55 @@ export function createController(io = {}) {
         return keys.filter((k) => typeof k === "string" && k.length);
     }
     function wireFor(def, index, key) { return resolveChildKey(def, index, key) || key; }
+    /*
+     * WHICH INSTANCE THE MODULE IS ON *NOW*, not which one the rotation last
+     * heard about.
+     *
+     * `childIndexFor` answers from `s.childIndex`, which syncChildIndexFromModule
+     * refreshes on ONE stop of the read rotation -- once every keys.length + 1
+     * ticks, ~150 ms on an eight-key drum page. That cadence is right for
+     * following a played pad on the page and wrong for this gesture twice over:
+     * the SOURCE would be the pad focused before the one you just hit, and a
+     * second tap inside the same window would be invisible, so "hold Copy and
+     * tap four pads" pasted into the last one only. Both were reproduced against
+     * this controller.
+     *
+     * So the gesture reads the selector itself: one round-trip per tick, and
+     * ONLY while a button is held -- the poll below returns before this on every
+     * other tick of the session. A level with no `child_index_param` (the picker
+     * is the only way in) has nothing to read and keeps the cache, which the
+     * picker writes synchronously.
+     *
+     * The answer is adopted into `s.childIndex` so the page follows it too:
+     * without that, dropChildLevelCache would re-warm the instance the cache
+     * still believed in and show the wrong pad's values over the write we just
+     * made.
+     */
+    function liveChildIndex(def, level) {
+        const idxParam = childIndexParam(def);
+        if (!idxParam) return childIndexFor(level);
+        const raw = getParam(`${s.prefix}:${idxParam}`);
+        const i = childIndexFromWire(def, raw);
+        if (i === null) return childIndexFor(level);   /* tri-state: not an answer */
+        if (i !== childIndexFor(level)) s.childIndex[level] = i;
+        return i;
+    }
+    /*
+     * A snapshot, or NULL if any key's read did not complete.
+     *
+     * The tri-state again, and it is load-bearing here: dropping a failed key
+     * silently produced a paste that left the target's own value in place --
+     * a pad copied without its sample -- while the notice still said PASTED.
+     * `""` is a VALUE (a filepath with no file) and is kept; only null/undefined
+     * is a read that did not answer, and one of those voids the whole snapshot,
+     * because a partial copy is indistinguishable from a whole one afterwards.
+     */
     function readInstance(def, index, keys) {
         const snap = Object.create(null);
         for (const k of keys) {
             const v = getParam(`${s.prefix}:${wireFor(def, index, k)}`);
-            if (v !== null && v !== undefined) snap[k] = String(v);
+            if (v === null || v === undefined) return null;
+            snap[k] = String(v);
         }
         return snap;
     }
@@ -3794,7 +3838,16 @@ export function createController(io = {}) {
         }
         return snap;
     }
-    function notice(text, ms) { s.notice = { text, until: now() + (ms || 1200) }; }
+    /*
+     * `prompt: true` marks the "PICK A TARGET" line, which belongs to the HOLD
+     * and is dropped when the button comes up. A RESULT ("PASTED PAD 2") must
+     * outlive the release -- the release is how you finish the gesture, so
+     * clearing every notice there meant the confirmation was only ever visible
+     * while you kept the button down.
+     */
+    function notice(text, ms, prompt) {
+        s.notice = { text, until: now() + (ms || 1200), prompt: !!prompt };
+    }
 
     /** Copy (60) / Delete (119) / Undo (56). Returns whether the event was taken. */
     function onEditCc(cc, down) {
@@ -3812,20 +3865,28 @@ export function createController(io = {}) {
         if (cc !== 60 && cc !== 119) return false;
         const kind = cc === 60 ? "copy" : "clear";
         if (!down) {
-            if (s.editGesture && s.editGesture.kind === kind) { s.editGesture = null; s.notice = null; }
+            if (s.editGesture && s.editGesture.kind === kind) {
+                s.editGesture = null;
+                if (s.notice && s.notice.prompt) s.notice = null;
+            }
             return true;
         }
         const lvl = instanceLevel();
         if (!lvl) return false;                      /* not on an instance page: Move keeps it? no -- claimed; just inert */
         const keys = copyKeysFor(lvl.def);
         if (!keys.length) return false;
-        const from = childIndexFor(lvl.name);
-        s.editGesture = {
-            kind, level: lvl.name, def: lvl.def, keys, from, last: from,
-            snap: kind === "copy" ? readInstance(lvl.def, from, keys) : null,
-        };
+        const from = liveChildIndex(lvl.def, lvl.name);
+        let snap = null;
+        if (kind === "copy") {
+            snap = readInstance(lvl.def, from, keys);
+            /* Nothing is armed from a source we could not read. Arming anyway
+             * would paste whatever partial answer arrived into every instance
+             * picked afterwards, and report each one as a copy. */
+            if (!snap) { notice("READ FAILED"); announce("read failed"); return true; }
+        }
+        s.editGesture = { kind, level: lvl.name, def: lvl.def, keys, from, last: from, snap };
         const label = childLabel(lvl.def, from).toUpperCase();
-        notice(kind === "copy" ? `COPY ${label}: PICK A TARGET` : "CLEAR: PICK A TARGET", 4000);
+        notice(kind === "copy" ? `COPY ${label}: PICK A TARGET` : "CLEAR: PICK A TARGET", 4000, true);
         announce(kind === "copy" ? `copy ${childLabel(lvl.def, from)}, pick a target` : "clear, pick a target");
         return true;
     }
@@ -3834,15 +3895,20 @@ export function createController(io = {}) {
     function serviceEditGesture() {
         const g = s.editGesture;
         if (!g) return;
-        const idx = childIndexFor(g.level);
+        const idx = liveChildIndex(g.def, g.level);
         if (idx === g.last) return;
         g.last = idx;
         if (g.kind === "copy" && idx === g.from) return;   /* pasting onto the source is a no-op */
+        /* The undo snapshot is taken FIRST and the write only happens if it
+         * came back whole: an overwrite we cannot put back is the one outcome
+         * this gesture must not produce silently. The instance is skipped and
+         * named, and the gesture stays armed for the next pick. */
         const before = readInstance(g.def, idx, g.keys);
+        const label = childLabel(g.def, idx).toUpperCase();
+        if (!before) { notice(label + ": READ FAILED", 4000); announce("read failed"); return; }
         writeInstance(g.def, idx, g.kind === "copy" ? g.snap : clearedInstance(g.keys));
         s.editUndo = { level: g.level, def: g.def, index: idx, snap: before };
         dropChildLevelCache(g.level);               /* the grid is showing the instance just written */
-        const label = childLabel(g.def, idx).toUpperCase();
         notice((g.kind === "copy" ? "PASTED " : "CLEARED ") + label, 4000);
         announce((g.kind === "copy" ? "pasted " : "cleared ") + childLabel(g.def, idx));
     }
@@ -3853,11 +3919,20 @@ export function createController(io = {}) {
         if (!n) return false;
         if (now() >= n.until) { s.notice = null; return false; }
         if (!ctx || typeof ctx.fillRect !== "function" || typeof ctx.print !== "function") return false;
-        const W = ctx.width || 128, H = ctx.height || 64;
+        /* Centred in the PAGE'S FRAME, the same rect a floating card is centred
+         * in: an embedded consumer (a module binding this controller from its
+         * own ui_chain.js) draws the grid into a region and owns the chrome
+         * around it, so a notice centred on the panel lands on somebody else's
+         * pixels. Defaults to the whole panel for the full-screen host. */
+        const fr = s.frameRect;
+        const fx = fr && Number.isFinite(fr.x) ? fr.x : 0;
+        const fy = fr && Number.isFinite(fr.y) ? fr.y : 0;
+        const W = fr && fr.w > 0 ? fr.w : (ctx.width || 128);
+        const H = fr && fr.h > 0 ? fr.h : (ctx.height || 64);
         const text = String(n.text);
         const tw = (typeof ctx.textWidth === "function") ? ctx.textWidth(text) : text.length * 6;
         const w = Math.min(W - 4, tw + 8), h = 13;
-        const x = Math.floor((W - w) / 2), y = Math.floor((H - h) / 2);
+        const x = fx + Math.floor((W - w) / 2), y = fy + Math.floor((H - h) / 2);
         ctx.fillRect(x, y, w, h, 0);
         ctx.fillRect(x, y, w, 1, 1); ctx.fillRect(x, y + h - 1, w, 1, 1);
         ctx.fillRect(x, y, 1, h, 1); ctx.fillRect(x + w - 1, y, 1, h, 1);

--- a/tests/host/test_child_copy_gesture.sh
+++ b/tests/host/test_child_copy_gesture.sh
@@ -53,9 +53,11 @@ import("./src/shared/param_pages/page_controller.mjs").then((PC) => {
   for (let i = 0; i < 4; i++) { dev[`pad${i}_sample`] = `/s/${i}.wav`; dev[`pad${i}_vol`] = String((i + 1) / 10); dev[`pad${i}_tune`] = String(i); dev[`pad${i}_gain`] = String(1 + i); }
   dev.verb = "0.3"; dev.ui_current_pad = "0";
   const writes = [];
+  let failKey = null;                       /* a read that does not complete */
   const io = {
     getParam: (k) => {
       const key = k.replace(/^synth:/, "");
+      if (failKey && key === failKey) return null;
       if (key === "ui_hierarchy") return JSON.stringify(HIER);
       if (key === "chain_params") return JSON.stringify(CP);
       if (key === "preset_name") return "";
@@ -121,8 +123,62 @@ import("./src/shared/param_pages/page_controller.mjs").then((PC) => {
   if (writes.some(([k]) => k.startsWith("pad1_"))) fail("returning to the source pasted onto it");
   c.onEditCc(60, false);
 
+  /* ---- 5. taps faster than the read rotation ---------------------------- */
+  focus(0); writes.length = 0;
+  c.onEditCc(60, true);
+  dev.ui_current_pad = "1"; c.tick();
+  dev.ui_current_pad = "2"; c.tick();
+  dev.ui_current_pad = "3"; spin(5);
+  const hit = [...new Set(writes.map(([k]) => k.slice(0, 4)))].sort();
+  if (JSON.stringify(hit) !== JSON.stringify(["pad1", "pad2", "pad3"]))
+    fail("quick picks were dropped: pasted into " + JSON.stringify(hit) + ", want pad1, pad2, pad3");
+  c.onEditCc(60, false);
+
+  /* ---- 6. the source is the instance focused NOW ------------------------ */
+  focus(0);
+  dev.pad3_sample = "/s/three.wav";            /* case 5 pasted over it */
+  dev.ui_current_pad = "3";                    /* hit a pad and hold Copy at once: */
+                                               /* no tick, so the cache is a pad behind */
+  writes.length = 0;
+  c.onEditCc(60, true);
+  if (!c.editGesture || c.editGesture.from !== 3) fail("Copy snapshotted instance " + (c.editGesture && c.editGesture.from) + ", want the one focused now (3)");
+  dev.ui_current_pad = "1"; spin(5);
+  const src = writes.filter(([k]) => k === "pad1_sample").map(([, v]) => v);
+  if (JSON.stringify(src) !== JSON.stringify(["/s/three.wav"])) fail("pasted from the wrong source: " + JSON.stringify(src));
+  c.onEditCc(60, false);
+
+  /* ---- 7. a read that did not complete -------------------------------- */
+  focus(0);
+  failKey = "pad0_sample";
+  writes.length = 0;
+  c.onEditCc(60, true);
+  if (c.editGesture) fail("a gesture was armed from a source that could not be read");
+  dev.ui_current_pad = "2"; spin(5);
+  if (writes.length) fail("a failed source read still wrote: " + JSON.stringify(writes));
+  c.onEditCc(60, false);
+  failKey = null;
+
+  /* ---- 8. the notice outlives the release, inside the page frame -------- */
+  focus(0);
+  c.onEditCc(60, true);
+  dev.ui_current_pad = "2"; spin(5);
+  /* Deliberately a frame whose centre is NOT the panel centre, so a notice
+   * that ignored the rect lands outside it and the assertion can fail. */
+  const RECT = { x: 4, y: 2, w: 70, h: 16 };
+  const prints = [];
+  const gctx = { fillRect: () => {}, print: (x, y, t) => { prints.push([x, y, String(t)]); }, textWidth: (t) => t.length * 6 };
+  c.onEditCc(60, false);
+  c.render(gctx, { title: "t", rect: RECT });
+  prints.length = 0;
+  c.renderOverlays(gctx, { clearScreen: () => {} });
+  const said = prints.filter(([, , t]) => t.indexOf("PASTED") === 0);
+  if (!said.length) fail("the result notice did not survive the release");
+  const [nx, ny] = said[0];
+  if (nx < RECT.x || nx > RECT.x + RECT.w || ny < RECT.y || ny > RECT.y + RECT.h)
+    fail("the notice was drawn at " + nx + "," + ny + ", outside the frame it was given " + JSON.stringify(RECT));
+
   if (bad) process.exit(1);
-  console.log("  ok  copy pastes the declared keys in order into each picked instance; undo restores; clear writes defaults; nothing without an instance");
+  console.log("  ok  copy pastes the declared keys in order into each picked instance; undo restores; clear writes defaults; quick picks are all taken; a failed read writes nothing; the notice outlives the release");
 }).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
 ' || fail "controller half"
 


### PR DESCRIPTION
## In short

Follow-up to #429 (merged as e7bcd159). Four fixes to the hold-Copy-then-pick gesture, each reproduced against the real controller before it was written, each pinned by an assertion that was mutation-checked to fail against the exact bug.

## The poll was too slow for the gesture

`serviceEditGesture` took the focused instance from `s.childIndex`, which `syncChildIndexFromModule` refreshes on **one stop of the read rotation** — every `keys.length + 1` ticks, ~150 ms on an eight-key drum page. That cadence is right for following a played pad onto the page and wrong here in two ways at once:

- the **source** was the pad focused *before* the one you just hit, because Copy went down inside the window — hit a pad, hold Copy, copy the wrong pad, nothing on screen to say so;
- a pad tapped **inside the same window was invisible**. Three taps one tick apart pasted into the third only. That is the headline workflow ("hold Copy, tap pads") degrading silently.

So the gesture reads `child_index_param` itself, once per tick and **only while a button is held** — the poll returns on `!s.editGesture` first, so it costs the session nothing. The answer is adopted into `s.childIndex` rather than kept beside it: without that, `dropChildLevelCache` re-warms the instance the cache still believed in and paints the wrong pad's values over the write just made.

## A read that did not complete voids the snapshot

`readInstance` dropped a key whose `getParam` returned `null`, which left the target's own value in place — a pad copied without its sample — while the notice still said `PASTED`. The tri-state again ([CLAUDE.md](CLAUDE.md): a failed read must never become a decision). Now a source that cannot be read arms nothing, and an undo snapshot that cannot be read **skips that instance rather than overwriting something it cannot put back**. `""` is still a value (a filepath with no file); only `null` is a failure.

## Two smaller ones

- **The result notice outlives the release.** Clearing every notice on button-up meant `PASTED PAD 2` was only visible while you kept holding the button — and the release is how the gesture ends. Only the "PICK A TARGET" prompt is a prompt.
- **It is centred in `s.frameRect`**, the rect a floating card is centred in, so a module binding the controller from its own `ui_chain.js` does not get it across its own chrome.

## Tests

`tests/host/test_child_copy_gesture.sh` gains four cases: quick picks one tick apart (all three taken), the source being the instance focused *now*, a failed read arming and writing nothing, and the notice surviving the release inside a frame whose centre is deliberately not the panel centre. All five new assertions were mutation-checked — reverting each fix in turn fails exactly the assertion written for it. Full `tests/host` suite green (shell + compiled units).

## Docs

The war story in `docs/PARAM_PAGES.md` with its hook in `CLAUDE.md` (this is a knob-grid subsystem change), and one sentence in `docs/MODULES.md` on what a failed read does to a copy. Not hardware-tested; `../schwung-catalog-site/manual.html` still wants a user-facing entry for the gesture at release time.

## Left as designed

Undo is one level and any focus change while Copy is held pastes, so spinning the instance knob overwrites a run of instances with only the last recoverable. Worth revisiting when #426's `child_press_param` lands — "a pad was pressed" is a better trigger than "the focus moved".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WntWvqaxdbi5VV7ApBfLS