### PR TITLE
Pad block: a canvas takeover owns the pads too, and the release relights them

### DIFF
--- a/docs/SHADOW_UI.md
+++ b/docs/SHADOW_UI.md
@@ -1643,3 +1643,26 @@ and why the shim branch logs nothing: `shadow_log` calls `unified_log`.
 Tests: `tests/host/test_snapshot_plan.sh` (the planner and its counts),
 `test_snapshot_gesture.sh` (the shim branch), `test_snapshot_wiring.sh` (the JS
 wiring and toast geometry), `test_ui_flags_layout.c` (the SHM layout).
+
+## Pad ownership is derived, and the release relights the grid
+
+`host_pad_block(1)` stops pad notes reaching Move and hands them to whoever is
+on screen — for EVERY module, not just the one that asked — so a UI that
+strands it costs every later module the pads until a reboot. `reconcilePadBlock()`
+therefore only ever CLEARS, deriving ownership from what is on screen rather
+than bookkeeping it.
+
+Three things it has to get right:
+
+- **A CANVAS PAGE OWNS THE PADS TOO.** A module page that is a picture takes
+  them in its `onOpen`. Counting only a loaded module UI as an owner meant the
+  block was cleared on the next tick and Move went on handling the pads
+  underneath the overlay — taken and revoked about sixty times a second.
+- **The display must actually be SHOWING.** `view` is where the shadow UI would
+  RESUME, not what is on screen: dismiss it with a view still open and `view`
+  stays put while Move owns the screen again. Testing the view alone keeps the
+  pads blocked for exactly the case this net exists to catch.
+- **The release RELIGHTS the grid.** Move writes a pad LED only when its own
+  value changes, so handing the pads back with the owner's colours still on
+  them — or blank — leaves pads that respond and are invisible. The shim
+  mirrors Move's pad state into overlay SHM; the release replays it, once.

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -19054,12 +19054,72 @@ function moduleClaimedCcs(moduleId) {
  * returns without writing or logging, which is also what lets this restate
  * rather than memoise — the shim drops the flag unilaterally on the
  * display-mode edge and at init, and a JS mirror of that would latch. */
+let padBlockWanted = false;
+
 function reconcilePadBlock() {
-    if (isTextEntryActive()) return;
+    if (typeof host_pad_block !== "function") return;
+    /*
+     * THE DISPLAY MUST ACTUALLY BE SHOWING.
+     *
+     * `view` is where the shadow UI would RESUME, not what is on screen:
+     * dismiss it with a view still open -- Menu, a Track tap, going off to a
+     * sound module -- and `view` stays put while Move owns the screen again.
+     * Testing the view alone keeps the pads blocked for exactly the case this
+     * net exists to catch, which is somebody leaving to use another module.
+     */
+    const shown = (typeof shadow_get_display_mode !== "function")
+                || shadow_get_display_mode() === 1;
     const moduleOwnsPads = view === VIEWS.COMPONENT_EDIT &&
                            loadedModuleUi && loadedModuleUi.tick &&
                            !coRunUiActive();
-    if (!moduleOwnsPads && typeof host_pad_block === "function") host_pad_block(0);
+    /*
+     * A CANVAS TAKEOVER OWNS THE PADS TOO, and this did not know it.
+     *
+     * A module page that is a picture (`type: "canvas"` + `as_page`) takes the
+     * pads in its onOpen -- that is how an overlay puts its own grid under your
+     * hand. With only COMPONENT_EDIT counted as an owner, the reconciler
+     * cleared the block on the very next tick, so Move went on handling the
+     * pads underneath the overlay: every pad press played the track's
+     * instrument and moved Move's selection while the overlay thought it had
+     * them. The block was being taken and revoked ~60 times a second.
+     */
+    const canvasOwnsPads = (view === VIEWS.CANVAS)
+                        || (coRunUiActive() && coRunView === VIEWS.CANVAS);
+    if (shown && (moduleOwnsPads || canvasOwnsPads || isTextEntryActive())) {
+        padBlockWanted = true;
+        return;                       /* leave it to the owner */
+    }
+
+    /* Unconditional, as before: a block stranded by something we never saw
+     * take it still has to come off, and this call is idempotent. */
+    host_pad_block(0);
+
+    /*
+     * GIVE MOVE ITS PAD LEDS BACK, do not just stop blocking.
+     *
+     * Move writes a pad LED only when its OWN value changes, so a pad left in
+     * a colour the overlay chose -- or blanked -- stays that way on that track
+     * until something else moves it. Handing the pads back dark reads as "the
+     * pads are dead": they respond, and they are invisible. It is the same
+     * failure `shadow_restore_knob_leds` exists to prevent for the rings.
+     *
+     * Once, on the release, rather than every tick -- hence the latch above,
+     * which also says we are restoring after an owner we actually saw. The
+     * shim mirrors Move's own pad LED state into overlay SHM continuously, so
+     * what Move wants is already there to be replayed. Doing it HERE rather
+     * than in the owner's close hook is deliberate: that hook is not
+     * guaranteed to run, which is the whole reason this reconciler exists.
+     */
+    if (!padBlockWanted) return;
+    padBlockWanted = false;
+    if (typeof shadow_get_pad_led_snapshot !== "function") return;
+    if (typeof move_midi_internal_send !== "function") return;
+    const snap = shadow_get_pad_led_snapshot();
+    if (!snap) return;
+    for (let note = 68; note <= 99; note++) {
+        const c = snap[String(note)];
+        move_midi_internal_send([0x09, 0x90, note, (c | 0) & 0x7F]);
+    }
 }
 
 function reconcileCcClaim() {

--- a/tests/host/test_pad_block_released.mjs
+++ b/tests/host/test_pad_block_released.mjs
@@ -1,0 +1,142 @@
+/*
+ * PAD BLOCK MUST NOT SURVIVE THE SCREEN THAT ASKED FOR IT.
+ *
+ * `host_pad_block(1)` stops pad notes reaching Move and routes them to whoever
+ * is on screen -- for EVERY module, not just the one that asked. Its two
+ * callers (a canvas overlay and the text-entry keyboard) release it in their
+ * close hooks, which is correct and is not enough: leave by any path that does
+ * not run that hook and the flag is stranded ON, and every module afterwards
+ * silently has no pads until a reboot. Reported from the device as "if I leave
+ * the midi module the pads are not released".
+ *
+ * The fix mirrors the CC claims: DERIVED from what is on screen, never
+ * bookkept, and one-directional -- the host only ever CLEARS, because setting
+ * belongs to whoever wants the pads and a component that has gone cannot clear
+ * anything.
+ *
+ * This lifts the reconciler out of shadow_ui.js and drives it, so the rule is
+ * tested rather than the comment describing it.
+ */
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("../../src/shadow/shadow_ui.js", import.meta.url), "utf8");
+const m = src.match(/let padBlockWanted = false;\s*\nfunction reconcilePadBlock\(\) \{[\s\S]*?\n\}/);
+if (!m) { console.log("FAIL: reconcilePadBlock() not found in shadow_ui.js"); process.exit(1); }
+
+let VIEWS = { CANVAS: "canvas", PARAM_PAGES: "grid", HIERARCHY_EDITOR: "hier",
+              COMPONENT_EDIT: "component" };
+let view, coRunView = null, textActive = false, blocked = null, shown = 1;
+/* A loaded module UI with a tick is the OTHER legitimate owner, and it is the
+ * one this reconciler was originally written for. */
+let loadedModuleUi = null;
+const host_pad_block = (v) => { blocked = v; };
+/* Move's own pad colours, as the shim mirrors them into overlay SHM. */
+const MOVE_PADS = {};
+for (let n = 68; n <= 99; n++) MOVE_PADS[String(n)] = (n % 7) + 1;
+let restored = [];
+const shadow_get_pad_led_snapshot = () => MOVE_PADS;
+const move_midi_internal_send = (m) => restored.push(m);
+const coRunUiActive = () => coRunView !== null;
+const isTextEntryActive = () => textActive;
+/* `view` and `coRunView` are module-level lets in shadow_ui.js; the lifted
+ * function reads both, so both are threaded in as accessors. */
+const shadow_get_display_mode = () => shown;
+const fn = new Function("VIEWS", "host_pad_block", "coRunUiActive",
+                        "isTextEntryActive", "getView", "getCoRunView",
+                        "shadow_get_display_mode", "getLoadedModuleUi",
+                        "shadow_get_pad_led_snapshot", "move_midi_internal_send",
+    m[0].replace(/\bcoRunView\b/g, "getCoRunView()")
+        .replace(/(^|[^\w.])view\b/g, "$1getView()")
+        .replace(/\bloadedModuleUi\b/g, "getLoadedModuleUi()") +
+    "\nreturn reconcilePadBlock;")
+    (VIEWS, host_pad_block, coRunUiActive, isTextEntryActive,
+     () => view, () => coRunView, shadow_get_display_mode, () => loadedModuleUi,
+     shadow_get_pad_led_snapshot, move_midi_internal_send);
+
+let bad = 0;
+const step = (what, setup, wantBlocked) => {
+    setup();
+    fn();
+    const ok = blocked === wantBlocked;
+    console.log(`  ${what.padEnd(46)} pad_block=${String(blocked).padEnd(5)} ${ok ? "ok" : "FAIL want " + wantBlocked}`);
+    if (!ok) bad = 1;
+};
+
+/* The canvas takes the pads and the host leaves it alone while it is up. */
+step("canvas open, module set the flag",
+     () => { view = VIEWS.CANVAS; blocked = 1; }, 1);
+
+/* Leaving to the hierarchy editor WITHOUT the close hook running. */
+step("left the module (no close hook ran)",
+     () => { view = VIEWS.HIERARCHY_EDITOR; }, 0);
+
+/*
+ * The CLEAR stays unconditional on every tick -- that is the existing
+ * behaviour and it is idempotent, and it is also the only thing that can
+ * recover a block stranded by something this reconciler never saw take it.
+ * What must happen exactly ONCE is the LED restore, which the latch governs
+ * and which the last section of this file checks.
+ */
+step("still released on later ticks (idempotent)",
+     () => { blocked = "untouched"; }, 0);
+
+/*
+ * DISMISSING THE SHADOW UI WITH THE CANVAS OPEN. `view` still says CANVAS --
+ * it is where the UI would RESUME, not what is on screen -- so testing the
+ * view alone kept the pads blocked for exactly the case this net exists for:
+ * leaving to use another module.
+ */
+step("canvas open again",
+     () => { view = VIEWS.CANVAS; shown = 1; blocked = 1; }, 1);
+step("shadow UI dismissed -> released",
+     () => { shown = 0; }, 0);
+step("...and stays released while away",
+     () => { blocked = "untouched"; }, 0);
+step("come back to it",
+     () => { shown = 1; blocked = 1; }, 1);
+
+/*
+ * A LOADED MODULE UI owns the pads too -- the case this reconciler was written
+ * for. Pinned here because the canvas support added beside it must not cost
+ * that one.
+ */
+step("module UI on screen with a tick",
+     () => { view = VIEWS.COMPONENT_EDIT; loadedModuleUi = { tick(){} }; blocked = 1; }, 1);
+step("module UI gone -> released",
+     () => { view = VIEWS.HIERARCHY_EDITOR; loadedModuleUi = null; }, 0);
+
+/* Text entry is the other legitimate owner and must not be cut off. */
+step("text entry open",
+     () => { view = VIEWS.PARAM_PAGES; shown = 1; textActive = true; blocked = 1; }, 1);
+step("text entry closed -> released",
+     () => { textActive = false; }, 0);
+
+/* Co-run canvas counts as on screen. */
+step("co-run canvas open",
+     () => { view = VIEWS.PARAM_PAGES; coRunView = VIEWS.CANVAS; blocked = 1; }, 1);
+step("co-run ended -> released",
+     () => { coRunView = null; }, 0);
+
+/*
+ * AND THE PADS COME BACK LIT.
+ *
+ * Move writes a pad LED only when its OWN value changes, so releasing the
+ * block while the grid still holds our colours -- or is blank -- leaves pads
+ * that respond and are invisible. Reported from the device as "the pads are
+ * dead". The shim mirrors Move's state into SHM continuously; the release puts
+ * it back.
+ */
+restored = [];
+view = VIEWS.CANVAS; shown = 1; blocked = 1; fn();     /* on screen */
+view = VIEWS.HIERARCHY_EDITOR; fn();                   /* left */
+const all32 = restored.length === 32;
+const matches = restored.every((m) => m[3] === MOVE_PADS[String(m[2])]);
+const anyLit = restored.some((m) => m[3] !== 0);
+console.log(`  ${"all 32 pads restored".padEnd(46)} ${restored.length} ${all32 ? "ok" : "FAIL"}`);
+console.log(`  ${"to MOVE's colours, not blanked".padEnd(46)} ${matches && anyLit ? "yes  ok" : "no   FAIL"}`);
+if (!all32 || !matches || !anyLit) bad = 1;
+
+console.log("\n" + (bad
+  ? "FAIL: pad_block can outlive the screen that asked for it"
+  : "pad_block is released whenever nothing on screen wants the pads"));
+process.exit(bad);

--- a/tests/host/test_pad_block_released.sh
+++ b/tests/host/test_pad_block_released.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# PAD BLOCK MUST NOT SURVIVE THE SCREEN THAT ASKED FOR IT.
+#
+# host_pad_block(1) stops pad notes reaching Move and routes them to whoever is
+# on screen -- for EVERY module, not just the one that asked. Its callers (a
+# canvas overlay, the text-entry keyboard) release it in their close hooks,
+# which is correct and is not enough: leave by any path that does not run that
+# hook and the flag is stranded ON, and every module afterwards silently has no
+# pads until a reboot.
+#
+# The reconciler mirrors the CC claims -- derived from what is on screen, never
+# bookkept -- and is ONE-DIRECTIONAL: the host only ever clears. Setting
+# belongs to whoever wants the pads; a component that has gone cannot clear
+# anything.
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+if node tests/host/test_pad_block_released.mjs; then
+    echo "PASS: $(basename "$0")  (pad_block cannot outlive its screen)"
+else
+    echo "FAIL: pad_block can be stranded on"; exit 1
+fi


### PR DESCRIPTION
`reconcilePadBlock()` derives pad ownership from what is on screen, which is the right shape — but it counts only a loaded module UI as an owner, and **a canvas page is the other one**.

A module page that is a picture (`type: "canvas"` + `as_page`) takes the pads in its `onOpen`; that is how an overlay puts its own grid under your hand. With only `COMPONENT_EDIT` recognised, the reconciler clears the block on the very next tick — so Move goes on handling the pads *underneath* the overlay: every press plays the track's instrument and moves Move's selection while the overlay believes it has them. Taken and revoked about sixty times a second.

Two more things fall out of doing it properly:

**The display must actually be SHOWING.** `view` is where the shadow UI would *resume*, not what is on screen: dismiss it with a view still open — Menu, a Track tap, going off to a sound module — and `view` stays put while Move owns the screen again. Testing the view alone keeps the pads blocked for exactly the case this net exists to catch, which is somebody leaving to use another module.

**And the pads must come back LIT.** Move writes a pad LED only when its *own* value changes, so releasing the block while the grid still holds the overlay's colours — or is blank — leaves pads that respond and are invisible, which reads as "the pads are dead". It is the same failure `shadow_restore_knob_leds` exists to prevent for the rings. The shim already mirrors Move's pad state into overlay SHM, so the release just replays it.

That restore happens **once**, on the release, which is what the new latch is for. The clear itself stays **unconditional** — it is idempotent, and it is also the only thing that can recover a block stranded by something this reconciler never saw take it, so I did not want to narrow it.

`tests/host/test_pad_block_released.sh` lifts the reconciler out of `shadow_ui.js` and drives it through every ownership transition — canvas, co-run canvas, text entry, and the existing module-UI case, which this must not cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)