### PR TITLE
Restore hardware audio_in for both overtake roles, not only the generator

### DIFF
--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -2145,33 +2145,42 @@ static void shadow_inprocess_render_to_buffer(void) {
     if (probe_burst_this_frame > spi_slot_probe_burst_max)
         spi_slot_probe_burst_max = probe_burst_this_frame;
 
+    /* Restore raw hardware audio_in so overtake plugins can read line-in.
+     * The resample bridge may have overwritten the shadow_mailbox AUDIO_IN
+     * region; re-copy from hardware to give plugins the actual input.
+     *
+     * For EITHER overtake role. This used to live inside the generator branch
+     * below, so an overtake module loaded as an audio FX (one whose .so exports
+     * move_audio_fx_init_v2, e.g. to declare end_of_chain and process the
+     * whole mix) read whatever the bridge had left in the region instead of
+     * the jack. Restoring here lets such a module offer both inputs -- the
+     * mix in place through process_block, the jack through audio_in_offset --
+     * as one module with an input-source setting, rather than shipping as two. */
+    if ((overtake_dsp_gen_inst || overtake_dsp_fx_inst) && hardware_mmap_addr) {
+        int16_t *hw_ain = (int16_t *)(hardware_mmap_addr + AUDIO_IN_OFFSET);
+        int16_t *sh_ain = (int16_t *)(global_mmap_addr + AUDIO_IN_OFFSET);
+        /* Log once to verify hardware audio levels */
+        static int ain_log_count = 0;
+        if (ain_log_count < 3) {
+            int16_t hw_peak = 0, sh_peak = 0;
+            for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
+                int16_t s = hw_ain[i] < 0 ? -hw_ain[i] : hw_ain[i];
+                if (s > hw_peak) hw_peak = s;
+                s = sh_ain[i] < 0 ? -sh_ain[i] : sh_ain[i];
+                if (s > sh_peak) sh_peak = s;
+            }
+            char msg[256];
+            snprintf(msg, sizeof(msg),
+                     "SampleRobot: audio_in restore - hw_peak=%d sh_peak=%d hw[0..3]=%d,%d,%d,%d",
+                     hw_peak, sh_peak, hw_ain[0], hw_ain[1], hw_ain[2], hw_ain[3]);
+            shadow_log(msg);
+            ain_log_count++;
+        }
+        memcpy(sh_ain, hw_ain, AUDIO_BUFFER_SIZE);
+    }
+
     /* Overtake DSP generator: mix its output into the deferred buffer */
     if (overtake_dsp_gen && overtake_dsp_gen_inst && overtake_dsp_gen->render_block) {
-        /* Restore raw hardware audio_in so overtake plugins can read line-in.
-         * The resample bridge may have overwritten the shadow_mailbox AUDIO_IN
-         * region; re-copy from hardware to give plugins the actual input. */
-        if (hardware_mmap_addr) {
-            int16_t *hw_ain = (int16_t *)(hardware_mmap_addr + AUDIO_IN_OFFSET);
-            int16_t *sh_ain = (int16_t *)(global_mmap_addr + AUDIO_IN_OFFSET);
-            /* Log once to verify hardware audio levels */
-            static int ain_log_count = 0;
-            if (ain_log_count < 3) {
-                int16_t hw_peak = 0, sh_peak = 0;
-                for (int i = 0; i < FRAMES_PER_BLOCK * 2; i++) {
-                    int16_t s = hw_ain[i] < 0 ? -hw_ain[i] : hw_ain[i];
-                    if (s > hw_peak) hw_peak = s;
-                    s = sh_ain[i] < 0 ? -sh_ain[i] : sh_ain[i];
-                    if (s > sh_peak) sh_peak = s;
-                }
-                char msg[256];
-                snprintf(msg, sizeof(msg),
-                         "SampleRobot: audio_in restore - hw_peak=%d sh_peak=%d hw[0..3]=%d,%d,%d,%d",
-                         hw_peak, sh_peak, hw_ain[0], hw_ain[1], hw_ain[2], hw_ain[3]);
-                shadow_log(msg);
-                ain_log_count++;
-            }
-            memcpy(sh_ain, hw_ain, AUDIO_BUFFER_SIZE);
-        }
         int16_t render_buffer[FRAMES_PER_BLOCK * 2];
         memset(render_buffer, 0, sizeof(render_buffer));
         struct timespec og_t0, og_t1;


### PR DESCRIPTION
## Why

The re-copy of the hardware `AUDIO_IN` region into the shadow mailbox
(`schwung_shim.c` ~2150, "Restore raw hardware audio_in so overtake plugins
can read line-in") runs inside the generator branch only. An overtake module
the shim loads as an **audio FX** — one whose `.so` exports
`move_audio_fx_init_v2`, which is the role `capabilities.end_of_chain` needs —
never gets it, so `mapped_memory + audio_in_offset` holds whatever the resample
bridge last wrote instead of the jack.

That forces a module that wants both inputs to ship as two modules: a
generator build for the jack and an FX build for the mix. With the restore
running for either role, one `end_of_chain` module can read the mix in place
through `process_block` **and** the jack through `audio_in_offset`, and offer
an input-source setting.

## What

Hoists the existing `if (hardware_mmap_addr) { … memcpy(sh_ain, hw_ain) }`
block out of the generator `if` into its own block, gated on
`(overtake_dsp_gen_inst || overtake_dsp_fx_inst)`, immediately before the
generator branch — so it still precedes both consumers. Pure move: the once-
only level log and the `memcpy` are unchanged. Comment updated to say why.

## Verification

- Behaviour for generator modules is unchanged (same copy, same place in the
  frame, one condition wider).
- Compiles clean in schwung's own Docker toolchain (`scripts/build.sh`, debian:bookworm + aarch64 cross); `build/schwung-shim.so` produced. Not yet run on a Move.
- Motivating module: timncox/schwung-work — Overwork's source machines fed by
  the Move's playback (Granulator on the mix, `sample_rec` capturing it).

Happy to split the comment change out if you'd rather keep the diff to the
condition alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
