### PR TITLE
catalog: add Maze Voice; fix Maze author + repo rename

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1404,9 +1404,9 @@
       "id": "maze_seq",
       "name": "Maze",
       "description": "Dual generative sequencer (Moog Labyrinth style) with pad + step-button control. Overtake tool.",
-      "author": "Sam Di Domizio",
+      "author": "sd88me",
       "component_type": "tool",
-      "github_repo": "sd88me/schwung-maze-sequencer",
+      "github_repo": "sd88me/schwung-maze",
       "default_branch": "main",
       "asset_name": "maze_seq-module.tar.gz",
       "min_host_version": "1.0.0"
@@ -1415,11 +1415,22 @@
       "id": "maze_seq_lite",
       "name": "Maze Lite",
       "description": "Dual generative clock-synced sequencer (Moog Labyrinth style). Slot MIDI FX.",
-      "author": "Sam Di Domizio",
+      "author": "sd88me",
       "component_type": "midi_fx",
-      "github_repo": "sd88me/schwung-maze-sequencer",
+      "github_repo": "sd88me/schwung-maze",
       "default_branch": "main",
       "asset_name": "maze_seq_lite-module.tar.gz",
+      "min_host_version": "1.0.0"
+    },
+    {
+      "id": "maze-voice",
+      "name": "Maze Voice",
+      "description": "Monophonic Moog Labyrinth-style thru-zero oscillator / wavefolder / state-variable filter voice. Chainable sound generator.",
+      "author": "sd88me",
+      "component_type": "sound_generator",
+      "github_repo": "sd88me/schwung-maze",
+      "default_branch": "main",
+      "asset_name": "maze-voice-module.tar.gz",
       "min_host_version": "1.0.0"
     },
     {


### PR DESCRIPTION
Follow-up to #391 (Maze / Maze Lite).

### Changes to `module-catalog.json`

- **New entry: `maze-voice`** — monophonic Moog-Labyrinth-style thru-zero oscillator / wavefolder / SVF voice, a chainable `sound_generator`. Pairs with Maze Lite in a Signal Chain.
- **`maze_seq` / `maze_seq_lite`: `github_repo` `sd88me/schwung-maze-sequencer` → `sd88me/schwung-maze`.** The repo was renamed. GitHub redirects the repo page, but `raw.githubusercontent.com/<old>/main/release.json` does **not** follow rename redirects, so the store's update check was about to start failing for the two merged entries.
- **`author` `"Sam Di Domizio"` → `"sd88me"`** on all three (matches the `author` field in each module's `module.json`).

All three modules ship from https://github.com/sd88me/schwung-maze — current release **v1.2.1**, tarballs `maze_seq-module.tar.gz`, `maze_seq_lite-module.tar.gz`, `maze-voice-module.tar.gz`. `release.json` there is the multi-module form keyed by catalog id.

JSON validated; no other entries touched.