### PR TITLE
param pages: the grid asked its value cache with the CONCRETE key, so a per-instance visible_if never hit it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -629,6 +629,20 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   load, an older host and a one-strike disable. Guarding in the shared walk
   instead of the singles branch silently yields a THREE-cell envelope with a key
   orphaned.
+- **`visible_if` FAILED OPEN on the whole knob grid**, and had since the grid
+  shipped. The evaluator resolved every condition against `hierEditorSlot` —
+  the LIST editor's slot, which `enterParamPages` never sets — so from the grid
+  it read slot -1, got `null`, and took the fail-open branch: a send meant to
+  collapse to the armed type's cells showed all twenty, three pages deep, with
+  nothing logged. The three synthesised contracts were already immune by
+  overriding `io.visible`; only real modules were exposed. On `PARAM_PAGES` the
+  grid's own identity is the context now, read **cache-first** — a re-plan
+  follows every detent of a gating knob, and a blocking read per condition
+  froze the OLED. And the cache is asked with the **TEMPLATE** key, never the
+  resolved one: the controller files a child level under what it *lists*
+  (`partlevel`), so asking with `sram_part_2_partlevel` missed every time and
+  paid the read anyway — silent, because *a miss still answers correctly, only
+  slowly.*
 - **`level_walk.mjs` is the walk, and the LFO target picker is its second
   consumer.** Names must not be copied — nothing shows a grid page title beside
   the picker's row for the same level.

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -409,6 +409,57 @@ level. The one sanctioned divergence is the root's name — the walker calls its
 root "Main", and the picker overrides that with the mode's own name when
 `modes` gives it more than one root.
 
+### `visible_if` on the grid failed OPEN, against the LIST editor's slot
+
+`page_plan.mjs` calls the caller's `visible` hook for a level's `visible_if`
+and for a param entry's, and the shadow UI wires that to
+`evaluateVisibilityCondition` (`shadow_ui_param_pages.mjs`, the `io.visible`
+fallback). That function resolved every condition against `hierEditorSlot` /
+`hierEditorComponent` — **the list editor's identity, which `enterParamPages`
+never sets.** From the grid that is slot `-1`: the read answers `null`, the
+evaluator's `// fail-open` fires, and **every `visible_if` on the knob grid was
+true.** A send level meant to collapse to the armed type's cells — a reverb
+*or* a delay — showed all twenty, three pages deep, with nothing logged.
+Reported from the device on schwung-dr32 0.2.0; it affected every module in the
+fleet that declares one.
+
+The three synthesised contracts were already immune, and said so: `io.visible`
+is overridden in `createSlotGridIo` under a comment naming this exact staleness
+(*"they belong to the list editor and are stale while the grid is up"*). Only
+real module components were exposed. On `PARAM_PAGES` the evaluator now takes
+the grid's own slot and component; the hand-off to the list editor calls
+`exitParamPages()` first, so the list can never fall into that branch.
+
+**Cache-first, because the naive fix froze the OLED.** `replanIfCondition` runs
+a full re-plan on every detent of a gating knob, and a plan evaluates every
+condition on the level — forty blocking ~2.8 ms reads per detent on a gated
+send page. The controller's own `state.values` answers first (it carries every
+write the grid made and every key its read cursor has landed on, condition keys
+included, so a fresh write is seen by the very next plan) and the TTL'd
+`getSlotParamCached` answers a miss. A miss on a *failed* read returns the last
+known-good value rather than `null`, so a channel stall no longer flashes every
+gated cell back in — the fail-open path is reached only when nothing has ever
+been read.
+
+**And the cache is asked with the TEMPLATE key, never the resolved one.** The
+key the evaluator holds has been through `hierChildKeyFor`, so on a child level
+it is concrete (`sram_part_2_partlevel`), while the controller files its values
+under what the level *lists* (`partlevel`) — the same dialect split
+`hierGenericKeyFor` exists to bridge, and the reason
+`openParamEditorFromGrid`'s owner search once missed. Asking with the concrete
+key missed **every time**, so a per-instance condition never hit the cache and
+paid the blocking read the branch is there to avoid — precisely the case the
+level-name lookup was added to serve. It was silent, because *a miss still
+answers correctly, only slowly*: a cache that cannot hit reports nothing. The
+invert uses the same level and index as the resolve, and the controller drops a
+level's values when its child index moves, so there is never a second
+instance's value under that key to find.
+
+`tests/host/test_grid_visible_if_context.sh` pins the call site and then drives
+a real controller through choosing a child, asserting `state.values` really is
+keyed by templates — if the controller ever files resolved keys, the inversion
+becomes wrong and that half fails.
+
 ### The grid FOLLOWS the focused voice, and writes no LEDs doing it
 
 A module can declare what its performance surface is — `pad_layout`, and a `note`

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -5046,7 +5046,9 @@ function evaluateVisibilityCondition(condition, levelDef) {
     if (view === VIEWS.PARAM_PAGES && paramPagesActive()) {
         const comp = paramPagesComponent();
         const slot = paramPagesSlot();
+        const gridPrefix = getComponentParamPrefix(comp);
         const lvlName = paramPagesLevelNameOf(levelDef);
+        const childIdx = lvlName ? paramPagesChildIndex(lvlName) : -1;
         /* Cache-first. A re-plan follows every detent of a gating knob and
          * evaluates every condition on the level; a blocking read per
          * condition (~2.8 ms each, forty on a gated send page) froze the OLED
@@ -5055,16 +5057,37 @@ function evaluateVisibilityCondition(condition, levelDef) {
          * the TTL cache answers a miss, so a plan costs IPC only for a key
          * nothing has touched yet. */
         const read = (s, k) => {
-            const held = paramPagesCachedValue(k);
+            /*
+             * ...and the cache is asked with the TEMPLATE key, never the one
+             * that arrived.
+             *
+             * `k` has been through hierChildKeyFor, so on a child level it is
+             * CONCRETE ("pad3_type"), while the controller keys its values by
+             * what the level LISTS ("type") -- see the dialect split
+             * hierGenericKeyFor exists for. Asking with the concrete key
+             * missed every single time, so a per-instance condition never hit
+             * the cache and paid the blocking read this branch is here to
+             * avoid: exactly the case paramPagesLevelNameOf was added to
+             * serve, and silent, because a miss still answers CORRECTLY --
+             * only slowly. A cache that cannot hit reports nothing.
+             *
+             * The invert uses the same level and index as the resolve did, so
+             * the value it finds belongs to the instance the grid is showing;
+             * the controller drops a level's values when its child index
+             * moves, so there is never a second instance's value under that
+             * key to find.
+             */
+            const bare = k.startsWith(`${gridPrefix}:`) ? k.slice(gridPrefix.length + 1) : k;
+            const held = paramPagesCachedValue(hierGenericKeyFor(levelDef, childIdx, bare));
             if (held !== undefined) return held;
             return getSlotParamCached(s, k, `grid:${s}:${comp}`);
         };
         return evaluateVisibilityConditionForContext(
             slot,
-            getComponentParamPrefix(comp),
+            gridPrefix,
             condition,
             levelDef,
-            lvlName ? paramPagesChildIndex(lvlName) : -1,
+            childIdx,
             read
         );
     }

--- a/tests/host/test_grid_visible_if_context.sh
+++ b/tests/host/test_grid_visible_if_context.sh
@@ -27,9 +27,86 @@ echo "$body" | command grep -q 'paramPagesLevelNameOf(levelDef)' || fail "a per-
 command grep -q '^export function paramPagesLevelNameOf' "$pp" || fail "paramPagesLevelNameOf is not exported by $pp"
 command grep -q 'paramPagesLevelNameOf,' "$ui" || fail "shadow_ui.js does not import paramPagesLevelNameOf"
 # A re-plan follows every detent of a gating knob; a blocking read per condition froze the OLED.
-echo "$body" | command grep -q 'paramPagesCachedValue(k)' || fail "the grid evaluator does not consult the controller's own values first -- every re-plan pays a blocking read per condition"
+echo "$body" | command grep -q 'paramPagesCachedValue(' || fail "the grid evaluator does not consult the controller's own values first -- every re-plan pays a blocking read per condition"
+# ...and it must ask with the TEMPLATE key. `k` arrives resolved by
+# hierChildKeyFor ("pad3_type"); the controller keys its values by what the
+# level LISTS ("type"). Asking with the concrete key missed every time, so a
+# per-instance condition never hit the cache -- the very case the level-name
+# lookup above was added to serve -- and it was SILENT, because a miss still
+# answers correctly, just with the blocking read this branch exists to avoid.
+echo "$body" | command grep -q 'paramPagesCachedValue(hierGenericKeyFor(' || fail "the grid evaluator asks the value cache with the CONCRETE key -- a per-instance condition can never hit it"
 echo "$body" | command grep -q 'getSlotParamCached(' || fail "a cache miss on the grid goes to an uncached blocking read"
 if echo "$body" | command grep -q '[^a-zA-Z]getSlotParam(' ; then fail "the grid branch still reads through the uncached getSlotParam"; fi
 command grep -q '^export function paramPagesCachedValue' "$pp" || fail "paramPagesCachedValue is not exported by $pp"
 echo "  ok  visible_if on the knob grid resolves against the grid's own slot and component"
+# ---- and the value cache is keyed by the TEMPLATE key ----------------------
+#
+# The pin above says the evaluator inverts before it asks. This says WHY: the
+# controller's own values -- the cache that branch consults first -- are filed
+# under what the level LISTS, while the key the evaluator is handed has already
+# been resolved to an instance. So the two dialects really do differ, and a
+# lookup with the concrete key really does miss. If the controller ever starts
+# filing resolved keys, this fails and the inversion above becomes wrong.
+#
+# Driven through a real controller rather than grepped, because the keying is a
+# runtime fact: nothing in the source says which of the two goes into s.values.
+
+if ! command -v node >/dev/null 2>&1; then echo "FAIL: node is required" >&2; exit 1; fi
+
+node -e '
+Promise.all([
+  import("./src/shared/param_pages/page_controller.mjs"),
+  import("./src/shared/param_pages/page_plan.mjs"),
+]).then(([C, P]) => {
+  const say = (m) => { console.log("FAIL: " + m); process.exit(1); };
+  const j = JSON.parse(require("fs").readFileSync("tests/fixtures/module-contracts.json", "utf8"));
+  const m = j.modules.find((x) => x.id === "minijv");
+  if (!m) say("minijv is not in the contract fixture -- nothing here declares a child level");
+  let h = m.ui_hierarchy, cp = m.chain_params;
+  if (typeof h === "string") h = JSON.parse(h);
+  if (typeof cp === "string") cp = JSON.parse(cp);
+
+  const ctl = C.createController({
+    getParam: (k) => {
+      const b = String(k).replace(/^[^:]+:/, "");
+      if (b === "ui_hierarchy") return JSON.stringify(h);
+      if (b === "chain_params") return JSON.stringify(cp);
+      if (b === "mode") return "Performance";
+      return "10";
+    },
+    setParam: () => {},
+    announce: () => {},
+  });
+  ctl.load({ slot: 0, component: "synth" });
+  for (let i = 0; i < 10; i++) ctl.tick();
+
+  const at = ctl.pages.findIndex((p) => p.childOf);
+  if (at < 0) say("minijv has no child selector -- the fixture no longer exercises this");
+  ctl.goToPage(at);
+  ctl.onClick(0);                 /* enter the list */
+  ctl.onJog(1); ctl.onJog(1);     /* Part 3 */
+  ctl.onClick(0);                 /* commit -- re-keys the level */
+  if (!(ctl.page && ctl.page.kind === P.PAGE_KNOBS && ctl.page.childLevel))
+    say("choosing a part did not land on a child-level knob page");
+  for (let i = 0; i < 24; i++) ctl.tick();
+
+  const vals = ctl.state && ctl.state.values;
+  if (!vals) say("the controller exposes no state.values -- paramPagesCachedValue reads that");
+  const held = Object.keys(vals);
+  if (!held.length) say("the controller cached no values at all after 24 ticks");
+
+  /* The keys on the page ARE the templates; the wire keys are resolved. */
+  const tmpl = (ctl.page.keys || []).filter((k) => k && k in vals);
+  if (!tmpl.length)
+    say("none of the page keys " + JSON.stringify((ctl.page.keys || []).slice(0, 4)) +
+        " reached state.values -- this test can no longer tell the dialects apart");
+  const concrete = held.filter((k) => /^sram_part_\d+_/.test(k));
+  if (concrete.length)
+    say("state.values holds RESOLVED keys " + JSON.stringify(concrete.slice(0, 3)) +
+        " -- the evaluator must stop inverting, the dialects now agree");
+  console.log("  ok  the controller files a child level under its template keys (" +
+              JSON.stringify(tmpl.slice(0, 2)) + "), never the resolved ones");
+}).catch((e) => { console.log("FAIL: " + (e && e.stack || e)); process.exit(1); });
+' || exit 1
+
 echo "PASS: test_grid_visible_if_context"


### PR DESCRIPTION
## In short

Follow-up to #427, found reviewing it. That PR made `visible_if` work on the knob grid at all, and read **cache-first** so a re-plan per knob detent stays cheap. The cache lookup used the key as it arrived — which on a child level is the *resolved* key, while the controller files its values under the *template* key. So on a child level the cache missed every time and the blocking read happened anyway.

## What

`normalizeVisibilityConditionKey` puts the condition key through `hierChildKeyFor`, so what the `read` callback is handed is concrete: `sram_part_2_partlevel`. `page_controller.mjs` keys `s.values` by the page key, which is the template — `partlevel` — and resolves only at the wire (`fullKey = (key, pg) => ${s.prefix}:${childResolve(key, pg)}`).

That is the same dialect split `hierGenericKeyFor` already exists to bridge, under a comment naming the last time it bit: *"the GRID addresses `synth:p01_sample_path` (the controller resolved it), while the editor's param list holds `sample_path`. So the lookup missed, the owner search missed, and the click opened nothing at all."*

Here the miss is quieter still. **A miss answers CORRECTLY, only slowly** — it falls through to `getSlotParamCached` and gets the right value — so nothing was wrong on screen, the branch just never paid off for the exact case `paramPagesLevelNameOf` was added in #427 to serve. A cache that cannot hit reports nothing.

## Fix

Invert with `hierGenericKeyFor` before asking. It uses the same level and index as the resolve, so the value found belongs to the instance the grid is showing; the controller drops a level's values when its child index moves, so there is never a second instance's value under that key to find. Non-child levels are unaffected — both helpers return the key unchanged when the level has no children.

## Tests

`tests/host/test_grid_visible_if_context.sh` gains a half with teeth: it drives a real `PageController` through minijv's part selector, chooses Part 3, and asserts `state.values` really is keyed by templates and holds no `sram_part_N_*` key. If the controller ever files resolved keys, that fails and the inversion above becomes wrong.

Both halves mutation-checked:
- dropping the invert → `FAIL: the grid evaluator asks the value cache with the CONCRETE key`
- making the controller file resolved keys → `FAIL: state.values holds RESOLVED keys [...]`

Full `tests/host` suite green (C units `ALL PASS`, 0 shell failures). Not hardware-verified — the behaviour is unchanged, only the read count.

## Docs

`docs/PARAM_PAGES.md` gets the war story for both #427 and this (there was none for #427); `CLAUDE.md` gets its one-bullet hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyhoEz4Y57gzJv8fjcmwzp