### PR TITLE
catalog: pull Hinge while it is renamed

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1422,17 +1422,6 @@
       "asset_name": "jp8000-module.tar.gz",
       "min_host_version": "1.1.1",
       "requires": "JP-8000 v1.5 firmware ROMs: all 8 .mid files in the module's roms/ folder"
-    },
-    {
-      "id": "hinge",
-      "name": "Hinge",
-      "description": "Two-operator FM on eight knobs, one page: ratio, brightness, bite, one envelope pair, noise and a tone sweep. 32 presets",
-      "author": "charlesvestal",
-      "component_type": "sound_generator",
-      "github_repo": "charlesvestal/schwung-hinge",
-      "default_branch": "main",
-      "asset_name": "hinge-module.tar.gz",
-      "min_host_version": "1.2.0"
     }
   ]
 }


### PR DESCRIPTION
Reverts #452 for now.

The module ships as `hinge`, and the id is the folder on disk and the key its presets are stored under — so renaming it after people have installed it leaves a stale folder and orphans their patches. It has been listed for under an hour; taking it out now costs nobody anything, and renaming it later costs everybody something.

The repository and its releases stay up, so anyone who already installed it keeps a working module. It goes back in under the new id.

Pure removal: 11 deletions, no additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxwBP9oMQyFttFvoDx3Nhy