### PR TITLE
param pages: two gaps found while building a module

### DIFF
--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -786,9 +786,21 @@ export function planPages({ hierarchy, chainParams, mode, visible, unresolved,
         /* The walk root's grid page is always "Main", even when the level
          * declares a label. 16 modules would otherwise open on a page called
          * "Patch" / "Console" / "BOOM"; one consistent name for "where you land"
-         * beats each module's own word for it. */
+         * beats each module's own word for it.
+         *
+         * `subtitle` is the OPT-IN exception: "Main - <subtitle>". It exists
+         * for a module that splits one level per page so the header can say
+         * which page you are on -- Hinge has three ADSR rows (OP2's, OP1's and
+         * the filter's) that draw the same graphic under the same four labels,
+         * so the header is the only thing distinguishing them, and its landing
+         * page had nothing to say. Deliberately NOT `name`: reading the level's
+         * own label here would rename the landing page of all 16 modules above,
+         * which is the thing this rule exists to prevent. A module must ask. */
         const isRoot = levelKey === rootKey;
-        const base = isRoot ? "Main" : nameOf(levelKey, lvl);
+        const subtitle = isRoot && lvl && typeof lvl.subtitle === "string"
+            ? lvl.subtitle.trim() : "";
+        const base = isRoot ? (subtitle ? `Main - ${subtitle}` : "Main")
+                            : nameOf(levelKey, lvl);
         const title = prefix ? `${prefix}/${base}` : base;
 
         /* Preset browser first — decided 2026-07-26. A level is routinely both

--- a/src/shared/param_pages/viz.mjs
+++ b/src/shared/param_pages/viz.mjs
@@ -231,7 +231,13 @@ function collectDeclared(keys, metaIndex, invalid) {
              * Such a role is also NOT claimed, so its own cell still draws as
              * an ordinary control. It informs the picture; it is not part of it.
              */
-            if (v.role) g.roles[v.role] = { key, slot, span: v.span !== false };
+            /* `viz` is retained because the group's extra_keys are read back
+             * off it below -- a role stored without it made that lookup
+             * (`declaredExtraKeys(r.viz)`) return null for every member, so a
+             * GROUP could never carry extra_keys at all while the comment
+             * there said it could. A spanning widget whose values live on
+             * another page then drew its "no answer" state forever. */
+            if (v.role) g.roles[v.role] = { key, slot, span: v.span !== false, viz: v };
             if (v.kind && !g.kind) g.kind = v.kind;
         } else if (v.kind) {
             /*

--- a/tests/host/test_root_page_subtitle.sh
+++ b/tests/host/test_root_page_subtitle.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+# THE LANDING PAGE IS "Main", AND `subtitle` IS THE ONLY WAY PAST THAT.
+#
+# page_plan.mjs fixes the walk root's grid page to "Main" on purpose, so that
+# 16 modules do not each open on their own word for "where you land". That
+# leaves a module which splits one level per page unable to say which page the
+# landing one IS -- and for a module with three identically-labelled ADSR rows
+# the header is the only thing telling them apart.
+#
+# `subtitle` is opt-in for exactly that. This pins all three properties:
+#   - absent  -> "Main" (the existing convention, unchanged for every module)
+#   - present -> "Main - <subtitle>"
+#   - a level `name` alone must NOT do it, or the 16 modules regress.
+
+node --input-type=module -e '
+import { planPages } from "./src/shared/param_pages/page_plan.mjs";
+
+const mk = (root) => ({ levels: { root, other: { name: "Other", knobs: ["z"] } } });
+const params = [
+    { key: "a", name: "A", type: "float", min: 0, max: 1 },
+    { key: "z", name: "Z", type: "float", min: 0, max: 1 },
+];
+const plan = (root) => planPages({ hierarchy: mk(root), chainParams: params });
+const nameOfFirst = (p) => (p.pages.find((q) => q.kind === "knobs") || {}).name;
+
+let fail = 0;
+const eq = (label, got, want) => {
+    if (got !== want) { console.error(`FAIL ${label}: got ${JSON.stringify(got)} want ${JSON.stringify(want)}`); fail = 1; }
+};
+
+eq("no subtitle",      nameOfFirst(plan({ knobs: ["a"] })), "Main");
+eq("name is not one",  nameOfFirst(plan({ name: "Patch", knobs: ["a"] })), "Main");
+eq("subtitle applies", nameOfFirst(plan({ name: "Patch", subtitle: "OP2", knobs: ["a"] })), "Main - OP2");
+eq("blank ignored",    nameOfFirst(plan({ subtitle: "   ", knobs: ["a"] })), "Main");
+
+if (fail) process.exit(1);
+console.log("ok - root page subtitle");
+'

--- a/tests/host/test_viz_group_extra_keys.sh
+++ b/tests/host/test_viz_group_extra_keys.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A VIZ GROUP MUST BE ABLE TO CARRY extra_keys.
+#
+# resolveViz builds a declared GROUP from `viz: {group, role, kind}` on several
+# keys, then reads that group's extra_keys back off its members:
+#
+#     for (const r of Object.values(g.roles)) {
+#         const ek = declaredExtraKeys(r.viz);
+#
+# The roles were stored as `{ key, slot, span }` with no `viz` field, so that
+# lookup returned null for every member and a group could NEVER carry
+# extra_keys -- while the comment directly above it said it could. The failure
+# is invisible in the contract and silent at runtime: a spanning widget whose
+# values live on another page simply draws its "no answer" state forever, which
+# reads as a broken widget rather than as a missing value.
+#
+# (Found by Hinge, whose output-waveform widget spans the phase cells on one
+# page and needs the OP2 ratio/level/feedback values from another.)
+#
+# SINGLES already worked -- that branch passes extraKeys explicitly -- so this
+# pins the GROUP path specifically, and asserts the singles path stays working
+# so a fix cannot trade one for the other.
+
+node --input-type=module -e '
+import { resolveViz } from "./src/shared/param_pages/viz.mjs";
+import { registerOverlayWidgets } from "./src/shared/param_pages/widget_registry.mjs";
+
+registerOverlayWidgets({ widgetKinds: ["custom:t"], drawCell() {} }, "test");
+
+const mk = (metas) => ({ getOrGuess: (k) => metas[k] || { key: k }, byKey: metas });
+let fail = 0;
+const check = (label, got, want) => {
+    const g = JSON.stringify(got), w = JSON.stringify(want);
+    if (g !== w) { console.error(`FAIL ${label}: got ${g} want ${w}`); fail = 1; }
+};
+
+/* GROUP: kind and extra_keys declared on one member, role on another. */
+const grp = mk({
+    a: { key: "a", viz: { group: "g", role: "r1", kind: "custom:t", extra_keys: ["off1", "off2"] } },
+    b: { key: "b", viz: { group: "g", role: "r2" } },
+});
+const gr = resolveViz({ keys: ["a", "b"], metaIndex: grp }).groups;
+check("group count", gr.length, 1);
+check("group spans both cells", gr[0].keys, ["a", "b"]);
+check("group extraKeys", gr[0].extraKeys, ["off1", "off2"]);
+
+/* SINGLE: the path that always worked, pinned so a fix cannot regress it. */
+const sng = mk({ s: { key: "s", viz: { kind: "custom:t", extra_keys: ["off3"] } } });
+const sr = resolveViz({ keys: ["s"], metaIndex: sng }).groups;
+check("single extraKeys", sr[0].extraKeys, ["off3"]);
+
+if (fail) process.exit(1);
+console.log("ok - viz groups carry extra_keys");
+'


### PR DESCRIPTION
Two independent defects in the param-pages layer, both found while building an external module (a 2-op FM synth) that needed a spanning custom widget and a named landing page. Each is one commit with its own test.

## 1. A viz GROUP could never carry `extra_keys`

`resolveViz` builds a declared group from `viz: {group, role, kind}` across several keys, then reads that group's `extra_keys` back off its members:

```js
for (const r of Object.values(g.roles)) {
    const ek = declaredExtraKeys(r.viz);
```

The roles were stored as `{ key, slot, span }` — no `viz` field — so that lookup returned `null` for every member and `built.extraKeys` was never set. The comment directly above it says a group's extra keys may be declared on any member; they could not be declared at all.

Silent in both directions: nothing is missing from the contract, and the widget simply draws its "no answer" state forever, which reads as a broken widget rather than as a value that never arrived. Singles were unaffected — that branch passes `extraKeys` explicitly.

`tests/host/test_viz_group_extra_keys.sh` pins the group path and asserts the singles path stays working, so a fix cannot trade one for the other.

## 2. The landing page could not say which page it is

The walk root's grid page is fixed to `"Main"` on purpose, so 16 modules don't each open on their own word for "where you land". That leaves a module which splits one level per page unable to name its landing page — and for a module whose pages carry three envelopes that draw the same graphic under the same four labels (`ATK DEC SUS REL`), the header is the only thing distinguishing them.

`subtitle` on the root level renders `"Main - <subtitle>"`. Opt-in, and deliberately **not** `name`: reading the level's own label here would rename the landing page of all 16 modules the rule exists to protect.

`tests/host/test_root_page_subtitle.sh` pins all three properties — absent gives `Main`, a `name` alone does **not** trigger it, and `subtitle` gives `Main - X`.

## Verification

- `tests/host`: 283 passed, 0 failed; `make -C tests/host test` all pass.
- Both changes exercised end-to-end by rendering a real module's pages through `tools/param-pages/preview.mjs` — the spanning widget draws its waveform from off-page values, and the headers read `Main - Perf`, `OP2 Env`, `OP1 Env`, `Filter`, `Filter Env`.

No hardware verification.