### PR TITLE
catalog: add Kit Builder module

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -2161,6 +2161,25 @@
       "default_branch": "main",
       "asset_name": "bouba-kiki-module.tar.gz",
       "min_host_version": "1.2.1"
+    },
+    {
+      "id": "kit-builder",
+      "name": "Kit Builder",
+      "description": "Randomly builds, auditions and exports 16-pad drum kits from your Move sample library, with loudness matching and an audition step sequencer",
+      "author": "sd88me",
+      "component_type": "overtake",
+      "subcategory": "sampler-looper",
+      "tags": [
+        "drums",
+        "generative",
+        "needs-assets",
+        "sample-based"
+      ],
+      "github_repo": "sd88me/schwung-kit-builder",
+      "default_branch": "main",
+      "asset_name": "kit-builder-module.tar.gz",
+      "min_host_version": "1.0.0",
+      "requires": "Drum samples in /data/UserData/UserLibrary/Samples (or /data/CoreLibrary/Samples), sorted into role folders (Kick, Snare, Hats, ...)"
     }
   ]
 }


### PR DESCRIPTION
Adds **Kit Builder** to the module catalog.

Kit Builder is an overtake module for building 16-pad drum kits on Move:
draws samples from the User/Core Library by category, lets you audition
and lock the ones that work, re-roll the rest, and even out the levels,
then save — exporting a native Move drum-rack preset (also loads in
MrDrums) and optionally an Akai MPC program.

- `id: kit-builder`, `component_type: overtake`, `subcategory: sampler-looper`
- `min_host_version: 1.0.0` — uses `param_pages/knob_leds.mjs`,
  `shadow_get_overlay_state`, and `move_midi_inject_to_move`, all present
  since schwung v1.0.0 (checked against the tagged history)
- Repo: https://github.com/sd88me/schwung-kit-builder
- Latest release: https://github.com/sd88me/schwung-kit-builder/releases/tag/v1.0.1

Validated the entry against `tools/catalog/taxonomy.mjs`'s rules by hand
(subcategory in `overtake`'s vocabulary, tags known/sorted/deduped, the
`needs-assets` derived tag included because `requires` is set) — `node`
wasn't available to run `tests/host/test_taxonomy.sh` directly, so I ported
its logic to confirm zero errors across the whole catalog, kit-builder
included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016hHu7yqsExtWLF2Nn4U3AD