### PR TITLE
shadow: step + volume knob is a VELOCITY edit, and the volume scanner read it

### DIFF
--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -895,6 +895,18 @@ static volatile int shadow_volume_knob_touched = 0;
 /* Count of currently-held pads (notes 68-99).  When > 0, volume knob adjusts
  * pad gain, not master volume, so display-based volume detection is skipped. */
 static volatile int shadow_pads_held = 0;
+/* Bitmask of currently-held step buttons (notes 16-31).  Same reason as the
+ * pad counter above: step + volume knob is Move's per-step VELOCITY edit and
+ * draws a velocity overlay, not the master volume overlay, so the pixel
+ * scanner must not read it.
+ *
+ * A mask rather than a counter because midi_monitor() only processes a MIDI_IN
+ * slot whose first four bytes CHANGED since last frame, and events shift
+ * between slots (that is why the dedup rings key on content, not position) —
+ * so the same note-on can be seen twice and a note-off can be seen in a slot
+ * that already held it.  Set/clear by note number is idempotent under both;
+ * a counter drifts, and a drifted counter latches the scanner off forever. */
+static volatile uint32_t shadow_steps_held_mask = 0;
 /* Is jog encoder currently being touched? (note 9) */
 static volatile int shadow_jog_touched = 0;
 /* Is shift button currently held? (CC 49) - global for cross-function access */
@@ -5375,6 +5387,21 @@ void midi_monitor()
             }
         }
 
+        /* Track step-button hold state (notes 16-31) for the same gating.
+         * Hold a programmed step and turn the volume knob and Move edits that
+         * step's velocity, showing a velocity overlay in the same rows the
+         * volume bar lives in — read as a volume bar it drags mailbox gain
+         * down with the velocity. */
+        if (midi_1 >= CC_STEP_UI_FIRST && midi_1 <= CC_STEP_UI_LAST) {
+            uint32_t bit = 1u << (midi_1 - CC_STEP_UI_FIRST);
+            if ((midi_0 & 0xF0) == 0x90 && midi_2 > 0) {
+                shadow_steps_held_mask |= bit;
+            } else if ((midi_0 & 0xF0) == 0x80 ||
+                       ((midi_0 & 0xF0) == 0x90 && midi_2 == 0)) {
+                shadow_steps_held_mask &= ~bit;
+            }
+        }
+
     }
 }
 
@@ -6161,10 +6188,14 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
             pin_accumulate_slice(idx, mem + 84, bytes);
         }
 
-        /* When volume knob touched (and no track or pad held), start capturing.
-         * Pad+volume adjusts pad gain and shows a gain overlay, not the
-         * master volume overlay — reading it would set master volume wrong. */
-        if (shadow_volume_knob_touched && shadow_held_track < 0 && shadow_pads_held == 0) {
+        /* When volume knob touched (and no track, pad or step held), start
+         * capturing.  Pad+volume adjusts pad gain, step+volume edits that
+         * step's velocity, track+volume the track level — each draws its own
+         * overlay, not the master volume overlay, and reading one of those
+         * sets master volume (mailbox gain) from a bar that means something
+         * else entirely. */
+        if (shadow_volume_knob_touched && shadow_held_track < 0 &&
+            shadow_pads_held == 0 && shadow_steps_held_mask == 0) {
             if (!volume_capture_active) {
                 volume_capture_active = 1;
                 volume_capture_warmup = 18;  /* Wait ~3 frames (6 slices * 3) for overlay to render */

--- a/tests/host/test_volume_scanner_gesture_gate.sh
+++ b/tests/host/test_volume_scanner_gesture_gate.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Source pin: the pixel volume-bar scanner reads MOVE'S MASTER VOLUME OVERLAY
+# and nothing else.
+#
+# The scanner reconstructs Move's OLED and converts a bar position into
+# shadow_master_volume — mailbox gain. Move draws a bar in those same rows for
+# gestures that are not the master volume at all:
+#
+#   track + volume   track level
+#   pad   + volume   pad gain
+#   step  + volume   that step's VELOCITY
+#
+# Read as a volume bar, each drags the mailbox gain along with it. The first
+# two were guarded when they bit; the third shipped unguarded and showed up as
+# "editing step velocity in the Schwung view also turns the volume down".
+#
+# So the capture gate must carry all three held-state terms, and the step term
+# must be a MASK keyed by note number rather than a counter: midi_monitor()
+# only processes a MIDI_IN slot whose first four bytes changed, and events
+# shift between slots, so the same note-on can be seen twice and a note-off can
+# arrive for a slot already counted. A drifted counter latches the scanner off
+# for the rest of the session.
+set -u
+
+SHIM="$(dirname "$0")/../../src/schwung_shim.c"
+fails=0
+fail() { echo "FAIL: $*" >&2; fails=$((fails + 1)); }
+
+[ -f "$SHIM" ] || { echo "FAIL: cannot find $SHIM" >&2; exit 1; }
+
+# --- 1. the capture gate carries track, pad AND step ----------------------
+gate_line=$(grep -n 'if (shadow_volume_knob_touched && shadow_held_track < 0' "$SHIM" | head -1 | cut -d: -f1)
+[ -n "$gate_line" ] || fail "cannot find the volume-capture gate — has it moved?"
+if [ -n "${gate_line:-}" ]; then
+    gate=$(sed -n "${gate_line},$((gate_line + 2))p" "$SHIM")
+    case "$gate" in
+        *shadow_pads_held\ ==\ 0*) ;;
+        *) fail "volume-capture gate does not exclude a held pad" ;;
+    esac
+    case "$gate" in
+        *shadow_steps_held_mask\ ==\ 0*) ;;
+        *) fail "volume-capture gate does not exclude a held STEP — step+volume is Move's velocity edit, and its overlay reads as a low master volume" ;;
+    esac
+fi
+
+# --- 2. the step hold is tracked, as a mask, in midi_monitor -------------
+grep -q 'static volatile uint32_t shadow_steps_held_mask' "$SHIM" \
+    || fail "shadow_steps_held_mask is not a uint32_t mask — a counter drifts when a slot is re-seen"
+
+mon_line=$(grep -n '^void midi_monitor' "$SHIM" | head -1 | cut -d: -f1)
+[ -n "$mon_line" ] || fail "cannot find midi_monitor()"
+if [ -n "${mon_line:-}" ]; then
+    body=$(sed -n "${mon_line},$((mon_line + 200))p" "$SHIM")
+    case "$body" in
+        *shadow_steps_held_mask\ \|=*) ;;
+        *) fail "midi_monitor() never sets a step bit — the gate above can never fire" ;;
+    esac
+    case "$body" in
+        *shadow_steps_held_mask\ \&=\ ~*) ;;
+        *) fail "midi_monitor() never clears a step bit — the scanner would stay off after one step press" ;;
+    esac
+fi
+
+# The mask is tracked from the hardware mailbox, like the pad counter and the
+# volume touch: a shadow-buffer read would go blind exactly when the shadow UI
+# filters the event, which is the state the bug was reported in.
+case "$(sed -n "${mon_line:-1},$((${mon_line:-1} + 20))p" "$SHIM")" in
+    *hardware_mmap_addr*) ;;
+    *) fail "midi_monitor() no longer reads the hardware mailbox — the held-state tracking would go blind under the shadow UI's own MIDI_IN filtering" ;;
+esac
+
+if [ "$fails" -eq 0 ]; then
+    echo "PASS: volume-bar scanner is gated on track, pad and step holds"
+    exit 0
+fi
+echo "$fails check(s) failed" >&2
+exit 1


### PR DESCRIPTION
Reported: 8W8 in a slot, Move sequencing it, Schwung view on screen showing 8W8's params. Hold a programmed step, turn the volume knob to trim that step's velocity — the velocity changes as it should, and the audible level drops with it. Dismiss the Schwung view and the same gesture on the Move track does not do it.

## What is actually happening

`shadow_master_volume` is mailbox gain for every Schwung slot, and it is not a value Move hands us — it is *estimated* by reconstructing Move's OLED and finding the volume bar's 1px indicator in rows 30-32 (the SLICE-BASED DISPLAY CAPTURE block in `schwung_shim.c`).

So the scanner has to be told which gestures put something else in those rows. Two already are, each added after it bit:

- **track + volume** — track level
- **pad + volume** — pad gain, whose comment states the failure mode outright: *"the pixel-based volume reader can misinterpret the gain overlay as a very low master volume, muting all audio."*

**step + volume is the third and was never listed.** It is Move's per-step velocity edit, it draws its own bar in the same rows, and dragging the velocity down drags the bar down with it — read as the user turning the master volume down. Move's own volume is untouched throughout, which is why the symptom reads as "Schwung ignored the held-step modifier" rather than as a misread screen.

## The change

- `shadow_steps_held_mask` (notes 16-31), tracked in `midi_monitor()` from the hardware mailbox beside the pad counter
- added to the volume-capture gate
- a **mask**, not a counter like the pads: `midi_monitor()` skips any MIDI_IN slot whose first four bytes are unchanged since last frame, and events shift between slots (the reason the dedup rings key on content, not position), so the same note-on can be processed twice and a note-off can arrive for a slot already accounted for. Set/clear by bit is idempotent under both; a counter drifts, and one that drifts positive latches the scanner off for the rest of the session.

`tests/host/test_volume_scanner_gesture_gate.sh` pins the gate's three terms and the mask's shape. Mutation-checked four ways: dropping the step term from the gate, mask -> counter, never setting a bit, never clearing one — each turns it red.

## What this does NOT explain, and is not verified

**NOT hardware-verified.**

The reported asymmetry does not follow from this diagnosis. With the shadow UI dismissed the scanner still runs — `native_display_visible` is true whenever `!shadow_display_mode` — so the same misread should be audible on the Move track, and the report says it is not. Either Move renders a different overlay in that context, or there is a second term I have not found.

The guard is correct on its own terms either way: step + volume never means the master volume, so the scanner must not read that frame. But if the log below shows `Master volume:` lines only in the shadow case, something else is also in play and this PR is half the story.

```
ssh ableton@move.local "touch /data/UserData/schwung/debug_log_on"
ssh ableton@move.local "tail -f /data/UserData/schwung/debug.log | grep 'Master volume'"
```

Repro in both states; disarm `debug_log_on` afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019fGrgxDcWpFGfyjWRP61dr