### PR TITLE
param pages: stop re-hashing a contract that has not changed

### DIFF
--- a/src/shared/param_pages/page_plan.mjs
+++ b/src/shared/param_pages/page_plan.mjs
@@ -272,14 +272,44 @@ function levelNameToPrefix(name) {
 /* FNV-1a over the declared contract. The page set is rebuilt when this changes:
  * module swap, an is_loading→ready re-fetch that rewrites the tree (Virus,
  * minijv expansions), or a mode change. */
+/*
+ * The last (parts -> fingerprint), compared by IDENTITY.
+ *
+ * Hashing means stringifying the whole contract and walking every character of
+ * it, and planPages runs on every detent of a gating knob (replanIfCondition).
+ * On those re-plans the contract has not changed at all -- only a VALUE has --
+ * and `hierarchy` and `chainParams` are the very objects the previous plan
+ * used, because the controller assigns them from parse() on a read and never
+ * mutates them in place (page_controller.mjs `load`). So the same objects mean
+ * the same bytes, and re-hashing them is pure waste.
+ *
+ * It is waste that scales with the contract: a 94 KB one costs ~0.78 ms in
+ * node, and the device runs QuickJS on an A72, where a 94,000-iteration
+ * charCodeAt loop is far slower. Turning a filter-type knob through its values
+ * paid that per detent, and the screen stalled.
+ *
+ * Identity, not equality: a re-read parses new objects, so a contract that
+ * really did change (osirus republishing rom_index's options once its ROM is
+ * known) arrives as a different object and is hashed.
+ */
+let fingerprintMemo = null;
+
 function fingerprintOf(parts) {
+    if (fingerprintMemo && fingerprintMemo.parts.length === parts.length &&
+        fingerprintMemo.parts.every((part, i) => part === parts[i])) {
+        return fingerprintMemo.value;
+    }
     let h = 0x811c9dc5;
     const s = JSON.stringify(parts);
     for (let i = 0; i < s.length; i++) {
         h ^= s.charCodeAt(i);
         h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
     }
-    return h.toString(16);
+    const value = h.toString(16);
+    /* One entry, holding one contract's objects alive -- the same ones the
+     * controller is already holding in `s.hierarchy` / `s.chainParams`. */
+    fingerprintMemo = { parts: parts.slice(), value };
+    return value;
 }
 
 function chunk(arr, size) {

--- a/tests/host/test_plan_fingerprint_memo.sh
+++ b/tests/host/test_plan_fingerprint_memo.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# planPages must not re-hash a contract it has already hashed.
+#
+# The fingerprint is a JSON.stringify of the whole contract plus a walk over
+# every character of it, and planPages runs on EVERY DETENT of a gating knob
+# (replanIfCondition). On those re-plans only a value changed; the contract
+# objects are the same ones, because the controller assigns them from parse()
+# and never mutates them in place. At 94 KB that hash was ~0.78 ms in node and
+# far worse under QuickJS on the device, and the screen stalled while a filter
+# type knob turned.
+#
+# The memo is keyed on IDENTITY, so this test asserts both halves: the same
+# objects skip the hash, and objects that are genuinely new do not.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+node --input-type=module -e '
+import { planPages } from "./src/shared/param_pages/page_plan.mjs";
+
+const hierarchy = { levels: { root: { knobs: ["a"], params: [{ key: "a" }] } } };
+const chainParams = [{ key: "a", name: "A", type: "int", min: 0, max: 9 }];
+const fp = () => planPages({ hierarchy, chainParams }).fingerprint;
+
+const first = fp();
+if (!first) { console.log("FAIL: no fingerprint returned"); process.exit(1); }
+if (fp() !== first) { console.log("FAIL: same objects gave two fingerprints"); process.exit(1); }
+
+// Mutating IN PLACE must not be seen -- which is the memo doing its job, and
+// is safe only because the controller never does this. If that ever changes,
+// this assertion is the thing that should fail.
+chainParams.push({ key: "b", name: "B", type: "int", min: 0, max: 9 });
+if (fp() !== first) {
+    console.log("FAIL: the fingerprint is not memoised on identity");
+    process.exit(1);
+}
+
+// A genuinely new object -- what a re-read produces -- must be hashed again.
+const reread = JSON.parse(JSON.stringify(chainParams));
+const after = planPages({ hierarchy, chainParams: reread }).fingerprint;
+if (after === first) {
+    console.log("FAIL: a changed contract kept the old fingerprint");
+    process.exit(1);
+}
+
+// Note there is no assertion that the ORIGINAL objects still answer their old
+// value: the memo holds one entry, so asking again re-hashes them -- and they
+// were mutated above, so they now legitimately hash to what the copy did.
+
+console.log("PASS: the fingerprint is memoised on identity and re-hashed on a new contract");
+'


### PR DESCRIPTION
## The cost

`planPages` fingerprints the whole contract on every call — `JSON.stringify` of the hierarchy and `chain_params`, then a walk over **every character** of the result. And `replanIfCondition` calls `planPages` on **every detent of a gating knob**.

On those re-plans the contract has not changed at all. Only a value has, and `hierarchy` / `chainParams` are the very objects the previous plan used — the controller assigns them from `parse()` on a read (`page_controller.mjs` `load`) and never mutates them in place.

So the hash is waste, and it scales with the contract:

| module | contract | fingerprint (node) |
|---|---|---|
| minijv | 83 KB | 0.39 ms |
| surge | 64 KB | 0.30 ms |
| osirus | 38 KB | 0.19 ms |
| obxd | 9 KB | 0.04 ms |

Node is a JIT; the device runs QuickJS on an A72, where an 83,000-iteration `charCodeAt` loop is much slower.

I found this on a module whose contract is 94 KB, where turning an FX type knob stalled the screen visibly. **But the cost isn't that module's — it's every gated page's**, and minijv and surge are already two thirds of the way to the size that made it obvious.

## The change

Memoise on the **identity** of the parts. That is exactly equivalent to hashing: a re-read parses new objects, so a contract that genuinely changed — osirus republishing `rom_index`'s options once its ROM is known — arrives as a different object and is hashed.

Re-plan cost: minijv 3.8 → 3.0 ms, surge 2.6 → 2.1, osirus 1.7 → 1.1, and 2.6 → 0.9 on the 94 KB module.

## Verification

- `tests/host/test_plan_fingerprint_memo.sh` — new. Pins both halves: the same objects skip the hash (asserted by mutating one **in place** and requiring the fingerprint not to move — safe only because the controller never does that, and precisely the assertion that should fail if it ever starts), and a genuinely new object is hashed again. Mutation-checked.
- `make -C tests/host test` + all `tests/host/*.sh`: 0 failures.
- Not exercised on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FcobDotKaWAEyiEg13MLtM