### PR TITLE
catalog: add Hank, a 2-operator FM synth on eight knobs

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1422,6 +1422,17 @@
       "asset_name": "jp8000-module.tar.gz",
       "min_host_version": "1.1.1",
       "requires": "JP-8000 v1.5 firmware ROMs: all 8 .mid files in the module's roms/ folder"
+    },
+    {
+      "id": "hank",
+      "name": "Hank",
+      "description": "Two-operator FM on eight knobs, one page: ratio, brightness, bite, one envelope pair, noise and a tone sweep. 32 presets",
+      "author": "charlesvestal",
+      "component_type": "sound_generator",
+      "github_repo": "charlesvestal/schwung-hank",
+      "default_branch": "main",
+      "asset_name": "hank-module.tar.gz",
+      "min_host_version": "1.2.0"
     }
   ]
 }


### PR DESCRIPTION
[charlesvestal/schwung-hank](https://github.com/charlesvestal/schwung-hank) — two-operator FM where eight knobs on one page are the whole instrument: Ratio, Bright, Bite, Tone, Attack, Decay, Sustain, Noise. No manual mode, no page of raw operator values. 32 presets across bass, keys, bells, leads, pads, percussion and effects.

Listed briefly as Hinge in #452 and pulled in #456 the same hour, so the rename would not strand anyone's presets — the id is the folder on disk and the key patches are stored under.

`min_host_version` is **1.2.0**: where `ensureComponentWidgets` and `canvas_script` first shipped, and so the oldest host that can draw the wave across Ratio/Bright/Bite. An older one loads the module and silently draws three dials, because an unregistered widget kind is not an error — it falls through to the detector.

Verified against the flow the manager actually runs: `release.json` on `main` resolves to v0.5.0, its `download_url` ends in the catalog's `asset_name`, and the asset serves (200, 24481 bytes). Textual insert, so the diff is 11 added lines and no deletions.

### Still worth knowing for 1.2.0 users

Two host bugs fixed on `main` but not in any release: **#450** (the widget registry is cleared by any module without a custom widget and never re-registers, so the wave disappears after visiting another module until reboot) and **#451** (choosing a preset does not drop the grid's cached values, so the first turn of a knob you had already used steps from the previous preset). A 1.2.1 before people install this would spare them both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WxwBP9oMQyFttFvoDx3Nhy