### PR TITLE
fix: a widget whose canvas.js failed to load was recorded as loaded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -677,6 +677,24 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   which is how a defect gets defended rather than merely missed. Authors: a
   redeployed `canvas.js` is not re-read until you leave the component and
   return.
+- **The widget latch is set BEFORE the load can fail, so it could not be the
+  whole answer.** `ensureComponentWidgets` writes `widgetModuleLoaded = id` and
+  only then resolves the module dir, reads `canvas.js` and registers — so a
+  module whose script failed once was byte-identical in state to one that had
+  succeeded: latched, empty registry, `id === widgetModuleLoaded` refusing every
+  later attempt, the tick stamping it RESOLVED, and the cells falling through to
+  ordinary dials in silence. Visiting a DIFFERENT module was the only escape,
+  which is why the report is *"the waveform sometimes appears, and later they are
+  plain dials"* and why switching away and back fixes it. It carries
+  `widgetLoadOk` now, and **a module declaring no custom kind is SETTLED, not
+  failed** — forgetting that half turns the fix into a permanent retry loop on
+  most of the fleet. A failure is scoped to the VISIT (a second attempt on the
+  same page reads the same bytes; not recording it re-parses a broken script
+  ~4x/sec), and the boundary must reset the THROTTLE too or the retry resumes
+  mid-count and a short visit ends before it lands. A script that loaded and
+  registered nothing usable is settled — only failing to reach an overlay is
+  retried — and the **one-strike disable survives**, structurally: a throw can
+  only follow a registration, which settles.
 - **A card is handed the PAGE's values, not only its own.** The payload is
   `{w, h, name, value, raw, values, nowMs}`. A card whose meaning depends on a
   sibling — the vowel of *which* character — otherwise had no route to it at

--- a/docs/PARAM_PAGES.md
+++ b/docs/PARAM_PAGES.md
@@ -1697,6 +1697,79 @@ will do this every time.
 component stays loaded — the latch is per module id, by design, so the script is
 parsed once. Leave the component and come back to pick up a new build.
 
+#### The latch is set BEFORE the load can fail, so it cannot be the whole answer
+
+`ensureComponentWidgets` writes `widgetModuleLoaded = id` and *then* resolves the
+module directory, reads its `canvas.js`, and registers whatever came back. It
+has to be that order — the latch is what `clearWidgets()` is paired with, and
+what stops the next frame re-entering. But for a while the latch was the only
+thing recorded, which made a module whose script failed to load **byte-identical
+in state to one that had succeeded**: latched, with an empty registry.
+
+Everything downstream then agreed. `id === widgetModuleLoaded` refused every
+later attempt. The tick stamped the signature as resolved, because the latch did
+name the module in front of it. The cells fell through to the detector and drew
+ordinary dials, silently, with the fall-through doing exactly what it is for.
+The only escape was visiting a **different** module, which relatches and so
+changes the signature — which is why the device report reads *"the waveform
+sometimes appears, and later the same knobs are plain dials"*, and why switching
+away and back is the thing that fixes it. That gesture is not a diagnosis; it is
+the one state transition the code left open.
+
+The latch is a two-part answer now: **which module, and whether its widgets are
+settled** (`widgetLoadOk`). Two states count as settled, and neither is retried:
+
+- a widget registered, and
+- **the module declares no custom kind at all** — a finished answer, not a
+  failure. Forgetting this half turns the fix into a permanent retry loop on the
+  large majority of modules, which declare no widget.
+
+Anything else is an attempt still owed. But *when* it is owed matters as much,
+because the two obvious policies are both wrong. Recording a failure as resolved
+is the bug above. Not recording it at all re-reads and re-parses a genuinely
+broken `canvas.js` ~4x/sec for as long as its page is up — the exact cost the
+throttle exists to prevent.
+
+**A visit is the unit.** Within one visit a second attempt cannot learn anything
+the first did not: the module directory and its script are the same bytes. So it
+stops, against its own record (`widgetFailedVisitSig`) held apart from
+`widgetResolvedSig` — leaving the grid clears one and not the other, because a
+success is a fact about the module and a failure is a fact about one attempt.
+Leaving and returning is a new visit and asks once more, which is also exactly
+the gesture available to someone who has just installed or repaired the module.
+
+Two details that are not optional:
+
+- **The visit boundary must reset the throttle too.** Clearing only the failure
+  record leaves `widgetAttemptedSig` describing the component being returned to,
+  so the next frame takes the throttle branch rather than the attempt-at-once
+  one — and it resumes from wherever `widgetRetryTick` was left, so a short
+  visit can end before the retry ever lands. A new visit is a new situation in
+  precisely the sense that branch means, and is spelled the same way.
+- **The one-strike disable must survive a retry.** A widget that threw while
+  drawing is disabled for the session, and that set is cleared by
+  `clearWidgets()` — so a retry that re-registered the module would quietly
+  re-arm a widget already known to crash. It cannot happen, structurally rather
+  than by a guard: a throw can only follow a successful registration, which
+  settles the module, and a settled module is never re-attempted.
+
+Only a failure to *reach* an overlay is retried. A script that loaded and
+registered nothing usable — a typo in the kind, no `drawCell` — is **settled**,
+because re-reading the same declaration gets the same answer, and the skip is
+already named in the log for its author.
+
+Which is the last piece: `if (!dir) return;` used to be silent, and an absent
+module directory is indistinguishable on screen from a module with no widget.
+It says so in `debug.log` now, as does every other way this can end.
+
+`tests/host/test_widget_load_failure_retry.sh` drives a broken `canvas.js`
+through a repair: one read on the first visit, **zero** while staying on the
+page, exactly one on each re-entry, the widget appearing once the module is
+fixed, and zero reads for a settled module or one declaring no widget. It also
+pins the *call site* of the visit boundary — the scenario drives that boundary
+directly, so nothing else could tell whether the device ever reaches it, and a
+boundary nobody calls is the original bug with more code.
+
 ### A module may declare SEVERAL widgets, and one call site said otherwise
 
 The registry has always been a `Map`, and `registerWidget` has always taken a

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -16324,8 +16324,10 @@ function exitHierarchyEditor() {
      * (rather than in the canvas teardown, which runs on every canvas open and
      * close) is what makes the next component ask the question afresh. */
     widgetModuleLoaded = "";
+    widgetLoadOk = false;
     widgetAttemptedSig = "";
     widgetResolvedSig = "";
+    widgetFailedVisitSig = "";
     hierEditorAllParams = [];
     hierEditorAllKnobs = [];
     hierEditorChildIndex = -1;
@@ -18531,6 +18533,29 @@ function getHierarchyActiveModuleId() {
 let widgetModuleLoaded = "";
 
 /*
+ * AND WHETHER THAT ATTEMPT ACTUALLY FINISHED. THE LATCH ALONE CANNOT SAY.
+ *
+ * `widgetModuleLoaded = id` is set BEFORE the three things that can still
+ * fail: resolving the module's directory, reading its canvas.js, and getting a
+ * usable widget out of it. It has to be -- it is what clearWidgets() is paired
+ * with, and what stops the next frame re-entering. But it meant a module whose
+ * script failed to load once was recorded exactly like one that succeeded:
+ * latched, with an empty registry. Its cells then fell through to the detector
+ * and drew ordinary dials, `id === widgetModuleLoaded` refused every later
+ * attempt, and the grid's own throttle stamped the signature as resolved. The
+ * only escape was visiting ANOTHER module, which relatches and so changes the
+ * signature -- which is why the device report reads "the waveform sometimes
+ * appears, and later the same knobs are plain dials", and why switching away
+ * and back is what fixes it.
+ *
+ * So the latch is a TWO-part answer now: which module, and whether its widgets
+ * are settled. `widgetLoadOk` is true when the module registered a widget AND
+ * when it declares none at all -- both are finished states with nothing left to
+ * retry. False means an attempt is still owed.
+ */
+let widgetLoadOk = false;
+
+/*
  * REGISTER A MODULE'S IN-GRID WIDGETS WHEN ITS CONTRACT IS KNOWN.
  *
  * This existed at the overlay load inside openCanvasPreview, which was wrong in
@@ -18581,6 +18606,69 @@ let widgetRetryTick = 0;
 let widgetAttemptedSig = "";
 let widgetResolvedSig = "";
 
+/*
+ * A FAILED LOAD IS ITS OWN ANSWER, AND IT IS SCOPED TO THE VISIT.
+ *
+ * The two obvious policies are both wrong. Recording a failure as "resolved"
+ * is the bug above -- one bad read and the module draws dials until another
+ * module is visited. NOT recording it leaves the signature unresolved, so the
+ * throttle retries forever: a module with a genuinely broken canvas.js would
+ * re-read and re-parse it ~4x/sec for as long as its page is on screen, which
+ * is the one cost the throttle exists to prevent.
+ *
+ * A visit is the right unit. Within one visit to the grid a second attempt
+ * cannot learn anything the first did not -- the module directory and its
+ * canvas.js are the same bytes -- so we stop. Leaving the grid and coming back
+ * is a new visit and asks again, which is also exactly the gesture available
+ * to a user who has just installed or repaired the module. `endComponentWidgetVisit`
+ * below is the boundary; it is driven off the view leaving PARAM_PAGES rather
+ * than off an entry point, because the grid has several entry points and only
+ * one way of not being on screen.
+ *
+ * This is deliberately NOT keyed on the failure REASON. A module that loaded
+ * its script and registered nothing usable (a typo in the kind, no drawCell) is
+ * marked settled, not failed -- retrying re-reads the same declaration and gets
+ * the same answer, and the skip is already logged for its author. Only an
+ * unresolved path or a script that would not load is retried.
+ */
+let widgetFailedVisitSig = "";
+
+/*
+ * The one-strike disable in widget_registry.mjs must survive a retry.
+ *
+ * A widget that THREW while drawing is disabled for the session and the page
+ * falls back to a correct built-in. That set is cleared by clearWidgets(), so
+ * a retry that re-registered the module would quietly re-arm a widget already
+ * known to crash. It cannot happen, and the reason is structural rather than
+ * guarded: a throw can only occur after a successful registration, which sets
+ * widgetLoadOk, and a settled module is never re-attempted.
+ */
+
+function endComponentWidgetVisit() {
+    /* Cheap enough to call every frame the grid is not up, and this makes it
+     * free after the first one. */
+    if (!widgetFailedVisitSig && !widgetAttemptedSig) return;
+    widgetFailedVisitSig = "";
+    /*
+     * AND THE THROTTLE IS RESET WITH IT, OR THE RETRY ARRIVES A QUARTER SECOND
+     * LATE -- OR NOT AT ALL.
+     *
+     * Clearing only the failure record leaves widgetAttemptedSig describing the
+     * component we are about to return to, so the next frame takes the throttle
+     * branch instead of the attempt-at-once one and waits out WIDGET_RETRY_TICKS
+     * -- from wherever widgetRetryTick happened to be left, so a short visit can
+     * end before the retry ever lands and the user sees dials for the whole of
+     * it. A new visit is a new situation in exactly the sense that branch
+     * means, so it is spelled the same way: no remembered attempt, no
+     * accumulated tick.
+     *
+     * This cannot make a SETTLED module re-attempt -- widgetResolvedSig is
+     * deliberately not cleared here, and its early-out is tested first.
+     */
+    widgetAttemptedSig = "";
+    widgetRetryTick = 0;
+}
+
 function tickComponentWidgets() {
     /*
      * "RESOLVED" IS A QUESTION ABOUT THE COMPONENT ON SCREEN.
@@ -18616,6 +18704,11 @@ function tickComponentWidgets() {
     const key = `${paramPagesSlot()}:${paramPagesComponent()}`;
     const sig = `${key}\u0000${widgetModuleLoaded}`;
     if (widgetModuleLoaded && widgetResolvedSig === sig) return;
+    /* Already tried and failed for this component, this visit. Held apart from
+     * widgetResolvedSig so that leaving the grid clears one and not the other:
+     * a success is a fact about the module and outlives the visit, a failure is
+     * a fact about one attempt and does not. */
+    if (widgetFailedVisitSig === sig) return;
 
     /*
      * FIRST ATTEMPT IS IMMEDIATE; ONLY RETRIES ARE THROTTLED.
@@ -18687,7 +18780,17 @@ function tickComponentWidgets() {
      * unsettled chain_params -- the tri-state rule -- and recording regardless
      * would re-create the bug one level down, closing the guard on a question
      * still open. */
-    if (id && widgetModuleLoaded === id) widgetResolvedSig = widgetAttemptedSig;
+    if (id && widgetModuleLoaded === id) {
+        if (widgetLoadOk) widgetResolvedSig = widgetAttemptedSig;
+        /* Latched but not settled: the load failed. Stop for this visit only,
+         * and stamp the world the attempt LEAVES -- widgetAttemptedSig, just
+         * computed -- for the same reason as the success above. The first
+         * attempt for a component usually CHANGES the latch (that is what
+         * latching is), so `sig`, read at the top of this frame, describes a
+         * state that no longer exists: the next frame would not match it and
+         * would pay a second load before settling. */
+        else widgetFailedVisitSig = widgetAttemptedSig;
+    }
 }
 
 function ensureComponentWidgets(moduleId, chainParams) {
@@ -18699,7 +18802,7 @@ function ensureComponentWidgets(moduleId, chainParams) {
      * function ACTUALLY sees, at the top, before any guard can hide it.
      * Bounded: the retry that drives this runs at most ~4x/sec and stops the
      * moment the id resolves. */
-    if (!widgetModuleLoaded) {
+    if (!widgetModuleLoaded || !widgetLoadOk) {
         const n = Array.isArray(chainParams) ? chainParams.length : -1;
         const kinds = Array.isArray(chainParams)
             ? chainParams.map((p) => (p && p.viz && p.viz.kind) || "-").join(",")
@@ -18724,7 +18827,11 @@ function ensureComponentWidgets(moduleId, chainParams) {
      * again.
      */
     if (!id) return;
-    if (id === widgetModuleLoaded) return;
+    /* Settled, so nothing to redo. NOT a bare id comparison: the latch is set
+     * before the load can fail, so an id match on its own also matched a module
+     * whose canvas.js never loaded -- and refused the retry that would have
+     * fixed it. See widgetLoadOk. */
+    if (id === widgetModuleLoaded && widgetLoadOk) return;
 
     /*
      * AND chain_params IS A READ TOO. Same rule, one layer down.
@@ -18748,18 +18855,31 @@ function ensureComponentWidgets(moduleId, chainParams) {
      * same custom: name would silently inherit the wrong art. */
     clearWidgets();
     widgetModuleLoaded = id;
+    /* Everything from here can fail, so the answer is "not yet" until one of
+     * the two finished states below is reached. */
+    widgetLoadOk = false;
 
     const wantsWidget = chainParams.some((p) => {
         const k = p && p.viz && p.viz.kind;
         return typeof k === "string" && k.startsWith("custom:");
     });
     /* Nothing is loaded for a module that declares no custom kind -- the script
-     * is only read when the contract says it is needed. */
-    if (!wantsWidget) return;
+     * is only read when the contract says it is needed. A finished state: there
+     * is nothing a later attempt could discover. */
+    if (!wantsWidget) { widgetLoadOk = true; return; }
 
     debugLog(`widgets: ${id} declares a custom viz kind; loading canvas.js`);
     const dir = getModuleBasePath(id);
-    if (!dir) return;
+    /* RETRYABLE, and it used to return in silence. getModuleBasePath stats
+     * module.json across seven category directories, so "" means the module is
+     * not where we looked -- mid-install, a category the installer has not
+     * finished moving, or a genuinely absent module. Indistinguishable, from
+     * here, from a module with no widget, which is exactly why it has to say so
+     * in the log: the device symptom is a plain dial either way. */
+    if (!dir) {
+        debugLog(`widgets: ${id} declares a custom viz kind but its module dir was not found`);
+        return;
+    }
 
     const loaded = loadCanvasOverlayScript(`${dir}/canvas.js`, "");
     const ov = loaded && loaded.overlay;
@@ -18768,6 +18888,11 @@ function ensureComponentWidgets(moduleId, chainParams) {
      * which meant a second declared kind was never registered and its cell
      * silently drew a built-in dial instead. */
     const { registered, skipped } = registerOverlayWidgets(ov);
+    /* The script LOADED and gave us an overlay. Whatever came of it -- widgets
+     * registered, or every declared kind skipped for a reason named below -- is
+     * this module's final answer, because a second read of the same file cannot
+     * produce a different one. Only the failure to get here is retried. */
+    if (ov) widgetLoadOk = true;
     if (registered.length) {
         debugLog(`widgets: ${id} registered ${registered.join(", ")}`);
     }
@@ -24451,6 +24576,10 @@ globalThis.tick = function() {
      * view is ticked at all, and loosening a real invariant to make room for a
      * new call is the wrong trade. */
     if (view === VIEWS.PARAM_PAGES) tickComponentWidgets();
+    /* Off the grid IS the end of the visit -- see endComponentWidgetVisit. Its
+     * own statement for the same reason as the line above: that one is pinned
+     * verbatim by test_param_pages_wiring.sh. */
+    else endComponentWidgetVisit();
     if (view === VIEWS.PARAM_PAGES) tickParamPages();
     /* The debounced `*` refresh (see tickUserPresetStale's own note) — driven
      * from the tick, never from a draw function, and cheap to poll when

--- a/tests/host/test_widget_latch_per_component.sh
+++ b/tests/host/test_widget_latch_per_component.sh
@@ -58,8 +58,10 @@ const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
  * instead of quietly creating a fresh global. */
 const preamble = `
   let widgetModuleLoaded = "";
+  let widgetLoadOk = false;
   let widgetAttemptedSig = "";
   let widgetResolvedSig = "";
+  let widgetFailedVisitSig = "";
   let widgetRetryTick = 0;
 `;
 
@@ -74,8 +76,16 @@ const stub = `
     if (!Array.isArray(chainParams) || chainParams.length === 0) return;
     registry.length = 0;                               /* clearWidgets() */
     widgetModuleLoaded = id;
+    widgetLoadOk = false;
     if (chainParams.some((p) => p && p.viz && String(p.viz.kind).startsWith("custom:")))
       registry.push(id);
+    /* Both outcomes here are settled ones -- a widget registered, or the module
+     * declares none. The stub loads nothing, so it has no failure to model; the
+     * per-visit retry that governs a FAILED load is
+     * test_widget_load_failure_retry.sh. Mirroring the real function is what
+     * keeps assertion 4 below honest: without this the tick would record a
+     * failure rather than a resolution and close the guard by the wrong door. */
+    widgetLoadOk = true;
   }
 `;
 

--- a/tests/host/test_widget_load_failure_retry.sh
+++ b/tests/host/test_widget_load_failure_retry.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# A module whose canvas.js FAILED TO LOAD must be tried again on the next visit
+# to its page -- and must not be tried again during this one.
+#
+# ensureComponentWidgets sets `widgetModuleLoaded = id` before the three things
+# that can still fail: resolving the module directory, reading canvas.js, and
+# getting a usable widget out of it. It has to -- that is what clearWidgets() is
+# paired with. But the latch was then the WHOLE answer, so a module whose script
+# failed once was recorded exactly like one that had succeeded: latched, with an
+# empty registry. `id === widgetModuleLoaded` refused every later attempt and
+# the grid's throttle stamped the signature resolved, so its cells fell through
+# to the detector and drew ordinary dials -- for the rest of the session, since
+# the only thing that clears the latch is visiting a DIFFERENT module.
+#
+# That is the device report: "the waveform sometimes appears, and later the same
+# knobs are plain dials", fixed by switching away and back.
+#
+# The naive repair -- never record a failure -- swaps it for the cost the
+# throttle exists to prevent: a genuinely broken canvas.js re-read and re-parsed
+# ~4x/sec for as long as its page is up. So four things are asserted together,
+# because each of the two plausible one-line fixes breaks one of the others.
+
+file="src/shadow/shadow_ui.js"
+
+command -v node >/dev/null 2>&1 || { echo "FAIL: node is required" >&2; exit 1; }
+
+tick=$(awk '/^function tickComponentWidgets\(/,/^}/' "$file")
+ensure=$(awk '/^function ensureComponentWidgets\(/,/^}/' "$file")
+visit=$(awk '/^function endComponentWidgetVisit\(/,/^}/' "$file")
+for pair in "tickComponentWidgets:$tick" "ensureComponentWidgets:$ensure" "endComponentWidgetVisit:$visit"; do
+  [ -n "${pair#*:}" ] || { echo "FAIL: ${pair%%:*} not found in $file" >&2; exit 1; }
+done
+
+retry_ticks=$(sed -n 's/^const WIDGET_RETRY_TICKS = \([0-9]*\);.*/\1/p' "$file")
+[ -n "$retry_ticks" ] || { echo "FAIL: WIDGET_RETRY_TICKS not found in $file" >&2; exit 1; }
+
+# WIRED, not merely defined. The scenario below drives the visit boundary
+# directly, which cannot see whether anything on the device ever calls it -- and
+# a boundary nobody calls is exactly the original bug with more code. So pin the
+# call site: the frame tick ends the visit on the branch where the grid is NOT
+# on screen.
+if ! grep -q 'else endComponentWidgetVisit();' "$file"; then
+  echo "FAIL: nothing calls endComponentWidgetVisit() when the view leaves PARAM_PAGES;" >&2
+  echo "      a failed widget load would then never be retried" >&2
+  exit 1
+fi
+if ! awk '/if \(view === VIEWS.PARAM_PAGES\) tickComponentWidgets\(\);/{f=1} f&&/else endComponentWidgetVisit\(\);/{ok=1} END{exit !ok}' "$file"; then
+  echo "FAIL: endComponentWidgetVisit() is not the else of the PARAM_PAGES widget tick" >&2
+  exit 1
+fi
+
+printf '%s\n%s\n%s\n' "$visit" "$ensure" "$tick" | node -e '
+const fs = require("fs");
+const src = fs.readFileSync(0, "utf8");
+const RETRY = Number(process.argv[1]);
+const fail = (m) => { console.log("FAIL: " + m); process.exit(1); };
+
+/* The real ensureComponentWidgets runs here, so the state it mutates has to be
+ * declared where it can see it. Declaring rather than lifting means a rename in
+ * the source fails loudly instead of silently creating a fresh global. */
+const preamble = `
+  let widgetModuleLoaded = "";
+  let widgetLoadOk = false;
+  let widgetAttemptedSig = "";
+  let widgetResolvedSig = "";
+  let widgetFailedVisitSig = "";
+  let widgetRetryTick = 0;
+`;
+
+let slot = 0, comp = "";
+let scriptLoads = 0;            /* how many times canvas.js was READ */
+let canvasBroken = true;        /* the failure under test, flipped by "repair" */
+const registry = [];
+
+const HANK = { id: "hank", params: [{ viz: { kind: "custom:hank_wave" } }] };
+const MODULES = { "0:synth": HANK, "1:synth": { id: "dr32", params: [{ viz: {} }] } };
+const here = () => MODULES[`${slot}:${comp}`] || { id: "", params: [] };
+
+const make = new Function(
+  "paramPagesSlot", "paramPagesComponent", "getSlotParam", "componentModuleIdKey",
+  "getComponentChainParams", "getModuleBasePath", "loadCanvasOverlayScript",
+  "registerOverlayWidgets", "clearWidgets", "debugLog", "WIDGET_RETRY_TICKS",
+  preamble + src +
+  "; return { tickComponentWidgets, ensureComponentWidgets, endComponentWidgetVisit," +
+  "           latch: () => widgetModuleLoaded, ok: () => widgetLoadOk };");
+
+const api = make(
+  () => slot,
+  () => comp,
+  () => here().id,
+  () => "synth_module",
+  () => here().params,
+  (id) => `/modules/${id}`,
+  () => {
+    scriptLoads++;
+    /* Exactly what the real one returns on a failed read: no overlay, an error
+     * string. This is the transient the whole feature is about. */
+    return canvasBroken
+      ? { overlay: null, error: "failed to load canvas script" }
+      : { overlay: { widgetKind: "custom:hank_wave", drawCell() {} }, error: "" };
+  },
+  (ov) => {
+    if (!ov) return { registered: [], skipped: [] };
+    registry.push(ov.widgetKind);
+    return { registered: [ov.widgetKind], skipped: [] };
+  },
+  () => { registry.length = 0; },
+  () => {},
+  RETRY);
+
+/* registerOverlayWidgets above only reports; the registry is filled here so the
+ * assertions read against what the grid would actually draw from. */
+const onGrid = (frames) => { for (let i = 0; i < frames; i++) api.tickComponentWidgets(); };
+const leaveGrid = () => api.endComponentWidgetVisit();
+const visitGrid = (s, c, frames) => { slot = s; comp = c; onGrid(frames); };
+
+/* 1. FIRST VISIT, canvas.js broken. Nothing registers -- that part is correct
+ *    and unchanged; the page falls back to the detector, which is the designed
+ *    behaviour for a module whose widget cannot be drawn. */
+visitGrid(0, "synth", 4);
+if (api.ok())
+  fail("a failed canvas.js load was recorded as settled; the module is latched " +
+       "with no widget and will never be retried");
+if (scriptLoads !== 1)
+  fail("expected exactly 1 canvas.js read on the first visit, got " + scriptLoads);
+
+/* 2. STAYING on the page must not re-read it. Retrying in place learns nothing
+ *    -- the file is the same bytes -- and costs a read and a parse ~4x/sec. */
+scriptLoads = 0;
+onGrid(RETRY * 4 + 4);
+if (scriptLoads !== 0)
+  fail("a broken canvas.js was re-read " + scriptLoads + " times while staying on " +
+       "its page; a failure must stop for the visit");
+
+/* 3. LEAVE AND COME BACK -- still broken. One more attempt, and only one. */
+leaveGrid();
+scriptLoads = 0;
+visitGrid(0, "synth", RETRY * 4 + 4);
+if (scriptLoads !== 1)
+  fail("re-entering the page made " + scriptLoads + " canvas.js reads, expected " +
+       "exactly 1: a new visit retries once, it does not reopen the throttle");
+
+/* 4. THE ACTUAL RECOVERY. The module is repaired (or its files finish
+ *    installing) and the user comes back. Without the retry this is the state
+ *    the device was stuck in: correct files on disk, dials on screen. */
+leaveGrid();
+canvasBroken = false;
+visitGrid(0, "synth", 4);
+if (!registry.includes("custom:hank_wave"))
+  fail("a repaired module did not register its widget on the next visit");
+if (!api.ok())
+  fail("a successful load was not recorded as settled");
+
+/* 5. AND SUCCESS STILL COSTS NOTHING. The visit boundary must not re-run a
+ *    settled module: clearWidgets() would re-arm any widget the one-strike
+ *    disable had already switched off after a throw. */
+scriptLoads = 0;
+leaveGrid();
+visitGrid(0, "synth", RETRY * 4 + 4);
+if (scriptLoads !== 0)
+  fail("a settled module re-read its canvas.js " + scriptLoads + " times after a " +
+       "visit boundary; that also re-arms a widget disabled for throwing");
+
+/* 6. A module that declares NO custom kind is settled too, and reads nothing. */
+scriptLoads = 0;
+visitGrid(1, "synth", RETRY * 2 + 2);
+if (!api.ok())
+  fail("a module declaring no custom widget was left unsettled, so it is retried forever");
+if (scriptLoads !== 0)
+  fail("a module declaring no custom kind read a canvas.js");
+
+console.log("PASS: a failed widget load retries per visit, once, and a settled one never does");
+' "$retry_ticks"


### PR DESCRIPTION
## What

`ensureComponentWidgets` sets `widgetModuleLoaded = id` **before** the three things that can still fail — resolving the module directory, reading `canvas.js`, and getting a usable widget out of it. It has to be that order: the latch is what `clearWidgets()` is paired with, and what stops the next frame re-entering.

But the latch was the *whole* answer, which made a module whose script failed to load byte-identical in state to one that had succeeded: latched, with an empty registry. Everything downstream then agreed —

- `id === widgetModuleLoaded` refused every later attempt,
- `tickComponentWidgets` stamped the signature as **resolved**, because the latch did name the component in front of it,
- the cells fell through to the detector and drew ordinary dials, silently, with the fall-through doing exactly what it is for.

The only escape was visiting a **different** module, which relatches and so changes the signature. That is the shape of the field report — *"Hank's waveform sometimes appears, and later Ratio/Bright/Bite are plain dials"*, fixed by switching away and back. That gesture is not a diagnosis; it is the one state transition the code left open.

## The fix

The latch is a two-part answer: which module, and whether its widgets are **settled** (`widgetLoadOk`). Two states settle, and neither is retried:

- a widget registered, and
- **the module declares no custom kind at all** — a finished answer, not a failure. Forgetting this half turns the fix into a permanent retry loop on the large majority of modules.

Anything else is an attempt still owed — but *when* matters as much, because both obvious policies are wrong. Recording a failure as resolved is the bug. Not recording it re-reads and re-parses a genuinely broken `canvas.js` ~4x/sec for as long as its page is up, which is the exact cost the throttle exists to prevent.

**A visit is the unit.** Within one visit a second attempt cannot learn anything the first did not — same directory, same bytes — so it stops, against its own record (`widgetFailedVisitSig`) held apart from `widgetResolvedSig`: leaving the grid clears one and not the other, because a success is a fact about the module and a failure is a fact about one attempt. Leaving and returning asks once more, which is also the gesture available to someone who has just installed or repaired the module.

Two details that are not optional:

- **The visit boundary resets the throttle too.** Clearing only the failure record leaves `widgetAttemptedSig` describing the component being returned to, so the next frame takes the throttle branch rather than attempt-at-once — resuming from wherever `widgetRetryTick` was left, so a short visit can end before the retry lands.
- **The one-strike disable survives a retry**, structurally rather than by a guard: a throw can only follow a successful registration, which settles the module, and a settled module is never re-attempted. (A retry that re-registered would call `clearWidgets()` and re-arm a widget already known to crash.)

Only failing to *reach* an overlay is retried. A script that loaded and registered nothing usable — a typo in the kind, no `drawCell` — is settled, since re-reading the same declaration gets the same answer and the skip is already named in the log.

Finally, `if (!dir) return;` was silent. An absent module directory is indistinguishable on screen from a module with no widget, so it says so in `debug.log` now, as does every other way this can end.

## Tests

`tests/host/test_widget_load_failure_retry.sh` drives a broken `canvas.js` through a repair:

| | reads of `canvas.js` |
|---|---|
| first visit, broken | 1 |
| staying on the page (60+ frames) | 0 |
| each re-entry, still broken | exactly 1 |
| after repair | widget registers |
| settled module, across a visit boundary | 0 |
| module declaring no widget | 0 |

It also pins the **call site** of the visit boundary — the scenario drives that boundary directly, so nothing else could tell whether the device ever reaches it, and a boundary nobody calls is the original bug with more code. Verified against six mutations, each of which reproduces one of the failure modes above.

`test_widget_latch_per_component.sh`'s stub mirrors the new settled state, so assertion 4 there still closes by the intended door.

All `tests/host/` shell + C tests pass.

## Not verified on hardware

This is a credible host-side defect and stands on its own, but without diagnostics from the affected device it is not proven to be *the* cause of that incident. Capturing that still wants `debug_log_on` armed before switching away from Hank and back; the new `debug.log` lines are what would settle it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrnqqAF9ZGeBqZWSbVJkf9