### PR TITLE
movy: require host 1.1.0, and say 16-track

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -1071,13 +1071,13 @@
     {
       "id": "movy",
       "name": "Movy",
-      "description": "Elektron-style knob UI + 4-track sequencer with per-step parameters, parameter automation, and live recording",
+      "description": "Elektron-style knob UI + 16-track sequencer with per-step parameters, parameter automation, and live recording",
       "author": "megadake",
       "component_type": "tool",
       "github_repo": "DimaDake/schwung-movy",
       "default_branch": "main",
       "asset_name": "movy-module.tar.gz",
-      "min_host_version": "0.9.13"
+      "min_host_version": "1.1.0"
     },
     {
       "id": "magneto",


### PR DESCRIPTION
Two edits to Movy's catalog entry.

**`min_host_version` 0.9.13 → 1.1.0.** Movy loads a master FX slot by writing `master_fx:fxN:module` straight to the shim. Before 1.1.0 `saveMasterFxChainConfig` persisted the master chain from the JS mirror, which never saw that write, so it wrote `{}` over a genuinely loaded slot and the chain was gone on the next boot. Movy carried a workaround that reached into `shadow_ui.js`'s published `ctx` and repaired the mirror itself.

#221 (persist from the shim, not the mirror) and #311 (ask the shim once, never act on a read that failed) fixed it properly, so Movy has now removed that workaround — and with it goes Movy's ability to cope with a host that lacks the fix. 1.1.0 is the first release carrying both.

Removing it was worth doing beyond tidiness: repairing the mirror meant re-reading all four positions, and `getMasterFxParam` ends in `|| ""`, so a read that failed was indistinguishable from an empty slot — exactly what #311 stopped the saver from acting on. Verified on 1.4.0 that a Movy-loaded master module still survives a reboot with the workaround gone.

**Description.** It has said "4-track" since before Movy's 16-track release (4 Schwung tracks + 12 Movy-hosted); corrected while here.

No other entry is touched — the file mixes literal and `\u`-escaped punctuation, so this is a textual edit rather than a JSON round-trip.