### PR TITLE
catalog: host.channels.stable, mirroring the release we already ship

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -6,7 +6,13 @@
     "asset_name": "schwung.tar.gz",
     "latest_version": "1.4.0",
     "download_url": "https://github.com/charlesvestal/schwung/releases/download/v1.4.0/schwung.tar.gz",
-    "min_host_version": "0.1.0"
+    "min_host_version": "0.1.0",
+    "channels": {
+      "stable": {
+        "version": "1.4.0",
+        "download_url": "https://github.com/charlesvestal/schwung/releases/download/v1.4.0/schwung.tar.gz"
+      }
+    }
   },
   "taxonomy": {
     "taxonomy_version": 1,

--- a/tests/host/test_host_channels_mirror_stable.sh
+++ b/tests/host/test_host_channels_mirror_stable.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# host.channels.stable and the top-level host fields describe the SAME
+# release to two different audiences, and nothing in the format makes
+# them agree.
+#
+# A Schwung Manager that predates channel support has no Channels field
+# on CatalogHost, so encoding/json drops the block and it upgrades from
+# host.latest_version / host.download_url. A manager that has it
+# resolves host.channels.stable first and only falls back to the top
+# level when that is absent.
+#
+# So the moment the two disagree the fleet splits in half by manager
+# version, silently, with both halves believing they are on stable.
+# That is not a visible failure — each device offers *a* coherent
+# upgrade — which is exactly why it needs a test rather than care.
+#
+# Only stable is constrained. beta is free to name anything: it is the
+# channel nothing falls back to, and it is meant to run ahead.
+
+node - <<'NODE'
+const fs = require("fs");
+
+const CATALOG = "module-catalog.json";
+const host = JSON.parse(fs.readFileSync(CATALOG, "utf8")).host;
+
+let failures = 0;
+const fail = (msg) => { console.error("FAIL: " + msg); failures++; };
+
+if (!host) {
+  fail(`${CATALOG} has no host block`);
+} else if (!host.channels || !host.channels.stable) {
+  // Absent is valid — an older-shaped catalog resolves entirely through
+  // the top level. Nothing to keep in sync.
+  console.log("host.channels.stable absent — nothing to mirror, OK");
+} else {
+  const s = host.channels.stable;
+  if (s.version !== host.latest_version) {
+    fail(`host.channels.stable.version (${s.version}) != host.latest_version (${host.latest_version}).\n` +
+         `      Managers with channel support would install ${s.version} while older ones install ${host.latest_version}.`);
+  }
+  if (s.download_url !== host.download_url) {
+    fail(`host.channels.stable.download_url != host.download_url.\n` +
+         `      stable: ${s.download_url}\n` +
+         `      top:    ${host.download_url}`);
+  }
+  if (!s.version || !s.download_url) {
+    fail("host.channels.stable must carry both version and download_url; " +
+         "a half-filled entry resolves to an empty download and the upgrade dies with no URL");
+  }
+  if (failures === 0) {
+    console.log(`host.channels.stable mirrors the top level (${s.version}), OK`);
+  }
+}
+
+// A beta, if present, must at least be complete — the resolver reads
+// both fields and a missing download_url is an upgrade with nowhere to go.
+if (host && host.channels && host.channels.beta) {
+  const b = host.channels.beta;
+  if (!b.version || !b.download_url) {
+    fail("host.channels.beta must carry both version and download_url");
+  } else {
+    console.log(`host.channels.beta present (${b.version}), complete, OK`);
+  }
+}
+
+process.exit(failures === 0 ? 0 : 1);
+NODE


### PR DESCRIPTION
A deliberate no-op: it makes the channel block real in production before any beta exists, so the shape is proven against real devices rather than only against a fixture.

```json
"channels": {
  "stable": {
    "version": "1.4.0",
    "download_url": ".../v1.4.0/schwung.tar.gz"
  }
}
```

Identical to `latest_version` / `download_url` directly above it.

## Why it changes nothing

- **Managers without channel support** have no `Channels` field on `CatalogHost`, so `encoding/json` drops the block. They keep reading the top level.
- **Managers with it** (once #390 lands) resolve `channels.stable` first — to the same version and the same URL.
- **A beta user** falls back to stable, because there's no beta to find.

Cutting the first real beta is then one key beside this one, with the shape already exercised.

## The hazard, and the guard

Drift here is invisible. The moment `channels.stable` and `latest_version` disagree, the fleet splits **by manager version** — both halves believing they're on stable, each offering a coherent upgrade, nothing erroring. That's not something to be careful about; it's something to test.

`tests/host/test_host_channels_mirror_stable.sh` derives both sides from the catalog and never restates a version. It also rejects a half-filled entry, which would resolve to an empty `download_url` and die with *"No download URL in catalog"*.

Only `stable` is constrained. `beta` may name anything — it's the channel nothing falls back to, and it's meant to run ahead; it's only checked for completeness.

Mutated four ways to confirm the guard isn't blind:

| mutation | result |
|---|---|
| `channels.stable.version` → `1.3.9` | caught |
| `channels.stable.download_url` → elsewhere | caught |
| `channels.stable` missing `download_url` | caught |
| `channels.beta` with no `download_url` | caught |

Related: #390 (the manager side), charlesvestal/schwung-catalog-site#5 (the metadata side). This one stands alone and is safe to merge before either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JhK7Wrd1UyFQAW5wqtAQ7h