### PR TITLE
docs: the hierarchy section's introduction contradicted its own rule

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1165,7 +1165,18 @@ The DSP plugin receives these in `set_param()` and `get_param()`.
 
 ## Shadow UI Parameter Hierarchy
 
-Modules expose a navigable parameter hierarchy to the Shadow UI via `ui_hierarchy` in module.json or `get_param("ui_hierarchy")`. The hierarchy uses a **levels dictionary** format with named levels:
+Modules expose a navigable parameter hierarchy to the Shadow UI via
+`ui_hierarchy`. **Where it must live depends on your `component_type`, and a
+sound generator has only one option: `get_param("ui_hierarchy")`.** A synth's
+`module.json` hierarchy is never read, and declaring one there produces no
+error -- the grid simply plans from `chain_params` as though you had declared
+nothing, which on the device looks like a module with no pages at all, just its
+preset row. Audio FX and MIDI FX may use either. The full rule, with the source
+lines that implement it, is under
+[Where the hierarchy must live](#where-the-hierarchy-must-live) below -- read it
+before choosing, not after.
+
+The hierarchy uses a **levels dictionary** format with named levels:
 
 ```json
 {
@@ -1671,6 +1682,8 @@ rack" would seat every one of them as one. Notes describe *voices*; `pad_layout`
 describes the *surface*; the two axes never imply each other. `"drums"` with no
 voices declared is legal (a rack whose pages are not published yet), and
 `"chromatic"` with a note on every zone page is legal and correct.
+
+### Where the hierarchy must live
 
 It lives in `ui_hierarchy` rather than in `module.json` capabilities so that a
 module whose answer depends on what is loaded — an sfz player, a slicer: drums


### PR DESCRIPTION
## The bug this is about

A sound generator that declares `ui_hierarchy` in `module.json` and does not serve it from `get_param` loads, plays, and shows **no pages at all** — just its preset row. No error, nothing logged. This has now cost two modules: JE-8086, and again this week building a 2-op FM synth.

## The documentation was already right

`docs/MODULES.md` states the rule in full — that `synth:ui_hierarchy` goes straight to the plugin with no fallback, with the source line that implements it, and this warning:

> "This is easy to get wrong because the declaration looks identical either way, and a synth that declares one in `module.json` gets no error — it is simply ignored."

That is the failure, named in advance. That passage is correct and unchanged here.

## What is actually wrong

It arrives ~500 lines after the **introduction** to the same section, which reads:

> "Modules expose a navigable parameter hierarchy to the Shadow UI via `ui_hierarchy` in module.json **or** `get_param(\"ui_hierarchy\")`."

That sentence is where a reader forms their model and makes the choice, and for a synth the "or" is false. Being right later in the document does not help someone who has already decided.

So the introduction now states the rule for sound generators, names the symptom (a module with no pages, only its preset row — the thing you actually see), and links forward to the detailed passage, which gains a `### Where the hierarchy must live` heading to be linkable.

Docs only. `tests/host`: 283 passed, 0 failed.