### PR TITLE
Seeded bus inserts all came up as the module default

### DIFF
--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -7738,6 +7738,59 @@ function moduleDefaultBuses(moduleId) {
     return list.filter((b) => b && typeof b === "object");
 }
 
+/*
+ * Param writes waiting for a bus insert to finish loading.
+ *
+ * Each entry is retried from the tick until the position reports the module we
+ * asked for, then written once and dropped. BOUNDED, so a load that fails --
+ * a missing module, a refused dlopen -- cannot leave an entry retrying forever.
+ */
+let pendingBusInsertWrites = [];
+const BUS_INSERT_WRITE_TRIES = 120;   /* ~2s at the 60Hz tick */
+
+function queueBusInsertParams(slotIndex, pos, entry) {
+    const params = (entry.params && typeof entry.params === "object") ? entry.params : null;
+    if (!params && !entry.preset) return;
+    pendingBusInsertWrites.push({
+        slot: slotIndex, pos, module: entry.module,
+        params, preset: entry.preset ? String(entry.preset) : "",
+        tries: 0,
+    });
+}
+
+/*
+ * One pass over the queue. Called from the tick.
+ *
+ * The readiness test is the position reporting the module we ASKED FOR, not
+ * merely reporting something: a position being reloaded answers with the
+ * outgoing module until the worker installs, and writing this module's params
+ * into that one would set parameters on somebody else's plugin.
+ */
+function flushPendingBusInsertWrites() {
+    if (!pendingBusInsertWrites.length) return;
+    const keep = [];
+    for (const w of pendingBusInsertWrites) {
+        const got = getSlotParam(w.slot, `${w.pos}:module`);
+        /* null is "the read did not complete" and "" is "nothing there yet" --
+         * neither is a reason to give up, only to wait. */
+        if (got !== w.module) {
+            if (++w.tries < BUS_INSERT_WRITE_TRIES) keep.push(w);
+            else debugLog(`default_buses: ${w.pos} never reported ${w.module}; params dropped`);
+            continue;
+        }
+        if (w.params) {
+            for (const pk in w.params) {
+                setSlotParam(w.slot, `${w.pos}:${pk}`, String(w.params[pk]));
+            }
+        }
+        /* Last, for the reason default_fx applies it last: a preset is a whole
+         * state and overwrites anything written after it. */
+        if (w.preset) setSlotParam(w.slot, `${w.pos}:preset_name`, w.preset);
+        debugLog(`default_buses: applied queued params to ${w.pos}`);
+    }
+    pendingBusInsertWrites = keep;
+}
+
 function seedDefaultBusesForSlot(slotIndex, moduleId) {
     const wanted = moduleDefaultBuses(moduleId);
     if (!wanted.length) return 0;
@@ -7787,16 +7840,25 @@ function seedDefaultBusesForSlot(slotIndex, moduleId) {
             const pos = `${bus}:fx${k + 1}`;
             if (!setSlotParam(slotIndex, `${pos}:module`, entry.module)) break;
             k++;
-            if (entry.params && typeof entry.params === "object") {
-                for (const pk in entry.params) {
-                    setSlotParam(slotIndex, `${pos}:${pk}`, String(entry.params[pk]));
-                }
-            }
-            /* Last, for the reason default_fx applies it last: a preset is a
-             * whole state and overwrites anything written after it. */
-            if (entry.preset) {
-                setSlotParam(slotIndex, `${pos}:preset_name`, String(entry.preset));
-            }
+            /*
+             * THE PARAMS ARE QUEUED, NOT WRITTEN. A bus insert loads on the
+             * WORKER -- chain_bus.c does the dlopen and create_instance off the
+             * RT thread -- and its set_param drops anything that arrives before
+             * the instance exists: "a write during a reconcile is dropped
+             * rather than queued: the UI re-sends on the next detent".
+             *
+             * A human turning a knob re-sends seconds later and never notices.
+             * Seeding writes microseconds later, so every param was dropped and
+             * four declared inserts all came up as the module's default -- four
+             * boxes reading "Crunch". Reported from hardware, and INTERMITTENT,
+             * because a reload lands the same writes after the load and works:
+             * the worst shape a race can have.
+             *
+             * The slot chain does not need this. chain_host.c loads an audio FX
+             * on the SPI callback, so default_fx's writes land on a plugin that
+             * already exists.
+             */
+            queueBusInsertParams(slotIndex, pos, entry);
         }
         made++;
     }
@@ -24469,6 +24531,11 @@ globalThis.tick = function() {
             if (_h && typeof host_trace_end === 'function') host_trace_end(_h);
         }
     }
+
+    /* Params for a bus insert that was still loading when it was seeded. Costs
+     * one read per waiting position and nothing at all once the queue drains,
+     * which it does within a second of a pick. */
+    flushPendingBusInsertWrites();
 
     /* Send levels, flushed off the knob. Marked dirty by the grid write and
      * written here at most a few times a second: the file I/O is what put

--- a/tests/host/test_default_buses_seed.sh
+++ b/tests/host/test_default_buses_seed.sh
@@ -42,7 +42,7 @@ const cfgJson = (n) => JSON.stringify({
   main_sends: [0, 0],
 });
 
-function rig(meta, existingBuses, voicesJson) {
+function rig(meta, existingBuses, voicesJson, declaredByPos) {
   const body = [
     "const BusModel = arguments[0];",
     "let writes = [];",
@@ -51,11 +51,28 @@ function rig(meta, existingBuses, voicesJson) {
     "function getSlotParam(slot, key) {",
     "  if (key === \"buses:config\") return " + JSON.stringify(existingBuses) + ";",
     "  if (key === \"synth:split_voices\") return " + JSON.stringify(voicesJson) + ";",
+    "  if (/:module$/.test(key)) return getSlotParamModule(slot, key);",
     "  return \"\"; }",
     "function setSlotParam(slot, key, val) { writes.push(key + \"=\" + val); return true; }",
     "function debugLog() {}",
+    "let pendingBusInsertWrites = []; const BUS_INSERT_WRITE_TRIES = 120;",
+    /* The position answers `loaded` only once the harness says so, which is how
+       the worker actually behaves: a bus insert is dlopened OFF the RT thread. */
+    "let loaded = false;",
+    /* Answers the module ACTUALLY declared for that position. A stub that
+       returned one id for every position would have fx2 (clap) never match, and
+       the refusal to write there is the readiness test doing its job. */
+    "const DECLARED = " + JSON.stringify(declaredByPos || {}) + ";",
+    "function getSlotParamModule(slot, key) {",
+    "  if (!loaded) return null;",
+    "  const m = /fx(\\d+):module$/.exec(key);",
+    "  return m ? (DECLARED[m[1]] || \"\") : \"\"; }",
+    grab("queueBusInsertParams"), grab("flushPendingBusInsertWrites"),
     grab("moduleDefaultBuses"), grab("seedDefaultBusesForSlot"),
-    "return { seed: (id) => seedDefaultBusesForSlot(0, id), writes };",
+    "return { seed: (id) => seedDefaultBusesForSlot(0, id), writes,",
+    "         flush: () => flushPendingBusInsertWrites(),",
+    "         load: () => { loaded = true; },",
+    "         pending: () => pendingBusInsertWrites.length };",
   ].join("\n");
   return new Function(body)(BusModel);
 }
@@ -73,8 +90,11 @@ const DRUMBUS = { capabilities: { default_buses: [{
 
 /* ---- the whole kit, routed by default -------------------------------- */
 {
-  const r = rig(DRUMBUS, cfgJson(0), VOICES);
+  const r = rig(DRUMBUS, cfgJson(0), VOICES, { "1": "dr32-fx", "2": "clap" });
   if (r.seed("dr32") !== 1) fail("no bus was created");
+  /* The params are QUEUED until the insert loads -- see the load-race case
+     below -- so drive that here before asserting on them. */
+  r.load(); r.flush();
   const w = r.writes;
   if (w[0] !== "bus1:create=1") fail("first write was " + w[0] + ", expected the create");
   /* ONE voices write carrying the WHOLE list -- every bus<N>:voices write is a
@@ -93,6 +113,89 @@ const DRUMBUS = { capabilities: { default_buses: [{
     fail("the preset was applied before the params it depends on");
   }
   ok("creates the bus, routes every voice in ONE write, fills its positions in order");
+}
+
+/* ---- THE LOAD RACE, which made four inserts identical ---------------- */
+/*
+ * A bus insert loads on the WORKER, and chain_bus.c drops any set_param that
+ * arrives before the instance exists. Writing params straight after the module
+ * write therefore lost every one of them, and four declared inserts all came up
+ * as the module default -- four boxes reading "Crunch". Reported from hardware,
+ * and INTERMITTENT: a reload lands the same writes after the load and works.
+ */
+{
+  const r = rig(DRUMBUS, cfgJson(0), VOICES, { "1": "dr32-fx", "2": "clap" });
+  r.seed("dr32");
+  /* The MODULE writes go immediately -- they are what starts the load. */
+  if (!r.writes.some((w) => w === "bus1:fx1:module=dr32-fx")) {
+    fail("the module write was deferred; it is what starts the load");
+  }
+  /* Nothing else may have been written yet. */
+  if (r.writes.some((w) => /fx\d+:(effect|plugin_id|preset_name)=/.test(w))) {
+    fail("params were written before the insert loaded: " + JSON.stringify(r.writes)
+         + " -- chain_bus.c drops those, which is the bug");
+  }
+  if (r.pending() !== 2) fail("expected 2 queued param sets, got " + r.pending());
+
+  /* Flushing while it is STILL loading must write nothing and keep waiting. */
+  r.flush();
+  if (r.writes.some((w) => /:effect=/.test(w))) fail("flushed into an unloaded insert");
+  if (r.pending() !== 2) fail("a not-yet-loaded position was dropped from the queue");
+
+  /* Once the position reports the module we asked for, the params land. */
+  r.load();
+  r.flush();
+  const want = ["bus1:fx1:effect=Crunch", "bus1:fx2:plugin_id=Pop3",
+                "bus1:fx2:preset_name=Glue"];
+  for (const k of want) if (r.writes.indexOf(k) < 0) fail("after load, missing: " + k);
+  if (r.pending() !== 0) fail("the queue did not drain after the writes landed");
+
+  /* And it does not write twice. */
+  r.flush();
+  if (r.writes.filter((w) => w === "bus1:fx1:effect=Crunch").length !== 1) {
+    fail("a drained entry was written again");
+  }
+  ok("params wait for the insert to load, land once, and drain");
+}
+
+/*
+ * A POSITION REPORTING ANOTHER MODULE IS NOT READY.
+ *
+ * A position being reloaded answers with the OUTGOING module until the worker
+ * installs the new one. Testing merely "did it answer" would write this
+ * params of THIS module into that plugin -- setting Crunch and Pop3 values on
+ * whatever used to be there. The test is the module we ASKED FOR.
+ */
+{
+  const r = rig(DRUMBUS, cfgJson(0), VOICES, { "1": "someone-else", "2": "clap" });
+  r.seed("dr32");
+  r.load();          /* the position answers, but with the WRONG module */
+  r.flush();
+  if (r.writes.some((w) => w === "bus1:fx1:effect=Crunch")) {
+    fail("params were written to a position reporting a different module -- that "
+         + "sets this module parameters on somebody else plugin");
+  }
+  if (r.pending() < 1) fail("the entry was dropped rather than kept waiting");
+  /* fx2 DOES match, so its params land -- one position waiting must not hold
+     up another that is ready. */
+  if (r.writes.indexOf("bus1:fx2:plugin_id=Pop3") < 0) {
+    fail("a ready position was held up by an unready one");
+  }
+  ok("a position reporting another module keeps waiting, and does not block its neighbour");
+}
+
+/* A load that never completes must not retry forever. */
+{
+  const r = rig(DRUMBUS, cfgJson(0), VOICES, { "1": "dr32-fx", "2": "clap" });
+  r.seed("dr32");
+  for (let i = 0; i < 200; i++) r.flush();     /* never loads */
+  if (r.pending() !== 0) {
+    fail("a position that never loaded is still queued after 200 passes");
+  }
+  if (r.writes.some((w) => /:effect=/.test(w))) {
+    fail("params were written to a position that never loaded");
+  }
+  ok("a load that never completes gives up rather than retrying forever");
 }
 
 /* ---- a SUBSET, which is what a bus is really for --------------------- */


### PR DESCRIPTION
Four declared inserts came up as four copies of the same effect — a Drum Bus reading `Crunch`, `Crunch`, `Crunch`, `Crunch`. Reported from hardware against #464.

**A bus insert loads on the worker.** `chain_bus.c` does the `dlopen` and `create_instance` off the RT thread, and its `set_param` drops anything arriving before the instance exists:

> a write during a reconcile is dropped rather than queued: the UI re-sends on the next detent

That last sentence is why nobody had hit it. A human turning a knob re-sends seconds later; seeding wrote microseconds after the module write, so every param was dropped and each insert stayed at its default.

**Intermittent, which is the worst shape** — reloading the module lands the same writes after the load and works, so the bug appears fixed by the thing that hides it.

## The fix

Params are queued and flushed from the tick once the position reports **the module we asked for** — not merely reports something. A position being reloaded answers with the *outgoing* module until the worker installs, and writing there would set this module's parameters on somebody else's plugin. Bounded at ~2 s so a load that never completes gives up rather than retrying forever, and one waiting position does not hold up a ready neighbour.

The slot chain needs none of this: `chain_host.c` loads an audio FX on the SPI callback, so `default_fx`'s writes land on a plugin that already exists.

## Verification

307 `tests/host` tests pass. Mutation-checked four ways — and the module-identity check **survived the first pass**, because the harness answered either the right module or nothing, never a *different* one, which is the only case that guard defends. It answers a foreign module now.