### PR TITLE
audio_in restore: stand down while the resample bridge is applying

### DIFF
--- a/src/host/audio_in_restore.h
+++ b/src/host/audio_in_restore.h
@@ -1,0 +1,35 @@
+#ifndef AUDIO_IN_RESTORE_H
+#define AUDIO_IN_RESTORE_H
+
+/*
+ * Should the post-ioctl restore re-copy hardware AUDIO_IN over the shadow
+ * mailbox's copy?
+ *
+ * Two writers want the same 512 bytes at offset 2304, in this order inside
+ * one shim_post_transfer:
+ *
+ *   1. native_resample_bridge_apply()  writes Schwung's mix there, so Move's
+ *      own Resample records what Schwung is playing.
+ *   2. the restore in shadow_inprocess_render_to_buffer() writes the jack
+ *      there, so an overtake plugin reading host->audio_in_offset gets the
+ *      actual input rather than the bridge's leftovers.
+ *
+ * The restore runs second, so unguarded it wins every frame and the bridge
+ * silently does nothing for as long as an overtake module is loaded — a
+ * resample that captures the jack instead of the mix, with nothing logged.
+ * The bridge is the deliberate, opt-in, user-visible setting (default OFF),
+ * so it takes precedence; the restore stands down while it is applying.
+ *
+ * Pure so tests/host can drive the four-way table.
+ */
+static inline int shadow_audio_in_restore_allowed(int overtake_inst_present,
+                                                  int hardware_mmap_present,
+                                                  int bridge_mode_on,
+                                                  int bridge_source_allows)
+{
+    if (!overtake_inst_present || !hardware_mmap_present) return 0;
+    if (bridge_mode_on && bridge_source_allows) return 0;
+    return 1;
+}
+
+#endif /* AUDIO_IN_RESTORE_H */

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -64,6 +64,7 @@
 extern align_capture_t g_align_capture;
 #include "host/shadow_process.h"
 #include "host/shadow_resample.h"
+#include "host/audio_in_restore.h"
 #include "host/shadow_overlay.h"
 #include "host/shadow_pin_scanner.h"
 #include "host/shadow_led_queue.h"
@@ -2223,8 +2224,18 @@ static void shadow_inprocess_render_to_buffer(void) {
      * whole mix) read whatever the bridge had left in the region instead of
      * the jack. Restoring here lets such a module offer both inputs -- the
      * mix in place through process_block, the jack through audio_in_offset --
-     * as one module with an input-source setting, rather than shipping as two. */
-    if ((overtake_dsp_gen_inst || overtake_dsp_fx_inst) && hardware_mmap_addr) {
+     * as one module with an input-source setting, rather than shipping as two.
+     *
+     * ...unless the native resample bridge is the one that wrote it. It runs
+     * earlier in this same post-ioctl pass, so an unguarded restore silently
+     * beats it and Move's Resample captures the jack instead of Schwung's mix
+     * for as long as any overtake module is loaded. The bridge is the opt-in
+     * setting, so it wins; see src/host/audio_in_restore.h. */
+    if (shadow_audio_in_restore_allowed(
+            (overtake_dsp_gen_inst || overtake_dsp_fx_inst) ? 1 : 0,
+            hardware_mmap_addr ? 1 : 0,
+            native_resample_bridge_mode != NATIVE_RESAMPLE_BRIDGE_OFF,
+            native_resample_bridge_source_allows_apply(native_resample_bridge_mode))) {
         int16_t *hw_ain = (int16_t *)(hardware_mmap_addr + AUDIO_IN_OFFSET);
         int16_t *sh_ain = (int16_t *)(global_mmap_addr + AUDIO_IN_OFFSET);
         /* Log once to verify hardware audio levels */
@@ -2239,7 +2250,7 @@ static void shadow_inprocess_render_to_buffer(void) {
             }
             char msg[256];
             snprintf(msg, sizeof(msg),
-                     "SampleRobot: audio_in restore - hw_peak=%d sh_peak=%d hw[0..3]=%d,%d,%d,%d",
+                     "shim: audio_in restore - hw_peak=%d sh_peak=%d hw[0..3]=%d,%d,%d,%d",
                      hw_peak, sh_peak, hw_ain[0], hw_ain[1], hw_ain[2], hw_ain[3]);
             shadow_log(msg);
             ain_log_count++;

--- a/tests/host/Makefile
+++ b/tests/host/Makefile
@@ -65,7 +65,8 @@ TARGETS = $(BUILD_DIR)/test_midi_inject_writer \
 	$(BUILD_DIR)/test_me_post_snapshot_fx \
 	$(BUILD_DIR)/test_boot_select_core \
 	$(BUILD_DIR)/test_chain_idle_tick \
-	$(BUILD_DIR)/test_heal_tool_id
+	$(BUILD_DIR)/test_heal_tool_id \
+	$(BUILD_DIR)/test_audio_in_restore
 
 # Read the Master FX cap out of the shipped header instead of restating it, so
 # the routing test covers whatever range Master FX actually runs with. Raising

--- a/tests/host/test_audio_in_restore.c
+++ b/tests/host/test_audio_in_restore.c
@@ -1,0 +1,47 @@
+/*
+ * Who owns shadow AUDIO_IN when both writers want it.
+ *
+ * native_resample_bridge_apply() writes Schwung's mix into the shadow
+ * mailbox's AUDIO_IN region, then — later in the SAME shim_post_transfer —
+ * the overtake restore writes the hardware jack over the top. Second writer
+ * wins, so without a guard the bridge is a no-op for as long as an overtake
+ * module is loaded, and Move's Resample records the jack. Nothing logs it.
+ *
+ * The precedence is a one-line predicate rather than a comment because that
+ * is the only form tests/host can run: schwung_shim.c does not build on the
+ * dev machine.
+ */
+#include <assert.h>
+#include <stdio.h>
+#include "audio_in_restore.h"
+
+int main(void) {
+    /* No overtake instance: nothing reads audio_in_offset, so no restore
+     * whatever the bridge is doing. */
+    assert(shadow_audio_in_restore_allowed(0, 1, 0, 1) == 0);
+    assert(shadow_audio_in_restore_allowed(0, 1, 1, 1) == 0);
+
+    /* No hardware mailbox: there is nothing to copy FROM. Reading
+     * hardware_mmap_addr when it is NULL is the crash this prevents. */
+    assert(shadow_audio_in_restore_allowed(1, 0, 0, 0) == 0);
+
+    /* The ordinary case the feature exists for: an overtake module loaded
+     * (either role — the caller ORs the two instances), bridge off. */
+    assert(shadow_audio_in_restore_allowed(1, 1, 0, 0) == 1);
+    assert(shadow_audio_in_restore_allowed(1, 1, 0, 1) == 1);
+
+    /* Bridge ON and actually applying — it wrote the region this frame, so
+     * the restore stands down. This is the assertion the fix is FOR: before
+     * it, this case returned 1 and silently reverted the bridge. */
+    assert(shadow_audio_in_restore_allowed(1, 1, 1, 1) == 0);
+
+    /* Bridge on but its SOURCE blocks the apply (Mic In / USB-C In under
+     * MIX mode — native_resample_bridge_source_allows_apply). It did not
+     * write the region, so there is nothing to protect and the overtake
+     * plugin still gets its jack. Gating on the mode alone would have
+     * broken line-in for every overtake module on a Mic In project. */
+    assert(shadow_audio_in_restore_allowed(1, 1, 1, 0) == 1);
+
+    printf("test_audio_in_restore: PASS\n");
+    return 0;
+}


### PR DESCRIPTION
Follow-up to #455, fixing the hazard that review turned up rather than asking the contributor to carry it.

## The bug

Two writers want the same 512 bytes at shadow mailbox offset 2304 (`AUDIO_IN_OFFSET` == `RESAMPLE_AUDIO_IN_OFFSET`), in this order inside **one** `shim_post_transfer`:

1. `native_resample_bridge_apply()` (`schwung_shim.c:7363`) writes Schwung's mix there, so Move's own Resample records what Schwung is playing.
2. the restore in `shadow_inprocess_render_to_buffer()` (`:9351`) writes the hardware jack over the top, so an overtake plugin reading `host->audio_in_offset` gets the actual input.

Second writer wins. So with the bridge on, it is a no-op for as long as an overtake module is loaded — the resample captures the jack instead of the mix, silently, with no way to tell from the device.

This was already true for the generator role. #455 correctly widened the restore to the FX role, which also widened this from a subset of overtake modules to all of them.

## The fix

The bridge is the deliberate, opt-in, user-visible setting (default `OFF`, persisted), so it takes precedence; the restore stands down while it is actually applying.

The predicate lives in `src/host/audio_in_restore.h` rather than inline because `schwung_shim.c` does not build on the dev machine, and this is exactly the shape of rule that fails silently — both writers are correct in isolation and only their *order* is wrong.

Note the fourth row of the table: gating on the bridge **mode** alone would have broken line-in for every overtake module on a Mic In / USB-C In project, where the bridge is on but `native_resample_bridge_source_allows_apply()` blocks it and it never touches the region. That is why the guard asks both questions.

Also retitles the once-only diagnostic, which still said `"SampleRobot:"` — a module name, on a line that now fires for either overtake role.

## Verification

- `tests/host/test_audio_in_restore.c` covers the four-way table; **mutation-checked** — deleting the guard line fails the `(1,1,1,1)` assertion.
- `make -C tests/host test` and all `tests/host/*.sh` green.
- Cross-compiles clean in the Docker toolchain (`build/schwung-shim.so`, ARM aarch64). Not run on a Move — the affected combination (bridge on + overtake module loaded) is worth one hardware check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4nCiTmaA3ox8SK5kyCZZN