### PR TITLE
forge: bump min_host_version to 1.3.0 (v0.2.5 UI redesign)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -955,7 +955,7 @@
       "github_repo": "filliformes/forge-move",
       "default_branch": "master",
       "asset_name": "forge-module.tar.gz",
-      "min_host_version": "0.9.0"
+      "min_host_version": "1.3.0"
     },
     {
       "id": "davebox",


### PR DESCRIPTION
Forge **v0.2.5** ships a Schwung v1.3 UI redesign: per-voice pages that follow the pad (pad-press UI following via `child_index_param`), momentary `access:"write"` trigger buttons, reorganised pages and a dedicated EQ page.

These rely on **host v1.3.0+** (pad-press following / child pages) — on older hosts the module fails to render. This bumps the catalog `min_host_version` for `forge` from `0.9.0` to `1.3.0` so it's only offered where it works.

Single-line change to the forge entry; no other entries touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)