### PR TITLE
param contract: 128KB, and get the 1.2MB frame off the callback stack

### DIFF
--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -105,7 +105,11 @@
  */
 #define CONTROL_BUFFER_SIZE 256
 #define SHADOW_UI_BUFFER_SIZE     512
-#define SHADOW_PARAM_BUFFER_SIZE  65664  /* Large buffer for complex ui_hierarchy */
+/* The param segment: SHADOW_PARAM_VALUE_LEN plus shadow_param_t's header,
+ * rounded up to a page with room to spare. A container with headroom, like
+ * CONTROL_BUFFER_SIZE above -- the `<=` assert below means growing the struct
+ * is free and only SHRINKING this fails the build. */
+#define SHADOW_PARAM_BUFFER_SIZE  133120
 /* The shadow_ui -> shim MIDI out buffer: 256 USB-MIDI packets.
  *
  * It was 512 bytes = 128 packets, and that made ONE js_shadow_midi_send() call
@@ -151,7 +155,26 @@
 #define SHADOW_UI_SLOTS 4
 #define SHADOW_UI_NAME_LEN 64
 #define SHADOW_PARAM_KEY_LEN 64
-#define SHADOW_PARAM_VALUE_LEN 65536  /* 64KB for large ui_hierarchy and state */
+/* 128KB. A module's chain_params and ui_hierarchy each travel through one of
+ * these, and the chain host REJECTS a module whose answer does not fit
+ * (chain_host.c, "UI buffer overflow") -- so this is the ceiling on how much
+ * of an instrument a module may publish. 64KB was not enough for a real
+ * synth: a Waldorf microQ reaches 79% of it with 286 of its 449 parameters,
+ * having already dropped half of both modulation matrices, because every
+ * matrix slot repeats its own 58-entry destination list.
+ *
+ * The cost is one page-aligned SHM segment growing by 64KB, plus the handful
+ * of STATIC buffers sized from this. Before raising it again, check that none
+ * of those buffers has become a local: chain_mod_refresh_target_param_cache
+ * used to put this and a 1.05MB chain_param_info_t array on the stack of a
+ * function called from the SPI callback.
+ *
+ * RESIZING IS A LAYOUT CHANGE, handled like SHADOW_UI_MIDI_BYTES (#358) and
+ * SHADOW_MIDI_OUT_BUFFER_SIZE (#361) above: shadow_shm_map() fstats on attach
+ * and refuses a stale short segment rather than handing back a mapping whose
+ * tail is SIGBUS. Deploy the shim and shadow_ui together, as install.sh does.
+ * Growing is the safe direction for the other order too. */
+#define SHADOW_PARAM_VALUE_LEN 131072
 #define SHADOW_SCREENREADER_TEXT_LEN 8192  /* Max text length for screen reader messages */
 
 /* ============================================================================

--- a/src/modules/chain/dsp/chain_mod.c
+++ b/src/modules/chain/dsp/chain_mod.c
@@ -555,17 +555,39 @@ void chain_mod_clear_source(void *ctx, const char *source_id) {
 }
 
 
+/*
+ * Scratch for the refresh below, deliberately NOT on the stack.
+ *
+ * chain_param_info_t is ~4.3 KB -- options[128][32] alone is 4 KB -- so
+ * chain_param_info_t[MAX_CHAIN_PARAMS] is about 1.05 MB, and the answer buffer
+ * is another SHADOW_PARAM_VALUE_LEN on top. As locals that was a ~1.2 MB stack
+ * frame on a function reachable from a plugin entry point, i.e. from the SPI
+ * callback, every MOD_PARAM_CACHE_REFRESH_MS.
+ *
+ * Static is safe here and heap is not: every caller reaches this through a
+ * plugin entry point, which is the callback thread, and malloc on that thread
+ * is a realtime violation. The function does not recurse. Keeping the
+ * temporary separate from the destination is what preserves the failure
+ * semantics -- a parse that fails must leave the previous cache intact, and
+ * parsing straight into inst->synth_params would half-overwrite it.
+ *
+ * tests/host/test_param_buffers_not_on_stack.sh fails if either goes back.
+ */
+static char s_refresh_buf[SHADOW_PARAM_VALUE_LEN];
+static chain_param_info_t s_refresh_parsed[MAX_CHAIN_PARAMS];
+
 int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *target) {
     if (!inst || !target) return -1;
 
-    char buf[SHADOW_PARAM_VALUE_LEN];
+    char *buf = s_refresh_buf;
+    const size_t buf_size = sizeof(s_refresh_buf);
     int result = -1;
-    chain_param_info_t parsed[MAX_CHAIN_PARAMS];
+    chain_param_info_t *parsed = s_refresh_parsed;
     int parsed_count = -1;
 
     if (strcmp(target, "synth") == 0) {
         if (inst->synth_plugin_v2 && inst->synth_instance && inst->synth_plugin_v2->get_param) {
-            result = inst->synth_plugin_v2->get_param(inst->synth_instance, "chain_params", buf, sizeof(buf));
+            result = inst->synth_plugin_v2->get_param(inst->synth_instance, "chain_params", buf, (int)buf_size);
         }
         if (result <= 0) return -1;
         parsed_count = parse_chain_params_array_json(buf, parsed, MAX_CHAIN_PARAMS);
@@ -581,7 +603,7 @@ int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *tar
 
         if (inst->fx_is_v2[fx_slot] && inst->fx_plugins_v2[fx_slot] &&
             inst->fx_instances[fx_slot] && inst->fx_plugins_v2[fx_slot]->get_param) {
-            result = inst->fx_plugins_v2[fx_slot]->get_param(inst->fx_instances[fx_slot], "chain_params", buf, sizeof(buf));
+            result = inst->fx_plugins_v2[fx_slot]->get_param(inst->fx_instances[fx_slot], "chain_params", buf, (int)buf_size);
         }
         if (result <= 0) return -1;
         parsed_count = parse_chain_params_array_json(buf, parsed, MAX_CHAIN_PARAMS);
@@ -602,7 +624,7 @@ int chain_mod_refresh_target_param_cache(chain_instance_t *inst, const char *tar
         result = inst->midi_fx_plugins[midi_fx_slot]->get_param(inst->midi_fx_instances[midi_fx_slot],
                                                                 "chain_params",
                                                                 buf,
-                                                                sizeof(buf));
+                                                                (int)buf_size);
         if (result <= 0) return -1;
         parsed_count = parse_chain_params_array_json(buf, parsed, MAX_CHAIN_PARAMS);
         if (parsed_count < 0) return -1;

--- a/tests/host/test_param_buffers_not_on_stack.sh
+++ b/tests/host/test_param_buffers_not_on_stack.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# A SHADOW_PARAM_VALUE_LEN buffer must never be a local, and neither must a
+# chain_param_info_t array.
+#
+# chain_mod_refresh_target_param_cache declared both: 128KB plus ~1.05MB
+# (chain_param_info_t is ~4.3KB, of which options[128][32] is 4KB, times
+# MAX_CHAIN_PARAMS). That is a ~1.2MB stack frame on a function reachable from
+# a plugin entry point -- which IS the SPI callback -- every 250ms. It survived
+# because it never crashed on a default 8MB pthread stack; it would not survive
+# a smaller one, and the constant it is sized from grows.
+#
+# Both buffers are `static` now: single callback thread, no recursion, and
+# malloc on that thread is a realtime violation.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+fail=0
+
+# A declaration of this buffer that is not static and not a parameter.
+while IFS= read -r hit; do
+    case "$hit" in
+        *static*|*"const char"*|*"char *"*) continue ;;
+        *shadow_constants.h*) continue ;;   # shadow_param_t's own member
+    esac
+    echo "FAIL: SHADOW_PARAM_VALUE_LEN buffer on the stack: $hit"
+    fail=1
+done < <(grep -rn "^[[:space:]]*[a-z_]* *char [a-z_]*\[SHADOW_PARAM_VALUE_LEN\]" src/ || true)
+
+while IFS= read -r hit; do
+    case "$hit" in
+        *static*) continue ;;
+        *chain_internal.h*) continue ;;   # the per-instance members, by design
+    esac
+    echo "FAIL: chain_param_info_t array on the stack: $hit"
+    fail=1
+done < <(grep -rn "^[[:space:]]*chain_param_info_t [a-z_]*\[" src/ || true)
+
+# The segment must be able to hold the struct; the compile-time check in
+# shadow_constants.h enforces it, this says so where a reader will look.
+value_len=$(grep -oE '^#define SHADOW_PARAM_VALUE_LEN +[0-9]+' src/host/shadow_constants.h | grep -oE '[0-9]+$')
+buffer=$(grep -oE '^#define SHADOW_PARAM_BUFFER_SIZE +[0-9]+' src/host/shadow_constants.h | grep -oE '[0-9]+$')
+if [ "$buffer" -le "$value_len" ]; then
+    echo "FAIL: SHADOW_PARAM_BUFFER_SIZE ($buffer) must exceed SHADOW_PARAM_VALUE_LEN ($value_len)"
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "PASS: param buffers are static, and the segment holds the struct ($value_len in $buffer)"
+exit "$fail"


### PR DESCRIPTION
## Why

`SHADOW_PARAM_VALUE_LEN` is the ceiling on how much of an instrument a module may publish — `chain_params` and `ui_hierarchy` each travel through one of these, and the chain host **rejects** a module whose answer does not fit (`chain_host.c`, "UI buffer overflow"). It does not truncate: the slot loads and shows an error.

64 KB is not enough for a real synth. A Waldorf microQ editor reaches **79% of it with 286 of the instrument's 449 parameters**, and only after dropping half of both modulation matrices — every matrix slot repeats its own 58-entry destination list verbatim, so sixteen slots cost ~18 KB on their own.

## What changed

- `SHADOW_PARAM_VALUE_LEN` 65536 → 131072, and `SHADOW_PARAM_BUFFER_SIZE` grown to match. The existing compile-time `sizeof(shadow_param_t) <= SHADOW_PARAM_BUFFER_SIZE` check caught the half of the change I had missed, which is exactly what it is for.
- **`chain_mod_refresh_target_param_cache`'s locals moved off the stack.** It declared both `char buf[SHADOW_PARAM_VALUE_LEN]` and `chain_param_info_t parsed[MAX_CHAIN_PARAMS]`. `chain_param_info_t` is ~4.3 KB (`options[128][32]` alone is 4 KB), so that array is ~1.05 MB and the frame ~1.2 MB — on a function reachable from a plugin entry point every `MOD_PARAM_CACHE_REFRESH_MS`. **A plugin entry point is the SPI callback.** It survived on a default 8 MB pthread stack; the raise would have added 64 KB to it.

`static`, not heap: every caller arrives on the callback thread where `malloc` is a realtime violation, and the function does not recurse. Kept separate from the destination rather than parsed in place, because a parse that fails must leave the previous cache intact.

## Verification

- `tests/host/test_param_buffers_not_on_stack.sh` — new; fails if either buffer returns to the stack, or if the segment stops being able to hold the struct. Mutation-checked (it does fail when the buffer is made a local).
- `make -C tests/host test` + all `tests/host/*.sh`: pass, 0 failures.
- ARM cross-compile via Docker: clean.
- Not yet exercised on hardware.

## Deploying

Resizing the segment follows the procedure already documented for `SHADOW_UI_MIDI_BYTES` (#358) and `SHADOW_MIDI_OUT_BUFFER_SIZE` (#361): `shadow_shm_map()` fstats on attach and refuses a stale short segment rather than handing back a mapping whose tail is SIGBUS, so the feature goes quiet with a log line instead of crashing. Deploy the shim and shadow_ui together, as `install.sh` does. Growing is the safe direction for the other order too.

Note the sequencing for module authors: a module larger than 64 KB is rejected by an un-upgraded host, so a module can only spend the new headroom once this has shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcobDotKaWAEyiEg13MLtM