### PR TITLE
catalog: add Overwork Mix

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1234,6 +1234,17 @@
       "min_host_version": "0.3.0"
     },
     {
+      "id": "overwork-mix",
+      "name": "Overwork Mix",
+      "description": "Overwork fed by what the Move is playing instead of the jack: granulate the mix live, sample it with the Sample button, play it back from the samplers, sequence all of it. End-of-chain placement; Shift + volume is its master",
+      "author": "timncox",
+      "component_type": "overtake",
+      "github_repo": "timncox/schwung-overwork-mix",
+      "default_branch": "main",
+      "asset_name": "overwork-mix-module.tar.gz",
+      "min_host_version": "1.0.0"
+    },
+    {
       "id": "beatbank",
       "name": "Beat Bank",
       "description": "Library of standard drum patterns from editable .beat files — pick a pattern, it prints one bar into Move.",


### PR DESCRIPTION
Adds one catalog entry: **Overwork Mix**, the fourth build of the Work family.

| id | type | what it is |
| --- | --- | --- |
| `overwork-mix` | `overtake` | Overwork fed by **what the Move is playing** instead of the jack |

Granulator granulates the mix live, the Move's Sample button records it, the samplers play it back, and the sequencer and parameter locks work on all of it. It sits beside Overwork in the Tools menu and shares its presets.

**How it gets the mix.** The module's `.so` exports `move_audio_fx_init_v2`, so the shim loads it as `overtake_dsp_fx`, and `capabilities.end_of_chain` has `process_block` run in place on the final Move+ME mix after the ME sum. As far as I can tell it is the first module to use `end_of_chain` — it worked first time on stock 1.2.0, so thank you for building the placement. `min_host_version` is `1.0.0` — a conservative floor; the placement is present there and I have not verified anything earlier.

**Why a separate module.** The generator role gets the jack and the FX role gets the bus; one module cannot take both today. #455 proposes the small shim change that would let it, after which Mix folds back into Overwork as an input setting and this entry can go.

Pointer repo: `timncox/schwung-overwork-mix` (release.json + README only; the tarball ships on `timncox/schwung-work`'s releases, currently v0.12.0). Manual: https://timncox.github.io/schwung-work/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
