### PR TITLE
catalog: MonkSynth

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1477,6 +1477,17 @@
       "default_branch": "main",
       "asset_name": "pixel-walkers-module.tar.gz",
       "min_host_version": "1.3.0"
+    },
+    {
+      "id": "monksynth",
+      "name": "MonkSynth",
+      "description": "Monophonic formant (FOF) vocal synthesizer with twelve singing characters - an homage to Delay Lama. Pad pressure sweeps the vowel.",
+      "author": "Jonathan Taylor (DSP), Charles Vestal (port)",
+      "component_type": "sound_generator",
+      "github_repo": "charlesvestal/schwung-monksynth",
+      "default_branch": "main",
+      "asset_name": "monksynth-module.tar.gz",
+      "min_host_version": "1.2.1"
     }
   ]
 }


### PR DESCRIPTION
Adds MonkSynth to the module catalog — a monophonic formant (FOF) vocal synthesizer with twelve singing characters, each with its own voice and its own face on the display. An homage to Delay Lama, by way of [JonET/monksynth](https://github.com/JonET/monksynth). Pad pressure sweeps the vowel, standing in for the pitch wheel Move does not have.

Repo: [charlesvestal/schwung-monksynth](https://github.com/charlesvestal/schwung-monksynth), released at [v0.1.1](https://github.com/charlesvestal/schwung-monksynth/releases/tag/v0.1.1) with `monksynth-module.tar.gz` attached and `release.json` on main pointing at it.

`min_host_version` is 1.2.1 — "anything after v1.2.0", when the card payload carrying `values`/`nowMs` and the other module-supplied draw surfaces it uses landed. On an older host it still loads, without the faces. No external assets, so no `requires`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EvpFkfvmfpYbMF3JKCNqVd