### PR TITLE
catalog: add Hinge, a 2-operator FM synth on eight knobs

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1422,6 +1422,17 @@
       "asset_name": "jp8000-module.tar.gz",
       "min_host_version": "1.1.1",
       "requires": "JP-8000 v1.5 firmware ROMs: all 8 .mid files in the module's roms/ folder"
+    },
+    {
+      "id": "hinge",
+      "name": "Hinge",
+      "description": "Two-operator FM on eight knobs, one page: ratio, brightness, bite, one envelope pair, noise and a tone sweep. 32 presets",
+      "author": "charlesvestal",
+      "component_type": "sound_generator",
+      "github_repo": "charlesvestal/schwung-hinge",
+      "default_branch": "main",
+      "asset_name": "hinge-module.tar.gz",
+      "min_host_version": "1.2.0"
     }
   ]
 }


### PR DESCRIPTION
Adds [charlesvestal/schwung-hinge](https://github.com/charlesvestal/schwung-hinge) to the catalog.

Two-operator FM where eight knobs on one page are the whole instrument — Ratio, Bright, Bite, Tone, Attack, Decay, Sustain, Noise. No manual mode and no page of raw operator values. 32 presets across bass, keys, bells, leads, pads, percussion and effects.

`min_host_version` is **1.2.0**: that is where `ensureComponentWidgets` and `canvas_script` first shipped, and so the oldest host that can draw the wave across Ratio/Bright/Bite. An older one loads the module and silently draws three dials instead, because an unregistered widget kind is not an error — it falls through to the detector.

Verified end to end against the flow the manager actually runs: `release.json` on `main` resolves to v0.4.0, its `download_url` ends in the catalog's `asset_name`, and the asset is served (200, 24392 bytes).

Inserted textually rather than by round-tripping the JSON — the file mixes literal and `\u`-escaped non-ASCII, so `json.dumps` normalises one way or the other and rewrites nineteen other entries whichever way it goes. The diff here is 11 added lines and no deletions.

### Worth knowing before this reaches 1.2.0 users

Two host bugs fixed on `main` but not in any release affect every 1.2.0 device:

- **#450** — the widget registry is cleared by any module without a custom widget and never re-registers, so Hinge's wave disappears after visiting another module and stays gone until reboot.
- **#451** — choosing a preset does not drop the grid's cached values, so the first turn of a knob you had already used steps from the previous preset's value.

Both are listed in the module's release notes, but a 1.2.1 before this merges would spare new users from meeting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxwBP9oMQyFttFvoDx3Nhy