### PR TITLE
Module dependencies, and modules declaring the FX behind them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1441,7 +1441,30 @@ Optional: `install_path`, `name`, `description`, `requires`, `post_install`, `re
 
 ### Catalog Entry
 
-Required: `id`, `name`, `description`, `author`, `component_type`, `github_repo`, `default_branch`, `asset_name`, `min_host_version`. Optional: `requires` (user-facing note about external assets like ROMs).
+Required: `id`, `name`, `description`, `author`, `component_type`, `github_repo`, `default_branch`, `asset_name`, `min_host_version`. Optional: `requires` (user-facing note about external assets like ROMs), `requires_modules`.
+
+**`requires` is PROSE, `requires_modules` is a LIST THE MANAGER ACTS ON**, and
+keeping them apart is the whole point of the second name: a module naming a ROM
+in `requires` must not have the manager go looking for a module called that.
+
+`requires_modules: ["clap"]` installs those ids first, depth first, and REFUSES
+to uninstall one while something on disk still declares it. A dependency
+failure fails the install and the message names the DEPENDENCY — a module whose
+effects silently do nothing because a dependency is absent is the outcome this
+exists to prevent, and it is undiagnosable from the device.
+
+Three rules that are not obvious:
+
+- **Already-installed dependencies are SKIPPED, never reinstalled.** A
+  dependency is a floor, not a version pin; reinstalling would quietly
+  downgrade a module the user updated on purpose.
+- **Only what is ON DISK pins anything.** The relationship comes from the
+  catalog, the dependents from the filesystem, so a module the user never
+  installed cannot make another un-removable by proxy.
+- **An unreachable (or absent) catalog answers "nobody depends on it"**, so
+  uninstall keeps working offline. That is the deliberate direction to fail in
+  — the alternative is a device that cannot remove a module because it cannot
+  reach the network.
 
 ## External Module Development
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -216,6 +216,46 @@ Use `defaults` to pass initial parameters to DSP plugins at load time:
 }
 ```
 
+## Declaring the effects that belong behind your module
+
+`capabilities.default_fx` names audio FX the slot chain should hold when the
+user picks this module:
+
+```json
+"capabilities": {
+  "default_fx": [
+    { "module": "clap", "params": { "plugin_id": "PurestDrive" } }
+  ]
+}
+```
+
+For a module whose sound genuinely includes a stage the chain can host — a drum
+kit voiced through a bus compressor, say. The alternative has been to build that
+effect INTO the module, which is a second and worse copy of what the slot chain
+already provides: reachable only from inside your UI, persisted by you, and
+invisible to the host's bypass, LFOs and presets.
+
+**Declare `requires_modules` in your catalog entry for anything you name here.**
+A `default_fx` naming a module the user does not have seeds nothing and says
+nothing; the catalog field is what installs it.
+
+Three rules, and they are the whole contract:
+
+- **It fires when the user PICKS your module, and at no other time.** Not on
+  boot, not on a set change, not on a patch load. Those reconstruct a chain the
+  user has already shaped, so seeding there would put back an effect they
+  deleted, on every boot, with no way to refuse it permanently.
+- **It fires only into an EMPTY FX section.** A slot that already carries
+  effects has been shaped by somebody, and appending to it silently rewrites
+  their signal path.
+- **What lands is an ORDINARY INSERT.** Editable, removable, saved by the same
+  autosave as anything else. Nothing marks it as yours, because a position that
+  could not be removed would be a worse version of the in-module effect this
+  exists to replace.
+
+A default is an opening position, not a policy. If your module cannot work
+without the effect, it belongs inside your module.
+
 ## Per-Module Settings
 
 A module that wants user-configurable settings exposed in the

--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -55,6 +55,13 @@ type CatalogModule struct {
 	AssetName     string `json:"asset_name"`
 	MinHostVer    string `json:"min_host_version"`
 	Requires      string `json:"requires,omitempty"`
+	// RequiresModules names other catalog modules this one cannot work without.
+	//
+	// Distinct from Requires, which is PROSE shown to the user about external
+	// assets it cannot fetch for them (ROMs, soundfonts). This is a list of ids
+	// the manager can and does act on: they are installed with the module and
+	// refused for uninstall while something still needs them.
+	RequiresModules []string `json:"requires_modules,omitempty"`
 }
 
 // CatalogHost describes the host entry in the catalog.
@@ -1165,6 +1172,55 @@ func (r ReleaseJSON) forModule(moduleID string) (ReleaseJSON, bool) {
 
 // installModule downloads and extracts a module from its GitHub release.
 func (app *App) installModule(mod *CatalogModule) error {
+	return app.installModuleWithDeps(mod, map[string]bool{})
+}
+
+// installModuleWithDeps installs `mod` and anything it declares in
+// requires_modules, depth first.
+//
+// DEPENDENCIES GO FIRST. A module that needs another one needs it at the moment
+// it is first loaded, not at the end of a batch -- and installing the dependent
+// first means a failure part-way leaves the thing that cannot work sitting on
+// the device looking installed.
+//
+// A dependency failure FAILS THE INSTALL, and the message names the dependency
+// rather than the module the user asked for. "requires" is not a suggestion; a
+// module whose effects silently do nothing because a dependency is absent is
+// the outcome this exists to prevent, and it is one nobody can diagnose from
+// the device.
+//
+// ALREADY-INSTALLED DEPENDENCIES ARE SKIPPED rather than reinstalled: a
+// dependency is a floor, not a version pin, and reinstalling one would quietly
+// downgrade a module the user had updated on purpose.
+//
+// `seen` breaks cycles. Two modules that require each other is a catalog
+// mistake rather than something to support, but it must not hang the manager.
+func (app *App) installModuleWithDeps(mod *CatalogModule, seen map[string]bool) error {
+	if seen[mod.ID] {
+		return nil
+	}
+	seen[mod.ID] = true
+
+	for _, depID := range mod.RequiresModules {
+		if depID == "" || depID == mod.ID || seen[depID] {
+			continue
+		}
+		if app.findModuleDir(depID) != "" {
+			app.logger.Info("dependency already installed", "id", mod.ID, "dep", depID)
+			seen[depID] = true
+			continue
+		}
+		dep := app.findCatalogModule(depID)
+		if dep == nil {
+			return fmt.Errorf("%s requires %q, which is not in the catalog", mod.ID, depID)
+		}
+		app.logger.Info("installing dependency", "id", mod.ID, "dep", depID)
+		if err := app.installModuleWithDeps(dep, seen); err != nil {
+			return fmt.Errorf("%s requires %s, which failed to install: %w",
+				mod.ID, depID, err)
+		}
+	}
+
 	if err := app.checkHostCompat(mod.MinHostVer); err != nil {
 		return err
 	}
@@ -1329,8 +1385,52 @@ func (app *App) uninstallModule(id string) error {
 	if modDir == "" {
 		return fmt.Errorf("module %q not found on disk", id)
 	}
+	if dependents := app.installedDependentsOf(id); len(dependents) > 0 {
+		return fmt.Errorf("%s is required by %s — uninstall %s first",
+			id, strings.Join(dependents, ", "),
+			map[bool]string{true: "it", false: "those"}[len(dependents) == 1])
+	}
 	app.logger.Info("uninstalling module", "id", id, "path", modDir)
 	return os.RemoveAll(modDir)
+}
+
+// installedDependentsOf lists the modules PRESENT ON DISK that declare `id` in
+// requires_modules, sorted so the message is stable.
+//
+// Asks the catalog for the relationship but the DISK for who is here: a module
+// the user never installed cannot pin anything, and a catalog that has moved on
+// must not make an installed module un-removable by proxy.
+//
+// An unreachable catalog answers "nobody", so uninstall keeps working offline.
+// That is the deliberate direction to fail in -- the alternative is a device
+// that cannot remove a module because it cannot reach the network.
+func (app *App) installedDependentsOf(id string) []string {
+	// No catalog service at all is the same answer as an unreachable one:
+	// nobody. uninstallModule calls this, so a nil here would turn "the
+	// catalog is not configured" into a panic on a path whose whole job is
+	// to keep working when the catalog cannot be consulted.
+	if app == nil || app.catalogSvc == nil {
+		return nil
+	}
+	cat, _ := app.catalogSvc.Fetch()
+	if cat == nil {
+		return nil
+	}
+	var out []string
+	for i := range cat.Modules {
+		m := &cat.Modules[i]
+		if m.ID == id {
+			continue
+		}
+		for _, dep := range m.RequiresModules {
+			if dep == id && app.findModuleDir(m.ID) != "" {
+				out = append(out, m.ID)
+				break
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // findCatalogModule looks up a module by ID in the catalog.

--- a/schwung-manager/module_deps_helpers_test.go
+++ b/schwung-manager/module_deps_helpers_test.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+func jsonUnmarshal(b []byte, v any) error { return json.Unmarshal(b, v) }
+func contains(s, sub string) bool         { return strings.Contains(s, sub) }

--- a/schwung-manager/module_deps_test.go
+++ b/schwung-manager/module_deps_test.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// A catalog served from memory: CatalogService.Fetch returns its cached copy
+// when `fetched` is recent, so a test never reaches the network.
+func depsApp(t *testing.T, mods []CatalogModule, installed ...string) *App {
+	t.Helper()
+	base := t.TempDir()
+	for _, id := range installed {
+		if err := os.MkdirAll(filepath.Join(base, "modules", "audio_fx", id), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return &App{
+		basePath: base,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		catalogSvc: &CatalogService{
+			catalog: &Catalog{Modules: mods},
+			fetched: time.Now(),
+		},
+	}
+}
+
+// requires_modules is a LIST THE MANAGER ACTS ON, where `requires` is prose for
+// the user about assets it cannot fetch. Keeping them apart matters: a module
+// that names a ROM in `requires` must not have the manager try to install one.
+func TestRequiresModulesIsSeparateFromRequiresProse(t *testing.T) {
+	var m CatalogModule
+	raw := []byte(`{"id":"dr32","requires":"WAV samples","requires_modules":["clap"]}`)
+	if err := jsonUnmarshal(raw, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.Requires != "WAV samples" {
+		t.Errorf("Requires = %q, want the prose", m.Requires)
+	}
+	if !reflect.DeepEqual(m.RequiresModules, []string{"clap"}) {
+		t.Errorf("RequiresModules = %v, want [clap]", m.RequiresModules)
+	}
+}
+
+func TestInstalledDependentsOf(t *testing.T) {
+	cat := []CatalogModule{
+		{ID: "clap", Name: "Airwindows"},
+		{ID: "dr32", RequiresModules: []string{"clap"}},
+		{ID: "other", RequiresModules: []string{"clap"}},
+		{ID: "unrelated"},
+	}
+
+	// Nothing installed: nobody pins it. A module the user never installed
+	// cannot make another one un-removable by proxy.
+	if got := depsApp(t, cat).installedDependentsOf("clap"); len(got) != 0 {
+		t.Errorf("dependents with nothing installed = %v, want none", got)
+	}
+
+	// Only what is ON DISK counts, and the answer is sorted so the message
+	// a user sees does not reorder between calls.
+	app := depsApp(t, cat, "dr32", "other")
+	if got := app.installedDependentsOf("clap"); !reflect.DeepEqual(got, []string{"dr32", "other"}) {
+		t.Errorf("dependents = %v, want [dr32 other]", got)
+	}
+
+	// A module never declares itself.
+	if got := app.installedDependentsOf("dr32"); len(got) != 0 {
+		t.Errorf("dr32 dependents = %v, want none", got)
+	}
+
+	// AN UNREACHABLE CATALOG ANSWERS NOBODY, so uninstall keeps working
+	// offline. That is the deliberate direction to fail in: the alternative is
+	// a device that cannot remove a module because it cannot reach the network.
+	offline := &App{
+		basePath:   app.basePath,
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		catalogSvc: nil,
+	}
+	if got := offline.installedDependentsOf("clap"); len(got) != 0 {
+		t.Errorf("offline dependents = %v, want none", got)
+	}
+}
+
+func TestUninstallRefusesWhileDependedOn(t *testing.T) {
+	cat := []CatalogModule{
+		{ID: "clap"},
+		{ID: "dr32", RequiresModules: []string{"clap"}},
+	}
+	app := depsApp(t, cat, "clap", "dr32")
+
+	err := app.uninstallModule("clap")
+	if err == nil {
+		t.Fatal("uninstalling a depended-on module succeeded; it must be refused")
+	}
+	// The message has to NAME the dependent. "cannot uninstall" alone leaves
+	// the user with no next step on a device with no other way to look it up.
+	if !contains(err.Error(), "dr32") {
+		t.Errorf("refusal %q does not name the dependent", err)
+	}
+	if app.findModuleDir("clap") == "" {
+		t.Error("the refused uninstall deleted the module anyway")
+	}
+
+	// Remove the dependent and it becomes removable.
+	if err := app.uninstallModule("dr32"); err != nil {
+		t.Fatalf("uninstalling the dependent failed: %v", err)
+	}
+	if err := app.uninstallModule("clap"); err != nil {
+		t.Fatalf("uninstalling clap after its dependent was removed failed: %v", err)
+	}
+	if app.findModuleDir("clap") != "" {
+		t.Error("clap survived its own uninstall")
+	}
+}
+
+// The dependency walk must terminate on a catalog that names a cycle, and must
+// not reinstall something already present -- a dependency is a floor, not a
+// version pin, so reinstalling one would quietly downgrade a module the user
+// updated on purpose.
+func TestInstallDepsBreaksCycles(t *testing.T) {
+	// NEITHER IS INSTALLED. An earlier version of this test pre-installed both,
+	// so the already-present check short-circuited before the recursion and the
+	// cycle guard was never reached -- removing the guard left the test green.
+	//
+	// min_host_version is unsatisfiable so the walk terminates at the compat
+	// check rather than attempting a download: the recursion happens in the
+	// dependency loop, which runs BEFORE that check, so the cycle is still what
+	// this exercises.
+	cat := []CatalogModule{
+		{ID: "a", RequiresModules: []string{"b"}, MinHostVer: "999.0.0"},
+		{ID: "b", RequiresModules: []string{"a"}, MinHostVer: "999.0.0"},
+	}
+	app := depsApp(t, cat)
+	if err := os.MkdirAll(filepath.Join(app.basePath, "host"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(app.basePath, "host", "version.txt"),
+		[]byte("0.1.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- app.installModuleWithDeps(&cat[0], map[string]bool{}) }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected the unsatisfiable min_host_version to stop the walk")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("installModuleWithDeps did not terminate on a dependency cycle")
+	}
+}
+
+// A dependency ALREADY PRESENT is skipped rather than reinstalled: a dependency
+// is a floor, not a version pin, so reinstalling would quietly downgrade a
+// module the user updated on purpose. Reaching the compat check at all proves
+// the dep loop returned without attempting a download for the present one.
+func TestInstallDepsSkipsPresent(t *testing.T) {
+	cat := []CatalogModule{
+		{ID: "dr32", RequiresModules: []string{"clap"}, MinHostVer: "999.0.0"},
+		{ID: "clap"},
+	}
+	app := depsApp(t, cat, "clap")
+	if err := os.MkdirAll(filepath.Join(app.basePath, "host"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(app.basePath, "host", "version.txt"),
+		[]byte("0.1.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err := app.installModuleWithDeps(&cat[0], map[string]bool{})
+	if err == nil || contains(err.Error(), "clap") {
+		t.Fatalf("expected to stop at dr32 own compat check, got %v", err)
+	}
+}
+
+// A dependency the catalog does not know about is an ERROR naming the
+// dependency, not a silent partial install: a module whose effects do nothing
+// because a dependency is absent is undiagnosable from the device.
+func TestMissingDependencyIsNamed(t *testing.T) {
+	cat := []CatalogModule{{ID: "dr32", RequiresModules: []string{"ghost"}}}
+	app := depsApp(t, cat)
+	err := app.installModuleWithDeps(&cat[0], map[string]bool{})
+	if err == nil {
+		t.Fatal("a dependency missing from the catalog was not reported")
+	}
+	if !contains(err.Error(), "ghost") {
+		t.Errorf("error %q does not name the missing dependency", err)
+	}
+}

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -7650,6 +7650,90 @@ function isLineInConsumerModule(moduleId) {
     return v;
 }
 
+/*
+ * ============================================================================
+ * default_fx — a module says what belongs in the chain behind it
+ * ============================================================================
+ *
+ * `capabilities.default_fx: [{ "module": "clap", "params": { ... } }]`
+ *
+ * A drum module whose kit is voiced through a bus compressor has no way to ship
+ * that today: the effect either lives INSIDE the module -- a second, worse copy
+ * of a facility the slot chain already provides, reachable only from in there
+ * and persisted by hand -- or the user adds it after every load and it is not
+ * part of the sound.
+ *
+ * SEEDED ON AN INTERACTIVE PICK AND NOWHERE ELSE. Not on boot restore, not on a
+ * set change, not on a patch load. Those all reconstruct a chain the user has
+ * already shaped, so seeding there would put back an effect they deleted, every
+ * boot, with no way to refuse it permanently. That is the whole of the design:
+ * a default is an opening position, not a policy.
+ *
+ * AND ONLY INTO AN EMPTY FX SECTION. A slot that already carries effects has
+ * been shaped by somebody; appending to it silently rewrites their signal path.
+ *
+ * What lands is an ORDINARY INSERT afterwards -- editable, removable, saved by
+ * the same autosave as any other. Nothing marks it as special, because a
+ * position that could not be removed is a worse version of the in-module
+ * effect this replaces.
+ */
+function moduleDefaultFx(moduleId) {
+    if (!moduleId) return [];
+    let meta = null;
+    try {
+        if (typeof host_get_module_metadata === "function") meta = host_get_module_metadata(moduleId);
+    } catch (e) { return []; }
+    if (typeof meta === "string") {
+        try { meta = JSON.parse(meta); } catch (e) { return []; }
+    }
+    const list = meta && meta.capabilities && meta.capabilities.default_fx;
+    if (!Array.isArray(list)) return [];
+    /* Bounded by the section cap, so a module cannot declare a chain longer
+     * than the slot can hold and have the tail vanish without a word. */
+    return list.filter((e) => e && typeof e.module === "string" && e.module)
+               .slice(0, CHAIN_CAP.fx);
+}
+
+/*
+ * Returns how many positions were seeded (0 when it declined), so the caller
+ * can decide whether the chain needs re-reading rather than re-reading always.
+ */
+function seedDefaultFxForSlot(slotIndex, moduleId) {
+    const wanted = moduleDefaultFx(moduleId);
+    if (!wanted.length) return 0;
+
+    /*
+     * The DSP's own count, not the cached model: this runs right after a synth
+     * write, and the cached chain is the one from before it.
+     *
+     * ONLY AN EXPLICIT ZERO SEEDS. The tri-state is covered by the NaN test
+     * rather than by a test of its own -- null, undefined and "" all parse to
+     * NaN, so an added `raw === null || ...` line is a branch no mutation can
+     * kill, and one of those was written here and removed for that reason.
+     * What matters is the direction: anything that is not a definite zero
+     * declines, so a read that did not complete cannot append a module to a
+     * chain somebody has already shaped.
+     */
+    const held = parseInt(getSlotParam(slotIndex, "fx_count"), 10);
+    if (!Number.isFinite(held) || held !== 0) return 0;
+
+    let seeded = 0;
+    for (const entry of wanted) {
+        const key = `fx${seeded + 1}`;
+        if (!setSlotParam(slotIndex, `${key}:module`, entry.module)) break;
+        seeded++;
+        if (entry.params && typeof entry.params === "object") {
+            for (const pk in entry.params) {
+                setSlotParam(slotIndex, `${key}:${pk}`, String(entry.params[pk]));
+            }
+        }
+    }
+    if (seeded) {
+        debugLog(`default_fx: seeded ${seeded} position(s) for ${moduleId}`);
+    }
+    return seeded;
+}
+
 /* Rotates the no-risk scan over the slots; see reconcileFeedbackHolds. */
 let _feedbackScanCursor = 0;
 
@@ -13373,6 +13457,13 @@ function applyComponentSelectionConfirmed(slotIndex, paramKey, moduleId, comp, c
         if (!success) {
             print(2, 50, "Failed to apply", 1);
         }
+    }
+
+    /* A SYNTH the user just picked may declare the effects that belong behind
+     * it. Only here -- this is the interactive pick; every restore path
+     * reconstructs a chain that has already been shaped. See moduleDefaultFx. */
+    if (moduleId && comp.key === "synth") {
+        seedDefaultFxForSlot(slotIndex, moduleId);
     }
 
     /* Track component selection for analytics. Outside the branches, because a

--- a/tests/host/test_default_fx_seed.sh
+++ b/tests/host/test_default_fx_seed.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# default_fx: a module says what belongs in the chain behind it.
+#
+# A drum module voiced through a bus compressor has had two bad options -- keep
+# the effect INSIDE the module (a second, worse copy of what the slot chain
+# provides, reachable only from in there and persisted by hand), or make the
+# user add it after every load, where it is not part of the sound.
+#
+# The whole design is in WHEN it fires:
+#
+#  - on an INTERACTIVE PICK only. Every restore path -- boot, set change, patch
+#    load -- reconstructs a chain the user has already shaped, so seeding there
+#    would put back an effect they deleted, every boot, with no way to refuse it.
+#  - into an EMPTY FX section only. A slot carrying effects has been shaped by
+#    somebody, and appending rewrites their signal path silently.
+#  - never on a FAILED read of the count. Seeding because a read did not
+#    complete is how a chain gets a module appended to it for no reason.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+UI="src/shadow/shadow_ui.js"
+[ -f "$UI" ] || { echo "FAIL: cannot find $UI"; exit 1; }
+
+node --input-type=module -e '
+import { readFileSync } from "node:fs";
+const src = readFileSync(process.argv[1], "utf8");
+let bad = 0;
+const fail = (m) => { console.log("FAIL: " + m); bad = 1; };
+const ok = (m) => console.log("  ok  " + m);
+const grab = (n) => {
+  const m = src.match(new RegExp("^function " + n + "\\([^)]*\\)\\s*\\{[^]*?^}", "m"));
+  if (!m) { fail("could not lift " + n + "()"); process.exit(1); }
+  return m[0];
+};
+
+function rig(meta, fxCount) {
+  const body = [
+    "const CHAIN_CAP = { fx: 8 };",
+    "let writes = [];",
+    "const META = " + JSON.stringify(meta) + ";",
+    "function host_get_module_metadata() { return META; }",
+    "function getSlotParam(slot, key) { return " + JSON.stringify(fxCount) + "; }",
+    "function setSlotParam(slot, key, val) { writes.push(key + \"=\" + val); return true; }",
+    "function debugLog() {}",
+    grab("moduleDefaultFx"), grab("seedDefaultFxForSlot"),
+    "return { seed: (id) => seedDefaultFxForSlot(0, id), writes,",
+    "         decl: (id) => moduleDefaultFx(id) };",
+  ].join("\n");
+  return new Function(body)();
+}
+
+const DECL = { capabilities: { default_fx: [
+  { module: "clap", params: { plugin_id: "PurestDrive" } },
+] } };
+
+/* An empty chain seeds, and the params land on the position just written. */
+{
+  const r = rig(DECL, "0");
+  if (r.seed("dr32") !== 1) fail("an empty FX section did not seed");
+  if (JSON.stringify(r.writes) !==
+      JSON.stringify(["fx1:module=clap", "fx1:plugin_id=PurestDrive"])) {
+    fail("seed wrote " + JSON.stringify(r.writes));
+  }
+  ok("an empty FX section is seeded, module first then its params");
+}
+
+/* A chain that already holds anything is LEFT ALONE. */
+{
+  const r = rig(DECL, "1");
+  if (r.seed("dr32") !== 0 || r.writes.length) {
+    fail("seeded into a chain that already held an effect: " + JSON.stringify(r.writes));
+  }
+  ok("a non-empty FX section is left alone");
+}
+
+/* A FAILED read is not a zero. */
+for (const answer of [null, undefined, ""]) {
+  const r = rig(DECL, answer);
+  if (r.seed("dr32") !== 0 || r.writes.length) {
+    fail("seeded on a " + JSON.stringify(answer) + " count read -- a read that did "
+         + "not complete is not an empty chain");
+  }
+}
+ok("a failed count read declines rather than seeding");
+
+/* A module that declares nothing costs nothing and writes nothing. */
+for (const meta of [{}, { capabilities: {} }, { capabilities: { default_fx: "clap" } },
+                    { capabilities: { default_fx: [{}, { module: "" }] } }, null]) {
+  const r = rig(meta, "0");
+  if (r.seed("x") !== 0 || r.writes.length) {
+    fail("a module declaring " + JSON.stringify(meta) + " produced writes");
+  }
+}
+ok("no declaration, a malformed one, or entries with no module: nothing written");
+
+/* Bounded by the section cap: a declaration longer than the slot can hold must
+   not have its tail vanish without a word -- it is truncated at the cap. */
+{
+  const many = { capabilities: { default_fx:
+    Array.from({ length: 20 }, (_, i) => ({ module: "m" + i })) } };
+  const r = rig(many, "0");
+  if (r.decl("x").length !== 8) {
+    fail("a 20-entry declaration resolved to " + r.decl("x").length + ", expected the cap of 8");
+  }
+  ok("a declaration longer than the section cap is truncated to it");
+}
+
+/* metadata handed over as a JSON STRING is parsed -- the binding has returned
+   both shapes across versions, and a string would otherwise read as "declares
+   nothing" rather than as an error. */
+{
+  const r = rig(JSON.stringify(DECL), "0");
+  if (r.seed("dr32") !== 1) fail("metadata delivered as a JSON string was not parsed");
+  ok("metadata as a JSON string is parsed");
+}
+
+/* ---- THE CALL SITE, which is the actual design ------------------------ */
+{
+  const m = src.match(/^function applyComponentSelectionConfirmed\([^)]*\)\s*\{[^]*?^}/m);
+  if (!m) fail("could not find applyComponentSelectionConfirmed");
+  else {
+    if (!/seedDefaultFxForSlot\(/.test(m[0])) {
+      fail("the interactive pick never seeds -- default_fx would be inert");
+    }
+    if (!/comp\.key === "synth"/.test(m[0])) {
+      fail("the seed is not gated on the SYNTH position; an audio FX pick would "
+           + "seed the chain it was just added to");
+    }
+  }
+  /* AND NOWHERE ELSE. A restore path that seeded would put back an effect the
+     user deleted, on every boot. */
+  const sites = [...src.matchAll(/seedDefaultFxForSlot\(/g)].length;
+  if (sites !== 2) {   /* the definition, and the single call */
+    fail("seedDefaultFxForSlot appears " + sites + " times; it must be defined "
+         + "once and called from the interactive pick ALONE -- a restore path "
+         + "that seeds re-adds an effect the user removed");
+  }
+  ok("seeded from the interactive synth pick, and from nowhere else");
+}
+
+if (bad) process.exit(1);
+console.log("PASS");
+' "$UI"


### PR DESCRIPTION
Two contracts that only make sense together, and the pair is what lets a module stop shipping its own effects.

## `requires_modules` — the manager installs what a module needs

Airwindows (`clap`) is 7.7 MB and 500+ plugins, and a module that wants one of them has had no way to say so.

`requires_modules: ["clap"]` in a catalog entry installs those ids **first, depth first**, and **refuses to uninstall** one while something on disk still declares it. Dependency-driven rather than unconditional — nothing installs Airwindows on a device whose modules never ask for it.

`requires` stays *prose* about external assets the manager cannot fetch (ROMs, soundfonts). Two names, because one field doing both would have the manager hunting the catalog for a module called `"WAV sample files for drum pads"`.

Three rules that are not obvious:

- **Already-present dependencies are skipped, never reinstalled.** A dependency is a floor, not a version pin; reinstalling would quietly downgrade a module the user updated on purpose.
- **Only what is on disk pins anything.** The relationship comes from the catalog, the dependents from the filesystem, so a module never installed cannot make another un-removable by proxy.
- **An unreachable or absent catalog answers "nobody".** Uninstall keeps working offline — the alternative is a device that cannot remove a module because it cannot reach the network.

## `default_fx` — a module declares the effects behind it

```json
"capabilities": { "default_fx": [{ "module": "clap", "params": { "plugin_id": "PurestDrive" } }] }
```

dr32 is the case, and its own header already records the author reaching this conclusion once and acting on it — about kit inserts:

> a Schwung chain slot already carries its own insert FX in front of the output, so a kit-level insert was a second, worse copy of a facility the host provides — worse because it was reachable only from inside DR32 and had to be persisted by DR32.

Its always-on Drum Bus is the one that survived, because there was no way to ship it as a slot insert. This is that way.

The whole design is **when it fires**:

- On an **interactive pick** and nowhere else — not boot, not a set change, not a patch load. Those reconstruct a chain the user has already shaped, so seeding there would put back an effect they deleted, every boot, with no way to refuse it permanently.
- Into an **empty FX section** only. A slot carrying effects has been shaped by somebody.
- Only on an **explicit zero** from `fx_count`. Anything that is not a definite zero declines, so a read that did not complete cannot append a module to somebody's chain.

What lands is an ordinary insert — editable, removable, saved by the same autosave. Nothing marks it as the module's, because a position that could not be removed would be a worse version of the in-module effect this replaces.

## Verification

306 `tests/host` tests, the C units, `go vet` + `go test`, and the ARM64 cross-compile all pass. Both features are mutation-checked; two branches were **deleted** because no mutation could kill them (a redundant tri-state guard, and a cycle test that pre-installed its modules so the recursion never ran).

Nothing declares either field yet. The dr32 side is a separate change on its own fork.