### PR TITLE
canvas extra_keys: the cap the docs promised, from the one constant that holds it

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2321,12 +2321,16 @@ declare it with `extra_keys`. Those values are added to the page's staggered
 read rotation without becoming visible or turnable cells:
 
 ```json
-{ "key": "activity", "name": "Activity", "type": "string",
-  "access": "read", "hidden": true }
+{ "key": "activity", "name": "Activity", "type": "string", "access": "read" }
 { "key": "face", "name": "Face", "type": "canvas",
   "canvas_script": "canvas.js", "as_page": true,
   "show_value": false, "extra_keys": ["activity"] }
 ```
+
+**Nothing hides `activity` and nothing needs to.** A param earns a cell by being
+in a level's `knobs`; one that is only ever named by `extra_keys` has no cell to
+suppress. (There is no `hidden` field — the planner honours `visible_if` and
+nothing else, so a `"hidden": true` would be read by no one.)
 
 ```javascript
 globalThis.canvas_overlay = {
@@ -2349,8 +2353,11 @@ globalThis.canvas_overlay = {
   and you should not draw any of your own.
 - `values` carries live values merged over the base; `base` is the knob
   positions, for a page that wants to show both.
-- `extra_keys` is capped by the same bounded read rotation as other visual
-  dependencies. Use it for compact state snapshots, not high-volume data.
+- `extra_keys` is **capped at four**, the same cap and the same reason as a
+  widget's `viz.extra_keys` above: one read per stop, so a page asking for
+  twenty would spend its whole read budget here and starve the knobs it is
+  drawn beside. A key that already has a cell on the page costs nothing extra —
+  it is already in the rotation and is skipped.
 - **One strike**, as everywhere else: a `drawPage` that throws is retired for
   the session and the body is left empty under a normal page.
 

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1666,6 +1666,15 @@ rotation only while that page is current. They never join `page.keys`, so an
 animation snapshot can reach `drawPage({ values })` without consuming a cell
 or encoder.
 
+**Capped at the same four**, from the same constant — `MAX_DECLARED_EXTRA_KEYS`
+is exported by `viz.mjs` rather than restated, because a widget and a canvas
+page spend the SAME rotation on the SAME page and two copies of the number
+would be two copies of the decision. It shipped uncapped in #433 and twenty
+keys took a three-knob page from a knob refresh every 4 ticks to every 24.
+Keys already carrying a cell on the page are skipped in the controller, not the
+planner: one canvas can serve both a custom page and the preset browser, and
+those two pages carry different key lists.
+
 **IT IS A PAGE_KNOBS PAGE WITH A DRAWER, NOT A NEW KIND**, and that is the whole
 reason it works. Twenty-two places in `page_controller` branch on PAGE_KNOBS:
 reads, knob turns, touch, the touch strip, announce, dive targets, the list

--- a/src/shared/param_pages/page_controller.mjs
+++ b/src/shared/param_pages/page_controller.mjs
@@ -2064,7 +2064,14 @@ export function createController(io = {}) {
          * Read it on this same bounded rotation; never synchronously in draw. */
         if (p.canvas && Array.isArray(p.canvas.extraKeys)) {
             for (const k of p.canvas.extraKeys) {
-                if (k && extraKeys.indexOf(k) < 0) extraKeys.push(k);
+                if (!k || extraKeys.indexOf(k) >= 0) continue;
+                /* A key that already has a cell on this page is already in the
+                 * rotation. Declaring it here as well would buy nothing and
+                 * cost a second stop reading the same value -- the planner
+                 * cannot rule it out, because the canvas travels to the preset
+                 * browser too and the two pages carry different key lists. */
+                if (p.keys.indexOf(k) >= 0) continue;
+                extraKeys.push(k);
             }
         }
         /*

--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -20,6 +20,7 @@
  */
 
 import { hasChildren, childCount, childIndexParam, childName } from "./child_key.mjs";
+import { MAX_DECLARED_EXTRA_KEYS } from "./viz.mjs";
 
 /**
  * Every param key the hierarchy lists ANYWHERE — so the planner can ask
@@ -426,6 +427,19 @@ export function levelShortNames(lvl) {
  * rather than by diving, and the eight encoders do there exactly what they do
  * on the level's grid.
  */
+function declaredCanvasExtraKeys(p) {
+    const raw = Array.isArray(p.extra_keys) ? p.extra_keys
+              : (Array.isArray(p.extraKeys) ? p.extraKeys : null);
+    if (!raw) return [];
+    const out = [];
+    for (const k of raw) {
+        if (typeof k !== "string" || !k) continue;
+        if (out.indexOf(k) < 0) out.push(k);
+        if (out.length >= MAX_DECLARED_EXTRA_KEYS) break;
+    }
+    return out;
+}
+
 function canvasPageParams(chainParams) {
     const out = new Map();
     for (const p of chainParams || []) {
@@ -442,12 +456,14 @@ function canvasPageParams(chainParams) {
                    : (typeof p.overlay === "string" ? p.overlay : ""),
             /* Read-only values the picture needs but which must not become
              * visible/turnable cells on the level grid. They join the normal
-             * staggered read rotation, never the draw path. */
-            extraKeys: Array.isArray(p.extra_keys)
-                ? p.extra_keys.filter((k) => typeof k === "string" && k)
-                : (Array.isArray(p.extraKeys)
-                    ? p.extraKeys.filter((k) => typeof k === "string" && k)
-                    : []),
+             * staggered read rotation, never the draw path.
+             *
+             * Capped at the SAME four a widget's `viz.extra_keys` gets, and for
+             * the same reason: one read per stop, so an uncapped page spends
+             * its whole budget here and starves the knobs it is drawn beside.
+             * Measured on the uncapped version -- twenty keys took a
+             * three-knob page from a knob refresh every 4 ticks to every 24. */
+            extraKeys: declaredCanvasExtraKeys(p),
             name: p.name || p.short_name || p.key,
         });
     }

--- a/src/shared/param_pages/viz.mjs
+++ b/src/shared/param_pages/viz.mjs
@@ -321,8 +321,15 @@ function collectDeclared(keys, metaIndex, invalid) {
  * ONE READ PER STOP, so this is not free: declare what the picture needs and
  * nothing else. Capped, because a module asking for twenty keys would spend the
  * page's whole read budget on one cell and starve every other value on screen.
+ *
+ * EXPORTED, because a widget is no longer the only thing that can declare them:
+ * an `as_page` canvas param takes `extra_keys` too, and it spends the SAME
+ * rotation on the SAME page. A second copy of the number is a second copy of
+ * the decision, and the canvas path shipped without one -- twenty keys were
+ * accepted, and a three-knob page went from refreshing a knob every 4 ticks to
+ * every 24.
  */
-const MAX_DECLARED_EXTRA_KEYS = 4;
+export const MAX_DECLARED_EXTRA_KEYS = 4;
 
 function declaredExtraKeys(v) {
     const raw = v && (v.extra_keys || v.extraKeys);

--- a/tests/host/test_canvas_page.sh
+++ b/tests/host/test_canvas_page.sh
@@ -75,6 +75,27 @@ ok(cp && cp.canvas.script === "canvas.js" && cp.canvas.overlay === "face_page",
 ok(cp && JSON.stringify(cp.canvas.extraKeys) === JSON.stringify(["activity"]),
    "read-only canvas dependencies travel with the page without becoming cells");
 
+/*
+ * CAPPED AT FOUR, the same cap a widgets viz.extra_keys gets and from the same
+ * exported constant.
+ *
+ * ONE READ PER STOP. Uncapped, a page asking for twenty spends its whole read
+ * budget on the picture and starves the knobs drawn beside it -- measured on
+ * the version that shipped that way: a three-knob page went from refreshing a
+ * knob every 4 ticks to every 24. Declaring ONE key, as the case above does,
+ * passes identically with and without a cap, so the assertion has to overrun
+ * it deliberately.
+ */
+{
+  const many = ["k0", "k1", "k2", "k3", "k4", "k5"];
+  const CPX = CP.map((p) => (p.key === "face" ? { ...p, extra_keys: many } : p));
+  const px = planPages({ hierarchy: HIER, chainParams: CPX }).pages.find((p) => p.canvas);
+  ok(px && px.canvas.extraKeys.length === 4,
+     "six declared extra keys are capped to four, so the read budget survives");
+  ok(px && JSON.stringify(px.canvas.extraKeys) === JSON.stringify(["k0", "k1", "k2", "k3"]),
+     "and it keeps the FIRST four, so the cap is a truncation the author can predict");
+}
+
 /* The canvas key must NOT also be a cell anywhere. */
 const celled = plan.pages.some((p) => (p.keys || []).indexOf("face") >= 0);
 ok(!celled, "the canvas key never gets a cell of its own");
@@ -154,6 +175,44 @@ ok(plan2.pages.some((p) => (p.keys || []).indexOf("face") >= 0),
    * cp.keys, so it does not consume a knob/cell. */
   ok(ctrl.state.values.activity === "frame-1",
      "the canvas extra key is fetched by the staggered value rotation");
+}
+
+/*
+ * A KEY THAT ALREADY HAS A CELL IS NOT A SECOND STOP.
+ *
+ * The rotation serves one key per tick, so a knob named in extra_keys as well
+ * would simply be read twice per lap -- the value it already had, at the cost
+ * of every other key on the page waiting a tick longer. The planner cannot
+ * rule it out (one canvas serves both a custom page and the preset browser,
+ * and those carry different key lists), so the controller does.
+ */
+{
+  const CPD = CP.map((p) => (p.key === "face" ? { ...p, extra_keys: ["a", "activity"] } : p));
+  const store = { ui_hierarchy: JSON.stringify(HIER), chain_params: JSON.stringify(CPD),
+                  a: "0.25", b: "0.5", c: "0.75", activity: "frame-1" };
+  const reads = {};
+  let t = 0;
+  const ctrl = createController({
+    getParam: (k) => { const b = String(k).split(":").pop();
+                       reads[b] = (reads[b] || 0) + 1;
+                       return store[b] === undefined ? null : store[b]; },
+    setParam: () => true, announce: () => {}, now: () => (t += 16),
+  });
+  ctrl.load({ prefix: "synth" });
+  ctrl.setLayout(LAYOUT_MOVY);
+  for (let i = 0; i < 8; i++) {
+    ctrl.goToPage(i, { remember: false });
+    if (ctrl.onCanvasPage()) break;
+  }
+  for (const k of Object.keys(reads)) delete reads[k];
+  for (let i = 0; i < 120; i++) ctrl.tick();
+  /* Three knobs + the preset name + ONE extra key = 5 stops. "a" is a knob, so
+   * it gets its own stop and no more; a second stop would read it ~1.5x as
+   * often as its neighbours. */
+  ok(reads.a && reads.b && Math.abs(reads.a - reads.b) <= 1,
+     "a knob also named in extra_keys is read no more often than its neighbours");
+  ok(ctrl.state.values.activity === "frame-1",
+     "and the genuinely off-page key is still fetched");
 }
 
 /* ---- a thrower is retired, not fatal ---- */


### PR DESCRIPTION
Follow-up to #433, fixed in house rather than sent back — the findings are all "you'd have to already know this codebase."

## The defect

#433 let an `as_page` canvas param declare `extra_keys`, reusing the read rotation a widget's `viz.extra_keys` already spends. It did not reuse the **cap**.

`MAX_DECLARED_EXTRA_KEYS = 4` sits in `viz.mjs` with its reasoning written beside it: *one read per stop, so a cell asking for twenty would spend the page's whole read budget and starve every other value on screen.* `canvasPageParams` filtered for non-empty strings and accepted whatever it was handed. Measured on the merged code, three knobs plus twenty declared extra keys:

```
planned extraKeys count: 20
reads of knob 'a' over 200 ticks: 10     → 1 refresh per 24 ticks (~545ms)
                            uncapped-vs-capped: 1-in-4 (~91ms) is the norm
```

That is the failure the viz cap was written to prevent, reachable by the same field name on a neighbouring declaration.

Meanwhile `docs/MODULES.md` asserted *"`extra_keys` is capped by the same bounded read rotation as other visual dependencies."* The rotation is not a cap — it is the budget the cap protects. That sentence is the part that would have stopped the next reader from noticing.

## Changes

- **Export `MAX_DECLARED_EXTRA_KEYS` from `viz.mjs`** and apply it in `canvasPageParams`, rather than restating the number. A widget and a canvas page spend the same rotation on the same page; two copies of the constant are two copies of the decision.
- **Skip a key that already has a cell on the page.** It was read twice per lap for a value it already had, costing every other key a tick. The check lives in the **controller**, not the planner: one canvas travels to both a custom page and the preset browser, and those two pages carry different key lists, so the planner cannot know.
- **Drop `"hidden": true` from the documented example.** No such field exists — the planner honours `visible_if` and nothing else — and the example never needed one: a param earns a cell by being in a level's `knobs`, so one only ever named by `extra_keys` has no cell to suppress.
- **Docs** in `MODULES.md` and `PARAM_PAGES.md` now state the cap, the number, and the reason.

## Verification

- `tests/host/test_canvas_page.sh` declared **one** extra key, which passes identically with or without a cap. It now overruns the cap deliberately (six declared, four survive, first-four so the truncation is predictable) and pins the dedup by **counting reads** rather than checking a value is present.
- Both new assertions were mutation-checked — each fails on its own defect reintroduced, passes restored:
  ```
  MUTATION 1 (cap removed):        FAIL x2  ✓
  MUTATION 2 (page-key dedup off): FAIL x1  ✓
  RESTORED:                        PASS
  ```
- Full `tests/host/*.sh`: **0 failures**. `make -C tests/host test`: **ALL PASS**.

## Blast radius

`as_page` appears **zero times** across the 95-module fleet capture. The only consumer today is [schwung-pixel-walkers](https://github.com/mestela/schwung-pixel-walkers) v0.1.0, declaring one key. The cap lands on nothing in the field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Feyvf78hdpqT8mGfqV17v