### PR TITLE
param pages: "already resolved" asked about the PROCESS, so one widgetless module killed every widget until reboot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -597,6 +597,23 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   nominal each); the rule lives in `registerOverlayWidgets`, beside the
   registry, so `tests/host/` can run it, and an unusable declaration is LOGGED
   rather than dropped.
+- **The widget registry is PROCESS-GLOBAL, and "already resolved" was asked
+  about the process rather than about the component.** `tickComponentWidgets`
+  opened `if (widgetModuleLoaded) return;` — the latch is a module id, so any
+  truthy value stopped the retry, and `ensureComponentWidgets` sets it from
+  EITHER call site. Open a module declaring no custom kind and the registry is
+  emptied and the latch set to it; every component after that returned on the
+  first line and registered nothing, so a module that HAS a widget drew the
+  detector's dials until reboot — silent, because an unregistered kind simply
+  does not claim its keys. The guard cannot be deleted (every frame would pay
+  the 2.8 ms `_module` read it exists to avoid) and the component alone is not
+  enough (the list editor relatches without this tick running), so it closes on
+  a SIGNATURE of component + latched id — **stamped with the world the attempt
+  LEAVES, not the one it found**, or a signature that recurs is mistaken for a
+  repeat and throttled. The old source pin asserted the buggy line verbatim,
+  which is how a defect gets defended rather than merely missed. Authors: a
+  redeployed `canvas.js` is not re-read until you leave the component and
+  return.
 - **A card is handed the PAGE's values, not only its own.** The payload is
   `{w, h, name, value, raw, values, nowMs}`. A card whose meaning depends on a
   sibling — the vowel of *which* character — otherwise had no route to it at

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1637,6 +1637,66 @@ shipped `src/modules/audio_fx/widget-test/{module.json,canvas.js}` rather than
 calling `registerWidget()` directly. Every other widget test registers directly,
 and that is exactly why none of them saw this.
 
+#### "Already resolved" is a question about the COMPONENT, not about the process
+
+`tickComponentWidgets` is the knob grid's half of that lifetime, and it opened
+with `if (widgetModuleLoaded) return;` — a comment reading *"resolved: nothing
+to ask"*. The latch is a module id, so any truthy value stopped the retry. That
+is sound only while the latch can only ever describe the component in front of
+you, and it cannot: `ensureComponentWidgets` wipes the process-global registry
+and latches whichever module reaches it, **from either call site** — this tick,
+and `loadHierarchyLevel` in the list editor.
+
+So visiting a module that declares no custom kind emptied the registry and set
+the latch to *its* id, after which this function returned on its first line for
+every component visited afterwards. Nothing registered again. A module that
+*has* a widget then drew the detector's dials, because an unregistered kind does
+not claim its keys — the same silent fall-through as the section above, reached
+from a completely different direction. No error, no log line, and no recovery
+short of a reboot.
+
+Observed on device on 2026-09-07 while developing a module's widget: it
+registered once, an unrelated drum module was opened six minutes later, and from
+then on the grid drew dials. The author's reading was "my widget is broken", and
+an hour of redeploys went into a registry that was never going to be re-read.
+
+Three things make the fix less obvious than it looks.
+
+**The guard cannot simply be deleted.** Without it every frame pays the ~2.8 ms
+`_module` IPC read the throttle exists to avoid — against a 1.68 ms whole-page
+render, so the "fix" costs more than redrawing the screen.
+
+**Remembering the component is not enough either.** The list editor relatches
+without this tick running, so the component can still match a registry that has
+since been emptied for somebody else. The guard closes on a **signature** —
+`<slot>:<component>` *and* the currently latched id — so it reopens whether the
+component changed or the registry was taken out from under it.
+
+**And the attempt must be stamped with the world it LEAVES, not the one it
+found.** Stamping the signature before the attempt looks equivalent; it is not,
+because the attempt itself usually changes the latch, so the stamp described a
+state that no longer existed. A later frame genuinely arriving in that state was
+then mistaken for a repeat and throttled — 250 ms of dials before the module's
+art appeared, which is the "an unresolved answer must not become a picture" rule
+broken by a subtler route. Stamping afterwards preserves what the throttle is
+for (an attempt that changed nothing leaves its signature, so the next frame is
+correctly a repeat) while any real change re-attempts at once.
+
+`tests/host/test_widget_latch_per_component.sh` drives the actual device
+sequence, including the entry through the list editor, and asserts both halves:
+that a module re-registers on the **first** frame after another module has been
+visited, and that a resolved component still costs **zero** IPC reads.
+
+**The old source pin asserted the bug.** `test_canvas_drawcell_wiring.sh`
+required the literal `if (widgetModuleLoaded) return;` — so the defect was not
+merely untested, it was defended. It pins the rule now, plus the *absence* of
+the old form. A source pin that quotes an expression rather than stating a rule
+will do this every time.
+
+**For module authors:** a redeployed `canvas.js` is not re-read while its
+component stays loaded — the latch is per module id, by design, so the script is
+parsed once. Leave the component and come back to pick up a new build.
+
 ### A module may declare SEVERAL widgets, and one call site said otherwise
 
 The registry has always been a `Map`, and `registerWidget` has always taken a

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -14204,7 +14204,8 @@ function exitHierarchyEditor() {
      * (rather than in the canvas teardown, which runs on every canvas open and
      * close) is what makes the next component ask the question afresh. */
     widgetModuleLoaded = "";
-    widgetAttemptedFor = "";
+    widgetAttemptedSig = "";
+    widgetResolvedSig = "";
     hierEditorAllParams = [];
     hierEditorAllKnobs = [];
     hierEditorChildIndex = -1;
@@ -16401,12 +16402,65 @@ let widgetModuleLoaded = "";
  * already does, and it stops entirely the moment the id resolves. */
 const WIDGET_RETRY_TICKS = 15;
 let widgetRetryTick = 0;
-/* The component the last attempt was made for, so a NEW one is attempted at
- * once rather than at the next throttle boundary. */
-let widgetAttemptedFor = "";
+/*
+ * BOTH TRACKERS KEY ON A SIGNATURE, NOT ON A COMPONENT.
+ *
+ * The signature is `<slot>:<component>\0<latched module id>` -- the component
+ * on screen AND what the process-global registry currently holds. Either half
+ * alone is a bug:
+ *
+ *   component only  the OTHER call site (loadHierarchyLevel, the list editor)
+ *                   relatches and wipes the registry without this tick ever
+ *                   running, so the component still matches a registry that
+ *                   has since been emptied for somebody else.
+ *   latch only      returning to a component whose module happens to still be
+ *                   latched would skip the attempt that re-registers it.
+ *
+ * Signature changes are what "new situation" means, so the throttle's
+ * attempt-at-once branch covers a latch stolen from underneath us for free --
+ * and it fires ONCE, because the next frame's signature is the same again.
+ * A bare "the latch is stale" test would have re-attempted every frame for as
+ * long as it stayed unresolvable, which is the IPC cost the throttle exists to
+ * avoid.
+ */
+let widgetAttemptedSig = "";
+let widgetResolvedSig = "";
 
 function tickComponentWidgets() {
-    if (widgetModuleLoaded) return;                 /* resolved: nothing to ask */
+    /*
+     * "RESOLVED" IS A QUESTION ABOUT THE COMPONENT ON SCREEN.
+     *
+     * This early-out read `if (widgetModuleLoaded) return;` -- the latch is a
+     * module id, so any truthy value meant "resolved, nothing to ask". That is
+     * only sound while the latch can only ever describe the component in front
+     * of you, and it cannot: `ensureComponentWidgets` calls `clearWidgets()`
+     * and sets the latch for whichever module reaches it, from EITHER call
+     * site (the list editor's `loadHierarchyLevel`, and this tick). Load a
+     * module that declares no custom kind and the registry is emptied and the
+     * latch set to that module's id -- after which this function returned on
+     * its first line for every component visited afterwards, and nothing was
+     * ever registered again.
+     *
+     * The registry is process-global, so the damage is not local: on device,
+     * opening a module with no custom widget left a module that HAS one
+     * drawing the detector's dials, with no error and no log line, until the
+     * next reboot. `ensureComponentWidgets` was right all along -- it compares
+     * the id -- but it was never reached to do the comparison.
+     *
+     * The guard cannot simply be deleted: without it every frame pays the
+     * ~2.8ms `_module` IPC read that the throttle below exists to avoid. So it
+     * asks the narrower question instead, against the same key the throttle
+     * already computes.
+     *
+     * That is the exact device sequence: the grid resolved for its slot, the
+     * list editor then loaded another module and emptied the registry, and the
+     * grid went on believing its own answer. So the guard closes only while the
+     * signature it resolved for still describes the world -- see the signature
+     * note above.
+     */
+    const key = `${paramPagesSlot()}:${paramPagesComponent()}`;
+    const sig = `${key}\u0000${widgetModuleLoaded}`;
+    if (widgetModuleLoaded && widgetResolvedSig === sig) return;
 
     /*
      * FIRST ATTEMPT IS IMMEDIATE; ONLY RETRIES ARE THROTTLED.
@@ -16425,9 +16479,7 @@ function tickComponentWidgets() {
      * genuinely-unsettled case, where repeating a ~2.8ms round trip every frame
      * would cost more than the render.
      */
-    const key = `${paramPagesSlot()}:${paramPagesComponent()}`;
-    if (key !== widgetAttemptedFor) {
-        widgetAttemptedFor = key;
+    if (sig !== widgetAttemptedSig) {
         widgetRetryTick = 0;
     } else if (++widgetRetryTick % WIDGET_RETRY_TICKS) {
         return;
@@ -16455,6 +16507,32 @@ function tickComponentWidgets() {
     if (!prefix) return;
     const id = getSlotParam(slot, `${prefix}_module`) || "";
     ensureComponentWidgets(id, getComponentChainParams(slot, comp));
+
+    /*
+     * RECORD THE ATTEMPT AGAINST THE WORLD IT LEAVES BEHIND, NOT THE ONE IT
+     * FOUND.
+     *
+     * Stamping `sig` before the attempt looks equivalent and is not: the
+     * attempt itself usually CHANGES the latch, so the stamp described a state
+     * that no longer existed the moment it was written -- and a later frame
+     * that genuinely arrived in that state was mistaken for a repeat and
+     * throttled. Concretely: enter a component while another module is latched,
+     * register, then have the list editor relatch that same other module. The
+     * signature then matched the stale stamp exactly, and the grid drew dials
+     * for the ~250ms until the throttle came round.
+     *
+     * Stamping afterwards keeps the property the throttle is for -- an attempt
+     * that changed nothing leaves the signature it was given, so the next frame
+     * is correctly a repeat -- while any real change re-attempts at once.
+     */
+    widgetAttemptedSig = `${key}\u0000${widgetModuleLoaded}`;
+
+    /* Resolved only if the latch actually describes THIS component.
+     * ensureComponentWidgets returns without latching on an unresolved id or
+     * unsettled chain_params -- the tri-state rule -- and recording regardless
+     * would re-create the bug one level down, closing the guard on a question
+     * still open. */
+    if (id && widgetModuleLoaded === id) widgetResolvedSig = widgetAttemptedSig;
 }
 
 function ensureComponentWidgets(moduleId, chainParams) {

--- a/tests/host/test_canvas_drawcell_wiring.sh
+++ b/tests/host/test_canvas_drawcell_wiring.sh
@@ -133,8 +133,24 @@ ok(cpGuardIdx < latchIdx, "the empty-chainParams guard also comes BEFORE the lat
 ok(/function tickComponentWidgets/.test(src), "there is a retry for the unresolved case");
 const tcwStart = src.indexOf("function tickComponentWidgets");
 const tcwBody = code(src.slice(tcwStart, src.indexOf("\nfunction ", tcwStart + 1)));
-ok(/if\s*\(\s*widgetModuleLoaded\s*\)\s*return;/.test(tcwBody),
-   "the retry stops once the id resolves");
+/* THE STOPPING CONDITION IS NARROWER THAN IT LOOKS, AND THIS PIN USED TO STATE
+ * THE BUG.
+ *
+ * It asserted, literally, `if (widgetModuleLoaded) return;` -- so it defended
+ * the defect rather than the rule. The latch is a module id and the registry is
+ * process-global, so ANY module reaching ensureComponentWidgets sets it and
+ * wipes the registry, from either call site. Once that happened the retry
+ * stopped for every component visited afterwards, and a module with a custom
+ * widget silently drew the detectors dials until reboot.
+ *
+ * The rule was always "stop once resolved". What it is resolved FOR is the
+ * component on screen together with what the registry currently holds -- which
+ * is what the signature carries. Pin the rule, and pin the absence of the old
+ * form, so a well-meaning simplification back to it fails here. */
+ok(/if\s*\(\s*widgetModuleLoaded\s*&&\s*widgetResolvedSig\s*===\s*sig\s*\)\s*return;/.test(tcwBody),
+   "the retry stops once resolved for THIS component and THIS registry");
+ok(!/if\s*\(\s*widgetModuleLoaded\s*\)\s*return;/.test(tcwBody),
+   "the retry does not stop merely because some module is latched");
 ok(/WIDGET_RETRY_TICKS/.test(tcwBody),
    "the retry is THROTTLED -- the id costs an IPC read, ~2.8ms against a 1.68ms render");
 

--- a/tests/host/test_widget_latch_per_component.sh
+++ b/tests/host/test_widget_latch_per_component.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A module's in-grid widgets must register again after ANOTHER module has been
+# visited in between.
+#
+# tickComponentWidgets began `if (widgetModuleLoaded) return;`. The latch holds
+# a module ID, so any truthy value read as "resolved, nothing to ask" -- sound
+# only if the latch can only describe the component on screen, which it cannot.
+# ensureComponentWidgets calls clearWidgets() and sets the latch for whichever
+# module reaches it, from either call site.
+#
+# So: open a module that declares no custom kind, and the registry is emptied
+# and the latch set to its id. From then on this function returned on its first
+# line for every component visited afterwards, and nothing registered again.
+# The registry is process-global, so a module that HAS a widget then drew the
+# detector's dials instead -- silently, with no log line, until reboot.
+# Observed on device 2026-09-07: hinge registered at 12:25, dr32 cleared it at
+# 12:31, and hinge drew dials for every entry after that.
+#
+# Two things are asserted, because the obvious fix breaks the other one:
+# deleting the guard makes re-entry work and costs a ~2.8ms `_module` IPC read
+# on EVERY frame, against a 1.68ms whole-page render. The guard has to stay and
+# ask the narrower question.
+
+file="src/shadow/shadow_ui.js"
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "FAIL: node is required" >&2
+  exit 1
+fi
+
+fn=$(awk '/^function tickComponentWidgets\(/,/^}/' "$file")
+if [ -z "$fn" ]; then
+  echo "FAIL: tickComponentWidgets not found in $file" >&2
+  exit 1
+fi
+
+# The retry throttle is read from the source rather than restated, so raising it
+# cannot silently invalidate the read-cost assertion below.
+retry_ticks=$(sed -n 's/^const WIDGET_RETRY_TICKS = \([0-9]*\);.*/\1/p' "$file")
+if [ -z "$retry_ticks" ]; then
+  echo "FAIL: WIDGET_RETRY_TICKS not found in $file" >&2
+  exit 1
+fi
+
+printf '%s' "$fn" | node -e '
+const fs = require("fs");
+const src = fs.readFileSync(0, "utf8");
+const RETRY = Number(process.argv[1]);
+const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+/* The scenario is a sequence of components, so the harness has to hold the
+ * latch state the function mutates. Declaring it here rather than lifting it
+ * keeps the scaffolding explicit -- and a rename in the source fails loudly
+ * instead of quietly creating a fresh global. */
+const preamble = `
+  let widgetModuleLoaded = "";
+  let widgetAttemptedSig = "";
+  let widgetResolvedSig = "";
+  let widgetRetryTick = 0;
+`;
+
+/* Stands in for the real ensureComponentWidgets, reproducing the only two
+ * behaviours this test depends on: it wipes the process-global registry, and
+ * it latches the id it was given. Defined inside the same source string so it
+ * shares the latch binding, exactly as the real pair do. */
+const stub = `
+  function ensureComponentWidgets(id, chainParams) {
+    if (!id) return;                                   /* tri-state: unresolved */
+    if (id === widgetModuleLoaded) return;
+    if (!Array.isArray(chainParams) || chainParams.length === 0) return;
+    registry.length = 0;                               /* clearWidgets() */
+    widgetModuleLoaded = id;
+    if (chainParams.some((p) => p && p.viz && String(p.viz.kind).startsWith("custom:")))
+      registry.push(id);
+  }
+`;
+
+let slot = 0, comp = "", moduleReads = 0;
+const registry = [];
+const MODULES = {
+  "0:synth": { id: "hinge", params: [{ viz: { kind: "custom:hinge_wave" } }] },
+  "1:synth": { id: "dr32",  params: [{ viz: {} }] },
+};
+const here = () => MODULES[`${slot}:${comp}`] || { id: "", params: [] };
+
+const make = new Function(
+  "paramPagesSlot", "paramPagesComponent", "getSlotParam",
+  "getComponentParamPrefix", "getComponentChainParams",
+  "WIDGET_RETRY_TICKS", "registry", "debugLog",
+  preamble + stub + src +
+  "; return { tickComponentWidgets, ensureComponentWidgets, latch: () => widgetModuleLoaded };");
+
+const api = make(
+  () => slot,
+  () => comp,
+  () => { moduleReads++; return here().id; },
+  () => "synth",
+  () => here().params,
+  RETRY, registry, () => {});
+
+const visit = (s, c, frames) => {
+  slot = s; comp = c;
+  for (let i = 0; i < frames; i++) api.tickComponentWidgets();
+};
+
+/* 1. hinge, which declares a custom kind. */
+visit(0, "synth", 4);
+if (!registry.includes("hinge"))
+  fail("hinge did not register its widget on first entry");
+
+/* 2. dr32, which declares none. Emptying the registry is correct and
+ *    deliberate -- a widget left behind would outlive its module. */
+visit(1, "synth", 4);
+if (registry.includes("hinge"))
+  fail("visiting dr32 left hinge widget registered; a stale widget outlives its module");
+
+/* 3. back to hinge. THE REGRESSION. */
+visit(0, "synth", 4);
+if (!registry.includes("hinge"))
+  fail("hinge did not re-register after visiting a module with no custom widget -- " +
+       "its cells fall through to the detector and draw dials, silently, until reboot");
+
+/* 3b. THE SEQUENCE OBSERVED ON DEVICE, which reaches the same guard by the
+ *     other door: the list editor (loadHierarchyLevel) registers a component
+ *     directly, without this tick ever running. That is how dr32 came to own
+ *     the latch at 12:31 while the knob grid was the only thing that could
+ *     have put hinge back. */
+api.ensureComponentWidgets("dr32", [{ viz: {} }]);
+if (registry.includes("hinge"))
+  fail("harness: the list-editor path did not clear the registry");
+/* ONE frame: the recovery must be immediate, not throttled. The signature
+ * changed, so this is a new situation, and ~250ms of dials from the detector
+ * before the module supplies its own art is the "an unresolved answer must not
+ * become a picture" rule broken with extra steps. */
+visit(0, "synth", 1);
+if (!registry.includes("hinge"))
+  fail("hinge did not re-register on the FIRST frame after the LIST EDITOR loaded " +
+       "another module; the knob grid either never re-asks, or waits out the throttle");
+
+/* 4. and the guard still has to close, or every frame pays an IPC read. */
+moduleReads = 0;
+visit(0, "synth", 120);
+if (moduleReads !== 0)
+  fail("staying on a resolved component cost " + moduleReads + " `_module` IPC reads " +
+       "across 120 frames, expected 0 (~2.8ms each, vs a 1.68ms whole-page render)");
+
+/* 5. an unresolved id must not close the guard -- the tri-state rule, one
+ *    level down. Recording the key regardless of whether the latch actually
+ *    took would re-create the bug in a new place. */
+MODULES["2:synth"] = { id: "", params: [] };
+visit(2, "synth", 1);
+moduleReads = 0;
+visit(2, "synth", RETRY * 2 + 2);
+if (moduleReads === 0)
+  fail("an unresolved module id stopped the retry; a read that did not answer " +
+       "must never become a cached verdict");
+
+console.log("PASS: widget latch is per-component, and still costs nothing once resolved");
+' "$retry_ticks"


### PR DESCRIPTION
`tickComponentWidgets` opened `if (widgetModuleLoaded) return;`, commented *"resolved: nothing to ask"*. The latch is a **module id**, so any truthy value stopped the retry — sound only if the latch could only ever describe the component on screen, and it cannot. `ensureComponentWidgets` wipes the process-global registry and latches whichever module reaches it, **from either call site**: this tick, and `loadHierarchyLevel` in the list editor.

So opening a module that declares no custom kind emptied the registry and set the latch to its id, after which this function returned on its first line for **every component visited afterwards**. A module that *has* a widget then drew the detector's dials, because an unregistered kind does not claim its keys — no error, no log line, no recovery short of a reboot.

Seen on device while developing a module's widget: it registered at 12:25, an unrelated drum module was opened at 12:31, and the grid drew dials from then on. It reads as "my widget is broken", so an hour of redeploys went into a registry that was never going to be re-read.

## Three things the fix has to get right

None of them the first thing you reach for.

**The guard cannot just be deleted.** Without it every frame pays the ~2.8 ms `_module` IPC read the throttle exists to avoid, against a 1.68 ms whole-page render — the "fix" would cost more than redrawing the screen.

**Remembering the component is not enough.** The list editor relatches without this tick running, so the component still matches a registry emptied for somebody else. The guard closes on a **signature** — `<slot>:<component>` plus the currently latched id — so it reopens whether the component changed or the registry was taken out from under it.

**The attempt must be stamped with the world it LEAVES, not the one it found.** Stamping before the attempt looks equivalent; the attempt usually changes the latch, so the stamp described a state that no longer existed, and a frame genuinely arriving in that state was mistaken for a repeat and throttled — 250 ms of dials before the module supplied its art. Stamping afterwards keeps what the throttle is for (an attempt that changed nothing leaves its signature, so the next frame is correctly a repeat) while any real change re-attempts at once.

## Tests

`tests/host/test_widget_latch_per_component.sh` drives the device sequence, including entry through the list editor, and asserts both halves: re-registration on the **first** frame after another module was visited, and **zero** IPC reads once resolved. Both mutations fail it — the old guard, and the pre-attempt stamp.

`tests/host/test_canvas_drawcell_wiring.sh` required the literal `if (widgetModuleLoaded) return;`, so the defect was **defended** rather than merely untested. It pins the rule now, plus the absence of the old form.

All 286 `tests/host/*.sh` plus `make -C tests/host test` green.

## Not covered

Not yet verified on hardware — the reboot that unstuck the reporting device also cleared the state this fixes, so reproducing it there means deliberately re-entering the bad sequence on a build with the fix.

Docs: a subsection in `docs/PARAM_PAGES.md` and a hook bullet in `CLAUDE.md`, including the author-facing consequence — a redeployed `canvas.js` is not re-read until you leave the component and return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxwBP9oMQyFttFvoDx3Nhy