### PR TITLE
Canvas takeover: onPoll, an event on a metronome

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,6 +701,13 @@ in `src/shadow/shadow_ui.js`.** The load-bearing claims, so you know when to loo
   all: no `getParam` on that path, and the card script is its own closure, so it
   cannot see what the module's `drawCell` set. The first module to need it used
   `globalThis` and a staleness stamp, which worked and was a side channel.
+- **A TAKEOVER MUST BE ABLE TO ASK AGAIN, and a frame is not the place.**
+  `draw` and `tick` are DRAW_PATH_HOOKS with the accessors stripped, so a
+  fullscreen canvas could read only on its own input -- and it owns the screen
+  for minutes while a worker finishes or a Remote UI panel edits the same
+  module from a browser. `onPoll` is the event on a metronome: optional, full
+  ctx, at most one call per `CANVAS_POLL_MS` (250ms, ~1% of the budget, the
+  same order as the knob rotation). Read a handful of keys there, never a page.
 - **A module's OTHER draw surface is a CARD, and it FLOATS.** `drawCell` gives it
   one cell; `card_script` gives it the page — a bordered picture raised while a
   knob is held, gone on release. It is centred in the page's **FRAME**, not on

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2442,7 +2442,17 @@ Behavior notes:
 
 - Clicking the parameter enters a dedicated fullscreen canvas view.
 - Set `show_value: false` for button-style canvas entries that should not show a value.
-- The loaded script should expose `globalThis.canvas_overlay` (or `globalThis.canvas_overlays`) with hooks such as `onOpen`, `onMidi`, `tick`, `draw`, `onClose`, `onExit`.
+- The loaded script should expose `globalThis.canvas_overlay` (or `globalThis.canvas_overlays`) with hooks such as `onOpen`, `onMidi`, `tick`, `draw`, `onPoll`, `onClose`, `onExit`.
+- **`draw` and `tick` have `getParam`/`setParam` REMOVED** — one read is ~2.8ms
+  against a 1.68ms whole render, so a per-frame read halves the frame rate of
+  everything on screen. Every other hook keeps them, because those are events.
+- **`onPoll` is the event on a metronome**: optional, full ctx, called at most
+  every `CANVAS_POLL_MS` (250ms) while the takeover is up. It exists because a
+  takeover owns the screen for minutes and things change under it that its own
+  input did not cause — a worker thread finishing, or a Remote UI panel editing
+  the same module from a browser. Without it a takeover tells the truth only
+  when the user touches something, which reads as a device that missed the
+  change. Read a HANDFUL of keys there, not a page.
 
 #### Custom widgets (`drawCell`)
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -19641,6 +19641,9 @@ function openCanvasPreview(paramKey, meta) {
     }
 
     canvasRuntime.ctx = createCanvasRuntimeContext();
+    /* onOpen has just read everything it wants; start the poll metronome here
+     * so the first tick does not read it all again a frame later. */
+    canvasRuntime.pollMs = Date.now();
     invokeCanvasOverlayHook("onOpen", {
         param_key: canvasParamKey,
         module_id: canvasRuntime.moduleId,
@@ -19663,9 +19666,41 @@ function closeCanvasPreview(cancelled) {
     needsRedraw = true;
 }
 
+/*
+ * A TAKEOVER MUST BE ABLE TO ASK AGAIN, AND A FRAME IS NOT THE PLACE.
+ *
+ * draw and tick have the accessors removed on purpose (DRAW_PATH_HOOKS above):
+ * one read is ~2.8ms against a 1.68ms whole render, so an overlay reading per
+ * frame halves its own frame rate and everything drawn with it.
+ *
+ * But a takeover owns the screen for minutes at a stretch, and things change
+ * under it that none of ITS OWN input caused -- a worker thread finishing, a
+ * Remote UI panel in a browser editing the same module. With reads only on
+ * events, the screen tells the truth only when the user touches something,
+ * which reads as "the device did not get the change" rather than as a missing
+ * refresh.
+ *
+ * So `onPoll` is an EVENT ON A METRONOME: the full ctx, at most one call every
+ * CANVAS_POLL_MS. At 250ms a single read is ~1% of the frame budget -- the same
+ * order as the knob rotation, which has always read on a metronome for exactly
+ * this reason. It is OPT-IN: an overlay that does not define it costs nothing,
+ * and one that does is expected to read a HANDFUL of keys, not a page.
+ */
+const CANVAS_POLL_MS = 250;
+
+function pollCanvasOverlay() {
+    if (!canvasRuntime || !canvasRuntime.overlay) return;
+    if (typeof canvasRuntime.overlay.onPoll !== "function") return;
+    const now = Date.now();
+    if (now - (canvasRuntime.pollMs || 0) < CANVAS_POLL_MS) return;
+    canvasRuntime.pollMs = now;
+    invokeCanvasOverlayHook("onPoll", { nowMs: now });
+}
+
 function tickCanvasPreview() {
     if (view !== VIEWS.CANVAS) return;
     invokeCanvasOverlayHook("tick", {});
+    pollCanvasOverlay();
 }
 
 function drawCanvasPreview() {

--- a/tests/host/test_canvas_onpoll_contract.sh
+++ b/tests/host/test_canvas_onpoll_contract.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# A CANVAS TAKEOVER'S ONLY WAY TO ASK AGAIN.
+#
+# `draw` and `tick` are DRAW_PATH_HOOKS and get a ctx with getParam/setParam
+# REMOVED, deliberately: one param read is ~2.8ms against a 1.68ms whole page
+# render, so an overlay reading per frame halves its own frame rate and
+# everything drawn with it.
+#
+# That leaves a takeover able to read only when the user touches something --
+# and a takeover owns the screen for minutes while things change under it that
+# its own input did not cause: a worker thread finishing, a Remote UI panel in
+# a browser editing the same module. The screen then tells the truth only when
+# poked, which reads as the device having missed the change.
+#
+# `onPoll` is the event on a metronome. What must stay true:
+#   * it is NOT a draw-path hook, or it loses the accessors that are its point
+#   * it is throttled by a named constant, not called per frame
+#   * it is opt-in, so an overlay without one costs nothing
+#   * it goes through invokeCanvasOverlayHook, so a throw disables it once
+#     rather than throwing at 60Hz forever
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+F="$ROOT/src/shadow/shadow_ui.js"
+fail=0
+note(){ echo "FAIL: $1"; fail=1; }
+
+grep -q 'DRAW_PATH_HOOKS = new Set(\["draw", "tick"\])' "$F" \
+  || note "DRAW_PATH_HOOKS changed -- onPoll must NOT be in it or it loses getParam"
+grep -q 'const CANVAS_POLL_MS' "$F" || note "CANVAS_POLL_MS is gone -- the poll is unthrottled"
+grep -q 'typeof canvasRuntime.overlay.onPoll !== "function"' "$F" \
+  || note "onPoll is no longer opt-in -- every overlay pays for it"
+grep -q 'invokeCanvasOverlayHook("onPoll"' "$F" \
+  || note "onPoll is not called through invokeCanvasOverlayHook -- a throw would not disable it"
+grep -q 'canvasRuntime.pollMs = Date.now();' "$F" \
+  || note "the metronome is not seeded at onOpen -- the first tick re-reads what onOpen just read"
+
+node --check "$F" 2>/dev/null || note "shadow_ui.js does not parse"
+
+[ "$fail" = 0 ] || exit 1
+echo "PASS: $(basename "$0")  (a takeover can ask again, on a metronome)"


### PR DESCRIPTION
A fullscreen canvas overlay can read params on its **events** — `onOpen`, `onMidi`, `onClose` — and *not* on `draw` or `tick`, which are handed a ctx with the accessors removed. That is right and should stay: one param read is ~2.8 ms against a 1.68 ms whole page render, so an overlay reading per frame halves its own frame rate and everything drawn with it.

It leaves a gap, though, and it is not a small one. **A takeover owns the screen for minutes at a stretch while things change under it that none of its own input caused**: a worker thread finishing a job, or — now that a component can ship a `web_ui.html` — somebody editing the same module from a browser. With reads only on events, the device tells the truth only when poked. It reads as the device having missed the change, not as a missing refresh.

`onPoll` is:

- **optional** — an overlay that does not define it costs nothing;
- given the **full ctx**, because it is an event, not a frame;
- called **at most once every `CANVAS_POLL_MS`** (250 ms, ~1% of the frame budget — the same order as the knob rotation, which has always read on a metronome for exactly this reason);
- dispatched through `invokeCanvasOverlayHook`, so a throw disables it once rather than throwing at 60 Hz forever;
- seeded at `onOpen`, so the first tick does not re-read what `onOpen` just read.

The expectation on the module side is a *handful* of keys, not a page. The first overlay to use it reads its whole progression as one key and buys its dozen-read knob refresh only when that value says the knobs are showing something else.

`tests/host/test_canvas_onpoll_contract.sh` pins the four properties above, including that `onPoll` must **not** be in `DRAW_PATH_HOOKS` — putting it there would remove the accessors that are its entire point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)