### PR TITLE
Remote UI: serve a module's own panel, and keep its derived values live

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -631,6 +631,28 @@ That means:
   Task 5). Bump `min_host_version` in your catalog entry if your
   module depends on it.
 
+#### A module's own panel, and the values that drive it
+
+Any component may ship a `web_ui.html` and the manager serves it. Three rules
+decide whether it actually works:
+
+- **A panel that never appears was FOLDED, not missing.** Section fold state is
+  DERIVED from what the component is, never seeded from a literal — the right
+  default depends on the `custom_ui` message, which arrives after the state is
+  built. Both render paths share one component order (signal flow: `midi_fx1,
+  synth, fx1, fx2`).
+- **`viz.extra_keys` reach the browser.** A widget names a value that owns no
+  cell of its own, and a panel driven by one is blind without them. Every path
+  that completes an initial value send fetches them — there are three, and the
+  `state` fast path returns early, so fixing only the streaming one is
+  invisible.
+- **An extra key is DERIVED, so no write ever names it.** A change to any of a
+  component's params refreshes them (throttled, cached key list, no read at all
+  when nothing is subscribed), and a slow heartbeat carries what no write
+  announces at all — the TRANSPORT. One push per component at a time: two
+  overlapping reads answer in channel order, and the browser then gets an older
+  value after a newer one, which presents as a playhead jumping backwards.
+
 ### Remote UI for overtake tools (the Tool tab)
 
 Overtake tools (dsp.so loaded by the shim as `overtake_dsp`, not a chain slot)

--- a/schwung-manager/remote_ui.go
+++ b/schwung-manager/remote_ui.go
@@ -70,6 +70,17 @@ type RemoteUI struct {
 	// (FX knob drags) bump the rev per set_param, and servicing every kick with
 	// a 64KB read + full push melts the WiFi link. Guarded by mu.
 	lastToolFull time.Time
+
+	// extrasMu guards the viz.extra_keys pump's state, all keyed by
+	// "slot|component": the declared key list (so a push costs one read per key
+	// and not a chain_params read on top of them; invalidated when the slot
+	// poller sees that component's module change), when it last pushed, whether
+	// a push is in flight, and the last value sent for each key.
+	extrasMu    sync.Mutex
+	extrasKeys  map[string][]string
+	extrasLast  map[string]time.Time
+	extrasBusy  map[string]bool
+	extrasValue map[string]string
 }
 
 // ruClient represents a single WebSocket connection.
@@ -317,6 +328,7 @@ func (ru *RemoteUI) Start(ctx context.Context) {
 	go ru.refreshLoop(ctx)
 	go ru.toolTickLoop(ctx)
 	go ru.setRingConnectLoop(ctx)
+	go ru.extrasHeartbeatLoop(ctx)
 }
 
 // setRingConnectLoop connects the web param set ring EAGERLY at startup,
@@ -577,18 +589,32 @@ func (ru *RemoteUI) sendInitialParamValues(ctx context.Context, c *ruClient, slo
 	// "1/0 Preset 0" until all individual params arrive.
 	ru.sendHierarchyParams(ctx, c, slot, comp)
 
-	// Fast path: "all" returns every param in one round-trip.
-	if ru.sendAllParamsAtOnce(ctx, c, slot, comp) {
+	// Read the declaration FIRST: it is what tells us whether the "state"
+	// fast path below is really a param map for this component.
+	params := ru.fetchChainParams(slot, comp)
+
+	// Fast path: "state" returns every param in one round-trip.
+	if all, ok := ru.fetchAllParams(slot, comp); ok && stateCoversParams(all, comp, params) {
+		ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: all})
+		ru.logger.Info("initial params: sent via 'state'", "slot", slot, "comp", comp, "count", len(all))
+		if xb := ru.fetchExtraKeysFrom(slot, comp, params); len(xb) > 0 {
+			ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: xb})
+		}
 		return
 	}
 
-	raw, err := ru.shm.GetParam(slot, comp+":chain_params")
-	if err != nil || raw == "" {
+	if len(params) == 0 {
 		return
 	}
-	var params []chainParam
-	if json.Unmarshal([]byte(raw), &params) != nil {
-		return
+
+	// EXTRAS FIRST. A viz extra key is what a module's own drawing is made of
+	// -- for stacks the whole progression arrives as `prog`, so the roll, the
+	// chord strip and the playhead cannot paint without it. Fetched after the
+	// 53-param sweep it landed ~300ms late and the picture visibly lagged the
+	// selection. The ordinary controls can populate a beat later; the picture
+	// is the thing being looked at.
+	if xb := ru.fetchExtraKeysFrom(slot, comp, params); len(xb) > 0 {
+		ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: xb})
 	}
 
 	ru.logger.Info("initial params: fetching", "slot", slot, "comp", comp, "count", len(params))
@@ -672,19 +698,6 @@ func (ru *RemoteUI) fetchAllParams(slot uint8, comp string) (map[string]string, 
 	return params, true
 }
 
-// sendAllParamsAtOnce sends a component's full param set to one client in a
-// single param_update. Returns true on success. Modules with many params
-// (e.g. Surge ~280) go from ~10s of fetches to one shm round-trip.
-func (ru *RemoteUI) sendAllParamsAtOnce(ctx context.Context, c *ruClient, slot uint8, comp string) bool {
-	params, ok := ru.fetchAllParams(slot, comp)
-	if !ok {
-		return false
-	}
-	ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: params})
-	ru.logger.Info("initial params: sent via 'state'", "slot", slot, "comp", comp, "count", len(params))
-	return true
-}
-
 // broadcastInitialParamValues sends a component's full param set to every
 // subscriber of a slot, reading shared memory ONCE and fanning the result out —
 // instead of re-reading per client. Avoids redundant heavy shm reads (e.g. the
@@ -696,17 +709,22 @@ func (ru *RemoteUI) broadcastInitialParamValues(ctx context.Context, slot uint8,
 		return
 	}
 	hierParams := ru.fetchHierarchyParams(slot, comp)
+	declared := ru.fetchChainParams(slot, comp)
 	allParams, ok := ru.fetchAllParams(slot, comp)
-	if !ok {
-		// No "state" fast path — fall back to per-client streaming (unchanged).
+	if !ok || !stateCoversParams(allParams, comp, declared) {
+		// No usable "state" fast path — fall back to per-client streaming.
 		for _, c := range clients {
 			ru.sendInitialParamValues(ctx, c, slot, comp)
 		}
 		return
 	}
+	extraParams := ru.fetchExtraKeys(slot, comp)
 	for _, c := range clients {
 		if len(hierParams) > 0 {
 			ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: hierParams})
+		}
+		if len(extraParams) > 0 {
+			ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: extraParams})
 		}
 		ru.writeJSON(ctx, c, wsParamUpdate{Type: "param_update", Slot: slot, Params: allParams})
 	}
@@ -814,7 +832,15 @@ func (ru *RemoteUI) handleSetParam(ctx context.Context, c *ruClient, msg wsMessa
 	if len(parts) == 2 {
 		comp := parts[0]
 		paramKey := parts[1]
-		if paramKey == "preset" || paramKey == "preset_index" || strings.HasSuffix(paramKey, "_index") {
+		// A SELECTION KEY IS NOT A GESTURE. The debounce below exists so a
+		// knob DRAG produces one sweep at the end instead of one per sample.
+		// Pointing at a different item is a single discrete act whose whole
+		// purpose is to fetch that item's values, so waiting 250ms and then
+		// sweeping means the panel shows the PREVIOUS item's numbers for
+		// half a second. `sel` is stacks' selected chord; the preset keys
+		// were already here for the same reason.
+		if paramKey == "preset" || paramKey == "preset_index" || paramKey == "sel" ||
+			strings.HasSuffix(paramKey, "_index") {
 			go func() {
 				time.Sleep(50 * time.Millisecond) // Let the plugin process the change
 				// Read shm once and fan out to all subscribers of this slot.
@@ -1633,6 +1659,11 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 	// ("master_fx:fxN") rather than sharing the chain-slot maps above.
 	var lastResendMasterFx time.Time
 	pendingMasterFxResend := make(map[string]bool) // comp -> needs full re-send
+	// A change to ANY of a component's params can move its derived viz.extra
+	// keys, and no write ever names those — see pushExtraKeys. Collected here
+	// and flushed on their own throttle, because they are what a custom panel
+	// draws with.
+	pendingExtras := make(map[uint8]map[string]bool) // slot -> comp -> extras stale
 
 	for {
 		select {
@@ -1647,7 +1678,8 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 		}
 
 		changes := ring.Drain()
-		if len(changes) == 0 && len(pendingResend) == 0 && len(pendingMasterFxResend) == 0 {
+		if len(changes) == 0 && len(pendingResend) == 0 && len(pendingMasterFxResend) == 0 &&
+			len(pendingExtras) == 0 {
 			continue
 		}
 
@@ -1705,6 +1737,12 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 					slotChanges[c.Slot] = m
 				}
 				m[c.Key] = c.Value
+				if i := strings.Index(c.Key, ":"); i > 0 && isChainComponent(c.Key[:i]) {
+					if pendingExtras[c.Slot] == nil {
+						pendingExtras[c.Slot] = make(map[string]bool)
+					}
+					pendingExtras[c.Slot][c.Key[:i]] = true
+				}
 				if i := strings.LastIndex(c.Key, ":"); i >= 0 && c.Key[i+1:] == "preset" {
 					// Only re-push full state when the preset VALUE actually
 					// changed. Some modules (e.g. jv880) re-assert preset on the
@@ -1752,6 +1790,35 @@ func (ru *RemoteUI) notifyLoop(ctx context.Context) {
 					if subscribed {
 						ru.writeJSONTry(ctx, c, update)
 					}
+				}
+			}
+		}
+
+		// Flush the derived values. Cheap (one read per declared extra key, and
+		// most components declare none), so this runs on its own short throttle
+		// rather than sharing the preset re-send's — a panel drawing a picture
+		// from `prog` is the thing the user is looking at while they turn the
+		// jog, and 150ms is the difference between "it follows" and "it lags".
+		if len(pendingExtras) > 0 {
+			for slot, comps := range pendingExtras {
+				subs := ru.subscribedClients(slot)
+				if len(subs) == 0 {
+					delete(pendingExtras, slot)
+					continue // nobody is looking: never touch the param channel
+				}
+				for comp := range comps {
+					// The gate is shared with the heartbeat, so the two can
+					// never have a push of the same component in flight at
+					// once — see extrasGate. A component still inside the
+					// throttle stays pending and goes on the next drain.
+					if !ru.extrasGate(slot, comp, extrasRefreshThrottle) {
+						continue
+					}
+					delete(comps, comp)
+					go ru.pushExtraKeys(ctx, slot, comp, subs)
+				}
+				if len(comps) == 0 {
+					delete(pendingExtras, slot)
 				}
 			}
 		}
@@ -1906,6 +1973,306 @@ func (ru *RemoteUI) activeSlotsAndMasterFx() ([]uint8, bool) {
 // chainParam is the minimal structure we parse from chain_params JSON.
 type chainParam struct {
 	Key string `json:"key"`
+	// A widget may NAME a value that owns no cell — `viz.extra_keys` (see
+	// docs/PARAM_PAGES.md). The knob grid has always read these; the Remote
+	// UI never did, so a module whose panel is driven by one went BLIND in
+	// the browser while working perfectly on the device. Stacks is the case:
+	// its whole progression arrives as the extra key "prog", so the browser
+	// panel drew no chord slots and no add button — with nothing to say why,
+	// because an unfetched key is indistinguishable from an empty one.
+	Viz struct {
+		ExtraKeys []string `json:"extra_keys"`
+	} `json:"viz"`
+}
+
+// extraKeysOf collects the distinct viz.extra_keys named across a component's
+// chain_params, in declaration order, minus any key that already has a param
+// of its own (those are fetched by the main loop).
+func extraKeysOf(params []chainParam) []string {
+	declared := make(map[string]bool, len(params))
+	for _, p := range params {
+		if p.Key != "" {
+			declared[p.Key] = true
+		}
+	}
+	seen := make(map[string]bool)
+	var out []string
+	for _, p := range params {
+		for _, k := range p.Viz.ExtraKeys {
+			if k == "" || declared[k] || seen[k] {
+				continue
+			}
+			seen[k] = true
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// fetchChainParams reads and parses a component's chain_params declaration.
+func (ru *RemoteUI) fetchChainParams(slot uint8, comp string) []chainParam {
+	raw, err := ru.shm.GetParam(slot, comp+":chain_params")
+	if err != nil || raw == "" {
+		return nil
+	}
+	var params []chainParam
+	if json.Unmarshal([]byte(raw), &params) != nil {
+		return nil
+	}
+	return params
+}
+
+// stateCoversParams reports whether a "state" snapshot is actually a map of
+// THIS component's parameters.
+//
+// The fast path's only test used to be that state started with "{", i.e. that
+// it parsed as a JSON object — and a module's state is an OPAQUE save blob
+// that is perfectly entitled to be an object without being a param map.
+// stacks returns {"s": "v6|9|2|..."}: one key, the whole module packed into a
+// string. That parsed, so the fast path "succeeded", pushed the single key
+// midi_fx1:s, AND RETURNED — skipping the sweep that fetches the 53 real
+// params. The browser therefore had no per-chord values at all; its controls
+// fell back to their range minimums, which reads as "the values are wrong"
+// rather than "the values were never sent", and selecting another chord
+// changed nothing because the refetch took the same path.
+//
+// A real param map contains at least one key the component declares. An
+// undeclarable component (no chain_params) can't be checked, so it keeps the
+// old behaviour rather than losing the fast path.
+func stateCoversParams(values map[string]string, comp string, params []chainParam) bool {
+	if len(params) == 0 {
+		return true
+	}
+	for _, p := range params {
+		if p.Key == "" {
+			continue
+		}
+		if _, ok := values[comp+":"+p.Key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// fetchExtraKeysFrom reads the values of the viz.extra_keys named by a
+// component's chain_params. Split from extraKeysOf so the caller that already
+// parsed chain_params does not read them twice.
+func (ru *RemoteUI) fetchExtraKeysFrom(slot uint8, comp string, params []chainParam) map[string]string {
+	extras := extraKeysOf(params)
+	if len(extras) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(extras))
+	for _, k := range extras {
+		fullKey := comp + ":" + k
+		val, err := ru.shm.GetParam(slot, fullKey)
+		if err != nil {
+			continue
+		}
+		out[fullKey] = val
+	}
+	return out
+}
+
+// extrasRefreshThrottle bounds how often a component's viz.extra_keys are
+// re-read because something CHANGED THEM FROM THE DEVICE. A jog spin is a
+// stream of writes; this makes it a stream of ~6 reads a second rather than
+// one per detent, and the device UI is using the same channel.
+const extrasRefreshThrottle = 150 * time.Millisecond
+
+// declaredExtraKeys answers "what does this component publish that has no cell
+// of its own", from a per-component cache.
+//
+// The list is a property of the loaded MODULE, not of its state, so re-reading
+// chain_params for it on every change would double the cost of the one thing
+// this path exists to keep cheap. invalidateExtraKeys drops the entry when the
+// slot poller sees the component's module change, which is the only event that
+// can make it wrong.
+func (ru *RemoteUI) declaredExtraKeys(slot uint8, comp string) []string {
+	k := fmt.Sprintf("%d|%s", slot, comp)
+
+	ru.extrasMu.Lock()
+	if ru.extrasKeys != nil {
+		if keys, ok := ru.extrasKeys[k]; ok {
+			ru.extrasMu.Unlock()
+			return keys
+		}
+	}
+	ru.extrasMu.Unlock()
+
+	keys := extraKeysOf(ru.fetchChainParams(slot, comp))
+
+	ru.extrasMu.Lock()
+	if ru.extrasKeys == nil {
+		ru.extrasKeys = make(map[string][]string)
+	}
+	// Cache the empty answer too: most components declare no extra keys, and
+	// re-asking them on every change is exactly the flood this avoids.
+	ru.extrasKeys[k] = keys
+	ru.extrasMu.Unlock()
+	return keys
+}
+
+func (ru *RemoteUI) invalidateExtraKeys(slot uint8, comp string) {
+	ru.extrasMu.Lock()
+	defer ru.extrasMu.Unlock()
+	if ru.extrasKeys != nil {
+		delete(ru.extrasKeys, fmt.Sprintf("%d|%s", slot, comp))
+	}
+}
+
+// pushExtraKeys re-reads a component's viz.extra_keys and pushes them to the
+// given subscribers.
+//
+// WHY THE NOTIFY RING IS NOT ENOUGH ON ITS OWN. The ring carries the key that
+// was WRITTEN. An extra key is DERIVED — stacks publishes its whole
+// progression as `prog`, computed from the edit that just landed — so no write
+// ever names it and it was never re-read outside an initial value send. The
+// visible result: turn the jog on the device and the browser's chord strip,
+// piano roll and playhead sat on the state they had when the tab was opened,
+// while the ordinary controls beside them updated correctly.
+func (ru *RemoteUI) pushExtraKeys(ctx context.Context, slot uint8, comp string, clients []*ruClient) {
+	defer ru.extrasDone(slot, comp)
+	if len(clients) == 0 {
+		return
+	}
+	keys := ru.declaredExtraKeys(slot, comp)
+	if len(keys) == 0 {
+		return
+	}
+	out := make(map[string]string, len(keys))
+	for _, k := range keys {
+		fullKey := comp + ":" + k
+		val, err := ru.shm.GetParam(slot, fullKey)
+		if err != nil {
+			continue
+		}
+		// Send only what MOVED. The heartbeat below asks twice a second
+		// whether the transport is running; a progression that has not
+		// changed must not become 2 messages a second on the wire.
+		vk := fmt.Sprintf("%d|%s", slot, fullKey)
+		ru.extrasMu.Lock()
+		same := ru.extrasValue != nil && ru.extrasValue[vk] == val
+		if !same {
+			if ru.extrasValue == nil {
+				ru.extrasValue = make(map[string]string)
+			}
+			ru.extrasValue[vk] = val
+		}
+		ru.extrasMu.Unlock()
+		if !same {
+			out[fullKey] = val
+		}
+	}
+	if len(out) == 0 {
+		return
+	}
+	update := wsParamUpdate{Type: "param_update", Slot: slot, Params: out}
+	for _, c := range clients {
+		ru.writeJSONTry(ctx, c, update)
+	}
+}
+
+// extrasGate answers whether a push for this component may START now: not
+// sooner than minInterval since the last one, and never while one is still in
+// flight.
+//
+// The in-flight half is not belt-and-braces. Two overlapping pushes read the
+// same keys and answer in whatever order the param channel serves them, so the
+// browser can receive an OLDER progression after a newer one — which presents
+// as a playhead that jumps backwards and a transport that flickers between
+// running and stopped, i.e. as a module misbehaving rather than as a manager
+// racing itself.
+func (ru *RemoteUI) extrasGate(slot uint8, comp string, minInterval time.Duration) bool {
+	k := fmt.Sprintf("%d|%s", slot, comp)
+	now := time.Now()
+
+	ru.extrasMu.Lock()
+	defer ru.extrasMu.Unlock()
+	if ru.extrasBusy[k] {
+		return false
+	}
+	if last, ok := ru.extrasLast[k]; ok && now.Sub(last) < minInterval {
+		return false
+	}
+	if ru.extrasLast == nil {
+		ru.extrasLast = make(map[string]time.Time)
+	}
+	if ru.extrasBusy == nil {
+		ru.extrasBusy = make(map[string]bool)
+	}
+	ru.extrasLast[k] = now
+	ru.extrasBusy[k] = true
+	return true
+}
+
+func (ru *RemoteUI) extrasDone(slot uint8, comp string) {
+	ru.extrasMu.Lock()
+	defer ru.extrasMu.Unlock()
+	delete(ru.extrasBusy, fmt.Sprintf("%d|%s", slot, comp))
+}
+
+// extrasHeartbeatMs is the SLOW ask, for the changes that no write announces.
+//
+// The change-driven push above covers edits, because an edit is a param write.
+// It cannot cover the TRANSPORT: press play on the Move and the module starts
+// running with nothing written anywhere, so the browser's playhead sat still
+// and its live dot stayed dark while the device was audibly playing. The same
+// is true of anything a worker thread finishes.
+//
+// 500ms is ~6 reads a second on the shared param channel while a panel with
+// extra keys is open, and nothing at all when none is. Only values that
+// actually moved are sent.
+const extrasHeartbeat = 500 * time.Millisecond
+
+func (ru *RemoteUI) extrasHeartbeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(extrasHeartbeat)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if ru.ensureShm() == nil {
+			continue
+		}
+		for slot := uint8(0); slot < 4; slot++ {
+			subs := ru.subscribedClients(slot)
+			if len(subs) == 0 {
+				continue // nobody is looking: never touch the param channel
+			}
+			for _, comp := range componentPrefixes {
+				if len(ru.declaredExtraKeys(slot, comp)) == 0 {
+					continue
+				}
+				if !ru.extrasGate(slot, comp, extrasHeartbeat) {
+					continue
+				}
+				go ru.pushExtraKeys(ctx, slot, comp, subs)
+			}
+		}
+	}
+}
+
+// fetchExtraKeys is fetchExtraKeysFrom for a caller that has not parsed
+// chain_params — the "state" fast paths, which never look at it.
+//
+// EVERY path that completes an initial value send must call one of these.
+// There are three, and the first fix missed two: the fast path RETURNS EARLY
+// on a module whose "state" is a JSON object, which is precisely the shape
+// stacks has ({"s": "v6|..."}), so the streaming loop — and the extras with
+// it — never ran and the panel got exactly one key.
+func (ru *RemoteUI) fetchExtraKeys(slot uint8, comp string) map[string]string {
+	raw, err := ru.shm.GetParam(slot, comp+":chain_params")
+	if err != nil || raw == "" {
+		return nil
+	}
+	var params []chainParam
+	if json.Unmarshal([]byte(raw), &params) != nil {
+		return nil
+	}
+	return ru.fetchExtraKeysFrom(slot, comp, params)
 }
 
 // pollSlot checks for module/hierarchy changes only (infrequent).
@@ -1922,6 +2289,9 @@ func (ru *RemoteUI) pollSlot(ctx context.Context, slot uint8, cache *slotCache) 
 		// Detect module change (loaded/unloaded/swapped).
 		if prev, ok := cache.modules[comp]; !ok || prev != modID {
 			cache.modules[comp] = modID
+			// A different module declares different extra keys — the one event
+			// that can make the cached list wrong.
+			ru.invalidateExtraKeys(slot, comp)
 			ru.broadcastSlotInfo(ctx, slot)
 			if modID != "" {
 				if url := ru.findModuleWebUI(modID); url != "" {

--- a/schwung-manager/static/remote-ui.js
+++ b/schwung-manager/static/remote-ui.js
@@ -6,6 +6,10 @@
     "use strict";
 
     var COMPONENT_KEYS = ["synth", "fx1", "fx2", "midi_fx1"];
+    // The order components are DRAWN in, which is signal flow and not the order
+    // they are enumerated in. Both render paths read this one list; when they
+    // each carried their own, the custom-synth path drew the MIDI FX last.
+    var COMPONENT_ORDER = ["midi_fx1", "synth", "fx1", "fx2"];
     var COMPONENT_LABELS = {
         synth: "Synth",
         fx1: "Audio FX 1",
@@ -33,8 +37,14 @@
                 fx2: makeComponent(),
                 midi_fx1: makeComponent()
             },
-            // Track which component sections are collapsed (true = collapsed).
-            collapsed: { synth: false, fx1: true, fx2: true, midi_fx1: true },
+            // Track which component sections the user has folded. A key is
+            // absent until the header is clicked -- see sectionCollapsed(),
+            // which derives the default from whether the component ships a
+            // panel. Storing `true` here for every non-synth component hid a
+            // MIDI FX's whole web_ui.html behind a one-line disclosure
+            // triangle, below a 3000px synth panel, with nothing to say a
+            // panel was there at all.
+            collapsed: {},
             // Custom web UI URLs, keyed by component ("synth", "fx1", …).
             // A component absent from this map uses the auto-generated UI.
             customUI: {},
@@ -55,7 +65,7 @@
             "master_fx:fx3": makeComponent(),
             "master_fx:fx4": makeComponent()
         },
-        collapsed: { "master_fx:fx1": false, "master_fx:fx2": true, "master_fx:fx3": true, "master_fx:fx4": true },
+        collapsed: {},
         // Keyed by component, exactly as a slot's is: two Master FX positions
         // can each ship a panel and must not collide.
         customUI: {},
@@ -1431,6 +1441,25 @@
         if (needsFullRender) renderSlot();
     }
 
+    /**
+     * Is this component's section folded?
+     *
+     * `state.collapsed[key]` records only what the USER chose -- a key is
+     * absent until the header is clicked. Everything else is DERIVED, because
+     * the right default depends on something that arrives after the state is
+     * built: a component that ships its own web_ui.html must open, or the
+     * panel is invisible and nothing on screen says one exists. That is
+     * exactly how a MIDI FX panel went missing -- the section rendered, folded,
+     * as a single line under a 3000px synth panel. The lead position opens too,
+     * so a slot is never a stack of closed triangles.
+     */
+    function sectionCollapsed(state, compKey, leadKey) {
+        var chosen = state.collapsed[compKey];
+        if (chosen === true || chosen === false) return chosen;
+        if (state.customUI && state.customUI[compKey]) return false;
+        return compKey !== leadKey;
+    }
+
     // ------------------------------------------------------------------
     // Render a single component section
     // ------------------------------------------------------------------
@@ -1454,7 +1483,8 @@
         header.appendChild(arrow);
         header.appendChild(title);
         header.onclick = function () {
-            slots[activeSlot].collapsed[compKey] = !slots[activeSlot].collapsed[compKey];
+            var st = slots[activeSlot];
+            st.collapsed[compKey] = !sectionCollapsed(st, compKey, "synth");
             renderSlot();
         };
         section.appendChild(header);
@@ -1639,14 +1669,14 @@
         if (knobSection) slotContentEl.appendChild(knobSection);
 
         // Render component sections in order: midi_fx, synth, fx1, fx2
-        var compOrder = ["midi_fx1", "synth", "fx1", "fx2"];
         var renderedCount = 0;
-        for (var k = 0; k < compOrder.length; k++) {
-            var compKey = compOrder[k];
+        for (var k = 0; k < COMPONENT_ORDER.length; k++) {
+            var compKey = COMPONENT_ORDER[k];
             var compState = s.components[compKey];
             if (!compState || !compState.module) continue;
 
-            var section = renderComponentSection(compKey, compState, s.collapsed[compKey]);
+            var section = renderComponentSection(
+                compKey, compState, sectionCollapsed(s, compKey, "synth"));
             slotContentEl.appendChild(section);
             renderedCount++;
         }
@@ -2199,18 +2229,24 @@
     }
 
     function renderCustomUI(s) {
-        slotContentEl.appendChild(
-            buildCustomUIFrame("synth", s.customUI.synth, "Custom Module UI"));
-
-        // The other components still render below the synth panel. Each one
-        // draws its own custom UI inside its section if it ships one.
-        for (var k = 0; k < COMPONENT_KEYS.length; k++) {
-            var compKey = COMPONENT_KEYS[k];
-            if (compKey === "synth") continue; // synth is replaced by iframe
+        // SIGNAL-FLOW order, the same one the generated path uses: a MIDI FX
+        // runs BEFORE the synth, so its section belongs above the synth panel.
+        // Rendering the synth iframe first and looping COMPONENT_KEYS after it
+        // put the MIDI FX dead last -- below a panel that measures itself at
+        // ~3000px, which is a long way past "not visible".
+        for (var k = 0; k < COMPONENT_ORDER.length; k++) {
+            var compKey = COMPONENT_ORDER[k];
             var compState = s.components[compKey];
+            if (compKey === "synth") {
+                // The synth's own panel replaces its section entirely.
+                slotContentEl.appendChild(
+                    buildCustomUIFrame("synth", s.customUI.synth, "Custom Module UI"));
+                continue;
+            }
             if (!compState.module) continue;
             slotContentEl.appendChild(
-                renderComponentSection(compKey, compState, s.collapsed[compKey]));
+                renderComponentSection(
+                    compKey, compState, sectionCollapsed(s, compKey, "synth")));
         }
 
         // Slot settings (volume, sends, channels, LFO, …) are module-independent
@@ -2480,7 +2516,9 @@
             var compState = masterFx.components[compKey];
             if (!compState.module) continue;
 
-            var section = renderMasterFxSection(compKey, compState, masterFx.collapsed[compKey]);
+            var section = renderMasterFxSection(
+                compKey, compState,
+                sectionCollapsed(masterFx, compKey, MASTER_FX_KEYS[0]));
             slotContentEl.appendChild(section);
             renderedCount++;
         }
@@ -2513,7 +2551,8 @@
         header.appendChild(arrow);
         header.appendChild(title);
         header.onclick = function () {
-            masterFx.collapsed[compKey] = !masterFx.collapsed[compKey];
+            masterFx.collapsed[compKey] =
+                !sectionCollapsed(masterFx, compKey, MASTER_FX_KEYS[0]);
             renderSlot();
         };
         section.appendChild(header);

--- a/tests/host/test_remote_ui_panel_visible.sh
+++ b/tests/host/test_remote_ui_panel_visible.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# A component that ships a web_ui.html must render its panel, and must render
+# it where signal flow puts it.
+#
+# THE PANEL WAS NEVER MISSING -- it was FOLDED.  The manager sent custom_ui for
+# midi_fx1 with the right URL, the client stored it, the section rendered, and
+# renderComponentSection returned at `if (isCollapsed)` one branch ABOVE the
+# custom-UI branch.  Slot state hard-coded `collapsed: { synth: false,
+# fx1: true, fx2: true, midi_fx1: true }`, a default written for generated rows
+# where folding saves space, so the whole Stacks UI sat behind a one-line
+# disclosure triangle roughly 3000px below the synth panel, with nothing on
+# screen to say a panel existed at all.  Every layer reported success.
+#
+# Two invariants, because fixing only the first still leaves it far off-screen:
+#   1. fold state is DERIVED for an untouched section -- a component with a
+#      panel opens -- and records only what the user actually chose.
+#   2. ONE draw order, signal flow, shared by both render paths.  They each
+#      carried their own list, and the custom-synth path's put midi_fx1 last.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+JS="$ROOT/schwung-manager/static/remote-ui.js"
+[ -f "$JS" ] || { echo "FAIL: $JS not found"; exit 1; }
+
+# --- 1. Behaviour: run the real sectionCollapsed, not a grep of it. ---------
+node - "$JS" <<'NODE'
+const fs = require("fs");
+const src = fs.readFileSync(process.argv[2], "utf8");
+
+const m = src.match(/function sectionCollapsed\(state, compKey, leadKey\)\s*\{[\s\S]*?\n    \}/);
+if (!m) { console.error("FAIL: sectionCollapsed(state, compKey, leadKey) not found"); process.exit(1); }
+const sectionCollapsed = new Function("return (" + m[0] + ")")();
+
+function check(cond, msg) { if (!cond) { console.error("FAIL: " + msg); process.exit(1); } }
+
+// The bug, exactly: a MIDI FX with a panel, nothing touched by the user.
+check(sectionCollapsed({ collapsed: {}, customUI: { midi_fx1: "/x.html" } }, "midi_fx1", "synth") === false,
+      "a component that ships a panel must NOT default to collapsed");
+
+// A component with no panel still folds -- that default was never the problem.
+check(sectionCollapsed({ collapsed: {}, customUI: {} }, "fx1", "synth") === true,
+      "a generated-rows FX section should still default to folded");
+
+// The lead position opens, so a slot is not a stack of closed triangles.
+check(sectionCollapsed({ collapsed: {}, customUI: {} }, "synth", "synth") === false,
+      "the lead component must default to open");
+
+// An explicit user choice WINS in both directions -- including folding a panel
+// away, which is the whole reason the state is stored at all.
+check(sectionCollapsed({ collapsed: { midi_fx1: true }, customUI: { midi_fx1: "/x.html" } }, "midi_fx1", "synth") === true,
+      "a user who folds a panel must keep it folded");
+check(sectionCollapsed({ collapsed: { fx1: false }, customUI: {} }, "fx1", "synth") === false,
+      "a user who opens a generated section must keep it open");
+
+// Master FX reuses the same helper with its own lead key.
+check(sectionCollapsed({ collapsed: {}, customUI: { "master_fx:fx3": "/x.html" } },
+                       "master_fx:fx3", "master_fx:fx1") === false,
+      "a Master FX position with a panel must default to open");
+
+// customUI may be absent entirely on a freshly-built state.
+check(sectionCollapsed({ collapsed: {} }, "fx2", "synth") === true,
+      "a state with no customUI map must not throw");
+
+console.log("  sectionCollapsed: 7 cases OK");
+NODE
+
+# --- 2. Structure: one draw order, shared, signal flow. ---------------------
+order="$(grep -n 'var COMPONENT_ORDER *=' "$JS" || true)"
+[ -n "$order" ] || { echo "FAIL: COMPONENT_ORDER not declared"; exit 1; }
+echo "$order" | grep -q '"midi_fx1", *"synth"' || {
+    echo "FAIL: COMPONENT_ORDER must place midi_fx1 before synth (signal flow)"; exit 1; }
+
+uses="$(grep -c 'COMPONENT_ORDER\[k\]' "$JS" || true)"
+[ "$uses" -ge 2 ] || {
+    echo "FAIL: both render paths must iterate COMPONENT_ORDER (found $uses)"; exit 1; }
+
+# A second hard-coded order is how the two paths drifted apart the first time.
+if grep -q 'compOrder *= *\[' "$JS"; then
+    echo "FAIL: a second hard-coded component order reappeared — use COMPONENT_ORDER"; exit 1
+fi
+
+# The fold default must not be restated as a literal in slot state.
+if grep -qE 'collapsed: *\{ *synth:|collapsed: *\{ *"master_fx' "$JS"; then
+    echo "FAIL: fold state is hard-coded again — it must start empty and be derived"; exit 1
+fi
+
+echo "PASS: a component that ships a panel renders it, open, in signal-flow order"


### PR DESCRIPTION
A component may ship a `web_ui.html` and the manager serves it — but three things stopped a module actually being *usable* through one, and all three reported success while they failed.

### The panel was FOLDED, not missing

Slot state seeded `collapsed: { synth: false, fx1: true, fx2: true, midi_fx1: true }` — a literal written when every non-synth section was generated rows — and `renderComponentSection` returns at `if (isCollapsed)` one branch **above** the custom-UI branch. So a module's entire UI sat behind a one-line triangle, thousands of pixels below the synth panel. Nothing anywhere reported a problem; it looked like the panel had never loaded.

Fold state is **derived** now (`sectionCollapsed()` stores only the user's own choice), because the right default depends on the `custom_ui` message, which arrives *after* the state is built. Both render paths share one `COMPONENT_ORDER` in signal flow (`midi_fx1, synth, fx1, fx2`) — the custom-synth path had its own list that drew MIDI FX last.

### `viz.extra_keys` never reached the browser

The knob grid has always read them — it is how a widget names a value that owns no cell — so a module whose panel is *driven* by one works on the device and goes blind in a browser.

Three paths complete an initial value send, and fixing only the streaming one is invisible because the `state` fast path returns early. That fast path also tested "does `state` parse as a JSON object", which an opaque save blob does — so it pushed one useless key and skipped the sweep entirely. `stateCoversParams` now requires the snapshot to contain at least one key the component actually declares.

### And an extra key is DERIVED, so no write ever names it

The notify ring carries the key that was **written**; a `viz` extra is *computed* from whatever edit landed. So it was re-read only on an initial send: edit on the device and the browser's ordinary controls follow while the picture beside them stays frozen at whatever it was when the tab opened.

A change to any of a component's params now refreshes its extras — throttled to 150 ms, with the declared key list cached per component (dropped when that component's module changes), and **no read at all when nothing is subscribed**. A 500 ms heartbeat carries what no write announces: the **transport**. One push per component at a time, because two overlapping reads answer in channel order and the browser then gets an older value after a newer one — a playhead that jumps backwards, read as a misbehaving module.

`tests/host/test_remote_ui_panel_visible.sh` pins the client rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)