### PR TITLE
catalog: add an overtake Kit Building subcategory; move kit-builder off Sampler & Looper

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -187,6 +187,10 @@
           "label": "Sampler & Looper"
         },
         {
+          "id": "kit-building",
+          "label": "Kit Building"
+        },
+        {
           "id": "performance-fx",
           "label": "Performance FX"
         }
@@ -2168,7 +2172,7 @@
       "description": "Randomly builds, auditions and exports 16-pad drum kits from your Move sample library, with loudness matching and an audition step sequencer",
       "author": "sd88me",
       "component_type": "overtake",
-      "subcategory": "sampler-looper",
+      "subcategory": "kit-building",
       "tags": [
         "drums",
         "generative",

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -172,6 +172,10 @@
         "label": "Sampler & Looper"
       },
       {
+        "id": "kit-building",
+        "label": "Kit Building"
+      },
+      {
         "id": "performance-fx",
         "label": "Performance FX"
       }


### PR DESCRIPTION
kit-builder (merged in #499) went in as `sampler-looper` because it is the closest of overtake's four subcategories, not because it fits.

Every other module wearing that tag records or loops audio:

| id | what it is |
|---|---|
| twinsampler | dual-grid sampler, auto-slicing |
| oversmack / overwork / overwork-mix | full-surface samplers with step-FX |
| mark | RC-505-style 5-track loop station |

Kit Builder samples nothing and loops nothing. It reads an existing library, randomizes pad assignments, auditions them, evens the levels, and exports a drum-rack preset (plus an optional MPC program). Filing it beside five live samplers makes the chip mean two things.

`tool` / `sampling-editing` is the accurate label in the existing vocabulary, but the wrong `component_type` — Kit Builder genuinely takes the whole surface, so `overtake` is right and the gap is in overtake's list.

## Change
- `taxonomy.json`: add `{"id": "kit-building", "label": "Kit Building"}` to the `overtake` subcategories, after `sampler-looper`.
- `module-catalog.json`: the same entry in the embedded taxonomy block, and `kit-builder`'s `subcategory` repointed. No other module moves.

Edited in place rather than with `sync_taxonomy.mjs --write`, which reformats every entry in the catalog.

## Test plan
- [x] `node tools/catalog/sync_taxonomy.mjs --check` → `taxonomy ok` (this is what fails if the two copies drift)
- [x] `bash tests/host/test_taxonomy.sh` → `PASS: taxonomy`
- [x] Grepped for other consumers of the subcategory ids — only historical plan docs under `docs/plans/`, which record the vocabulary as it was on their date and are deliberately left alone.
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9yyscvx4tac1UTju9ghbB