### PR TITLE
A module can declare a bus it ships with

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -216,6 +216,52 @@ Use `defaults` to pass initial parameters to DSP plugins at load time:
 }
 ```
 
+## Declaring a bus your module ships with
+
+`capabilities.default_buses` hands your own effects over as a BUS — a container
+of ordinary inserts — rather than baking them in:
+
+```json
+"capabilities": {
+  "default_buses": [{
+    "name": "Drum Bus",
+    "voices": "*",
+    "fx": [
+      { "module": "dr32-fx", "params": { "effect": "Crunch" } },
+      { "module": "clap", "params": { "plugin_id": "Pop3" }, "preset": "Glue" }
+    ]
+  }]
+}
+```
+
+Shipping a multi-stage effect as ONE insert loses the only thing anyone wants
+from it: swapping just the compressor, or putting a drive between two stages. As
+a bus, every stage is a normal chain position — reorderable, bypassable with
+`Mute`+`Jog Click`, an LFO target, swappable, removable.
+
+**A bus, not the slot chain, and the difference is real.** A bus catches the
+VOICES; the slot chain catches your whole output including anything you sum
+internally. A bus also keeps your glue out of the eight slot positions the user
+wants for their own effects.
+
+**A bus returns BEFORE `fx1`**, so the user's slot effects see the glued result
+— and sends are tapped post-insert, so a bus feeding Send A sends the glued
+signal rather than the raw voices.
+
+`voices: "*"` routes every voice you publish in `split_voices`. A list routes
+those; an id you do not publish is dropped rather than written, since each
+`bus<N>:voices` write is a whole-list replace and the host would otherwise keep
+it as an orphan.
+
+Same rules as `default_fx`: it fires on an interactive pick only, and only into
+a slot with **no buses**. A slot that has buses has been arranged by somebody,
+and adding to it silently re-routes their voices.
+
+**Shipping several effects from one binary is the normal case.** Airwindows does
+it — one `.so`, 500+ effects, chosen by `plugin_id`. `plugin_api_v2` is
+multi-instance, so declaring the same module four times with a different
+`effect` each is four ordinary instances of one file.
+
 ## Declaring the effects that belong behind your module
 
 `capabilities.default_fx` names audio FX the slot chain should hold when the

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -7698,6 +7698,112 @@ function moduleDefaultFx(moduleId) {
  * Returns how many positions were seeded (0 when it declined), so the caller
  * can decide whether the chain needs re-reading rather than re-reading always.
  */
+/*
+ * `capabilities.default_buses: [{ name, voices, fx: [...] }]`
+ *
+ * A module that ships its own effects can hand them over as a BUS rather than
+ * bake them in. dr32 is the case: its Drum Bus is four stages in series over the
+ * whole kit, and shipping that as one insert loses the only thing anyone wants
+ * from it -- swapping just the compressor, or putting a drive between two
+ * stages. A container of positions is the point.
+ *
+ * A BUS AND NOT THE SLOT CHAIN, and the difference is real rather than
+ * cosmetic. A bus catches the VOICES; the slot chain catches the synth's whole
+ * output, including any returns it sums internally. And a bus keeps the
+ * module's own glue out of the eight slot positions the user wants for their
+ * effects.
+ *
+ * `voices: "*"` means every voice the synth publishes -- the "everything, by
+ * default" routing. A list of ids means those, for a module that wants its kick
+ * glued and its hats left alone.
+ *
+ * Same rules as default_fx, for the same reasons: interactive pick only, and
+ * only into a slot that has NO buses yet. A slot with buses has been arranged
+ * by somebody, and adding to it silently re-routes their voices.
+ */
+function moduleDefaultBuses(moduleId) {
+    if (!moduleId) return [];
+    let meta = null;
+    try {
+        if (typeof host_get_module_metadata === "function") meta = host_get_module_metadata(moduleId);
+    } catch (e) { return []; }
+    if (typeof meta === "string") {
+        try { meta = JSON.parse(meta); } catch (e) { return []; }
+    }
+    const list = meta && meta.capabilities && meta.capabilities.default_buses;
+    if (!Array.isArray(list)) return [];
+    /* NOT capped here. The seeding loop breaks at SLOT_BUSES, and a second cap
+     * in front of it is a branch no mutation can kill -- one was written and
+     * removed for exactly that. */
+    return list.filter((b) => b && typeof b === "object");
+}
+
+function seedDefaultBusesForSlot(slotIndex, moduleId) {
+    const wanted = moduleDefaultBuses(moduleId);
+    if (!wanted.length) return 0;
+
+    /* Only into a slot with NO buses. Read through the model rather than a raw
+     * param so an unresolved config answers -1 and declines -- busCount returns
+     * -1 for "the read did not complete", never 0, exactly so this can tell the
+     * two apart. */
+    const cfg = BusModel.parseBusesConfig(getSlotParam(slotIndex, "buses:config"));
+    if (BusModel.busCount(cfg) !== 0) return 0;
+
+    /*
+     * The voices the synth publishes.
+     *
+     * DECLINING ON EMPTY CARRIES THE TRI-STATE HERE, rather than a test of its
+     * own. parseSplitVoices answers `unresolved: true` only for null/undefined,
+     * and always with `voices: []` alongside it -- so an explicit unresolved
+     * check is a branch nothing can kill, and one was written and removed. Both
+     * roads lead to the same place and the same place is right: a read that did
+     * not complete must not create a bus with nothing routed into it, and
+     * neither must a synth that genuinely splits into nothing.
+     */
+    const sv = BusModel.parseSplitVoices(getSlotParam(slotIndex, "synth:split_voices"));
+    const allIds = ((sv && sv.voices) || []).map((v) => v && v.id).filter((x) => x);
+    if (!allIds.length) return 0;
+
+    let made = 0;
+    for (const decl of wanted) {
+        const at = made;   /* buses are positional; we are filling an empty set */
+        if (at >= BusModel.SLOT_BUSES) break;
+        const bus = `bus${at + 1}`;
+        if (!setSlotParam(slotIndex, `${bus}:create`, "1")) break;
+
+        const ids = (decl.voices === "*" || decl.voices === undefined)
+            ? allIds
+            : (Array.isArray(decl.voices) ? decl.voices.filter((v) => allIds.indexOf(v) >= 0) : []);
+        /* ONE write, the whole list: every bus<N>:voices write is a replace, so
+         * the write has to carry the complete membership. */
+        if (ids.length) setSlotParam(slotIndex, `${bus}:voices`, ids.join(","));
+        if (decl.name) setSlotParam(slotIndex, `${bus}:name`, String(decl.name));
+
+        const fx = Array.isArray(decl.fx) ? decl.fx : [];
+        let k = 0;
+        for (const entry of fx) {
+            if (!entry || typeof entry.module !== "string" || !entry.module) continue;
+            if (k >= BusModel.BUS_FX_SLOTS) break;
+            const pos = `${bus}:fx${k + 1}`;
+            if (!setSlotParam(slotIndex, `${pos}:module`, entry.module)) break;
+            k++;
+            if (entry.params && typeof entry.params === "object") {
+                for (const pk in entry.params) {
+                    setSlotParam(slotIndex, `${pos}:${pk}`, String(entry.params[pk]));
+                }
+            }
+            /* Last, for the reason default_fx applies it last: a preset is a
+             * whole state and overwrites anything written after it. */
+            if (entry.preset) {
+                setSlotParam(slotIndex, `${pos}:preset_name`, String(entry.preset));
+            }
+        }
+        made++;
+    }
+    if (made) debugLog(`default_buses: created ${made} bus(es) for ${moduleId}`);
+    return made;
+}
+
 function seedDefaultFxForSlot(slotIndex, moduleId) {
     const wanted = moduleDefaultFx(moduleId);
     if (!wanted.length) return 0;
@@ -13485,6 +13591,7 @@ function applyComponentSelectionConfirmed(slotIndex, paramKey, moduleId, comp, c
      * reconstructs a chain that has already been shaped. See moduleDefaultFx. */
     if (moduleId && comp.key === "synth") {
         seedDefaultFxForSlot(slotIndex, moduleId);
+        seedDefaultBusesForSlot(slotIndex, moduleId);
     }
 
     /* Track component selection for analytics. Outside the branches, because a

--- a/tests/host/test_default_buses_seed.sh
+++ b/tests/host/test_default_buses_seed.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+#
+# default_buses: a module hands its own effects over as a BUS.
+#
+# dr32 is the case. Its Drum Bus is four stages in series over the whole kit,
+# and shipping that as ONE insert loses the only thing anyone wants from it --
+# swapping just the compressor, or putting a drive between two stages. A
+# container of positions is the point.
+#
+# A BUS AND NOT THE SLOT CHAIN, and the difference is real: a bus catches the
+# VOICES, while the slot chain catches the synth's whole output including any
+# returns it sums internally. A bus also keeps the module glue out of the eight
+# slot positions the user wants for their own effects.
+#
+# Same guards as default_fx and for the same reasons -- an interactive pick
+# only, and only into a slot with NO buses, because a slot that has buses has
+# been arranged by somebody and adding to it silently re-routes their voices.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+UI="src/shadow/shadow_ui.js"
+[ -f "$UI" ] || { echo "FAIL: cannot find $UI"; exit 1; }
+
+node --input-type=module -e '
+import { readFileSync } from "node:fs";
+const src = readFileSync(process.argv[1], "utf8");
+const BusModel = await import(process.cwd() + "/src/shared/bus_model.mjs");
+let bad = 0;
+const fail = (m) => { console.log("FAIL: " + m); bad = 1; };
+const ok = (m) => console.log("  ok  " + m);
+const grab = (n) => {
+  const m = src.match(new RegExp("^function " + n + "\\([^)]*\\)\\s*\\{[^]*?^}", "m"));
+  if (!m) { fail("could not lift " + n + "()"); process.exit(1); }
+  return m[0];
+};
+
+/* A config with `n` buses already present, in the shape parseBusesConfig makes. */
+const cfgJson = (n) => JSON.stringify({
+  buses: Array.from({ length: BusModel.SLOT_BUSES }, (_, i) =>
+    i < n ? { present: 1, name: "B" + i, orphans: 0, voices: [], sends: [0, 0], fx: [] }
+          : { present: 0 }),
+  main_sends: [0, 0],
+});
+
+function rig(meta, existingBuses, voicesJson) {
+  const body = [
+    "const BusModel = arguments[0];",
+    "let writes = [];",
+    "const META = " + JSON.stringify(meta) + ";",
+    "function host_get_module_metadata() { return META; }",
+    "function getSlotParam(slot, key) {",
+    "  if (key === \"buses:config\") return " + JSON.stringify(existingBuses) + ";",
+    "  if (key === \"synth:split_voices\") return " + JSON.stringify(voicesJson) + ";",
+    "  return \"\"; }",
+    "function setSlotParam(slot, key, val) { writes.push(key + \"=\" + val); return true; }",
+    "function debugLog() {}",
+    grab("moduleDefaultBuses"), grab("seedDefaultBusesForSlot"),
+    "return { seed: (id) => seedDefaultBusesForSlot(0, id), writes };",
+  ].join("\n");
+  return new Function(body)(BusModel);
+}
+
+const VOICES = JSON.stringify([{ id: "pad0", label: "Kick" },
+                               { id: "pad1", label: "Snare" },
+                               { id: "pad2", label: "Hats" }]);
+
+const DRUMBUS = { capabilities: { default_buses: [{
+  name: "Drum Bus",
+  voices: "*",
+  fx: [ { module: "dr32-fx", params: { effect: "Crunch" } },
+        { module: "clap",    params: { plugin_id: "Pop3" }, preset: "Glue" } ],
+}] } };
+
+/* ---- the whole kit, routed by default -------------------------------- */
+{
+  const r = rig(DRUMBUS, cfgJson(0), VOICES);
+  if (r.seed("dr32") !== 1) fail("no bus was created");
+  const w = r.writes;
+  if (w[0] !== "bus1:create=1") fail("first write was " + w[0] + ", expected the create");
+  /* ONE voices write carrying the WHOLE list -- every bus<N>:voices write is a
+     replace, so a per-voice write would leave only the last one in the bus. */
+  const vw = w.filter((x) => x.startsWith("bus1:voices="));
+  if (vw.length !== 1 || vw[0] !== "bus1:voices=pad0,pad1,pad2") {
+    fail("voices written as " + JSON.stringify(vw));
+  }
+  if (w.indexOf("bus1:name=Drum Bus") < 0) fail("the bus was not named");
+  /* Inserts are POSITIONS: module first, then its params, then its preset. */
+  const want = ["bus1:fx1:module=dr32-fx", "bus1:fx1:effect=Crunch",
+                "bus1:fx2:module=clap", "bus1:fx2:plugin_id=Pop3",
+                "bus1:fx2:preset_name=Glue"];
+  for (const k of want) if (w.indexOf(k) < 0) fail("missing write: " + k);
+  if (w.indexOf("bus1:fx2:preset_name=Glue") < w.indexOf("bus1:fx2:plugin_id=Pop3")) {
+    fail("the preset was applied before the params it depends on");
+  }
+  ok("creates the bus, routes every voice in ONE write, fills its positions in order");
+}
+
+/* ---- a SUBSET, which is what a bus is really for --------------------- */
+{
+  const sub = { capabilities: { default_buses: [{
+    name: "Low", voices: ["pad0", "pad1", "ghost"], fx: [] } ] } };
+  const r = rig(sub, cfgJson(0), VOICES);
+  r.seed("dr32");
+  const vw = r.writes.filter((x) => x.startsWith("bus1:voices="));
+  /* An id the synth does not publish is DROPPED, not passed through: the write
+     is a whole-list replace and the chain host would keep it as an orphan. */
+  if (vw[0] !== "bus1:voices=pad0,pad1") {
+    fail("subset routing wrote " + JSON.stringify(vw) + " -- an unknown id must be dropped");
+  }
+  ok("a subset routes only its own voices, and an unpublished id is dropped");
+}
+
+/* ---- the guards ------------------------------------------------------ */
+{
+  /* A slot that already has a bus has been arranged by somebody. */
+  const r = rig(DRUMBUS, cfgJson(1), VOICES);
+  if (r.seed("dr32") !== 0 || r.writes.length) {
+    fail("seeded into a slot that already had buses: " + JSON.stringify(r.writes));
+  }
+  ok("a slot with buses is left alone");
+
+  /* A FAILED config read is not an empty slot. busCount answers -1 for a read
+     that did not complete, never 0, exactly so this can tell them apart. */
+  for (const answer of [null, "", "not json"]) {
+    const q = rig(DRUMBUS, answer, VOICES);
+    if (q.seed("dr32") !== 0 || q.writes.length) {
+      fail("seeded on a " + JSON.stringify(answer) + " config read");
+    }
+  }
+  ok("a failed config read declines rather than creating buses");
+
+  /* An UNRESOLVED voice read is not "no voices". parseSplitVoices answers
+     { unresolved: true } for a read that did not complete, and treating that as
+     empty gives a slow synth a bus with nothing routed into it and no second
+     chance to fill it. Covered by the null/"" cases below, which is what an
+     incomplete read looks like on the wire. */
+  /* No voices means nothing to route, and a bus with no voices does nothing. */
+  for (const v of [null, "", "[]"]) {
+    const q = rig(DRUMBUS, cfgJson(0), v);
+    if (q.seed("dr32") !== 0 || q.writes.length) {
+      fail("created a bus with no voices to put in it (" + JSON.stringify(v) + ")");
+    }
+  }
+  ok("a synth that publishes no voices gets no bus");
+
+  /* Nothing declared costs nothing. */
+  for (const m of [{}, { capabilities: {} }, { capabilities: { default_buses: "x" } }]) {
+    const q = rig(m, cfgJson(0), VOICES);
+    if (q.seed("x") !== 0 || q.writes.length) fail("a module declaring nothing produced writes");
+  }
+  ok("no declaration writes nothing");
+}
+
+/* ---- caps ------------------------------------------------------------ */
+{
+  const many = { capabilities: { default_buses:
+    Array.from({ length: 20 }, (_, i) => ({ name: "B" + i, voices: "*",
+      fx: Array.from({ length: 20 }, (_, j) => ({ module: "m" + j })) })) } };
+  const r = rig(many, cfgJson(0), VOICES);
+  const made = r.seed("x");
+  if (made !== BusModel.SLOT_BUSES) {
+    fail("20 declared buses produced " + made + ", expected the cap of " + BusModel.SLOT_BUSES);
+  }
+  const f1 = r.writes.filter((x) => /^bus1:fx\d+:module=/.test(x));
+  if (f1.length !== BusModel.BUS_FX_SLOTS) {
+    fail("20 declared inserts produced " + f1.length + ", expected " + BusModel.BUS_FX_SLOTS);
+  }
+  ok("both caps truncate rather than letting the tail vanish silently");
+}
+
+/* ---- the call site --------------------------------------------------- */
+{
+  const m = src.match(/^function applyComponentSelectionConfirmed\([^)]*\)\s*\{[^]*?^}/m);
+  if (!m || !/seedDefaultBusesForSlot\(/.test(m[0])) {
+    fail("the interactive pick never seeds buses -- default_buses would be inert");
+  }
+  const sites = [...src.matchAll(/seedDefaultBusesForSlot\(/g)].length;
+  if (sites !== 2) {
+    fail("seedDefaultBusesForSlot appears " + sites + " times; defined once and called "
+         + "from the interactive pick ALONE -- a restore path that seeds re-creates "
+         + "buses the user deleted, on every boot");
+  }
+  ok("seeded from the interactive synth pick, and from nowhere else");
+}
+
+if (bad) process.exit(1);
+console.log("PASS");
+' "$UI"


### PR DESCRIPTION
Follow-up to #460/#463. `capabilities.default_buses: [{ name, voices, fx: [...] }]`

dr32 is the case. Its Drum Bus is four stages in series over the whole kit, and shipping that as **one** insert loses the only thing anyone wants from it — swapping just the compressor, or putting a drive between two stages. A container of positions is the point.

```json
"default_buses": [{
  "name": "Drum Bus",
  "voices": "*",
  "fx": [ { "module": "dr32-fx", "params": { "effect": "Crunch" } },
           { "module": "clap", "params": { "plugin_id": "Pop3" }, "preset": "Glue" } ]
}]
```

**A bus, not the slot chain**, and the difference is real rather than a naming preference: a bus catches the *voices*, while the slot chain catches the synth's whole output including anything it sums internally. A bus also keeps the module's glue out of the eight slot positions the user wants for their own effects.

**A bus returns before `fx1`** — `chain_host.c` says so at the accumulate, *"so a slot compressor sees the whole kit"* — the same relationship dr32 has internally today. Sends are tapped post-insert, so a bus feeding Send A sends the glued signal rather than raw voices.

## Details that are easy to get wrong

- Voices are written in **one** call carrying the whole list. Every `bus<N>:voices` write is a replace, so a per-voice loop would leave only the last one in the bus.
- An id the synth does not publish is **dropped**, not passed through — the replace would otherwise keep it as an orphan.
- Same guards as `default_fx`: interactive pick only, and only into a slot with **no** buses, since a slot that has them has been arranged by somebody.

## Verification

307 `tests/host` tests pass. Mutation-checked eight ways — and **two guards were written and then deleted** because nothing could kill them: `parseSplitVoices` reports `unresolved` only alongside an empty voice list, so the emptiness check already carries the tri-state; and a cap in `moduleDefaultBuses` duplicated the seeding loop's own break.