### PR TITLE
catalog: add Sophie percussion synth

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -2128,6 +2128,21 @@
       "default_branch": "main",
       "asset_name": "busdriver-module.tar.gz",
       "min_host_version": "0.9.0"
+    },
+    {
+      "id": "sophie",
+      "name": "Sophie",
+      "description": "Sixteen-pad metallic FM percussion synthesizer with per-pad synthesis, filtering, distortion, and resonant ring delay",
+      "author": "mestela",
+      "component_type": "sound_generator",
+      "subcategory": "drum-machine",
+      "tags": [
+        "fm"
+      ],
+      "github_repo": "mestela/schwung-sophie",
+      "default_branch": "main",
+      "asset_name": "sophie-module.tar.gz",
+      "min_host_version": "1.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Adds Sophie to the Schwung module catalog as a sound generator. Sophie is a sixteen-pad metallic FM percussion synth with per-pad synthesis, filtering, distortion, resonant ring delay, and bundled Movy layout support.

## Release
- Repository: https://github.com/mestela/schwung-sophie
- Release: https://github.com/mestela/schwung-sophie/releases/tag/v0.5.1
- Asset: `sophie-module.tar.gz`
- Minimum Schwung version: v1.0.0

## Validation
- Catalog JSON parses successfully
- Module IDs remain unique
- Release asset is live
- Tested successfully on Move hardware