### PR TITLE
validate: report a visible_if that only exists in chain_params

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1366,6 +1366,12 @@ Rate options are emitted from slowest to fastest timing, for example:
 - `wav_position` in module.json
 - `canvas` in module.json
 
+`visible_if` is a LEVEL field. It goes on a level, or on one of that level's
+`params` entries -- **not** in `chain_params`. The planner reads it from the
+level and nowhere else, so a gate declared beside a param's other metadata
+hides nothing: every gated cell is drawn, with no error and nothing logged.
+`validate.mjs` reports that as `visible-if-not-on-level`.
+
 `visible_if` can be attached to level entries and param entries:
 
 ```json

--- a/src/shared/param_pages/validate_contract.mjs
+++ b/src/shared/param_pages/validate_contract.mjs
@@ -282,6 +282,39 @@ export function validateContract({ id, hierarchy, chainParams, capabilities } = 
         }
     }
 
+    /* ---- a gate declared where nothing reads it ---------------------------- */
+
+    /*
+     * `visible_if` is a LEVEL-entry field. The planner reads it off the level's
+     * own `params` (isHiddenParam in page_plan.mjs) and nowhere else, so the
+     * same key carrying `visible_if` in chain_params and not on the level
+     * hides nothing -- every gated cell is drawn, with no error and nothing in
+     * a log.
+     *
+     * It is an easy mistake because chain_params is where a param's other
+     * metadata lives. It cost a microQ editor a day: eight FX types' controls
+     * all on screen at once, and three LFO pages holding one knob each.
+     */
+    {
+        const gatedInLevels = new Set();
+        for (const lvl of Object.values((hierarchy && hierarchy.levels) || {})) {
+            for (const item of (lvl && lvl.params) || []) {
+                const key = item && (item.key || item.param);
+                if (key && item.visible_if) gatedInLevels.add(String(key));
+            }
+        }
+        const orphaned = cp
+            .filter((p) => p && p.key && p.visible_if && !gatedInLevels.has(String(p.key)))
+            .map((p) => p.key);
+        if (orphaned.length) {
+            add("warn", "visible-if-not-on-level",
+                `${orphaned.length} chain_params declare visible_if that no level entry ` +
+                `mirrors, so nothing is hidden: ` +
+                `${orphaned.slice(0, 6).join(", ")}${orphaned.length > 6 ? ", …" : ""}. ` +
+                `The planner reads visible_if from the level's params entries.`);
+        }
+    }
+
     /* ---- metadata gaps ---------------------------------------------------- */
 
     const index = buildMetaIndex({ hierarchy, chainParams: cp });

--- a/tests/host/test_visible_if_on_level.sh
+++ b/tests/host/test_visible_if_on_level.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# `visible_if` in chain_params, and not on the level entry, hides NOTHING.
+#
+# The planner reads it off the level's own params (page_plan.mjs isHiddenParam)
+# and nowhere else. Declaring it beside a param's other metadata -- where every
+# other field lives -- is the natural mistake, and it fails silently: every
+# gated cell is drawn, no error, nothing logged. A microQ editor shipped that
+# way with eight effects' controls on screen at once.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+out=$(node --input-type=module -e '
+import { validateContract } from "./src/shared/param_pages/validate_contract.mjs";
+const gate = { key: "b", equals: 1 };
+const cp = [{ key: "a", name: "A", type: "int", min: 0, max: 9, visible_if: gate },
+            { key: "b", name: "B", type: "int", min: 0, max: 9 }];
+const ids = (f) => (Array.isArray(f) ? f : (f.findings || [])).map((x) => x.id || x.rule)
+                     .filter((i) => /visible-if-not-on-level/.test(i));
+
+const orphaned = validateContract({ id: "t",
+  hierarchy: { levels: { root: { knobs: ["a", "b"], params: [{ key: "a" }, { key: "b" }] } } },
+  chainParams: cp });
+const mirrored = validateContract({ id: "t",
+  hierarchy: { levels: { root: { knobs: ["a", "b"],
+                                 params: [{ key: "a", visible_if: gate }, { key: "b" }] } } },
+  chainParams: cp });
+
+if (ids(orphaned).length !== 1) { console.log("FAIL: an orphaned visible_if was not reported"); process.exit(1); }
+if (ids(mirrored).length !== 0) { console.log("FAIL: a mirrored visible_if was reported anyway"); process.exit(1); }
+console.log("PASS: a visible_if that only exists in chain_params is reported");
+')
+echo "$out"
+case "$out" in *PASS*) exit 0 ;; *) exit 1 ;; esac


### PR DESCRIPTION
## The silent failure

`visible_if` is a **level** field. The planner reads it off the level's own `params` entries (`page_plan.mjs` `isHiddenParam`) and nowhere else.

Declaring it in `chain_params` — beside where every other piece of a param's metadata lives — is the natural mistake, and it fails in the worst way available: nothing is hidden, no error is raised, nothing reaches a log. The page just has more cells on it than the author intended, and the contract reads as though the gating is there.

It cost a microQ editor a day. Each effects unit drew all seven effects' controls at once, and each LFO carried a second page holding a single knob, while its `chain_params` said plainly that they were gated. With the gate moved to the level entries, that module plans 41 pages instead of 52.

## The change

- `validate.mjs` reports `visible-if-not-on-level` (warn) for any `chain_params` entry carrying `visible_if` that no level entry mirrors.
- `docs/MODULES.md` says where the field belongs *before* showing the example, which previously demonstrated the correct placement without ever saying the wrong one doesn't work.

No planner behaviour changes — this only makes the existing rule visible. I considered making the planner fall back to the `chain_params` entry instead, and didn't: `visible_if` is documented as a level field, the level is where a per-page gate belongs (the same key can be gated differently on two pages), and widening the lookup would make the two placements silently equivalent rather than one of them wrong.

## Verification

- `tests/host/test_visible_if_on_level.sh` — new; pins both directions (an orphaned gate is reported, a mirrored one is not).
- Full `tests/host` shell suite: 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcobDotKaWAEyiEg13MLtM