### PR TITLE
default_fx can name a factory preset

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -224,10 +224,28 @@ user picks this module:
 ```json
 "capabilities": {
   "default_fx": [
-    { "module": "clap", "params": { "plugin_id": "PurestDrive" } }
+    { "module": "clap",
+      "params":  { "plugin_id": "Galactic" },
+      "preset":  "Big Room" }
   ]
 }
 ```
+
+`params` are written first, then `preset` — and that order is load-bearing. A
+preset is a whole state, so anything written after it is overwritten by it, and
+for a host like Airwindows `plugin_id` has to land first or the preset names
+nothing.
+
+**`preset` names one of the effect's own FACTORY presets**, written as
+`preset_name` — the contract its preset browser already uses. Not a user preset:
+those are dialled in after the fact and their names are unknowable when you are
+authoring a module.
+
+By name and not by index, because a module's preset list is its own and reorders
+between versions — an index would quietly start naming a different sound.
+
+Both fields are optional. `params` alone is a complete declaration, and so is
+`preset` alone.
 
 For a module whose sound genuinely includes a stage the chain can host — a drum
 kit voiced through a bus compressor, say. The alternative has been to build that

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -7727,6 +7727,27 @@ function seedDefaultFxForSlot(slotIndex, moduleId) {
                 setSlotParam(slotIndex, `${key}:${pk}`, String(entry.params[pk]));
             }
         }
+        /*
+         * THE FACTORY PRESET, applied LAST.
+         *
+         * A module can only name a preset it SHIPS. A user preset is by
+         * definition something dialled in afterwards, whose name the module
+         * cannot know, so a fallback to one was written here and removed: the
+         * declaration is "start from this known sound", and only the factory
+         * list is knowable at authoring time.
+         *
+         * Last, because a preset is a whole state and any param written after
+         * it would be overwritten by it -- and `plugin_id` in particular has to
+         * land FIRST for a host like Airwindows, where the preset only means
+         * something once the plugin behind it is chosen.
+         *
+         * By name rather than by index: a module's preset list is its own and
+         * reorders between versions, so an index would silently start naming a
+         * different sound.
+         */
+        if (entry.preset) {
+            setSlotParam(slotIndex, `${key}:preset_name`, String(entry.preset));
+        }
     }
     if (seeded) {
         debugLog(`default_fx: seeded ${seeded} position(s) for ${moduleId}`);

--- a/tests/host/test_default_fx_seed.sh
+++ b/tests/host/test_default_fx_seed.sh
@@ -106,6 +106,40 @@ ok("no declaration, a malformed one, or entries with no module: nothing written"
   ok("a declaration longer than the section cap is truncated to it");
 }
 
+/* ---- THE FACTORY PRESET, which is the point of declaring an FX at all -- */
+{
+  const DECL_P = { capabilities: { default_fx: [
+    { module: "clap", params: { plugin_id: "Galactic" }, preset: "Big Room" },
+  ] } };
+  const r = rig(DECL_P, "0");
+  r.seed("dr32");
+
+  /* ORDER IS LOAD-BEARING: module, then params, then the preset. A preset is a
+     whole state and overwrites anything written after it; plugin_id has to
+     land first or there is no plugin for the preset to name. */
+  if (JSON.stringify(r.writes) !== JSON.stringify(
+        ["fx1:module=clap", "fx1:plugin_id=Galactic", "fx1:preset_name=Big Room"])) {
+    fail("preset seeding wrote " + JSON.stringify(r.writes));
+  }
+
+  /* A module can only name a preset it SHIPS. A user preset is dialled in
+     afterwards and its name is unknowable at authoring time, so nothing here
+     may reach for the <prefix>:state blob. */
+  if (r.writes.some((w) => w.indexOf(":state=") >= 0)) {
+    fail("seeding touched a user preset state blob: " + JSON.stringify(r.writes));
+  }
+
+  /* params alone, with no preset, is a complete declaration. */
+  const q = rig({ capabilities: { default_fx: [
+    { module: "clap", params: { plugin_id: "Galactic" } } ] } }, "0");
+  q.seed("dr32");
+  if (JSON.stringify(q.writes) !== JSON.stringify(
+        ["fx1:module=clap", "fx1:plugin_id=Galactic"])) {
+    fail("params without a preset wrote " + JSON.stringify(q.writes));
+  }
+  ok("preset: the module factory preset, applied after the params it depends on");
+}
+
 /* metadata handed over as a JSON STRING is parsed -- the binding has returned
    both shapes across versions, and a string would otherwise read as "declares
    nothing" rather than as an error. */


### PR DESCRIPTION
Follow-up to #460. A module could already say *which* Airwindows plugin to load; naming the plugin is not naming the sound. `plugin_id: "Galactic"` gets you a reverb at its defaults — the preset is what makes it the one the module meant.

```json
{ "module": "clap", "params": { "plugin_id": "Galactic" }, "preset": "Big Room" }
```

**Factory presets only.** A first draft also reached for a *user* preset of the same name (a state blob under `presets/<module-id>/`). That was wrong on its face: a user preset is dialled in after the fact, so its name is unknowable when the module is authored — a module could only ever match one by accident. The declaration means "start from this known sound", and only the shipped list is knowable at authoring time. The standalone loader written for it is removed with it.

**By name, not index** — a module's preset list is its own and reorders between versions, so an index would quietly start naming a different sound.

**Applied last, after params**, and that order is load-bearing: a preset is a whole state so anything written after it is overwritten, and `plugin_id` has to land first or there is no plugin for the preset to name.

Both fields are optional; `params` alone is a complete declaration, and so is `preset` alone.

306 `tests/host` tests pass. Mutation-checked, including that seeding never touches a `:state` blob.