### PR TITLE
A bus insert can say what it is

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -22869,6 +22869,10 @@ function drawHelpDetail() {
     /* Utility functions */
     _ctx.setView = setView;
     _ctx.getSlotParam = getSlotParam;
+    /* The polled identity of a bus insert, or "" -- read from the cache the
+     * ~1 Hz poll fills, never from IPC: this is consulted on the draw path. */
+    _ctx.busInsertDisplayName = (bus, pos) =>
+        fxDisplayNameCache[`bus:${busSlot}:${bus}:${pos}`] || "";
     _ctx.setSlotParam = setSlotParam;
     _ctx.updateFocusedSlot = updateFocusedSlot;
     /* The slot list's Master FX row. Wrapped, because it reads the mirror and
@@ -25254,6 +25258,38 @@ globalThis.tick = function() {
          * masterFxConfig — i.e. the SEND's positions — so it would poll
          * whatever master slots the send happens to occupy and skip whatever
          * master slots the send leaves empty. */
+        /*
+         * BUS INSERTS, and only the bus on screen.
+         *
+         * A module that ships several effects from one binary -- which is what
+         * default_buses encourages, and what Airwindows already is -- puts
+         * several instances of ONE module in a bus. The diagram labels a box
+         * with the MODULE's abbreviation and the band with the POSITION, so
+         * four of them read as the same three letters over "FX 1".."FX 4".
+         * display_name is the existing answer for an effect with a live
+         * identity; bus inserts were simply never added to the poll.
+         *
+         * SCOPED TO THE OPEN BUS. Four slots x eight buses x eight positions is
+         * 256 reads a second for a screen nobody is looking at. The bus chain
+         * editor is the only place these are drawn, so it is the only place
+         * they are asked -- at most eight reads a second, while you are looking
+         * at them, and pollFxDisplayName's own backoff drops a module that does
+         * not implement it after the first miss.
+         */
+        if (view === VIEWS.BUS_CHAIN && busConfig && !busConfig.unresolved) {
+            const b = busConfig.buses[busChainBus];
+            const fx = (b && b.fx) || [];
+            for (let k = 0; k < fx.length; k++) {
+                if (!fx[k]) continue;
+                const cacheKey = `bus:${busSlot}:${busChainBus}:${k}`;
+                const name = pollFxDisplayName(busSlot,
+                    `bus${busChainBus + 1}:fx${k + 1}:display_name`, cacheKey);
+                if (name && name !== fxDisplayNameCache[cacheKey]) {
+                    fxDisplayNameCache[cacheKey] = name;
+                    needsRedraw = true;
+                }
+            }
+        }
         withFxBus(0, () => {
             for (const { key } of masterFxChainComponents()) {
                 if (key === "settings") continue;

--- a/src/shadow/shadow_ui_buses.mjs
+++ b/src/shadow/shadow_ui_buses.mjs
@@ -181,7 +181,16 @@ export function drawBusChain() {
     const comp = comps[busChainPos];
     let info = "(empty)";
     if (comp && comp.kind === "add") info = "New effect";
-    else if (comp && comp.module) info = comp.module;
+    else if (comp && comp.module) {
+        /* The module, plus what it says it IS when it says anything. Four
+         * instances of one binary are otherwise indistinguishable here -- same
+         * abbreviation on every box, and a band naming only the position. Read
+         * from the cache the display_name poll fills; a draw path cannot afford
+         * a ~2.8 ms round trip to label itself. */
+        const live = ctx.busInsertDisplayName
+            ? ctx.busInsertDisplayName(busChainBus, busChainPos) : "";
+        info = live ? `${comp.module} (${live})` : comp.module;
+    }
     drawChainEditorBands(movy, {
         headerLeft: truncateText(bus.name, 14),
         headerRight: "BUS",


### PR DESCRIPTION
The bus chain editor labels a box with the **module's** abbreviation and the band below with the **position**. Four inserts that are four instances of one module therefore read as the same three letters over `FX 1`..`FX 4` — which is exactly what a module shipping several effects from one binary looks like, and the shape `default_buses` (#464) encourages.

Reported from hardware against a dr32 Drum Bus holding Crunch / Attack / Sustain / Comp.

`display_name` is the existing answer for an effect with a live identity. Slot components and Master FX have been polled for it all along; **bus inserts were never added to the poll.**

**Scoped to the open bus.** Four slots × eight buses × eight positions is 256 reads a second for a screen nobody is looking at. The bus chain editor is the only place these are drawn, so it is the only place they are asked — at most eight a second, while you are looking at them, and `pollFxDisplayName`'s own per-component backoff drops a module that does not implement it after the first miss.

The band reads the **cache** the poll fills, never IPC: a ~2.8 ms round trip to label a 1.68 ms page render costs more than the thing it is labelling.

307 `tests/host` tests pass.