### PR TITLE
catalog: add Acid module

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -2161,6 +2161,19 @@
       "default_branch": "main",
       "asset_name": "bouba-kiki-module.tar.gz",
       "min_host_version": "1.2.1"
+    },
+    {
+      "id": "acid",
+      "name": "Acid",
+      "description": "Dual generative acid-bassline sequencer, blendable algorithms, slot MIDI FX.",
+      "author": "sd88me",
+      "component_type": "midi_fx",
+      "subcategory": "sequencer",
+      "tags": ["bass", "generative"],
+      "github_repo": "sd88me/schwung-acid",
+      "default_branch": "master",
+      "asset_name": "acid-module.tar.gz",
+      "min_host_version": "1.2.0"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the `acid` entry to `module-catalog.json`: a dual generative acid-bassline sequencer (slot MIDI FX) with blendable algorithms.
- Sequence A's Algo 1 reproduces [schwung-tb3po](https://github.com/charlesvestal/schwung-tb3po)'s density/accent/slide/octave model exactly; higher settings blend in a second generator. Two independent sequencers merge into one output via a bipolar Blend knob.
- Tagged `sequencer` / `bass`, `generative` — matching `tb3po`'s taxonomy.

## Test plan
- [x] `module-catalog.json` validated as well-formed JSON
- [x] Entry follows the v2 catalog format and taxonomy vocabulary (`subcategory`/`tags` matched against `taxonomy.json`)
- [ ] CI (`host-tests` incl. `tests/host/test_taxonomy.sh`) — will run on this PR
- Module repo: https://github.com/sd88me/schwung-acid (release v1.1.1, asset `acid-module.tar.gz`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019yVnBrH9cicMgFaoDnJaGW