### PR TITLE
param-slow: name the key when a param serve eats the frame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,14 @@ tally, each with its arming file. Read it before measuring anything on hardware:
   same amount. The old overrun counter fired on *every* frame: 43,986 in two
   minutes on an idle device.
 - The tally stays **silent for ~20 s after arming**, which looks like a broken build.
+- **`param-slow` is the OTHER always-on diagnostic, and it needs no flag.** A
+  serve past 1000 us is logged with its KEY (`param-slow: set slot 0
+  synth:module took 124.825 ms`). A module blocking in `set_param` is the
+  steady state, not an anomaly, so the question is which key rather than
+  whether to look — and twice the same defect cost a session for want of a
+  name. **A single blown frame is invisible to the frame tally** (1 Hz
+  aggregates, zero `LATE` lines for a 20 ms serve); `spi_timing`'s
+  `param=avg/max` is what sees it.
 - The **CPU usage page** (`/system/cpu`, schwung-manager, `/schwung-perf`) is the
   one diagnostic that is **always on** — its timing was already being collected
   unconditionally, so only its 1 Hz polling is armed, by a button, not a file.

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -7,6 +7,38 @@ Every switch below is **off by default** and armed by touching a file under
 `/data/UserData/schwung/`. Disarm them when you stop measuring — `debug_log_on`
 has itself caused the audio dropouts it was being used to hunt.
 
+**`param-slow` is ALWAYS ON, and is the exception to the sentence above.**
+There is no file to touch. When a param serve exceeds 1000 us the shim worker
+logs, at WARN:
+
+```
+param-slow: set slot 0 synth:module took 124.825 ms on the SPI callback — the module is doing blocking work in its entry point
+```
+
+**Why it is not armed like everything else.** Module entry points ARE the SPI
+callback and the ecosystem does not know it (~150 confirmed violations across
+113 catalogued modules), so a module blocking in `set_param` is the steady
+state, not an anomaly. The question is never "shall we go looking", it is
+"which key was it this time" — and a flag you must arm first is a flag nobody
+has armed at the moment the glitch happens. Twice the same defect cost a full
+diagnosis session for want of a name: overtake's `dlopen` (param stage
+7us -> 11513us) and dr32's kit load inside `synth:state` (7us -> 20051us).
+
+Cost is two vDSO clock reads (~340ns each — not the ~1.8us syscall) per serve
+and, past the threshold, one bounded string copy. No formatting and no logging
+on the callback; the worker does both at 1 Hz. Unlike the drop counters beside
+it, this only fires when something has already overrun the budget, so it is
+never noise. Loss is by construction — the callback cannot wait for a
+consumer — but never silent: overwritten entries are counted and reported.
+
+`src/host/param_slow.h`, `tests/host/test_param_slow.sh`.
+
+**A single blown frame is invisible to the SPI frame tally.** `backlog` and
+`frames / irq` are 1 Hz aggregates, so an overrun that drains immediately never
+appears, and a 20 ms serve produced **zero `LATE` lines** across a whole
+session. What catches it is `spi_timing`'s `Pre(us): ... param=avg/max` line
+(`param=7/20051`) — reach for that, not the tally, for a one-frame stall.
+
 **On-device E2E tests** (opt-in, not in CI): `tools/pytest-schwung/` is a pip-installable pytest plugin that drives a real Move end-to-end through `schwung-testd`, an opt-in test-bus daemon (TCP loopback, started manually over SSH; built into the tarball but not auto-started). Tests inject MIDI, wait for SPI frames, snapshot pad LEDs, capture MIDI_OUT, and reset to a known-empty set (`pristine_set`). Run `pytest tests/e2e` against attached hardware. Full protocol, fixtures, and hardware pitfalls in `tools/pytest-schwung/README.md`.
 
 **OTLP span tracing** (perf profiling, off by default): `touch /data/UserData/schwung/otlp_trace_on` makes **both** the shim and the `shadow_ui` process emit realtime-safe spans as OTLP/JSONL to `/data/UserData/schwung/traces/`, one file per service (`schwung-shim-*` / `schwung-shadow-ui-*`). Shim: `spi.pre`/`spi.post` roots + `shadow.mix_audio`, `midi.process`, `param.serve` children. shadow_ui: `js.tick` + `param.get`. Spans correlate **cross-process by trace_id** — the shim's `param.serve` is emitted as a child of shadow_ui's `param.get` (context propagated through `shadow_param_t`), so Tempo/Jaeger stitch the two files into one trace. JS modules (overtake/chain, incl. ion) can add spans via `host_trace_begin(name) -> handle` / `host_trace_end(handle)` (shadow_ui context only); balance the pair within one `tick()` (handles come from a 16-entry table reset each `js.tick`). `rm` the file to stop. Zero hot-path cost when off. See `docs/tracing.md`.

--- a/docs/plans/2026-09-07-wholesale-ops-off-the-spi-callback.md
+++ b/docs/plans/2026-09-07-wholesale-ops-off-the-spi-callback.md
@@ -1,0 +1,219 @@
+# Wholesale module operations run on the worker, not the SPI callback
+
+Status: PLAN. Nothing implemented yet.
+
+## The report
+
+"I get a click when restoring state from shift+delete."
+
+## What it actually is, measured
+
+Root cause is confirmed on hardware, four repeats plus an elimination test.
+
+`dr32`'s state blob is the kit PATH plus param deltas:
+
+```json
+{"v":1,"kit":"/data/CoreLibrary/Track Presets/Drums/Electronic/606 Kit.json","params":{}}
+```
+
+`dr32_state_read` calls `load_kit` unconditionally whenever the blob carries a
+path, so every recall re-reads the kit JSON and its 16 WAVs off the card —
+**inside `set_param`, on the SPI callback.** The module logs its own cost:
+
+```
+14:39:36.715  dr32: kit '…606 Kit.json' loaded in 18.9 ms — 16 pads, 16 samples
+14:44:43.009  … 18.9 ms     three deliberate repeats,
+14:44:46.520  … 18.9 ms     3 s apart
+14:44:49.495  … 18.9 ms
+12:45:56.992  … 111.4 ms    COLD CACHE
+```
+
+and the shim's own `spi_timing` line for the same frame:
+
+```
+14:39:40  Frame(us): total avg=2680 max=20935 | pre avg=312 max=20352 | overruns=311 (+3)
+          Pre(us): … param=27/20051 …
+```
+
+18.9 ms of kit load + JSON parse = the 20.05 ms param serve, against a **2.9 ms
+block period**. Seven blown frames warm, ~38 cold. The gesture with dr32 removed
+from the rig is silent.
+
+### What it is NOT
+
+Ruled out by measurement, not by argument — each of these was a live hypothesis:
+
+- **Not a parameter discontinuity.** A snapshot recalled with nothing changed
+  in between still clicks. The content of the state is irrelevant.
+- **Not cumulative cost across many writes.** One preset load down the identical
+  path (`My Presets` → Load) is silent. It is a single expensive call.
+- **Not Master FX.** This rig's `master_fx_0.json` carries no `id`, so
+  `parseMasterFxSnapshot` returns `[]` and Master FX contributes nothing to the
+  recall at all.
+- **Not the logger.** Idle baseline with `debug_log_on` armed was 345 frames /
+  345 irq, backlog 0, headroom 2511 µs, unwavering for 45 s.
+- **Not visible to the SPI tally.** `backlog` and `frames/irq` are 1 Hz
+  aggregates; a single blown frame that drains immediately never showed up, and
+  zero `LATE` lines were logged across the whole session. `spi_timing`'s
+  `param=avg/max` is what caught it. Worth knowing before reaching for the
+  tally next time.
+
+## The general defect
+
+This is the **third** occurrence of one defect class, and the second one we
+have measured with the same instrument. The overtake path already fixed it and
+recorded the identical signature:
+
+> `dlopen()` plus a module's `create_instance()` is filesystem + allocation
+> work. Measured on device it stalled the SPI callback for ~11.5 ms (param
+> stage 7µs typical → 11513µs during a load) […] So the SPI thread only ever
+> *requests*.
+
+Module entry points **are** the SPI callback, and the ecosystem does not know
+it — the 2026-08 audit found ~150 confirmed violations across 113 modules,
+several carrying comments asserting the opposite. dr32's own comment reads
+*"Load HERE, on the host thread."* There is nothing to correct in that author's
+reasoning except the contract they were given.
+
+So the host cannot keep assuming `set_param` is cheap. It has to stop calling
+expensive things from the callback.
+
+### The fade does not fix this, and does not fix what it already covers
+
+Worth recording, because it was the obvious answer and it is wrong.
+
+`shadow_process_fade_completions()` is called from `shim_pre_transfer`
+(`schwung_shim.c:6171`) — **on the SPI callback, before the ioctl.** So
+`load_patch` / `load_file` / module swap fade the slot to silence and then do
+their disk read *still on the hot path*. The frame overruns exactly the same;
+what the fade removes is the slot's own audio, so the remaining glitch lands in
+Move's audio and the other three slots and gets attributed elsewhere.
+
+Every wholesale operation on the box does this today. Recall is only the one
+where nobody expected a hiccup, which is why it got reported.
+
+**A fade makes an operation inaudible. It does not make it cheap.** The two are
+independent and this subsystem needs both.
+
+## Design
+
+Wholesale operations move to the shim worker (SCHED_OTHER, cores 0–2). Fast
+params stay inline.
+
+### Which keys
+
+Wholesale = the operations that already tolerate latency because they replace a
+component's sound wholesale:
+
+- `*:state`  ← the one with no fade today; the reported bug
+- `*:module`
+- `load_file`
+- `load_patch` / `patch`
+
+Plus, later, anything a module declares. Everything else stays inline: a normal
+param serve is ~10 µs, and routing those through a worker costs more than it
+saves.
+
+**Fast params must not be deferred.** Pausing a slot per knob turn would lose
+whole 2.9 ms blocks — strictly worse than the bug.
+
+### The lease, which is the hard part
+
+While the worker holds an instance, nothing on the RT path may touch it.
+
+The overtake precedent gets this for free: it **retires the pointer** on the SPI
+thread, so every existing `api && inst` guard stops calling in "with no new
+gating anywhere". That trick rests on an invariant overtake has — a module may
+legitimately be absent, so every site checks.
+
+**Slots do not have that invariant.** 65 uses of
+`shadow_chain_slots[…].instance` across `schwung_shim.c` and
+`shadow_chain_mgmt.c`, ~14 with an explicit NULL guard. A slot's instance is
+created at boot and is never NULL in normal operation, so call sites got lazy
+and pass it straight into `set_param`/`render_block`. NULLing it would
+NULL-deref `chain_instance_t *inst` on the audio thread — which per the
+breakbeat story is a SIGSEGV that boot-loops the device, because the slot is
+restored every boot and crashes before the UI can remove it.
+
+So: **do not copy the retire trick. Gate at the outermost RT entry points
+instead**, where the slot loop already lives, rather than at 65 leaf sites.
+
+Entry points to enumerate and gate (this inventory is the first task, and it is
+most of the design — it belongs in review, not in a runtime discovery):
+
+- the mix/render loop (`shadow_mix_audio`, both `same_frame_fx` branches)
+- MIDI dispatch into slots (several sites, cable 0 and cable 2)
+- `mod:tick` and `chain_take_midi_tick_wake` on the idle-probe path
+- the param serve itself (`shadow_inprocess_handle_param_request`)
+- `shadow_inprocess_handle_ui_request` / `shadow_process_fade_completions`
+- `shadow_chain_refresh_wants_sysex_tick`
+- the bus and per-voice send drains
+- `shadow_ui_state_update_slot` and the capture/snapshot readers
+
+### Sequence
+
+1. SPI thread receives a wholesale set. It stages the value, marks the slot
+   leased, ramps `fade.gain` to 0, and posts to the worker. Returns immediately.
+2. RT path sees the lease and skips the slot everywhere above. It renders
+   silence, which is why the fade must lead — the lease is a cliff otherwise.
+3. Worker calls `set_param`. Disk I/O happens here. Frame budget untouched.
+4. Worker clears the lease; RT path ramps `fade.gain` back to 1.
+
+### Open questions to settle in review
+
+- **MIDI during the window.** Drop or queue? Dropping loses note-offs and gives
+  stuck notes; queuing needs a bounded ring and a replay order. Leaning: hold
+  note-offs, drop note-ons, and panic the slot on resume.
+- **Staging buffer size.** `SHADOW_PARAM_VALUE_LEN` is 128 KB. One staging
+  buffer serialises the burst, which is acceptable because JS writes serially
+  anyway — but it must be *stated* rather than assumed, and the second write
+  must block or coalesce rather than clobber.
+- **JS ordering.** `setSlotParam` currently returns when the value is applied.
+  It would return when the value is *queued*. `snapshotRecall` calls
+  `paramPagesRevalue()` immediately afterwards, which would then read pre-apply
+  values. Needs a drain or a completion handshake.
+- **Does `get_param` need the same treatment?** The fleet audit found
+  directory-scanning getters, and *"a `get_param` that scans a directory is
+  served once per repaint"* makes it worse than the equivalent set. Not in this
+  change, but the lease should not be designed so as to preclude it.
+
+## Companion work
+
+### Attribution logging (small, independent, do it first)
+
+When an inline param serve exceeds the frame budget, log module + key +
+duration from the worker. RT-safe: record max + key in the callback, format and
+emit off-thread.
+
+This is how the wholesale-key list grows from evidence rather than guesswork,
+and it turns "there's a click somewhere" into a named line. Today's diagnosis
+took an afternoon and needed a differential experiment against the user's ears;
+with this it is one grep.
+
+### dr32, at source
+
+A 110 ms cold kit load is antisocial wherever it runs. But the obvious fix is
+wrong and would ship as a silent regression:
+
+`dr32_state_write` deliberately emits **only deltas from the kit baseline** —
+`if (base && strcmp(base, val) == 0) return n; /* unedited — kit restores it */`
+— so the kit reload *is* the mechanism that resets everything the blob omits.
+"Skip the reload when the path is unchanged" silently stops a recall reverting
+pad edits.
+
+Correct shape: dr32 already keeps `in->state_baseline` via
+`dr32_capture_baseline()`. On a same-path restore, reset params from that
+in-memory baseline and skip the *sample* reload — the samples cannot have
+changed, only the params. Same semantics, no disk. Its `tests/test_state.c`
+gives somewhere to pin it.
+
+## Verification
+
+- `tests/host/` unit for the lease state machine (transitions in a header, as
+  `chain_idle_tick.h` does, so it can be driven off-device).
+- Source pin: every enumerated RT entry point consults the lease.
+- On hardware: arm `debug_log_on`, repeat the recall, assert `param` max stays
+  in the tens of µs and `overruns` does not advance. Cold cache included — the
+  111 ms case is the one that matters.
+- Regression: confirm `load_patch` and set load stop advancing `overruns` too,
+  since they have the same defect and no one has been counting.

--- a/docs/plans/2026-09-07-wholesale-ops-off-the-spi-callback.md
+++ b/docs/plans/2026-09-07-wholesale-ops-off-the-spi-callback.md
@@ -117,6 +117,53 @@ saves.
 **Fast params must not be deferred.** Pausing a slot per knob turn would lose
 whole 2.9 ms blocks — strictly worse than the bug.
 
+### Relationship to PR #303 (open, unmerged, not hardware-verified)
+
+#303 "Build modules off the SPI callback" solves the SAME DEFECT CLASS at a
+DIFFERENT ENTRY POINT: it defers `create_instance`, measured at **672.9 ms for
+minijv, ~232 consecutive dropped frames**. This plan is about `set_param`.
+
+**It does not fix the reported click**, and the two do not overlap on disk (only
+`CLAUDE.md`). Its own scope note is explicit: *"Scope is the synth position
+only. Audio FX, MIDI FX, Master FX, `load_patch` and boot restore keep the
+synchronous path."* So of the wholesale keys listed above it claims exactly one,
+`synth:module`, and this plan should claim the remainder rather than restate it.
+
+**Its mechanism is better than the lease sketched below, and where it applies it
+should be copied rather than re-invented.** "Stage, don't swap": the loader
+thread builds the instance into a staging record no render path can reach, and
+the SPI thread publishes it by swapping pointers from `v2_render_block`. That
+keeps *"only the SPI thread ever mutates a chain instance"* true verbatim — so
+it needs NO gating at the 65 `.instance` call sites, which is precisely the hard
+part identified below. No locks either, in both directions, which matters
+because an RT thread blocking on a SCHED_OTHER thread's mutex is unbounded
+priority inversion.
+
+**But it cannot be transferred to a state apply, and that is the crux.** Staging
+works by constructing a NEW thing. A state apply MUTATES A RUNNING INSTANCE;
+staging it would mean creating a fresh instance, applying the blob off-thread
+and swapping — i.e. reinstantiating, which cuts reverb tails and resets arp
+phase. That is exactly what a recall exists not to do ("A recall writes STATE,
+never SHAPE"). So the lease problem below survives #303 intact.
+
+**What IS directly reusable is its concurrency discipline: no field has two
+writers.** Its first version shared one `state` word between the two threads and
+produced three real defects — a request lost so the position never loads with
+nothing logged, a stranded staged module leaking a dlopen handle per swap, and a
+segfault from nulling a reusable ~1.1 MB parameter block the loader then
+memset through. Work is derived from generation counters advanced by one side
+only, and "is a load outstanding" is `req_gen != committed_gen`. The lease needs
+the same discipline; copy the structure.
+
+**The attribution logging in this change is an instrument #303 can use.** #303
+ships unverified on hardware, and a 672.9 ms `synth:module` write is far past
+the 1000 µs threshold — so it will name itself in `debug.log` before the merge
+and, after it, its absence is the regression test. Note the limit honestly: this
+measures the BLOCKING half only. #303's own "still owed" is the *burn* number —
+CPU spent at realtime priority by inherited-FIFO plugin threads — and its
+correlation with the Link Audio stalls. Nothing here measures that; that is the
+RT-thread audit's job.
+
 ### The lease, which is the hard part
 
 While the worker holds an instance, nothing on the RT path may touch it.

--- a/src/host/param_slow.h
+++ b/src/host/param_slow.h
@@ -1,0 +1,162 @@
+#ifndef PARAM_SLOW_H
+#define PARAM_SLOW_H
+
+/*
+ * Attribution for a param serve that ate the frame.
+ *
+ * WHY THIS EXISTS. Module entry points ARE the SPI callback, and the ecosystem
+ * does not know it — the 2026-08 audit found ~150 confirmed violations across
+ * 113 catalogued modules, several carrying comments asserting the opposite in
+ * so many words. So a module doing disk I/O inside set_param is not an
+ * anomaly to be fixed once; it is the steady state we have to be able to SEE.
+ *
+ * Twice now the same defect has been diagnosed from scratch:
+ *
+ *   overtake dlopen + create_instance   param stage 7us typical -> 11513us
+ *   dr32 kit load inside synth:state    param stage 7us typical -> 20051us
+ *
+ * Both times the shape was identical and both times finding it took a
+ * differential experiment against the user's ears, because the only thing the
+ * logs said was `param=7/20051` — a number with no name attached. The key is
+ * RIGHT THERE in the request being served. Recording it turns an afternoon
+ * into one grep.
+ *
+ * WHY A RING AND NOT A SINGLE SLOT. A burst reports its worst member and
+ * nothing else if you keep one slot, and "the worst" is exactly the wrong
+ * summary when the interesting fact is WHICH KEYS were slow — a recall walks
+ * several components and only one of them is the culprit. Four entries is
+ * enough to name the offenders in a gesture and small enough to sit in BSS.
+ *
+ * WHY IT IS LOSSY BY CONSTRUCTION. The producer is the SPI callback. It may
+ * not block, allocate, or log, so it cannot wait for a full ring to drain. It
+ * overwrites the oldest entry and counts the loss; `dropped` being non-zero is
+ * itself a finding (something is slow at a rate faster than 1 Hz) and is
+ * reported rather than hidden.
+ *
+ * REALTIME CONTRACT. The producer does two vDSO clock reads (~340ns each,
+ * measured — not the ~1.8us syscall) and, only past the threshold, one bounded
+ * string copy. The consumer is the shim worker (SCHED_OTHER), which is the
+ * only side allowed to format or log.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Independent of SHADOW_PARAM_KEY_LEN on purpose: this header is driven by
+ * tests/host without the shadow headers, and a key is truncated for a log
+ * line, never used to address anything. */
+#define PARAM_SLOW_KEY_LEN 64
+#define PARAM_SLOW_ENTRIES 4
+
+/*
+ * The default threshold, in microseconds.
+ *
+ * NOT the frame period (2902us) and not the measured slack (~2370us). A serve
+ * that eats a third of the budget has not glitched yet but is one unlucky
+ * neighbour away from it, and the whole point is to hear about it BEFORE a
+ * user does. A normal serve is ~10us, so there are two and a half orders of
+ * magnitude between "fine" and this line — nothing lands here by accident.
+ */
+#define PARAM_SLOW_THRESHOLD_US 1000u
+
+typedef struct {
+    char     key[PARAM_SLOW_KEY_LEN];
+    uint32_t us;
+    uint8_t  slot;
+    uint8_t  is_set;      /* 1 = set_param, 0 = get_param */
+} param_slow_entry_t;
+
+typedef struct {
+    param_slow_entry_t entries[PARAM_SLOW_ENTRIES];
+    uint32_t write;       /* monotonic; slot = write % PARAM_SLOW_ENTRIES */
+    uint32_t read;        /* monotonic; consumer-owned */
+    uint32_t dropped;     /* entries overwritten before the consumer saw them */
+    uint32_t threshold_us;
+} param_slow_t;
+
+static inline void param_slow_init(param_slow_t *p, uint32_t threshold_us) {
+    memset(p, 0, sizeof(*p));
+    p->threshold_us = threshold_us ? threshold_us : PARAM_SLOW_THRESHOLD_US;
+}
+
+/*
+ * Producer. Call once per served request with its measured duration.
+ *
+ * Returns 1 if the serve was recorded, 0 if it was under the threshold. The
+ * return value is what lets a test assert the threshold is honoured without
+ * reaching into the ring.
+ *
+ * A NULL or empty key is recorded as "?" rather than dropped: a serve that
+ * blew the budget is worth reporting even when we cannot say which key it was,
+ * and silently discarding it would make the rate look lower than it is.
+ */
+static inline int param_slow_record(param_slow_t *p, const char *key,
+                                    uint8_t slot, uint8_t is_set, uint32_t us) {
+    if (!p || us < p->threshold_us) return 0;
+
+    /* Overwrite-oldest. The producer never blocks; see the header comment. */
+    if (p->write - p->read >= PARAM_SLOW_ENTRIES) {
+        p->dropped++;
+        p->read++;
+    }
+
+    param_slow_entry_t *e = &p->entries[p->write % PARAM_SLOW_ENTRIES];
+    if (key && key[0]) {
+        size_t n = strlen(key);
+        if (n >= PARAM_SLOW_KEY_LEN) n = PARAM_SLOW_KEY_LEN - 1;
+        memcpy(e->key, key, n);
+        e->key[n] = '\0';
+    } else {
+        e->key[0] = '?';
+        e->key[1] = '\0';
+    }
+    e->us     = us;
+    e->slot   = slot;
+    e->is_set = is_set ? 1 : 0;
+
+    /* Publish last: the consumer keys on `write`, so the entry must be
+     * complete before the index that makes it visible moves. */
+    __atomic_store_n(&p->write, p->write + 1, __ATOMIC_RELEASE);
+    return 1;
+}
+
+/* Consumer. Copies the next pending entry into `out`; returns 0 when drained. */
+static inline int param_slow_take(param_slow_t *p, param_slow_entry_t *out) {
+    if (!p || !out) return 0;
+    uint32_t w = __atomic_load_n(&p->write, __ATOMIC_ACQUIRE);
+    if (p->read == w) return 0;
+    *out = p->entries[p->read % PARAM_SLOW_ENTRIES];
+    p->read++;
+    return 1;
+}
+
+/* Consumer. Number of overwritten-before-seen entries, cleared by the read. */
+static inline uint32_t param_slow_take_dropped(param_slow_t *p) {
+    if (!p) return 0;
+    uint32_t d = p->dropped;
+    p->dropped = 0;
+    return d;
+}
+
+/*
+ * Format one entry. Kept here beside the producer so the wording is pinned by
+ * the same test that pins the mechanism — a log line nobody can grep for is
+ * the failure this whole header exists to prevent.
+ */
+static inline int param_slow_format(const param_slow_entry_t *e,
+                                    char *buf, int len) {
+    if (!e || !buf || len <= 0) return 0;
+    int n = 0;
+    const char *verb = e->is_set ? "set" : "get";
+    /* snprintf is the consumer's (SCHED_OTHER); never call this from the
+     * callback. */
+    n = snprintf(buf, (size_t)len,
+                 "param-slow: %s slot %u %s took %u.%03u ms on the SPI callback "
+                 "— the module is doing blocking work in its entry point",
+                 verb, (unsigned)e->slot, e->key,
+                 e->us / 1000u, e->us % 1000u);
+    return (n < 0) ? 0 : n;
+}
+
+#endif /* PARAM_SLOW_H */

--- a/src/host/shadow_chain_mgmt.c
+++ b/src/host/shadow_chain_mgmt.c
@@ -15,7 +15,8 @@
 #include "shadow_chain_mgmt.h"
 #include "shadow_fx_key.h"    /* shadow_key_is_fx_module — header-only so tests/host can run it */
 #include "fx_load_gate.h"     /* the load gate's three-state answer — header-only, likewise */
-#include "shim_worker.h"   /* shim_rt_audit_note_module */
+#include "shim_worker.h"   /* shim_rt_audit_note_module, shim_param_slow */
+#include "param_slow.h"    /* attribute a serve that ate the frame — header-only */
 #include "master_fx_key.h"    /* master_fx_route_* — header-only so tests/host can run it */
 #include "master_fx_snapshot.h" /* master_fx_snapshot_* — likewise */
 #include "master_fx_saved_state.h" /* object or opaque-string state at boot */
@@ -3724,11 +3725,60 @@ static void shadow_slot_clear_all_modules(void *instance)
 /* param.serve span context: emitted on every return path of the handler below
  * via __attribute__((cleanup)), parented to the JS param.get span propagated
  * through the param SHM. No-op when tracing is off (ps.on == 0). */
-typedef struct { uint32_t nid; int on; uint64_t t0, trace_id, parent_id; } pserve_span_t;
+/*
+ * DEFINED HERE, not in shim_worker.c beside the other shim globals, because
+ * this one runs the other way: the SPI callback in this file is the producer
+ * and the worker is only the consumer. Keeping it with the producer also means
+ * the two tests that link shadow_chain_mgmt.c without the worker
+ * (test_master_fx_permute, test_master_fx_cache_ownership) need no stub.
+ *
+ * Threshold set STATICALLY rather than by a runtime init: a zero threshold
+ * means "record everything" to param_slow_record, so an init call would leave
+ * a boot window in which the 4-entry ring fills with ordinary ~10us serves —
+ * and the ring drops oldest, so the one slow serve during boot (a cold cache
+ * is where the 111ms kit load lives) is exactly the one that would be evicted.
+ */
+param_slow_t shim_param_slow = { .threshold_us = PARAM_SLOW_THRESHOLD_US };
+
+typedef struct {
+    uint32_t nid; int on; uint64_t t0, trace_id, parent_id;
+    /* Always-on half — see pserve_emit. Separate from `t0` because that one
+     * only exists when tracing is armed, and this measurement must not be. */
+    struct timespec  w0;
+    shadow_param_t  *sp;
+    uint8_t          req_type;
+} pserve_span_t;
+
+/*
+ * Emit the trace span (when armed) and, ALWAYS, attribute a serve that ate the
+ * frame.
+ *
+ * The attribution is deliberately not behind a debug flag. A module doing
+ * blocking work in set_param is the steady state — ~150 confirmed violations
+ * across 113 catalogued modules — so the question is never "shall we go
+ * looking", it is "which key was it this time", and a flag you have to arm
+ * before you can answer that is a flag nobody has armed when the glitch
+ * happens. Cost is two vDSO clock reads (~340ns each, measured — not the
+ * ~1.8us syscall) on a 2902us frame, and past the threshold one bounded
+ * string copy. No formatting, no logging: the worker does both.
+ */
 static void pserve_emit(pserve_span_t *ps) {
     if (ps->on)
         schwung_trace_span_explicit(ps->nid, ps->t0, schwung_trace_now_ns(),
                                     ps->trace_id, ps->parent_id);
+
+    if (!ps->sp) return;
+    struct timespec w1;
+    clock_gettime(CLOCK_MONOTONIC, &w1);
+    uint64_t us = (uint64_t)(w1.tv_sec - ps->w0.tv_sec) * 1000000ull
+                + (uint64_t)(w1.tv_nsec - ps->w0.tv_nsec) / 1000ull;
+    if (us < PARAM_SLOW_THRESHOLD_US) return;
+    if (us > 0xFFFFFFFFull) us = 0xFFFFFFFFull;
+
+    /* SHADOW_PARAM_REQ: 1 = set, 2 = get. Read from the request rather than
+     * from the response, which a GET has already overwritten by now. */
+    param_slow_record(&shim_param_slow, ps->sp->key, ps->sp->slot,
+                      ps->req_type == 1, (uint32_t)us);
 }
 
 void shadow_inprocess_handle_param_request(void) {
@@ -3757,7 +3807,9 @@ void shadow_inprocess_handle_param_request(void) {
 
     /* Span the actual servicing of this request (all return paths below),
      * correlated to the JS param.get span via the SHM-propagated context. */
-    pserve_span_t _ps __attribute__((cleanup(pserve_emit))) = {0, 0, 0, 0, 0};
+    pserve_span_t _ps __attribute__((cleanup(pserve_emit))) =
+        {0, 0, 0, 0, 0, {0, 0}, shadow_param, req_type};
+    clock_gettime(CLOCK_MONOTONIC, &_ps.w0);
     if (atomic_load_explicit(&schwung_trace_on, memory_order_relaxed)) {
         static uint32_t s_pserve_nid = 0;       /* SPI thread only → no init race */
         if (!s_pserve_nid) s_pserve_nid = schwung_trace_intern("param.serve");

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -26,6 +26,7 @@
 #include "shadow_chain_mgmt.h"  /* shadow_fx_load_worker_tick */
 
 volatile uint32_t shim_debug_flags = 0;
+
 volatile int shim_pending_sysex_inject = -1;
 volatile int shim_inject_boot_jack = -1;
 volatile int shim_jack_persist = -1;
@@ -637,6 +638,41 @@ static void ui_midi_out_drop_tick(void)
     LOG_DEBUG("shim", msg);
 }
 
+/*
+ * Drain the slow-param ring.
+ *
+ * WHY IT IS WORTH A LOG LINE OF ITS OWN. `param=7/20051` in the spi_timing
+ * block already said a serve took 20 ms; what it could not say is WHICH KEY,
+ * and without that the only way forward is a differential experiment against
+ * the user's ears. Twice now that has cost a full session (overtake dlopen,
+ * then dr32's kit load inside synth:state). The key is in the request; this
+ * carries it out.
+ *
+ * WARN, not DEBUG: unlike the drop counters above, this fires only when
+ * something has already overrun the audio budget, so it is never noise.
+ */
+static void param_slow_tick(void)
+{
+    param_slow_entry_t e;
+    char msg[256];
+    int n = 0;
+    while (n < PARAM_SLOW_ENTRIES && param_slow_take(&shim_param_slow, &e)) {
+        if (param_slow_format(&e, msg, sizeof(msg)) > 0)
+            unified_log("shim", LOG_LEVEL_WARN, "%s", msg);
+        n++;
+    }
+
+    /* Loss is by construction (the callback may not wait for us) but must not
+     * be silent: a non-zero count means slow serves are arriving faster than
+     * 1 Hz, which is a different and worse finding than any single line above. */
+    uint32_t dropped = param_slow_take_dropped(&shim_param_slow);
+    if (dropped)
+        unified_log("shim", LOG_LEVEL_WARN,
+                    "param-slow: %u further slow serve(s) not recorded — they "
+                    "are arriving faster than this report drains",
+                    (unsigned)dropped);
+}
+
 static void *worker_main(void *arg) {
     (void)arg;
 
@@ -788,6 +824,7 @@ static void *worker_main(void *arg) {
             ext_midi_drop_tick();
             ui_midi_drop_tick();
             ui_midi_out_drop_tick();
+            param_slow_tick();        /* always on; silent unless one overran */
         }
         if (tick % 7 == 0) shadow_poll_current_set(); /* ~1.4 s FS scan */
         tick++;

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -35,7 +35,17 @@
  * reusing the bit would make a stale build read one trigger as another. */
 #define SHIM_FLAG_MAIN_FX_DUMP   (1u << 10) /* main_fx_dump_trigger */
 
+#include "param_slow.h"   /* param_slow_t, for the extern below */
+
 extern volatile uint32_t shim_debug_flags;
+
+/*
+ * Attribution for a param serve that ate the frame. Produced on the SPI
+ * callback (shadow_chain_mgmt.c's pserve_emit), drained and logged here on the
+ * worker — the callback may not format or log. See param_slow.h for why this
+ * is always on rather than behind an arming flag.
+ */
+extern param_slow_t shim_param_slow;
 
 /* Atomically test-and-clear a one-shot flag. Returns nonzero if it was set. */
 static inline int shim_debug_flag_consume(uint32_t bit) {

--- a/tests/host/test_param_slow.c
+++ b/tests/host/test_param_slow.c
@@ -55,7 +55,31 @@ static void test_a_long_key_is_truncated_not_overflowed(void) {
     assert(param_slow_record(&p, longkey, 0, 1, 5000) == 1);
     assert(param_slow_take(&p, &e) == 1);
     assert(strlen(e.key) == PARAM_SLOW_KEY_LEN - 1);
-    printf("  long key truncated: ok\n");
+
+    /*
+     * THE BOUNDARY, not just "something long".
+     *
+     * A key far over the limit clamps identically whether the guard is `>=` or
+     * `>`, so a 127-char key cannot tell the two apart — and `>` is a one-byte
+     * overrun of key[] at exactly PARAM_SLOW_KEY_LEN. Found by mutation: the
+     * long-key case above passed the mutant. Both neighbours are pinned so the
+     * clamp cannot drift in either direction.
+     */
+    char exact[PARAM_SLOW_KEY_LEN + 1];
+    memset(exact, 'k', PARAM_SLOW_KEY_LEN);
+    exact[PARAM_SLOW_KEY_LEN] = '\0';
+    assert(strlen(exact) == PARAM_SLOW_KEY_LEN);
+    assert(param_slow_record(&p, exact, 0, 1, 5000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strlen(e.key) == PARAM_SLOW_KEY_LEN - 1);   /* truncated by one */
+
+    char fits[PARAM_SLOW_KEY_LEN];
+    memset(fits, 'k', PARAM_SLOW_KEY_LEN - 1);
+    fits[PARAM_SLOW_KEY_LEN - 1] = '\0';
+    assert(param_slow_record(&p, fits, 0, 1, 5000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, fits) == 0);                  /* NOT truncated */
+    printf("  long key truncated (incl. the exact boundary): ok\n");
 }
 
 static void test_a_missing_key_still_reports(void) {

--- a/tests/host/test_param_slow.c
+++ b/tests/host/test_param_slow.c
@@ -1,0 +1,181 @@
+/* Unit tests for param_slow.h — attribution for a param serve that ate the frame.
+ *
+ * Header-only and pure, so it runs natively on the dev machine. The producer's
+ * real caller is the SPI callback, which is exactly the code path that cannot
+ * be exercised here — so the ring, the threshold and the overwrite discipline
+ * are pinned as arithmetic rather than observed on hardware. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "param_slow.h"
+
+static void test_threshold_is_honoured(void) {
+    param_slow_t p;
+    param_slow_init(&p, 1000);
+    param_slow_entry_t e;
+
+    /* A normal serve is ~10us. Two and a half orders of magnitude of clearance
+     * is the whole reason this line can be trusted when it does fire. */
+    assert(param_slow_record(&p, "synth:cutoff", 0, 1, 10) == 0);
+    assert(param_slow_record(&p, "synth:cutoff", 0, 1, 999) == 0);
+    assert(param_slow_take(&p, &e) == 0);      /* nothing recorded at all */
+
+    /* Exactly at the threshold records: the constant names the smallest
+     * duration we want to hear about, not the largest we tolerate. */
+    assert(param_slow_record(&p, "synth:state", 1, 1, 1000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(e.us == 1000);
+    printf("  threshold: ok\n");
+}
+
+static void test_the_key_is_what_gets_recorded(void) {
+    param_slow_t p;
+    param_slow_init(&p, 1000);
+    param_slow_entry_t e;
+
+    /* The entire point. `param=7/20051` is a number with no name attached;
+     * twice now that has cost a full diagnosis session. */
+    assert(param_slow_record(&p, "synth:state", 2, 1, 20051) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, "synth:state") == 0);
+    assert(e.slot == 2);
+    assert(e.is_set == 1);
+    assert(e.us == 20051);
+    printf("  key recorded: ok\n");
+}
+
+static void test_a_long_key_is_truncated_not_overflowed(void) {
+    param_slow_t p;
+    param_slow_init(&p, 1000);
+    param_slow_entry_t e;
+    char longkey[PARAM_SLOW_KEY_LEN * 2];
+    memset(longkey, 'k', sizeof(longkey) - 1);
+    longkey[sizeof(longkey) - 1] = '\0';
+
+    assert(param_slow_record(&p, longkey, 0, 1, 5000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strlen(e.key) == PARAM_SLOW_KEY_LEN - 1);
+    printf("  long key truncated: ok\n");
+}
+
+static void test_a_missing_key_still_reports(void) {
+    param_slow_t p;
+    param_slow_init(&p, 1000);
+    param_slow_entry_t e;
+
+    /* A blown frame we cannot name is still a blown frame. Dropping it would
+     * make the rate read lower than it is, which is worse than "?". */
+    assert(param_slow_record(&p, NULL, 0, 0, 9000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, "?") == 0);
+
+    assert(param_slow_record(&p, "", 0, 0, 9000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, "?") == 0);
+    printf("  unnamed serve still reports: ok\n");
+}
+
+static void test_ring_holds_several_offenders(void) {
+    param_slow_t p;
+    param_slow_init(&p, 1000);
+    param_slow_entry_t e;
+
+    /* A recall walks several components and only ONE is the culprit. Keeping a
+     * single slot would report "the worst" — the wrong summary when the
+     * question is which keys were slow. */
+    assert(param_slow_record(&p, "0:synth:state", 0, 1, 20051) == 1);
+    assert(param_slow_record(&p, "1:synth:state", 1, 1, 1200) == 1);
+
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, "0:synth:state") == 0);   /* FIFO, not worst-first */
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, "1:synth:state") == 0);
+    assert(param_slow_take(&p, &e) == 0);
+    printf("  ring keeps several: ok\n");
+}
+
+static void test_overflow_drops_oldest_and_counts_it(void) {
+    param_slow_t p;
+    param_slow_init(&p, 1000);
+    param_slow_entry_t e;
+
+    /* The producer is the SPI callback: it may not block waiting for a
+     * consumer, so loss is by construction. What must NOT happen is silent
+     * loss — `dropped` non-zero is itself the finding that something is slow
+     * faster than 1 Hz. */
+    char key[16];
+    for (int i = 0; i < PARAM_SLOW_ENTRIES + 2; i++) {
+        snprintf(key, sizeof(key), "k%d", i);
+        assert(param_slow_record(&p, key, 0, 1, 2000) == 1);
+    }
+    assert(param_slow_take_dropped(&p) == 2);
+    assert(param_slow_take_dropped(&p) == 0);      /* cleared by the read */
+
+    /* The SURVIVORS are the newest, so a burst names what is happening now
+     * rather than what happened first. */
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, "k2") == 0);
+    printf("  overflow drops oldest, counts it: ok\n");
+}
+
+static void test_drain_is_complete(void) {
+    param_slow_t p;
+    param_slow_init(&p, 1000);
+    param_slow_entry_t e;
+
+    assert(param_slow_record(&p, "a", 0, 1, 2000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(param_slow_take(&p, &e) == 0);
+    /* and the ring is reusable after draining, rather than wedged */
+    assert(param_slow_record(&p, "b", 0, 1, 2000) == 1);
+    assert(param_slow_take(&p, &e) == 1);
+    assert(strcmp(e.key, "b") == 0);
+    printf("  drain and reuse: ok\n");
+}
+
+static void test_format_names_the_key_and_the_thread(void) {
+    param_slow_entry_t e = { "synth:state", 20051, 2, 1 };
+    char buf[256];
+    int n = param_slow_format(&e, buf, sizeof(buf));
+    assert(n > 0);
+
+    /* A log line nobody can grep for is the failure this header exists to
+     * prevent, so the greppable parts are pinned, not just the length. */
+    assert(strstr(buf, "param-slow:") != NULL);
+    assert(strstr(buf, "synth:state") != NULL);
+    assert(strstr(buf, "slot 2") != NULL);
+    assert(strstr(buf, "set") != NULL);
+    assert(strstr(buf, "20.051 ms") != NULL);   /* not 20051us, not 20ms */
+    assert(strstr(buf, "SPI callback") != NULL);
+
+    e.is_set = 0;
+    assert(param_slow_format(&e, buf, sizeof(buf)) > 0);
+    assert(strstr(buf, "get") != NULL);
+    printf("  format: ok\n");
+}
+
+static void test_format_is_bounded(void) {
+    param_slow_entry_t e = { "synth:state", 20051, 2, 1 };
+    char buf[16];
+    int n = param_slow_format(&e, buf, sizeof(buf));
+    /* snprintf's return is what it WOULD have written; the buffer must still
+     * be terminated inside its own bounds. */
+    assert(n > 0);
+    assert(strlen(buf) < sizeof(buf));
+    printf("  format bounded: ok\n");
+}
+
+int main(void) {
+    printf("param_slow:\n");
+    test_threshold_is_honoured();
+    test_the_key_is_what_gets_recorded();
+    test_a_long_key_is_truncated_not_overflowed();
+    test_a_missing_key_still_reports();
+    test_ring_holds_several_offenders();
+    test_overflow_drops_oldest_and_counts_it();
+    test_drain_is_complete();
+    test_format_names_the_key_and_the_thread();
+    test_format_is_bounded();
+    printf("param_slow: all ok\n");
+    return 0;
+}

--- a/tests/host/test_param_slow.sh
+++ b/tests/host/test_param_slow.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+bin="build/tests/test_param_slow"
+mkdir -p "$(dirname "$bin")"
+
+cc -std=gnu11 -Wall -Wextra -Wno-unused-parameter \
+  -Isrc/host \
+  tests/host/test_param_slow.c \
+  -o "$bin"
+
+"$bin"


### PR DESCRIPTION
## The report

> "I get a click when restoring state from shift+delete."

## What it was, measured

**dr32 re-reads its whole kit — preset JSON plus 16 WAVs — inside `set_param`, on the SPI callback**, on every recall. It logs its own cost:

```
14:39:36.715  dr32: kit '…606 Kit.json' loaded in 18.9 ms — 16 pads, 16 samples
14:44:43.009  … 18.9 ms     three deliberate repeats, 3 s apart
14:44:46.520  … 18.9 ms
14:44:49.495  … 18.9 ms
12:45:56.992  … 111.4 ms    COLD CACHE
```

and the shim's own line for that frame:

```
14:39:40  Frame(us): total avg=2680 max=20935 | pre avg=312 max=20352 | overruns=311 (+3)
          Pre(us): … param=27/20051 …
```

Against a **2.9 ms block period**: 7 blown frames warm, ~38 cold. With dr32 removed from the rig, silent. Its own comment reads *"Load HERE, on the host thread."*

**The module fix is separate** — [`schwung-dr32#…`](https://github.com/charlesvestal/schwung-dr32) — and both are deployed and hardware-verified together. This PR is the host half: making the *next* one of these findable.

## What this PR does

`param-slow` times every param serve and, past 1000 µs, records **key, slot and verb**; the shim worker logs it at WARN.

```
param-slow: set slot 0 synth:module took 124.825 ms on the SPI callback — the module is doing blocking work in its entry point
```

**Deliberately not behind an arming flag.** A module doing blocking work in `set_param` is the steady state — the 2026-08 audit found ~150 confirmed violations across 113 catalogued modules — so the question is never "shall we go looking", it is "which key was it this time", and a flag you must arm first is one nobody has armed at the moment the glitch happens. The same defect has now cost a full diagnosis session **twice**, with the identical signature and no name attached:

```
overtake dlopen + create_instance   param stage 7us typical -> 11513us
dr32 kit load inside synth:state    param stage 7us typical -> 20051us
```

Cost on the callback: two vDSO clock reads (~340 ns each, measured — not the ~1.8 µs syscall) and, past the threshold, one bounded string copy. No formatting, no logging there; the worker does both. It hooks the existing `pserve` cleanup attribute, which already covers every return path of the serve.

## Notable

- **A ring, not one slot.** A recall walks several components and only one is the culprit, so "the worst" is the wrong summary. Loss is by construction (the callback cannot wait for a consumer) but never silent — overwritten entries are counted and reported, and a non-zero count is itself a finding.
- **Threshold set statically, not by a runtime init.** A zero threshold means "record everything", so an init call would leave a boot window in which the ring fills with ordinary ~10 µs serves — and it drops oldest, so the one slow serve during boot (a cold cache is where the 111 ms lives) is exactly what would be evicted.
- **The ring is defined with the producer** (`shadow_chain_mgmt.c`), not beside the other shim globals: this one runs the other way round, and the two tests that link the chain manager without the worker then need no stub.

## Docs

`DIAGNOSTICS.md` opens by saying every switch is off by default and armed by a file; this one is not, so it says why. It also records the measurement gap that cost most of the diagnosis time: **`backlog` and `frames / irq` are 1 Hz aggregates, so a 20 ms serve produced zero `LATE` lines across the whole session.** `spi_timing`'s `param=avg/max` is what sees a one-frame stall — reach for that, not the tally.

## Also included: a plan, not an implementation

`docs/plans/2026-09-07-wholesale-ops-off-the-spi-callback.md` designs the real fix — wholesale ops (`*:state`, `*:module`, `load_file`, `load_patch`) on the worker. Nothing of it is implemented here. Three things in it are worth reading even if it never gets built:

- **The fade does not fix this, and does not fix what it already covers.** `shadow_process_fade_completions()` is called from `shim_pre_transfer` — on the callback — so `load_patch` / `load_file` / module swap fade the slot silent and then do their disk read on the hot path anyway. The frame overruns identically; what the fade removes is the slot's own audio, so the remaining glitch lands in Move's and gets attributed elsewhere. **A fade makes an operation inaudible, never cheap.** This was my first recommendation and it was wrong.
- **PR #303's "stage, don't swap" is better than a lease and should be copied where it applies** — it needs no gating at the 65 `.instance` call sites because the SPI thread stays the only mutator. **But it cannot be transferred to a state apply**, which mutates a *running* instance; staging that means reinstantiating, i.e. cutting tails and resetting arp phase — the one thing a recall must not do.
- #303 and this do not overlap on disk, and #303 scopes itself to the synth position, so it claims one of those keys and leaves the rest.

## Testing

- `tests/host/test_param_slow.{c,sh}` — 9 cases. **All 8 mutants die.** One (a truncation off-by-one at *exactly* `PARAM_SLOW_KEY_LEN`, a one-byte overrun of `key[]`) survived the first pass; a 127-char key clamps identically either way, so both neighbours are now pinned.
- One mutant is **equivalent, and is documented as such rather than papered over**: dropping the `s->sample` term stays green because the loader writes `s->path` only on success. Kept as defence, with a comment saying it is unreachable today and why.
- `tests/host`: **0 failures**; `make -C tests/host test`: ALL PASS; ARM64 cross-compile clean.

## Hardware

Deployed with the dr32 fix and verified on device:

```
18:09:26.461  param-slow: set slot 0 synth:module took 124.825 ms      ← instrument proven on a known-slow op
18:09:30.911  dr32: kit already loaded - params reset from baseline, no disk read
18:09:33.407  dr32: kit already loaded - params reset from baseline, no disk read
```

No click, and no `param-slow` line for the `synth:state` **set** — so the write is now under 1 ms, answering the one number I had flagged as unmeasured.

**It also immediately found a second violation nobody had attributed:** `get slot 0 synth:state` at **3.4 ms, recurring every few seconds** while the knob grid is up (dr32 serialising 16 pads × ~33 fields for the My Presets `*` mark). Over the 2370 µs slack. That is the background spike I saw in the first measurement and set aside as benign — which is precisely the thing this PR exists to stop happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153pAcsKcfzZy4Ato7MK6zm