### PR TITLE
claims_ccs: the display mode is part of the claim key, because the shim clears it

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16654,8 +16654,39 @@ function reconcileCcClaim() {
     const onGrid = view === VIEWS.PARAM_PAGES && paramPagesActive();
     const slot = onGrid ? paramPagesSlot() : hierEditorSlot;
     const comp = onGrid ? paramPagesComponent() : hierEditorComponent;
+    /*
+     * THE DISPLAY MODE IS PART OF THE IDENTITY, because the SHIM CLEARS THE
+     * CLAIM AND DOES NOT TELL US.
+     *
+     * shadow_display_mode drops from four sites in the SPI callback -- Menu
+     * tap, Track tap, Shift+Track, Shift+Step -- and the shim memsets
+     * claim_cc_bits on that edge. None of them runs any JS. So `ccClaimed`
+     * below is a MIRROR OF STATE ANOTHER PROCESS OWNS, and after a dismiss it
+     * says "claimed" while the shim holds nothing: the claim is not restated
+     * on the way back in, and the module's buttons go to Move for the rest of
+     * the session.
+     *
+     * Without this the save was incidental. Every re-entry raises a jump flag,
+     * and those mostly land on a NON-claim view (CHAIN_EDIT, MASTER_FX,
+     * TOOLS), which empties the key and re-arms. But Shift+Vol+Step2 lands on
+     * VIEWS.PARAM_PAGES -- a claim view -- via enterGlobalSettings ->
+     * enterGlobalSettingsGrid -> enterParamPages, and it was only the SLOT and
+     * COMPONENT halves of this tuple (Global Settings carries a synthesised
+     * component of its own) that made the key differ anyway. That is a real
+     * invariant resting on a coincidence, and nothing at either site said so.
+     *
+     * Reading it is an SHM byte, not an IPC round-trip, so it costs nothing on
+     * the gate it guards. The flag the shim clears is now the flag this key
+     * turns on, which is the fact itself rather than a proxy for it.
+     *
+     * The pad_observe register next to it (#426) had no key at all and could
+     * only be fixed by restating it every tick; the read behind THIS gate is
+     * ~2.8 ms and must stay memoised, so the gate is widened instead.
+     */
+    const displayOn = (typeof shadow_get_display_mode === "function")
+        ? shadow_get_display_mode() : 1;
     const key = onScreen
-        ? (view + "|" + coRunView + "|" + slot + "|" + comp)
+        ? (view + "|" + coRunView + "|" + slot + "|" + comp + "|" + displayOn)
         : "";
     if (key === ccClaimKey) return;
     /* THE READ COMES FIRST, AND null IS NOT AN ANSWER.

--- a/tests/host/test_claims_ccs.sh
+++ b/tests/host/test_claims_ccs.sh
@@ -164,6 +164,35 @@ echo "$mcc" | command grep -q 'not cached' \
   || fail "a THROWN metadata read is cached -- one bad read then answers \"no claim\" for the rest of the session"
 echo "  ok  a read that did not answer produces no claim, no cache entry and no latch"
 
+# ---- the claim key survives a shim-side drop ---------------------------------
+# The SHIM clears claim_cc_bits when the shadow display closes, from four sites
+# in the SPI callback that run no JS (Menu tap, Track tap, Shift+Track,
+# Shift+Step). `ccClaimed` is therefore a mirror of state another process owns,
+# and the key gate above it is what decides whether the claim is ever restated.
+#
+# So the display mode must be PART OF THAT KEY. Without it the save is
+# incidental: most re-entries raise a jump flag that lands on a non-claim view
+# and empties the key, but Shift+Vol+Step2 lands on VIEWS.PARAM_PAGES -- a
+# claim view -- and only the slot/component halves of the tuple made it differ.
+echo "$rec" | command grep -q 'shadow_get_display_mode' \
+  || fail "reconcileCcClaim's key does not include the display mode -- the shim clears claim_cc_bits on the display-close edge without telling JS, so the claim is never restated on the way back in"
+# grep is line-based and the key spans three lines, so match the assignment and
+# the two lines under it rather than writing a regex that cannot see a newline.
+echo "$rec" | command grep -A2 'const key = onScreen' | command grep -q 'displayOn' \
+  || fail "the display mode is read in reconcileCcClaim but not folded into the key -- reading it changes nothing on its own"
+
+# And the reason it is needed at all: a CC_CLAIM_VIEW that a jump flag lands on
+# directly. Asserted rather than described, so that the day PARAM_PAGES stops
+# being one (or another claim view becomes one) the comment above does not
+# quietly become fiction.
+claim_views=$(command grep -c '^CC_CLAIM_VIEWS\[' "$ui_js")
+[ "$claim_views" -ge 1 ] || fail "CC_CLAIM_VIEWS is empty -- the claim can never be armed"
+command grep -q '^CC_CLAIM_VIEWS\[VIEWS.PARAM_PAGES\]' "$ui_js" \
+  || fail "PARAM_PAGES is no longer a claim view -- re-check the display-mode key above, which exists because a jump flag (Shift+Vol+Step2 -> enterGlobalSettings -> enterParamPages) lands straight on it"
+sed -n '/^function enterGlobalSettings()/,/^}/p' "$ui_js" | command grep -q 'enterGlobalSettingsGrid' \
+  || fail "enterGlobalSettings no longer routes through the grid -- the jump-flag-onto-a-claim-view case this guards may have moved"
+echo "  ok  the claim key turns on the display mode, the flag the shim actually clears"
+
 # ---- docs say what the code does ---------------------------------------------
 command grep -q '| `claims_ccs` |' "$docs" || fail "docs/MODULES.md capability table has no claims_ccs row"
 command grep -q '| `claims_edit_ccs` |' "$docs" || fail "docs/MODULES.md capability table has no claims_edit_ccs row"


### PR DESCRIPTION
## In short

`reconcileCcClaim` compares against `ccClaimed`, a JS-side mirror — but the **shim owns that state and drops it without telling JS**. One line puts the display mode into the key so the flag the shim clears is the flag that re-arms the claim.

Found while reviewing #426, which had the same shape and *was* live.

## Why

`shadow_display_mode` falls from four sites in the SPI callback — Menu tap, Track tap, Shift+Track, Shift+Step — and the shim memsets `claim_cc_bits` on that edge. None of them runs any JS. After a dismiss the mirror still says "claimed" while the shim holds nothing, so the claim is never restated on the way back in and the module's buttons go to Move for the rest of the session.

**It has not been reachable — but by coincidence, not design.** Every re-entry raises a jump flag, and most land on a non-claim view (`CHAIN_EDIT`, `MASTER_FX`, `TOOLS`), which empties the key and re-arms. But **Shift+Vol+Step2 lands on `VIEWS.PARAM_PAGES`**, a claim view, through `enterGlobalSettings` → `enterGlobalSettingsGrid` → `enterParamPages`. What saved it there was only the *slot* and *component* halves of the tuple, Global Settings carrying a synthesised component of its own.

An invariant resting on that, with nothing at either site saying so, is one claim view away from a silent bug.

## Not the #426 fix

`pad_observe` next door had **no key at all** and could only be repaired by restating it every tick. Here the gate exists to skip a ~2.8 ms blocking module-id read and has to stay — so the gate is *widened* rather than removed. Reading `shadow_get_display_mode()` is an SHM byte, not an IPC round-trip, so it costs nothing on the gate it guards.

## Tests

`test_claims_ccs.sh` pins the display mode **into** the key, not merely read near it — the key spans three lines, so it matches the assignment plus what follows rather than a regex that cannot see a newline. It also asserts the hazard itself: `PARAM_PAGES` is a claim view **and** `enterGlobalSettings` routes through the grid, so the day either stops being true the comment does not quietly become fiction.

Mutation-checked four ways (key reverted; the value read but unused; `PARAM_PAGES` dropped from the claim views; `enterGlobalSettings` rerouted). Full `tests/host` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8qAWiChxMZqAij27P96y5