### PR TITLE
Pad block: if the pads are yours, so are their lights

### DIFF
--- a/src/host/shadow_constants.h
+++ b/src/host/shadow_constants.h
@@ -274,7 +274,9 @@ typedef struct shadow_control_t {
     volatile uint8_t wake_slots;       /* 1=clear all slot idle flags (auto-clears after read) */
     volatile uint8_t skipback_require_volume; /* 0=Shift+Capture, 1=Shift+Vol+Capture */
     volatile uint8_t preview_cmd;          /* 0=none, 1=play (path in file), 2=stop */
-    volatile uint8_t pad_block;            /* 1=suppress pad notes (68-99) from reaching Move */
+    volatile uint8_t pad_block;            /* 1=pads belong to whoever is on screen: their
+                                              notes do not reach Move, and Move's LED writes
+                                              for 68-99 do not reach the hardware */
     volatile uint8_t suspend_overtake;  /* 1=suspend (skip exit hook), 0=normal exit */
     volatile uint8_t open_tool_cmd;     /* 0=none, 1=open tool (path in /data/UserData/schwung/open_tool_cmd.json) */
     volatile uint8_t shadow_ui_trigger; /* Shadow UI trigger mode: 0=long-press only, 1=Shift+Vol only, 2=both */

--- a/src/host/shadow_led_queue.c
+++ b/src/host/shadow_led_queue.c
@@ -440,6 +440,43 @@ void shadow_clear_move_leds_if_overtake(void) {
 
     prev_overtake_mode = cur_overtake;
 
+    /*
+     * IF THE PADS ARE YOURS, SO ARE THEIR LIGHTS.
+     *
+     * `pad_block` stops pad PRESSES reaching Move and hands them to whoever is
+     * on screen. It said nothing about the LEDs, so Move went on lighting the
+     * pad of every note sounding on the track -- and a MIDI FX plays notes on
+     * that track, so its own chords wrote their pitches onto the grid, on top
+     * of whatever the owner had drawn. Reported from the device as the played
+     * notes "shining through" the pads.
+     *
+     * It cannot be fixed from the owner's side. Its writes are diffed against
+     * what it believes each pad shows, and Move overwriting a pad falsifies
+     * exactly that belief; even reconciling against this cache only turns a
+     * permanent bleed into a fight, because Move re-asserts a pad whose colour
+     * has not changed and the cache cannot see a repaint of the same value.
+     *
+     * So the block owns both directions. Stripped AFTER the caching scan
+     * above, deliberately: `move_note_led_state` keeps tracking what Move
+     * WANTS the grid to look like, which is what the release replays -- the
+     * owner's colours come off and Move's picture comes back without Move ever
+     * having to repaint it.
+     *
+     * Notes only, and only the pad range. This is the same surgery the co-run
+     * block below performs per surface group, with the group being "the pads"
+     * and the claim being pad_block.
+     */
+    if (ctrl && ctrl->pad_block) {
+        for (int i = 0; i < HW_MIDI_OUT_SIZE; i += 4) {
+            if (((midi_out[i] >> 4) & 0x0F) != 0) continue;   /* cable 0 only */
+            uint8_t type = midi_out[i + 1] & 0xF0;
+            uint8_t d1 = midi_out[i + 2];
+            if ((type != 0x90 && type != 0x80) || d1 < 68 || d1 > 99) continue;
+            midi_out[i] = 0; midi_out[i + 1] = 0;
+            midi_out[i + 2] = 0; midi_out[i + 3] = 0;
+        }
+    }
+
     /* During overtake: clear Move's cable-0 LED packets from MIDI_OUT
      * so the overtake module has full LED control.
      * If skip_led_clear is set, let Move's LEDs pass through (e.g. song-mode

--- a/tests/host/test_pad_block_owns_leds.sh
+++ b/tests/host/test_pad_block_owns_leds.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# IF THE PADS ARE YOURS, SO ARE THEIR LIGHTS.
+#
+# `pad_block` hands pad presses to whoever is on screen. It said nothing about
+# the LEDs, so Move went on lighting the pad of every note sounding on the
+# track -- and a MIDI FX plays notes on that track, so its own chords wrote
+# their pitches onto the grid over whatever the owner had drawn.
+#
+# Two properties, and the second is the one that is easy to lose:
+#
+#   * Move's cable-0 note LED writes for 68-99 are STRIPPED while the block is
+#     held, so the owner's picture stands;
+#   * they are stripped AFTER the caching scan, so `move_note_led_state` still
+#     tracks what Move WANTS -- which is what the release replays. Strip before
+#     the scan and the cache goes stale, the release restores a picture from
+#     before the block, and the grid comes back wrong.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+F="$ROOT/src/host/shadow_led_queue.c"
+fail=0
+note(){ echo "FAIL: $1"; fail=1; }
+
+grep -q 'if (ctrl && ctrl->pad_block) {' "$F" \
+  || note "the pad LED strip is gone -- Move's note lighting bleeds through the owner's grid again"
+grep -q 'd1 < 68 || d1 > 99' "$F" \
+  || note "the strip is not bounded to the pad range"
+
+# Order: the caching scan must come FIRST, or the release replays a stale picture.
+python3 - "$F" <<'PY' || fail=1
+import sys
+src = open(sys.argv[1]).read()
+scan = src.index("move_note_led_state[d1] = color;")
+strip = src.index("if (ctrl && ctrl->pad_block) {")
+if not scan < strip:
+    print("FAIL: pad LEDs are stripped BEFORE Move's state is cached -- "
+          "the release would restore a picture from before the block")
+    sys.exit(1)
+PY
+
+# And only Move's own writes: cable 0. Cable 2 is external gear, not the grid.
+grep -q "(midi_out\[i\] >> 4) & 0x0F) != 0" "$F" \
+  || note "the strip is not restricted to cable 0"
+
+[ "$fail" = 0 ] || exit 1
+echo "PASS: $(basename "$0")  (a held pad block owns the pad LEDs too)"


### PR DESCRIPTION
`pad_block` stops pad **presses** reaching Move and hands them to whoever is on screen. It says nothing about the **LEDs** — so Move goes on lighting the pad of every note sounding on the track, and a MIDI FX plays notes on that track. Its own chords write their pitches onto the grid, on top of whatever the owner has drawn. Reported from a device as the played notes *"shining through"* the pads.

**It cannot be fixed from the owner's side**, which is worth saying because that is where I tried first. An owner diffs its pad writes against what it believes each pad shows, and Move overwriting a pad falsifies exactly that belief. Even reconciling against the mirrored Move state only turns a permanent bleed into a fight, because Move re-asserts a pad whose colour has not *changed*, and no cache can see a repaint of the same value.

So the block owns both directions: Move's cable-0 note LED writes for 68–99 are stripped from `MIDI_OUT` while it is held. This is the same surgery the co-run block a few lines below already performs per surface group — the group here being "the pads", and the claim being `pad_block`.

Stripped **after** the caching scan, deliberately: `move_note_led_state` keeps tracking what Move *wants* the grid to look like, which is what the release replays — so the owner's colours come off and Move's picture comes back without Move having to repaint it. `tests/host/test_pad_block_owns_leds.sh` pins that ordering, because reversing it is invisible until the moment somebody leaves the screen and gets a grid from before they arrived.

Pairs with #492, which is what makes the release replay the snapshot in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)