### PR TITLE
catalog: add DrumRack32 (dr32)

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1488,6 +1488,17 @@
       "default_branch": "main",
       "asset_name": "monksynth-module.tar.gz",
       "min_host_version": "1.2.1"
+    },
+    {
+      "id": "dr32",
+      "name": "DrumRack32",
+      "description": "Move's Drum Rack with 32 pads instead of 16 - loads Move's own .ablpreset kits and plays them through a reconstruction of the same Drum Sampler voice, with per-pad sends into the host's return buses",
+      "author": "legsmechanical",
+      "component_type": "sound_generator",
+      "github_repo": "legsmechanical/schwung-dr32",
+      "default_branch": "master",
+      "asset_name": "dr32-module.tar.gz",
+      "min_host_version": "1.3.0"
     }
   ]
 }


### PR DESCRIPTION
Adds **DrumRack32** to `module-catalog.json`. One entry, no other changes.

Move's Drum Rack with **32 pads instead of 16**. It loads Move's own `.ablpreset` drum kits out of the Core and User libraries and plays them through a reconstruction of the same Drum Sampler voice — so a kit built on the device opens here and sounds like itself, with twice the pads.

- **Kit browser is the module's own catalogue, not the file browser.** The file browser filters by extension, and a user's Track Presets tree holds every instrument's presets — measured on device, 365 files of which 75 are drum racks. DR32 filters by *content* (one 1 KB read per file, scanned incrementally so it stays inside the SPI budget), so every entry offered will actually load.
- **Four knob banks**: Sample, Shape, Mix and Master, plus the two-level Category → Kit browser. The three pad banks are sibling child levels sharing one `child_index_param`, so they edit one pad and the generated picker page is suppressed.
- **Per-pad Send A / Send B** into the host's return buses via `voice_send_params`, in dB, which is what a send amount means in a Move kit — so an imported kit's send levels arrive pointing at real returns.

### Why `min_host_version` is 1.3.0

DR32 loads, plays and edits on 1.2.0, but `voice_send_params` landed in 1.3.0 and the sends are a headline feature: below it the two knobs turn, save and restore while nothing reads them. 1.3.0 is the version where everything advertised actually works.

### Notes on the entry

- `default_branch` is **`master`** for this repo (as it is for `palette`). `release.json` lives there and is current.
- `asset_name` is `dr32-module.tar.gz`, named from the module id rather than the repo name.

### Verified

Published [v0.3.0](https://github.com/legsmechanical/schwung-dr32/releases/tag/v0.3.0) was downloaded via the `release.json` `download_url`, extracted, and installed on a Move — the running device's `dsp.so`, `module.json`, `help.json` and `ui.js` all hash-match the release asset. The DSP is built in a pinned container and the compiler version is asserted out of the artifact's `.comment` section at build time.

DR32 ships on-device help (`help.json`) and an HTML manual in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

