### PR TITLE
catalog: add Pixel Walkers MIDI FX

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1466,6 +1466,17 @@
       "default_branch": "main",
       "asset_name": "hank-module.tar.gz",
       "min_host_version": "1.2.0"
+    },
+    {
+      "id": "pixel-walkers",
+      "name": "Pixel Walkers",
+      "description": "Animated gravity MIDI sequencer where played notes become tiny walkers and retrigger as they land and bounce across platforms",
+      "author": "mestela",
+      "component_type": "midi_fx",
+      "github_repo": "mestela/schwung-pixel-walkers",
+      "default_branch": "main",
+      "asset_name": "pixel-walkers-module.tar.gz",
+      "min_host_version": "1.3.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds Pixel Walkers to the Schwung module catalog as a MIDI FX. Played notes become tiny animated walkers that retrigger their original notes when they land and bounce across generated platforms.

## Release

- Repository: https://github.com/mestela/schwung-pixel-walkers
- Release: https://github.com/mestela/schwung-pixel-walkers/releases/tag/v0.2.0
- Asset: `pixel-walkers-module.tar.gz`
- Minimum Schwung version: v1.3.0

## Validation

- Catalog JSON parses successfully
- Module IDs remain unique
- `release.json` reports v0.2.0
- Release asset URL is live
- Tested successfully on Move hardware with Schwung v1.3.x