### PR TITLE
catalog: Bouba-Kiki

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -2149,6 +2149,18 @@
       "default_branch": "main",
       "asset_name": "sophie-module.tar.gz",
       "min_host_version": "1.0.0"
+    },
+    {
+      "id": "bouba-kiki",
+      "name": "Bouba-Kiki",
+      "description": "Contour synth: six geometric controls deform a shape, and the shape is the wave. Six voices, amp ADSR, six presets",
+      "author": "charlesvestal",
+      "component_type": "sound_generator",
+      "subcategory": "fm",
+      "github_repo": "charlesvestal/schwung-bouba-kiki",
+      "default_branch": "main",
+      "asset_name": "bouba-kiki-module.tar.gz",
+      "min_host_version": "1.2.1"
     }
   ]
 }


### PR DESCRIPTION
Adds Bouba-Kiki to the module catalog. First release is [v0.5.0](https://github.com/charlesvestal/schwung-bouba-kiki/releases/tag/v0.5.0); the asset is published and downloads clean.

A contour synthesizer: six geometric controls deform a shape between the Bouba and Kiki silhouettes, and the deformed outline is what the oscillators read — two-operator feedback phase modulation whose operators are geometry rather than sines, with the curve's X and Y as the stereo pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5stx4QXjtN6V3TtHeKj19