### PR TITLE
install.sh: one builder for schwung-manager, and no silent skip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ than restating one.
 
 Cross-compile via `${CROSS_PREFIX}gcc` for Move's ARM. See `BUILDING.md`.
 
+### install.sh could skip the manager build in SILENCE
+
+Its rebuild was guarded on `command -v go`, so on a machine with Docker but no
+local Go the whole block evaluated to false and was skipped without a word --
+the only warning sat on the build-FAILED branch, inside an `if` that never ran.
+`install.sh local` then uploaded whatever `schwung-manager` was already in the
+tarball and reported success, so a manager fix could be deployed, confirmed
+deployed, and still not be running.
+
+`scripts/build-manager.sh` is the single builder for both callers (local `go`,
+else a golang container, else a hard failure), and install.sh now FAILS rather
+than warns: shipping a stale manager takes `SCHWUNG_ALLOW_STALE_MANAGER=1`,
+which says so on the way past. Same defect class as the link sidecar's silent
+skip -- a build step that can be skipped silently defeats every bisect after it.
+
+
 ## Testing
 
 Static/regression suite: `for t in tests/{host,shadow,store,build}/*.sh; do bash "$t"; done`

--- a/scripts/build-manager.sh
+++ b/scripts/build-manager.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Build schwung-manager (Go) for the device: linux/arm64, static.
+#
+# THE SINGLE PLACE THIS IS BUILT.  It used to be built twice, and the two
+# copies did not agree: build.sh preferred a local `go` and fell back to a
+# golang container, while install.sh's rebuild was guarded on
+# `command -v go` alone.  On a machine with Docker but no Go the install
+# block evaluated to false and was skipped in silence — no warning, because
+# the only warning sat on the build-FAILED branch inside an if that never
+# ran — so `install.sh local` uploaded whatever schwung-manager happened to
+# be in the existing tarball and reported success.  A manager fix could then
+# be deployed, verified as deployed, and still not be running.
+#
+# That is the same defect already recorded for the link sidecar in
+# CLAUDE.md: a build step that can be skipped silently defeats every bisect
+# that follows.  So this script is loud and it is shared — a caller gets a
+# fresh binary or a non-zero exit, never a quiet no-op.
+#
+# Usage: scripts/build-manager.sh [output_path]
+#   Default output: <repo>/build/schwung-manager
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${1:-$REPO_ROOT/build/schwung-manager}"
+SRC="$REPO_ROOT/schwung-manager"
+
+if [ ! -d "$SRC" ]; then
+    echo "ERROR: $SRC not found" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+
+if command -v go &>/dev/null; then
+    echo "Building schwung-manager with local go..."
+    (cd "$SRC" && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+        go build -o "$OUT" -ldflags="-s -w" .)
+elif command -v docker &>/dev/null; then
+    echo "Local 'go' not found — building schwung-manager via golang:1.26-bookworm container"
+    mkdir -p "$REPO_ROOT/.cache/go-cache" "$REPO_ROOT/.cache/go-mod-cache"
+    OUT_DIR="$(cd "$(dirname "$OUT")" && pwd)"
+    docker run --rm \
+        -v "$SRC:/src" \
+        -v "$OUT_DIR:/out" \
+        -v "$REPO_ROOT/.cache/go-cache:/gocache" \
+        -v "$REPO_ROOT/.cache/go-mod-cache:/go-mod-cache" \
+        -u "$(id -u):$(id -g)" \
+        -w /src \
+        -e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
+        -e GOCACHE=/gocache -e GOMODCACHE=/go-mod-cache \
+        golang:1.26-bookworm \
+        go build -buildvcs=false -o "/out/$(basename "$OUT")" -ldflags="-s -w" .
+else
+    echo "ERROR: neither 'go' nor 'docker' available — cannot build schwung-manager." >&2
+    exit 1
+fi
+
+[ -s "$OUT" ] || { echo "ERROR: $OUT was not produced" >&2; exit 1; }
+echo "Built: schwung-manager ($(wc -c < "$OUT" | tr -d ' ') bytes)"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,34 +45,14 @@ if [ -z "$CROSS_PREFIX" ] && [ ! -f "/.dockerenv" ]; then
     # Build schwung-manager (Go, ARM64 cross-compile) BEFORE the Docker
     # build: package.sh runs inside the container and picks the binary up
     # from build/ via its existing conditional — no tarball injection.
-    # Prefer local `go` (fast); fall back to a golang container.
+    #
+    # ONE BUILDER, because there were two and they did not agree -- see
+    # scripts/build-manager.sh for what that cost.
     if [ -d "$REPO_ROOT/schwung-manager" ]; then
-        echo "=== Building schwung-manager (Go) ==="
-        mkdir -p "$REPO_ROOT/build"
-        if command -v go &>/dev/null; then
-            cd "$REPO_ROOT/schwung-manager"
-            GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$REPO_ROOT/build/schwung-manager" -ldflags="-s -w" .
-            cd "$REPO_ROOT"
-        elif command -v docker &>/dev/null; then
-            echo "Local 'go' not found — building via golang:1.26-bookworm container"
-            mkdir -p "$REPO_ROOT/.cache/go-cache" "$REPO_ROOT/.cache/go-mod-cache"
-            docker run --rm \
-                -v "$REPO_ROOT/schwung-manager:/src" \
-                -v "$REPO_ROOT/build:/out" \
-                -v "$REPO_ROOT/.cache/go-cache:/gocache" \
-                -v "$REPO_ROOT/.cache/go-mod-cache:/go-mod-cache" \
-                -u "$(id -u):$(id -g)" \
-                -w /src \
-                -e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
-                -e GOCACHE=/gocache -e GOMODCACHE=/go-mod-cache \
-                golang:1.26-bookworm \
-                go build -buildvcs=false -o /out/schwung-manager -ldflags="-s -w" .
-        else
-            echo "ERROR: neither 'go' nor 'docker' available — cannot build schwung-manager."
-            echo "       The web manager will be missing from the tarball."
-        fi
-        [ -f "$REPO_ROOT/build/schwung-manager" ] && \
-            echo "Built: schwung-manager ($(wc -c < "$REPO_ROOT/build/schwung-manager" | tr -d ' ') bytes)"
+        "$REPO_ROOT/scripts/build-manager.sh" || {
+            echo "ERROR: schwung-manager build failed."
+            exit 1
+        }
     fi
 
     # Run build inside container

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1148,12 +1148,25 @@ ssh_root_with_retry "if [ ! -L /data/UserData/move-anything ] && [ ! -d /data/Us
 # then re-run package.sh — the single packaging authority — instead of
 # injecting into the existing tarball (the old gunzip/append/gzip dance was
 # the third copy of that logic; see the 2026-06-11 cleanup review C-8).
-if [ "$use_local" = true ] && command -v go &>/dev/null && [ -d "$REPO_ROOT/schwung-manager" ] && [ -d "$REPO_ROOT/build" ]; then
-    echo "Rebuilding schwung-manager..."
-    if (cd "$REPO_ROOT/schwung-manager" && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$REPO_ROOT/build/schwung-manager" -ldflags="-s -w" .); then
+#
+# THE `go` GUARD WAS THE BUG. This was `command -v go && ...`, so on a machine
+# with Docker but no local Go the whole block evaluated to false and was
+# skipped IN SILENCE -- the only warning sat on the build-failed branch INSIDE
+# an if that never ran. `install.sh local` then uploaded whatever
+# schwung-manager happened to be in the existing tarball and reported success,
+# so a manager fix could be deployed, confirmed deployed, and still not be
+# running. Same defect the link sidecar already has a war story for: a build
+# step that can be skipped silently defeats every bisect that follows.
+#
+# scripts/build-manager.sh is the shared builder (go, else Docker, else a hard
+# failure). SCHWUNG_ALLOW_STALE_MANAGER=1 opts out deliberately and says so.
+if [ "$use_local" = true ] && [ -d "$REPO_ROOT/schwung-manager" ] && [ -d "$REPO_ROOT/build" ]; then
+    if [ "${SCHWUNG_ALLOW_STALE_MANAGER:-0}" = "1" ]; then
+        echo "SCHWUNG_ALLOW_STALE_MANAGER=1 — shipping the schwung-manager already in the tarball"
+    elif "$REPO_ROOT/scripts/build-manager.sh"; then
         "$REPO_ROOT/scripts/package.sh" && echo "Repackaged tarball with fresh schwung-manager"
     else
-        echo "Warning: schwung-manager build failed, using existing binary in tarball"
+        fail "schwung-manager build failed — refusing to ship a stale one (SCHWUNG_ALLOW_STALE_MANAGER=1 to override)"
     fi
 fi
 


### PR DESCRIPTION
`install.sh`'s manager rebuild is guarded on `command -v go`, so on a machine with Docker but no local Go the whole block evaluates to false and is skipped **in silence** — the only warning sits on the build-failed branch, inside an `if` that never runs. `install.sh local` then uploads whatever `schwung-manager` happens to be sitting in the existing tarball and reports success.

The failure mode is the nasty one: **a manager fix can be deployed, confirmed deployed, and still not be running.** I lost an afternoon to it — a Remote UI fix that provably did not take effect on the device, with the deploy reporting success each time.

It is the same defect the link sidecar already has a war story for in `CLAUDE.md`: *a build step that can be skipped silently defeats every bisect that follows.*

`build.sh` already grew the right logic (local `go`, else a golang container, else a hard error). This:

- lifts that into `scripts/build-manager.sh` so there is **one** builder rather than two that disagree;
- has both callers use it;
- makes `install.sh` **fail** rather than warn — shipping a stale manager now needs `SCHWUNG_ALLOW_STALE_MANAGER=1`, which says so on the way past.

Verified: `scripts/build-manager.sh` builds via the container on a Go-less machine, and `tests/host/test_features_json_preserved.sh` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)