### PR TITLE
fix: the lone-37-12 repair is not persistence, and must not share its gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1214,6 +1214,34 @@ Compatibility is deliberately non-destructive: `usbc_out_state` and the old
 feature and `master_fx:usbc_out_persist` accepts old SETs only as no-ops while
 GET reports `0`. The dormant wire codec and investigation history remain in
 `docs/SPI_PROTOCOL.md`.
+
+**Retiring the REPLAY retired the REPAIR with it, because one variable meant
+one gate.** They are not the same feature: the replay restores a preference
+from a FILE that Move is not advertising — that is what booted a device with
+its speaker muted and its own settings page reading Mic — while the repair
+fires only while Move's LIVE `37 14` still says Main Out, restoring the mode
+Move is advertising this second. Both were armed through
+`shim_usbc_out_replay`, so 1.3.2 fixed the muted speaker and shipped a stuck
+microphone: Move's sample/record page emits a **lone `37 12`** carrying bit1
+(monitoring) from its own stale "Mic" UI state, monitoring is *how* Main Out
+reaches USB-C, and with no `37 14` to show for it nothing re-asserted. The
+symptom is USB-C on the microphone with Move's settings page insisting on Main
+Out, unfixable until reboot **because re-picking Main Out there emits
+nothing** — from Move's side nothing changed. `usbc_emit_gate.h` splits the two
+producers and the repair is un-gated; `usbc_gate_tick_monitor` no longer
+consults the stored preference either, which had made the repair a servant of
+the feature that was switched off (a device with no state file went
+undefended).
+
+**The lone `37 12` is real, and its bit1 is not always stale** — captured on
+hardware 2026-09-09, seven of them from one mic/resample/mic pass on the
+sample/record page, every one with monitoring *preserved*, so nothing reverted
+and the repair correctly did nothing. Waiting for the failure is therefore not
+a test. Forcing it is: `echo 0 > /data/UserData/schwung/spi_sysex_inject` puts
+Move's stale message on the wire, and the repair answered 138 frames (~395 ms,
+the two-tick debounce) later with `37 12` bit1 set and `37 14 01` behind it,
+both visible in the POSThw view — bit0 preserved, so Move's input select is not
+clobbered.
 ### Shadow Architecture
 
 `src/schwung_shim.c` (LD_PRELOAD, intercepts ioctl, mixes audio), `src/shadow/shadow_ui.js` (slot/patch UI), `src/host/shadow_constants.h` (SHM structs).

--- a/docs/SPI_PROTOCOL.md
+++ b/docs/SPI_PROTOCOL.md
@@ -198,12 +198,28 @@ Injecting too many MIDI events per frame causes SIGABRT. Safe limits:
 Moved here from `CLAUDE.md`, which keeps a summary. This is the `37 12` /
 `37 14` TLV pair on MIDI_OUT cable 0, and the boot arbitration around it.
 
-> **Disabled in Schwung 1.3.2.** Two field reports demonstrated that the
-> source and monitoring fields can become inconsistent: USB-C can carry the
-> microphone while the source still reports Main Out, and replaying monitoring
-> can mute the built-in speaker. Schwung no longer restores or repairs this
-> state. The codec and state file remain dormant so the change is reversible;
-> Move's own Settings screen is the sole owner of USB-C output routing.
+> **Persistence disabled in Schwung 1.3.2; the monitor-loss repair restored
+> after it.** Two field reports drove the 1.3.2 hotfix: USB-C carrying the
+> microphone while the source still reported Main Out, and replaying monitoring
+> muting the built-in speaker. The hotfix disabled *both* the boot replay and
+> the repair, because both were armed through `shim_usbc_out_replay` — one
+> variable, therefore one gate. That fixed the second report and made the first
+> permanent-until-reboot.
+>
+> They are different things and are now separated by `usbc_emit_gate.h`:
+>
+> - **boot replay — retired.** Restores a preference from a FILE that Move is
+>   not advertising. Dropped unless `usbc_out_persist_enabled`, which is a
+>   compile-time `0`. The state file and codec stay so the change is reversible.
+> - **monitor-loss repair — live, and not gated by persistence.** Fires only
+>   while Move's own `37 14` still says Main Out, so it restores the mode Move
+>   is advertising rather than overriding it. It cannot fire at boot from a
+>   file, and it consults no stored preference (requiring `stored == 1` had made
+>   it a servant of the retired feature, leaving a device with no state file
+>   undefended).
+>
+> Move's Settings screen owns the *selection*; Schwung only stops Move's own
+> sampling page from silently undoing it.
 
 Move's Settings menu picks what a connected computer receives over USB-C (Mic or
 Main Out). Move's firmware **never persists it** — there is no key in
@@ -247,7 +263,32 @@ the leading half of a split Mic selection. Two consecutive worker ticks
 `37 12 01` at f75529, our `37 12 03` at f75635 (**bit0 preserved, bit1
 restored**), then quiet.
 
-Historical flow (dormant as of 1.3.2): the SPI pre-transfer callback scans MIDI_OUT via `xmos_audio_scan`; the
+**Forcing the failure is the only way to test the repair.** Captured on
+hardware 2026-09-09: a full mic → resample → mic pass on Move's sample/record
+page emitted **seven lone `37 12` messages, no `37 14` anywhere** — the shape
+the repair exists for — but every one carried bit1 **set**, so monitoring
+survived, nothing reverted, and the repair correctly did nothing. Bit1 is
+carried from Move's settings-page UI state and is only sometimes stale, so a
+session that does not reproduce proves nothing. The debug trigger puts the
+stale message on the wire directly:
+
+```
+echo 0 > /data/UserData/schwung/spi_sysex_inject      # 37 12 00 — monitoring cleared
+```
+
+```
+f365650  ROUTE  37 12  monitor_bit1=0   injected failure
+f365788  ROUTE  37 12  monitor_bit1=1   repair, 138 frames (~395 ms) later
+f365789  OUTSRC 37 14  value=1
+```
+
+All three appear in the POSThw view as well as PRE, so they crossed the ioctl
+rather than merely landing in the shadow buffer, and `usbc_in_bit0` is
+unchanged through the repair — it reuses Move's own route payload, so the
+sampling input select is never clobbered. Arm the capture with
+`touch /data/UserData/schwung/log_xmos_sysex_on`.
+
+Historical flow (replay dormant as of 1.3.2): the SPI pre-transfer callback scans MIDI_OUT via `xmos_audio_scan`; the
 worker persists the value to `/data/UserData/schwung/usbc_out_state`; ~5 s after
 boot the worker arms a replay, which the SPI callback emits one message per
 frame. Only Main Out is replayed — Mic is Move's own boot default, so there is
@@ -287,7 +328,8 @@ Two behaviours worth knowing:
 The former **Global Settings → Audio → USB-C Persist** row is removed.
 `master_fx:usbc_out_persist` remains only as a compatibility parameter: SET is
 a no-op and GET reports `0`. Existing `shadow_config.json` and
-`usbc_out_state` values are preserved but ignored.
+`usbc_out_state` values are preserved but ignored — including by the repair,
+which reads the wire and not the file.
 
 Impl: `src/host/shadow_xmos_audio.c` (pure codec — no I/O, allocation or locks,
 so it is both SPI-callback-safe and host-testable; unit tests in
@@ -295,7 +337,10 @@ so it is both SPI-callback-safe and host-testable; unit tests in
 pre-transfer callback, persisted and armed in `src/host/shim_worker.c`. The
 boot arbitration is split out as `src/host/usbc_out_gate.c` — also pure state,
 with no clock of its own, which is what makes the boot orderings testable
-without a device.
+without a device. Which of the two armed requests may reach the wire is
+`src/host/usbc_emit_gate.h`, pure selection for the same reason
+(`tests/host/test_usbc_emit_gate.sh`); the wiring that silenced the repair is
+pinned in `tests/host/test_usbc_out_persist_disabled.sh`.
 
 `xmos_audio_emit` is also the only sanctioned way to put SysEx into MIDI_OUT: it
 requires a **contiguous** run of free slots, refuses while any cable-0 SysEx is

--- a/src/host/shim_worker.c
+++ b/src/host/shim_worker.c
@@ -32,6 +32,7 @@ volatile int shim_inject_boot_jack = -1;
 volatile int shim_jack_persist = -1;
 volatile int shim_usbc_out_persist = -1;
 volatile int shim_usbc_out_replay = -1;
+volatile int shim_usbc_out_reassert = -1;
 volatile int shim_usbc_out_level = -1;
 volatile int shim_usbc_monitor = -1;
 
@@ -773,10 +774,16 @@ static void *worker_main(void *arg) {
             usbc_gate_out_t act = {0};
             usbc_gate_tick_monitor(&usbc_gate, shim_usbc_out_level,
                                    shim_usbc_monitor, &act);
-            if (act.replay && usbc_out_persist_enabled) {
-                shim_usbc_out_replay = act.replay_value;
+            /* Deliberately NOT gated on usbc_out_persist_enabled. This is a
+             * repair of the live state, not a replay of a saved one: it fires
+             * only while Move's own 37 14 still says Main Out, so it restores
+             * what Move is advertising rather than overriding it. Sharing the
+             * replay's variable — and therefore its gate — is what made
+             * retiring persistence in 1.3.2 silently retire this too. */
+            if (act.replay) {
+                shim_usbc_out_reassert = act.replay_value;
                 unified_log("shim", LOG_LEVEL_DEBUG,
-                            "USB-C out: monitoring cleared by a lone 37 12 — re-asserting Main Out");
+                            "USB-C out: monitoring cleared by a lone 37 12 — restoring Main Out");
             }
         }
 

--- a/src/host/shim_worker.h
+++ b/src/host/shim_worker.h
@@ -86,6 +86,14 @@ extern volatile int shim_usbc_out_persist;
  * then); the RT consumer emits the SysEx pair and swaps it back to -1. */
 extern volatile int shim_usbc_out_replay;
 
+/* Monitor-loss repair, armed by the same RT consumer contract as
+ * shim_usbc_out_replay above but kept SEPARATE from it on purpose: the replay
+ * restores a saved preference and is retired, while this restores the mode
+ * Move's live 37 14 is advertising right now. One variable meant one gate, so
+ * retiring the first silenced the second and left USB-C stuck on the
+ * microphone until reboot. See usbc_emit_gate.h. */
+extern volatile int shim_usbc_out_reassert;
+
 /* Live view of the two bits that together decide whether Main Out actually
  * reaches USB-C, republished by the RT path every frame (-1 until observed).
  * Unlike shim_usbc_out_persist these are levels, not edges: the worker polls

--- a/src/host/usbc_emit_gate.h
+++ b/src/host/usbc_emit_gate.h
@@ -1,0 +1,56 @@
+/* usbc_emit_gate.h - which armed USB-C request may reach the XMOS wire.
+ *
+ * TWO PRODUCERS, AND THEY ARE NOT THE SAME FEATURE
+ *
+ *   boot replay  Retired in 1.3.2. It restored a preference from a FILE that
+ *                Move itself was not advertising, so a device booted with its
+ *                built-in speaker muted (monitoring is how Main Out reaches
+ *                USB-C, and the XMOS mutes the speaker while it is set) and
+ *                Move's own settings page reading Mic. Nothing on screen
+ *                explained it, which is why it had to go.
+ *
+ *   repair       The lone-37-12 defence. It fires only while Move's LIVE
+ *                37 14 still says Main Out — it restores the mode Move is
+ *                advertising this second and invents nothing. Without it,
+ *                Move's sampling page clears monitoring behind our back
+ *                (it emits a lone 37 12 carrying bit1 from its own stale
+ *                "Mic" UI state) and USB-C silently carries the microphone
+ *                until the next reboot, with Move's settings page insisting
+ *                otherwise and re-picking Main Out emitting nothing.
+ *
+ * They were armed through ONE variable and therefore shared one gate, so
+ * retiring the first silenced the second: 1.3.2 fixed the muted speaker and
+ * shipped the stuck microphone. Selection is kept pure so tests/host can
+ * drive it — the wiring, not the arithmetic, is where this went wrong.
+ *
+ * `boot_replay` and `repair` are armed values (0 = Mic, 1 = Main Out) or -1
+ * for "not armed", read straight off the worker's request variables.
+ */
+#ifndef USBC_EMIT_GATE_H
+#define USBC_EMIT_GATE_H
+
+typedef enum {
+    USBC_EMIT_NONE        = 0,
+    USBC_EMIT_BOOT_REPLAY = 1,
+    USBC_EMIT_REPAIR      = 2,
+} usbc_emit_kind_t;
+
+/* Returns what to put on the wire and writes its value to *value. *value is
+ * left untouched when nothing is emitted. */
+static inline usbc_emit_kind_t usbc_emit_select(int boot_replay, int repair,
+                                                int persist_enabled, int *value)
+{
+    /* The repair describes what Move is advertising right now; the replay
+     * describes a file. When both are armed, live state wins. */
+    if (repair >= 0) {
+        if (value) *value = repair;
+        return USBC_EMIT_REPAIR;
+    }
+    if (boot_replay >= 0 && persist_enabled) {
+        if (value) *value = boot_replay;
+        return USBC_EMIT_BOOT_REPLAY;
+    }
+    return USBC_EMIT_NONE;
+}
+
+#endif /* USBC_EMIT_GATE_H */

--- a/src/host/usbc_out_gate.c
+++ b/src/host/usbc_out_gate.c
@@ -110,8 +110,15 @@ void usbc_gate_tick_monitor(usbc_gate_t *g, int usbc_out, int monitor,
 {
     /* Boot arbitration owns the wire until it settles — it is already
      * re-asserting on its own budget, and two defences bidding at once would
-     * double-spend. */
-    if (g->phase != USBC_GATE_PHASE_SETTLED || g->stored != 1) {
+     * double-spend.
+     *
+     * The stored preference is deliberately NOT consulted. This defence used
+     * to require `g->stored == 1`, which made it a servant of persistence:
+     * with persistence retired nothing writes an authoritative file, and a
+     * device with none (or with a stale Mic left by an older install) went
+     * undefended. `usbc_out == 1` below is the real precondition — Move's
+     * live 37 14 says Main Out this second — and it needs no help from disk. */
+    if (g->phase != USBC_GATE_PHASE_SETTLED) {
         g->monitor_pending = 0;
         return;
     }

--- a/src/schwung_shim.c
+++ b/src/schwung_shim.c
@@ -70,6 +70,7 @@ extern align_capture_t g_align_capture;
 #include "host/shadow_led_queue.h"
 #include "host/shadow_state.h"
 #include "host/shadow_xmos_audio.h"
+#include "host/usbc_emit_gate.h"
 #include "host/shadow_midi.h"
 #include "host/shadow_overtake_midi.h"
 #include "host/ext_midi_ring.h"
@@ -5884,12 +5885,15 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
         }
     }
 
-    /* XMOS audio-IO SysEx emission — one active producer and one dormant path.
+    /* XMOS audio-IO SysEx emission — three producers, one slot-safe path.
      *
-     * 1. Retained USB-C replay machinery. Persistence is disabled as of 1.3.2,
-     *    so the gate below drops this before it can reach XMOS.
-     * 2. The active spi_sysex_inject debug trigger (file content = 37 12 value
-     *    byte).
+     * 1. Retained USB-C boot replay. Persistence is disabled as of 1.3.2, so
+     *    usbc_emit_select drops this before it can reach XMOS.
+     * 2. The monitor-loss repair, which is NOT persistence and is not gated by
+     *    it: it restores the mode Move's live 37 14 is advertising after Move's
+     *    own sampling page clears monitoring with a lone 37 12. See
+     *    usbc_emit_gate.h for why these two cannot share a variable.
+     * 3. The spi_sysex_inject debug trigger (file content = 37 12 value byte).
      *
      * Both go through xmos_audio_emit, which only ever writes free MIDI_OUT
      * slots. The previous implementation blind-wrote out[0..31] regardless of
@@ -5902,24 +5906,28 @@ static void shim_pre_transfer(void *ctx, uint8_t *shadow, int size)
         static int pending_next = 0;   /* index of the next one */
 
         if (pending_count == 0) {
-            int replay = shim_usbc_out_replay;
-            if (replay >= 0 && !usbc_out_persist_enabled) {
-                /* Persistence is retired; discard any stale worker request. */
-                shim_usbc_out_replay = -1;
-                replay = -1;
-            }
-            if (replay >= 0) {
-                shim_usbc_out_replay = -1;
-                xmos_audio_build(&xmos_audio_observed, replay, pending[0], pending[1]);
+            int emit_val = -1;
+            usbc_emit_kind_t emit_kind = usbc_emit_select(shim_usbc_out_replay,
+                                                          shim_usbc_out_reassert,
+                                                          usbc_out_persist_enabled,
+                                                          &emit_val);
+            /* Consume both requests whatever was selected: an unpicked one is
+             * stale by definition (persistence is retired, or the repair lost
+             * to nothing), and leaving it armed re-offers it every frame. */
+            shim_usbc_out_replay = -1;
+            shim_usbc_out_reassert = -1;
+
+            if (emit_kind != USBC_EMIT_NONE) {
+                xmos_audio_build(&xmos_audio_observed, emit_val, pending[0], pending[1]);
                 pending_count = 2;
                 pending_next = 0;
-                /* Neutral wording on purpose: this path serves the boot replay
-                 * AND the monitor-loss defence, and the shim cannot tell them
-                 * apart — the worker arms both through the same variable. It
-                 * logs the specific reason before arming, so saying "boot"
-                 * here mislabelled every mid-session re-assert. */
-                shadow_log(replay ? "USB-C out: re-asserting Main Out"
-                                  : "USB-C out: re-asserting Mic");
+                /* The two paths are named apart now. They shared one variable
+                 * before, so the shim could not tell them apart and every
+                 * mid-session repair was logged as a boot re-assert. */
+                shadow_log(emit_kind == USBC_EMIT_REPAIR
+                    ? "USB-C out: monitoring cleared by a lone 37 12 — restoring Main Out"
+                    : (emit_val ? "USB-C out: re-asserting Main Out"
+                                : "USB-C out: re-asserting Mic"));
             } else if (shim_pending_sysex_inject >= 0) {
                 int val_byte = shim_pending_sysex_inject;
                 shim_pending_sysex_inject = -1;

--- a/tests/host/test_usbc_emit_gate.c
+++ b/tests/host/test_usbc_emit_gate.c
@@ -1,0 +1,79 @@
+/* test_usbc_emit_gate.c - which armed USB-C request may reach the wire.
+ *
+ * The defect this pins: the retired boot replay and the live monitor-loss
+ * repair were armed through ONE variable, so one gate silenced both. Disabling
+ * persistence in 1.3.2 therefore also disabled the repair, and a lone 37 12
+ * from Move's sampling page left USB-C on the microphone until reboot while
+ * Move's own settings page still read Main Out.
+ */
+#include <stdio.h>
+#include "usbc_emit_gate.h"
+
+static int fails;
+#define CHECK(c, msg) do { \
+    if (!(c)) { fprintf(stderr, "FAIL: %s\n", (msg)); fails++; } \
+} while (0)
+
+/* Persistence stays retired: an armed boot replay must never reach the wire. */
+static void test_boot_replay_stays_retired(void)
+{
+    int v = -1;
+    CHECK(usbc_emit_select(1, -1, 0, &v) == USBC_EMIT_NONE,
+          "retired: a boot replay is dropped while persistence is off");
+    CHECK(usbc_emit_select(0, -1, 0, &v) == USBC_EMIT_NONE,
+          "retired: a boot replay of Mic is dropped too");
+}
+
+/* The whole point of the split: the repair is not persistence and is not
+ * gated by it. */
+static void test_repair_reaches_the_wire_with_persistence_off(void)
+{
+    int v = -1;
+    CHECK(usbc_emit_select(-1, 1, 0, &v) == USBC_EMIT_REPAIR,
+          "repair: reaches the wire with persistence disabled");
+    CHECK(v == 1, "repair: carries Main Out");
+}
+
+static void test_nothing_armed_emits_nothing(void)
+{
+    int v = 7;
+    CHECK(usbc_emit_select(-1, -1, 0, &v) == USBC_EMIT_NONE, "idle: nothing armed");
+    CHECK(usbc_emit_select(-1, -1, 1, &v) == USBC_EMIT_NONE, "idle: nothing armed, persist on");
+    CHECK(v == 7, "idle: value untouched");
+}
+
+/* The compatibility register still works if persistence is ever revived, so
+ * the two paths stay genuinely independent rather than one being dead code. */
+static void test_boot_replay_permitted_when_persistence_is_on(void)
+{
+    int v = -1;
+    CHECK(usbc_emit_select(1, -1, 1, &v) == USBC_EMIT_BOOT_REPLAY,
+          "revived: a boot replay is permitted when persistence is on");
+    CHECK(v == 1, "revived: carries the stored value");
+}
+
+/* Both armed: the repair describes what Move is advertising right now, the
+ * replay describes a file. Live state wins. */
+static void test_repair_wins_over_boot_replay(void)
+{
+    int v = -1;
+    CHECK(usbc_emit_select(0, 1, 1, &v) == USBC_EMIT_REPAIR,
+          "both: the live repair takes precedence");
+    CHECK(v == 1, "both: repair value is used");
+}
+
+int main(void)
+{
+    test_boot_replay_stays_retired();
+    test_repair_reaches_the_wire_with_persistence_off();
+    test_nothing_armed_emits_nothing();
+    test_boot_replay_permitted_when_persistence_is_on();
+    test_repair_wins_over_boot_replay();
+
+    if (fails) {
+        fprintf(stderr, "%d check(s) failed\n", fails);
+        return 1;
+    }
+    printf("PASS\n");
+    return 0;
+}

--- a/tests/host/test_usbc_emit_gate.sh
+++ b/tests/host/test_usbc_emit_gate.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+bin="build/tests/test_usbc_emit_gate"
+mkdir -p "$(dirname "$bin")"
+
+cc -std=gnu11 -Wall -Wextra -Isrc/host \
+  tests/host/test_usbc_emit_gate.c \
+  -o "$bin"
+
+"$bin"

--- a/tests/host/test_usbc_out_gate.c
+++ b/tests/host/test_usbc_out_gate.c
@@ -245,15 +245,39 @@ static void test_monitor_healthy_does_nothing(void)
     }
 }
 
-static void test_monitor_loss_not_defended_when_mic_stored(void)
+/* Persistence is retired, so there is no stored preference to defend and the
+ * worker force-settles the gate instead of replaying a file. The precondition
+ * is the LIVE wire — 37 14 says Main Out this second — so a device that has
+ * never written a state file must still be defended. Keying this off `stored`
+ * made the repair depend on the very feature that was switched off. */
+static void test_monitor_loss_defended_without_a_stored_preference(void)
+{
+    usbc_gate_t g;
+    usbc_gate_init(&g, -1);        /* no state file */
+    usbc_gate_force_settle(&g);    /* what the worker does with persistence off */
+    mon(&g, 1, 1);                 /* monitoring live */
+
+    mon(&g, 1, 0);
+    CHECK(OUT.replay == 0, "no-stored: debounced like any other loss");
+    mon(&g, 1, 0);
+    CHECK(OUT.replay == 1 && OUT.replay_value == 1,
+          "no-stored: the live 37 14 is the precondition, not the file");
+    CHECK(OUT.persist == 0, "no-stored: repairing persists nothing");
+}
+
+/* Same, with a stale file left by a pre-1.3.2 install. A file saying Mic
+ * cannot veto what Move is advertising right now. */
+static void test_monitor_loss_defended_over_a_stale_mic_file(void)
 {
     usbc_gate_t g;
     usbc_gate_init(&g, 0);
-    boot_replay(&g);      /* stored Mic settles immediately */
-    for (int i = 0; i < 4; i++) {
-        mon(&g, 1, 0);
-        CHECK(OUT.replay == 0, "mic-stored: nothing to defend");
-    }
+    usbc_gate_force_settle(&g);
+    mon(&g, 1, 1);
+
+    mon(&g, 1, 0);
+    mon(&g, 1, 0);
+    CHECK(OUT.replay == 1 && OUT.replay_value == 1,
+          "stale-mic-file: the live wire decides, not the file");
 }
 
 /* Boot arbitration owns the wire; the monitor defence must not cut in. */
@@ -313,7 +337,8 @@ int main(void)
     test_monitor_loss_triggers_reassert();
     test_split_mic_selection_is_not_fought();
     test_monitor_healthy_does_nothing();
-    test_monitor_loss_not_defended_when_mic_stored();
+    test_monitor_loss_defended_without_a_stored_preference();
+    test_monitor_loss_defended_over_a_stale_mic_file();
     test_monitor_defence_inert_before_settling();
     test_monitor_reasserts_are_bounded();
     test_monitor_budget_rearms_on_fresh_loss();

--- a/tests/host/test_usbc_out_persist_disabled.sh
+++ b/tests/host/test_usbc_out_persist_disabled.sh
@@ -45,4 +45,24 @@ if grep -q 'restores it a few' "$help"; then
     fail "built-in help still claims Schwung restores USB-C output"
 fi
 
-echo "PASS: USB-C output persistence is disabled and cannot be restored from saved state"
+# Retired means the REPLAY is retired, not the repair. The two were armed
+# through one variable, so 1.3.2 disabled both at once — fixing the muted
+# speaker and shipping a microphone stuck on USB-C until reboot. The repair
+# restores what Move's live 37 14 already advertises, so it must reach the wire
+# with persistence off. usbc_emit_gate.h owns the arithmetic; these pin the
+# wiring that silenced it.
+worker=src/host/shim_worker.c
+monitor_block=$(sed -n '/usbc_gate_tick_monitor(&usbc_gate/,/^        }$/p' "$worker")
+[ -n "$monitor_block" ] || fail "could not locate the monitor-loss block in $worker"
+grep -q 'shim_usbc_out_reassert = act.replay_value;' <<<"$monitor_block" ||
+    fail "the monitor-loss repair does not arm its own request variable"
+# Strip comment lines first: this block DESCRIBES the retired switch by name,
+# and a pin that reads prose as code fails on its own explanation.
+monitor_code=$(grep -Ev '^[[:space:]]*(/\*|\*)' <<<"$monitor_block")
+if grep -q 'usbc_out_persist_enabled' <<<"$monitor_code"; then
+    fail "the monitor-loss repair is gated on the retired persistence switch"
+fi
+grep -q 'usbc_emit_select(shim_usbc_out_replay' "$shim" ||
+    fail "the shim no longer selects between the retired replay and the repair"
+
+echo "PASS: USB-C output persistence is disabled, and the monitor-loss repair still reaches the wire"


### PR DESCRIPTION
## The bug

1.3.2 (#475) retired USB-C output persistence — and retired the **monitor-loss repair** with it, because both were armed through `shim_usbc_out_replay`. One variable meant one gate. That fixed the muted-speaker report and made the *other* field report permanent-until-reboot.

Move's sample/record page emits a **lone `37 12`** whose bit1 (monitoring) is carried from its own stale "Mic" UI state. Monitoring is *how* Main Out reaches USB-C, and there is no `37 14` in the frame, so nothing re-asserts. The result: USB-C carries the microphone while Move's settings page still reads Main Out — and re-picking Main Out there **emits nothing**, because from Move's side nothing changed. Reboot is the only escape.

## The fix

The two producers are not the same feature:

| | restores | fires when |
|---|---|---|
| boot replay (**retired**) | a preference from a **file** | ~5 s after boot, whatever Move says |
| monitor-loss repair (**live**) | the mode Move's **live `37 14`** advertises | monitoring is lost with no `37 14` to explain it |

- `src/host/usbc_emit_gate.h` (new) — pure selection of which armed request reaches the wire. The replay stays dropped behind `usbc_out_persist_enabled`; the repair is not gated by it.
- `usbc_gate_tick_monitor` no longer requires `stored == 1`. That made the repair a servant of the retired feature — a device with no state file, or with a stale Mic from an old install, went undefended. The live `37 14` is the whole precondition.
- `shim_usbc_out_reassert` separates the two request variables, so the log can name them apart (every mid-session repair used to be logged as a boot re-assert).

## Hardware verification

**Waiting for the failure does not test it.** A full mic → resample → mic pass on Move's sample/record page emitted **seven lone `37 12` messages, no `37 14` anywhere** — the exact shape — but every one carried bit1 **set**, so monitoring survived and the repair correctly did nothing. Bit1 is only *sometimes* stale.

So the failure was forced (`echo 0 > /data/UserData/schwung/spi_sysex_inject`):

```
f365650  ROUTE  37 12  monitor_bit1=0   injected failure
f365788  ROUTE  37 12  monitor_bit1=1   repair, 138 frames (~395 ms) later
f365789  OUTSRC 37 14  value=1
```

All three also appear in the POSThw view, so they crossed the ioctl rather than just landing in the shadow buffer, and `usbc_in_bit0` is preserved — the repair reuses Move's own route payload, so the sampling input select is never clobbered.

## Tests

- `tests/host/test_usbc_emit_gate.{c,sh}` (new) — the replay stays retired, the repair reaches the wire with persistence off, the compatibility register still works if persistence is ever revived.
- `test_usbc_out_gate.c` — two new cases: defended with **no** state file, and over a **stale Mic** file. The debounce and bounded-replay cases that stop it fighting a real Mic selection are unchanged and still pass.
- `test_usbc_out_persist_disabled.sh` — pins the wiring that silenced the repair. Both new pins mutation-checked; the persist-gate pin strips comment lines first, because the block names the retired switch in its own explanation.

No version bump — not releasing yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PjPTb5ri5R94R8whdkZte