### PR TITLE
fix(install): tolerate missing preselector boot default

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1965,7 +1965,9 @@ ssh_ableton_with_retry "test -x /opt/move/Move" || fail "Missing /opt/move/Move"
 # target, no MoveOriginal, no shim, and the check reports a phantom failure;
 # hit in the field with default=dronage). Payload verification happened above;
 # skip the shim probe and say why.
-boot_default=$($ssh_ableton "head -n 1 /data/UserData/boot-targets/default 2>/dev/null" 2>/dev/null | tr -d '[:space:]')
+# Pre-selector payloads do not create boot-targets/default.  With pipefail,
+# the expected non-zero `head` status must not abort the installer here.
+boot_default=$($ssh_ableton "head -n 1 /data/UserData/boot-targets/default 2>/dev/null" 2>/dev/null | tr -d '[:space:]' || true)
 if [ -n "$boot_default" ] && [ "$boot_default" != "schwung" ]; then
   iecho "Boot default is '$boot_default' (not Schwung) — rebooting without the shim check."
   iecho "  The update is installed; it activates next time Schwung boots."

--- a/tests/host/test_install_preselector_reboot.sh
+++ b/tests/host/test_install_preselector_reboot.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A v1.2 payload has no boot-targets directory.  Reading the selector's
+# optional default must therefore be successful even when head exits 1: with
+# the installer's pipefail setting, an unguarded command substitution aborts
+# the installer immediately after "Rebooting Move...".
+if awk '
+  /^boot_default=\$/ {
+    found = 1
+    if (index($0, "|| true")) guarded = 1
+  }
+  END { exit !(found && guarded) }
+' scripts/install.sh; then
+  echo "PASS: optional boot-target default read is safe for pre-selector payloads"
+else
+  echo "FAIL: boot_default read can abort a pre-selector installation under pipefail" >&2
+  exit 1
+fi


### PR DESCRIPTION
Summary: keep the boot-target default probe optional for pre-selector v1.2 payloads, so pipefail cannot exit immediately after Rebooting Move when boot-targets/default is absent. Adds a regression test. Verification: make -C tests/host test; all tests/host shell tests were run; bash -n scripts/install.sh; git diff --check.