### PR TITLE
Canvas: a param may claim the jog click

### DIFF
--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -2435,6 +2435,13 @@ Use `type: "canvas"` to open a module-defined fullscreen canvas UI from the hier
 - `display_value_type` (optional): `string`, `int`, `float`, or `percent` formatting for value display.
 - `canvas_script` (optional): Script path relative to module root (default `canvas.js`), supports `file.js#overlay_name`.
 - `canvas_overlay` (optional): Named overlay object selector (aliases: `canvas_target`, `overlay`).
+- `claims_jog_click` (optional, on the canvas PARAM): the fullscreen canvas
+  steals CC 3 to close itself before the overlay sees it, which is right for a
+  viewer and wrong for an EDITOR whose primary gesture is the click. Declaring
+  it leaves the click to the overlay and makes Back the only way out. Opt-in
+  by design — a param that declares nothing behaves exactly as before — and
+  not honoured in co-run, where the click belongs to the tool sharing the
+  surface.
 - `show_footer` (optional): Show/hide footer in canvas view (default `true`; alias `showfooter`).
 - `show_value` (optional): Show/hide parameter value in hierarchy and canvas footer (default `true`; alias `showvalue`).
 

--- a/src/shadow/shadow_ui.js
+++ b/src/shadow/shadow_ui.js
@@ -26245,8 +26245,29 @@ globalThis.onMidiMessageInternal = function(data) {
      * (wrapped so coRunView returns to the hierarchy editor), mirroring the
      * non-co-run steal below. */
     var canvasInCorun = coRunUiActive() && coRunView === VIEWS.CANVAS;
+    /*
+     * A CANVAS PARAM MAY CLAIM THE JOG CLICK, and then Back is the only exit.
+     *
+     * MoveMainButton is CC 3, and the branch below steals it to close the
+     * fullscreen canvas BEFORE dispatchCanvasMidi runs -- so an overlay can
+     * never see it. That is right for a viewer you look at and leave, and
+     * wrong for an EDITOR meant to be worked in: the click is its primary
+     * gesture, and an overlay that wants it currently cannot have it.
+     *
+     * The opt-in is why this is safe, and it is the same shape as
+     * capabilities.claims_ccs. #154 took Undo/Copy/Delete unconditionally
+     * whenever the shadow display was up and had to be reverted (#175) because
+     * it stole them from everyone. A param declaring nothing behaves exactly
+     * as it does today.
+     *
+     * Not honoured in CO-RUN: there the click belongs to the tool sharing the
+     * surface, and a claim would take it from a peer that never agreed to it.
+     */
+    var canvasClaimsClick = !canvasInCorun && !!(canvasParamMeta &&
+        (canvasParamMeta.claims_jog_click === true ||
+         canvasParamMeta.claimsJogClick === true));
     if ((view === VIEWS.CANVAS || canvasInCorun) && (status & 0xF0) === 0xB0) {
-        if (d1 === MoveMainButton && d2 > 0) {
+        if (d1 === MoveMainButton && d2 > 0 && !canvasClaimsClick) {
             if (canvasInCorun) runCoRunChainEdit(function() { closeCanvasPreview(false); });
             else closeCanvasPreview(false);
             announce("Hierarchy Editor");

--- a/tests/host/test_canvas_claims_jog_click.sh
+++ b/tests/host/test_canvas_claims_jog_click.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# A canvas param may CLAIM the jog click, and then Back is the only exit.
+#
+# MoveMainButton is CC 3 -- the jog click -- and shadow_ui steals it to close
+# the fullscreen canvas BEFORE dispatchCanvasMidi runs, so an overlay can never
+# see it. That is right for a viewer you look at and leave, and wrong for an
+# editor meant to be worked in: the click is its primary gesture.
+#
+# The opt-in is why this is safe. #154 took Undo/Copy/Delete unconditionally
+# whenever the shadow display was up and had to be reverted (#175) because it
+# stole them from everyone; claims_ccs was the capability answer to that, and
+# this is the same shape. So the pins below are BOTH directions: a param that
+# declares nothing must behave exactly as it did before.
+set -uo pipefail
+cd "$(dirname "$0")/../.."
+F=src/shadow/shadow_ui.js
+fail=0
+bad(){ echo "FAIL: $1"; fail=1; }
+
+grep -q 'canvasClaimsClick' "$F" || bad "no canvasClaimsClick gate in shadow_ui.js"
+
+# The gate must sit on the CLOSE, not on the dispatch: the overlay only ever
+# sees the click because the close no longer swallows it.
+grep -q 'd1 === MoveMainButton && d2 > 0 && !canvasClaimsClick' "$F" \
+  || bad "the close still swallows the click unconditionally"
+
+# Declaring nothing must be indistinguishable from today.
+grep -q 'canvasParamMeta.claims_jog_click === true' "$F" \
+  || bad "the claim is not read from the param's own declaration"
+
+# A co-run peer shares the surface and never agreed to give up the click.
+grep -q 'var canvasClaimsClick = !canvasInCorun' "$F" \
+  || bad "the claim is honoured in co-run, where the click belongs to the peer"
+
+node --check "$F" 2>/dev/null || bad "shadow_ui.js does not parse"
+
+[ "$fail" -eq 0 ] || exit 1
+echo "PASS: $(basename "$0")  (a canvas param can claim CC 3, opt-in only)"


### PR DESCRIPTION
`MoveMainButton` is CC 3, and the fullscreen canvas view steals it to close itself **before** `dispatchCanvasMidi` runs — so an overlay can never see the click at all.

That is right for a viewer you look at and leave, and wrong for an **editor** meant to be worked in, where the click is the primary gesture: audition this, commit that, toggle the thing under the cursor. Such an overlay currently cannot have its own most obvious control.

`claims_jog_click: true` on the canvas param opts in, and Back becomes the way out.

The opt-in is the whole safety argument, and it is deliberately the same shape as `capabilities.claims_ccs`: #154 took Undo/Copy/Delete unconditionally whenever the shadow display was up, and had to be reverted in #175 because it stole them from everybody. A param that declares nothing behaves exactly as it does today — which is what `tests/host/test_canvas_claims_jog_click.sh` pins, in both directions.

Not honoured in **co-run**: there the click belongs to the tool sharing the surface, and a claim would take it from a peer that never agreed to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)