### PR TITLE
schwung-manager: one builder, and a CI pin that can see it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,16 @@ jobs:
       - uses: actions/checkout@v4
         with: { submodules: recursive, fetch-depth: 0 }
       - uses: docker/setup-buildx-action@v3
+      # "Same path as release.yml" was not quite true: release.yml builds the
+      # manager on the RUNNER first, and package.sh (inside the container)
+      # picks it up from build/. This job skipped that, so the CI tarball never
+      # carried a schwung-manager and nothing downstream could check for one —
+      # the manager was the one shipped component with no CI cover at all,
+      # which is how install.sh came to skip building it in silence for months.
+      - uses: actions/setup-go@v5
+        with: { go-version: '1.26' }
+      - name: Build schwung-manager (Go), as release.yml does
+        run: scripts/build-manager.sh
       - name: Build (same path as release.yml)
         run: |
           docker build -t schwung-builder .
@@ -97,7 +107,8 @@ jobs:
             build/modules/tools/wav-player/dsp.so \
             build/bin/display_ctl \
             build/bin/jack_midi_connect \
-            build/lib/jack/jack_shadow.so ; do
+            build/lib/jack/jack_shadow.so \
+            build/schwung-manager ; do
             printf '%-48s ' "$f"
             test -f "$f" || { echo "MISSING"; exit 1; }
             file "$f" | grep -q 'aarch64' || { echo "WRONG ARCH"; file "$f"; exit 1; }
@@ -169,3 +180,11 @@ jobs:
           # is where a silent skip actually reaches users.
           tar -tzf schwung.tar.gz | grep -q 'schwung/link-subscriber$' || {
             echo "tarball has no link-subscriber — Move->Schwung audio would be dead"; exit 1; }
+          # Same reasoning, same silent skip: install.sh's manager rebuild was
+          # guarded on `command -v go`, so a Docker-only machine shipped
+          # whatever manager was already in the tarball and said "success". The
+          # old pre-split entrypoint still on never-blessed devices launches
+          # $SCHWUNG_DIR/schwung-manager, so a payload without one leaves the
+          # device with no web UI and no way to update itself back out.
+          tar -tzf schwung.tar.gz | grep -q 'schwung/schwung-manager$' || {
+            echo "tarball has no schwung-manager — no web UI, and no way to update off this build"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # go.mod declares `go 1.26`. 1.24 built only because the toolchain
+      # auto-downloads on demand; ci.yml's `go` job pins 1.26 and says to keep
+      # it there. Two pins for one go.mod is how they drift.
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Set version from tag
         run: |
@@ -41,10 +44,14 @@ jobs:
         run: |
           # Built BEFORE Docker: package.sh runs inside the container and
           # picks the binary up from build/ — no tarball injection.
-          mkdir -p build
-          cd schwung-manager
-          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o ../build/schwung-manager -ldflags="-s -w" .
-          echo "Built: schwung-manager ($(wc -c < ../build/schwung-manager | tr -d ' ') bytes)"
+          #
+          # Through the SHARED builder. This step used to carry its own
+          # `go build`, which made three copies of one build (here, build.sh,
+          # install.sh) that were free to disagree — and they did: install.sh's
+          # was guarded on `command -v go` and skipped itself in silence.
+          # This is the copy that ships to every user, so it is the last place
+          # that should have had its own.
+          scripts/build-manager.sh
 
       - name: Build with Docker
         run: |
@@ -55,7 +62,13 @@ jobs:
         run: |
           ls -la schwung.tar.gz
           echo "=== Checking for schwung-manager ==="
-          tar -tzf schwung.tar.gz | grep schwung-manager || echo "WARNING: schwung-manager not in tarball!"
+          # NOT a warning. This was `|| echo "WARNING: ..."`, which is the same
+          # non-check ci.yml already condemns for link-subscriber: "A soft
+          # check on the one file that can rot invisibly is no check." A
+          # release whose tarball has no manager leaves every device that takes
+          # it with no web UI and no way to update itself back out.
+          tar -tzf schwung.tar.gz | grep -q 'schwung/schwung-manager$' || {
+            echo "schwung-manager is not in the tarball — refusing to publish this release"; exit 1; }
           tar -tzvf schwung.tar.gz | head -20
 
       - name: Create Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,24 @@ the only warning sat on the build-FAILED branch, inside an `if` that never ran.
 tarball and reported success, so a manager fix could be deployed, confirmed
 deployed, and still not be running.
 
-`scripts/build-manager.sh` is the single builder for both callers (local `go`,
-else a golang container, else a hard failure), and install.sh now FAILS rather
-than warns: shipping a stale manager takes `SCHWUNG_ALLOW_STALE_MANAGER=1`,
+`scripts/build-manager.sh` is the single builder for all THREE callers (local
+`go`, else a golang container, else a hard failure), and install.sh now FAILS
+rather than warns: shipping a stale manager takes `SCHWUNG_ALLOW_STALE_MANAGER=1`,
 which says so on the way past. Same defect class as the link sidecar's silent
 skip -- a build step that can be skipped silently defeats every bisect after it.
 
+**The third caller is `release.yml`, and it is the one that ships.** Fixing the
+two local scripts and leaving the workflow's own `go build` in place would have
+kept the copies free to disagree on exactly the path users take. Its tarball
+check was `grep schwung-manager || echo "WARNING: ..."` — the same non-check
+ci.yml condemns for link-subscriber — and now fails the release.
+
+**CI could not have caught any of this**, which is why it went unnoticed: the
+`cross-compile` job builds through Docker, where build.sh's manager block is
+skipped by `/.dockerenv`, so the CI tarball never carried a manager for
+anything to check. That job now builds one on the runner exactly as release.yml
+does, checks it is aarch64 with the other artifacts, and verifies it reached the
+tarball. `tests/host/test_manager_build_single_source.sh` pins the shape.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,22 @@ than restating one.
 
 Cross-compile via `${CROSS_PREFIX}gcc` for Move's ARM. See `BUILDING.md`.
 
+### install.sh could skip the manager build in SILENCE
+
+Its rebuild was guarded on `command -v go`, so on a machine with Docker but no
+local Go the whole block evaluated to false and was skipped without a word --
+the only warning sat on the build-FAILED branch, inside an `if` that never ran.
+`install.sh local` then uploaded whatever `schwung-manager` was already in the
+tarball and reported success, so a manager fix could be deployed, confirmed
+deployed, and still not be running.
+
+`scripts/build-manager.sh` is the single builder for both callers (local `go`,
+else a golang container, else a hard failure), and install.sh now FAILS rather
+than warns: shipping a stale manager takes `SCHWUNG_ALLOW_STALE_MANAGER=1`,
+which says so on the way past. Same defect class as the link sidecar's silent
+skip -- a build step that can be skipped silently defeats every bisect after it.
+
+
 ## Testing
 
 Static/regression suite: `for t in tests/{host,shadow,store,build}/*.sh; do bash "$t"; done`

--- a/scripts/build-manager.sh
+++ b/scripts/build-manager.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# Build schwung-manager (Go) for the device: linux/arm64, static.
+#
+# THE SINGLE PLACE THIS IS BUILT.  It used to be built twice, and the two
+# copies did not agree: build.sh preferred a local `go` and fell back to a
+# golang container, while install.sh's rebuild was guarded on
+# `command -v go` alone.  On a machine with Docker but no Go the install
+# block evaluated to false and was skipped in silence — no warning, because
+# the only warning sat on the build-FAILED branch inside an if that never
+# ran — so `install.sh local` uploaded whatever schwung-manager happened to
+# be in the existing tarball and reported success.  A manager fix could then
+# be deployed, verified as deployed, and still not be running.
+#
+# That is the same defect already recorded for the link sidecar in
+# CLAUDE.md: a build step that can be skipped silently defeats every bisect
+# that follows.  So this script is loud and it is shared — a caller gets a
+# fresh binary or a non-zero exit, never a quiet no-op.
+#
+# Usage: scripts/build-manager.sh [output_path]
+#   Default output: <repo>/build/schwung-manager
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT="${1:-$REPO_ROOT/build/schwung-manager}"
+SRC="$REPO_ROOT/schwung-manager"
+
+if [ ! -d "$SRC" ]; then
+    echo "ERROR: $SRC not found" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+
+if command -v go &>/dev/null; then
+    echo "Building schwung-manager with local go..."
+    (cd "$SRC" && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
+        go build -o "$OUT" -ldflags="-s -w" .)
+elif command -v docker &>/dev/null; then
+    echo "Local 'go' not found — building schwung-manager via golang:1.26-bookworm container"
+    mkdir -p "$REPO_ROOT/.cache/go-cache" "$REPO_ROOT/.cache/go-mod-cache"
+    OUT_DIR="$(cd "$(dirname "$OUT")" && pwd)"
+    docker run --rm \
+        -v "$SRC:/src" \
+        -v "$OUT_DIR:/out" \
+        -v "$REPO_ROOT/.cache/go-cache:/gocache" \
+        -v "$REPO_ROOT/.cache/go-mod-cache:/go-mod-cache" \
+        -u "$(id -u):$(id -g)" \
+        -w /src \
+        -e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
+        -e GOCACHE=/gocache -e GOMODCACHE=/go-mod-cache \
+        golang:1.26-bookworm \
+        go build -buildvcs=false -o "/out/$(basename "$OUT")" -ldflags="-s -w" .
+else
+    echo "ERROR: neither 'go' nor 'docker' available — cannot build schwung-manager." >&2
+    exit 1
+fi
+
+[ -s "$OUT" ] || { echo "ERROR: $OUT was not produced" >&2; exit 1; }
+echo "Built: schwung-manager ($(wc -c < "$OUT" | tr -d ' ') bytes)"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -45,34 +45,14 @@ if [ -z "$CROSS_PREFIX" ] && [ ! -f "/.dockerenv" ]; then
     # Build schwung-manager (Go, ARM64 cross-compile) BEFORE the Docker
     # build: package.sh runs inside the container and picks the binary up
     # from build/ via its existing conditional — no tarball injection.
-    # Prefer local `go` (fast); fall back to a golang container.
+    #
+    # ONE BUILDER, because there were two and they did not agree -- see
+    # scripts/build-manager.sh for what that cost.
     if [ -d "$REPO_ROOT/schwung-manager" ]; then
-        echo "=== Building schwung-manager (Go) ==="
-        mkdir -p "$REPO_ROOT/build"
-        if command -v go &>/dev/null; then
-            cd "$REPO_ROOT/schwung-manager"
-            GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$REPO_ROOT/build/schwung-manager" -ldflags="-s -w" .
-            cd "$REPO_ROOT"
-        elif command -v docker &>/dev/null; then
-            echo "Local 'go' not found — building via golang:1.26-bookworm container"
-            mkdir -p "$REPO_ROOT/.cache/go-cache" "$REPO_ROOT/.cache/go-mod-cache"
-            docker run --rm \
-                -v "$REPO_ROOT/schwung-manager:/src" \
-                -v "$REPO_ROOT/build:/out" \
-                -v "$REPO_ROOT/.cache/go-cache:/gocache" \
-                -v "$REPO_ROOT/.cache/go-mod-cache:/go-mod-cache" \
-                -u "$(id -u):$(id -g)" \
-                -w /src \
-                -e GOOS=linux -e GOARCH=arm64 -e CGO_ENABLED=0 \
-                -e GOCACHE=/gocache -e GOMODCACHE=/go-mod-cache \
-                golang:1.26-bookworm \
-                go build -buildvcs=false -o /out/schwung-manager -ldflags="-s -w" .
-        else
-            echo "ERROR: neither 'go' nor 'docker' available — cannot build schwung-manager."
-            echo "       The web manager will be missing from the tarball."
-        fi
-        [ -f "$REPO_ROOT/build/schwung-manager" ] && \
-            echo "Built: schwung-manager ($(wc -c < "$REPO_ROOT/build/schwung-manager" | tr -d ' ') bytes)"
+        "$REPO_ROOT/scripts/build-manager.sh" || {
+            echo "ERROR: schwung-manager build failed."
+            exit 1
+        }
     fi
 
     # Run build inside container

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1160,6 +1160,15 @@ ssh_root_with_retry "if [ ! -L /data/UserData/move-anything ] && [ ! -d /data/Us
 #
 # scripts/build-manager.sh is the shared builder (go, else Docker, else a hard
 # failure). SCHWUNG_ALLOW_STALE_MANAGER=1 opts out deliberately and says so.
+#
+# The `build/` guard is the LAST silent skip in this block, and it is kept
+# deliberately rather than dropped: `install.sh local` needs only
+# schwung.tar.gz (see the local_file check above), so a tarball-only checkout
+# has no build/ tree for package.sh to re-package from. But it says so now --
+# an unexplained skip here is the whole bug in miniature.
+if [ "$use_local" = true ] && [ -d "$REPO_ROOT/schwung-manager" ] && [ ! -d "$REPO_ROOT/build" ]; then
+    echo "No build/ tree — shipping the schwung-manager already in the tarball (run ./scripts/build.sh for a fresh one)"
+fi
 if [ "$use_local" = true ] && [ -d "$REPO_ROOT/schwung-manager" ] && [ -d "$REPO_ROOT/build" ]; then
     if [ "${SCHWUNG_ALLOW_STALE_MANAGER:-0}" = "1" ]; then
         echo "SCHWUNG_ALLOW_STALE_MANAGER=1 — shipping the schwung-manager already in the tarball"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1148,12 +1148,25 @@ ssh_root_with_retry "if [ ! -L /data/UserData/move-anything ] && [ ! -d /data/Us
 # then re-run package.sh — the single packaging authority — instead of
 # injecting into the existing tarball (the old gunzip/append/gzip dance was
 # the third copy of that logic; see the 2026-06-11 cleanup review C-8).
-if [ "$use_local" = true ] && command -v go &>/dev/null && [ -d "$REPO_ROOT/schwung-manager" ] && [ -d "$REPO_ROOT/build" ]; then
-    echo "Rebuilding schwung-manager..."
-    if (cd "$REPO_ROOT/schwung-manager" && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$REPO_ROOT/build/schwung-manager" -ldflags="-s -w" .); then
+#
+# THE `go` GUARD WAS THE BUG. This was `command -v go && ...`, so on a machine
+# with Docker but no local Go the whole block evaluated to false and was
+# skipped IN SILENCE -- the only warning sat on the build-failed branch INSIDE
+# an if that never ran. `install.sh local` then uploaded whatever
+# schwung-manager happened to be in the existing tarball and reported success,
+# so a manager fix could be deployed, confirmed deployed, and still not be
+# running. Same defect the link sidecar already has a war story for: a build
+# step that can be skipped silently defeats every bisect that follows.
+#
+# scripts/build-manager.sh is the shared builder (go, else Docker, else a hard
+# failure). SCHWUNG_ALLOW_STALE_MANAGER=1 opts out deliberately and says so.
+if [ "$use_local" = true ] && [ -d "$REPO_ROOT/schwung-manager" ] && [ -d "$REPO_ROOT/build" ]; then
+    if [ "${SCHWUNG_ALLOW_STALE_MANAGER:-0}" = "1" ]; then
+        echo "SCHWUNG_ALLOW_STALE_MANAGER=1 — shipping the schwung-manager already in the tarball"
+    elif "$REPO_ROOT/scripts/build-manager.sh"; then
         "$REPO_ROOT/scripts/package.sh" && echo "Repackaged tarball with fresh schwung-manager"
     else
-        echo "Warning: schwung-manager build failed, using existing binary in tarball"
+        fail "schwung-manager build failed — refusing to ship a stale one (SCHWUNG_ALLOW_STALE_MANAGER=1 to override)"
     fi
 fi
 

--- a/tests/host/test_manager_build_single_source.sh
+++ b/tests/host/test_manager_build_single_source.sh
@@ -86,11 +86,25 @@ fi
 # ------------------------------------- 5. a missing binary FAILS, never warns
 # ci.yml says it in its own words, about link-subscriber: "A soft check on the
 # one file that can rot invisibly is no check."
+#
+# Asserted POSITIVELY -- the check must reach an `exit 1` -- not as the absence
+# of `|| echo`. The historical bug was a one-liner (`grep schwung-manager ||
+# echo "WARNING: ..."`), and the first draft of this pin, written against that
+# shape, passed happily when the same softening came back across two lines.
+# What matters is that the workflow STOPS, not which way it was written.
+hard_fails_on_missing_manager() {
+  awk '
+    /^[[:space:]]*#/            { next }
+    /schwung-manager/ && /grep/ { pending = 3 }
+    pending > 0                 { if ($0 ~ /exit 1/) { ok = 1; pending = 0 } else { pending-- } }
+    END                         { exit !ok }
+  ' "$1"
+}
 for f in .github/workflows/release.yml .github/workflows/ci.yml; do
-  if has "$f" 'schwung-manager.*\\|\\|[[:space:]]*echo'; then
-    bad "$f warns instead of failing when schwung-manager is missing from the tarball"
+  if hard_fails_on_missing_manager "$f"; then
+    ok "$f FAILS when schwung-manager is missing from the tarball"
   else
-    ok "$f does not soft-warn about a missing schwung-manager"
+    bad "$f does not fail when schwung-manager is missing from the tarball -- a warning is not a check"
   fi
 done
 

--- a/tests/host/test_manager_build_single_source.sh
+++ b/tests/host/test_manager_build_single_source.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# scripts/build-manager.sh is THE builder for the manager binary, and it is
+# LOUD: local go, else a golang container, else a non-zero exit.
+#
+# It exists because there were THREE builders and they did not agree.
+# install.sh's was guarded on `command -v go`, so on a machine with Docker and
+# no local Go the whole block evaluated to false and was skipped IN SILENCE --
+# the only warning sat on the build-FAILED branch, inside an `if` that never
+# ran. `install.sh local` then uploaded whatever schwung-manager happened to be
+# in the tarball already and reported success, so a manager fix could be
+# deployed, confirmed deployed, and still not be running. An afternoon went
+# into a Remote UI fix that provably never reached the device.
+#
+# This pins the shape that cannot regress quietly: one builder, no `go` guard
+# in front of it, every caller through it, and a HARD check that the binary
+# reached the tarball -- the rules the link sidecar earned the same way.
+
+status=0
+ok()  { printf 'PASS: %s\n' "$1"; }
+bad() { printf 'FAIL: %s\n' "$1" >&2; status=1; }
+
+# A comment is prose about the bug: it must neither satisfy a pin nor trip one.
+# awk on a file argument, never a pipeline -- a `grep -q` closing a pipe early
+# under `set -o pipefail` is how the first draft of this test silently stopped
+# scanning after its first hit.
+# Exit 0 = matched, 1 = did not. Anything else is awk refusing the pattern,
+# which must NOT read as "did not match" -- a broken regex reporting PASS is
+# how a pin comes to measure nothing.
+has() {
+  local rc=0
+  awk -v pat="$2" '/^[[:space:]]*#/ { next } $0 ~ pat { found = 1 } END { exit !found }' "$1" || rc=$?
+  if [ "$rc" -gt 1 ]; then
+    printf 'FAIL: awk rejected the pattern %s (test bug, not a source finding)\n' "$2" >&2
+    exit 2
+  fi
+  return "$rc"
+}
+
+scanned_files() { git ls-files 'scripts/*.sh' '.github/workflows/*.yml'; }
+
+# ----------------------------------------------------------------- 1. builder
+if [ -x scripts/build-manager.sh ]; then
+  ok "scripts/build-manager.sh exists and is executable"
+else
+  bad "scripts/build-manager.sh must exist and be executable"
+fi
+
+# -------------------------------------------------- 2. it is the ONLY builder
+# ci.yml's `go build ./...` is a compile check, not the artifact -- the rule is
+# about a build naming schwung-manager as its OUTPUT.
+offenders=""
+for f in $(scanned_files); do
+  case "$f" in scripts/build-manager.sh) continue ;; esac
+  if has "$f" 'go build.*-o[[:space:]]+[^[:space:]]*schwung-manager'; then
+    offenders="$offenders $f"
+  fi
+done
+if [ -z "$offenders" ]; then
+  ok "one builder: nothing but build-manager.sh compiles the manager binary"
+else
+  bad "a second manager builder is back in:$offenders -- call scripts/build-manager.sh instead"
+fi
+
+# -------------------------------------------------- 3. every caller uses it
+for f in scripts/build.sh scripts/install.sh .github/workflows/release.yml; do
+  if has "$f" 'build-manager\.sh'; then
+    ok "$f builds the manager through the shared builder"
+  else
+    bad "$f does not call scripts/build-manager.sh"
+  fi
+done
+
+# --------------------------------------------- 4. no `go` guard in install.sh
+# THE GUARD WAS THE BUG: `command -v go` in front of the block is what made a
+# Docker-only machine skip it without a word.
+if has scripts/install.sh 'command -v go'; then
+  bad "install.sh gates the manager rebuild on 'command -v go' again -- that guard IS the silent skip"
+else
+  ok "install.sh does not gate the manager rebuild on a local 'go'"
+fi
+
+# ------------------------------------- 5. a missing binary FAILS, never warns
+# ci.yml says it in its own words, about link-subscriber: "A soft check on the
+# one file that can rot invisibly is no check."
+for f in .github/workflows/release.yml .github/workflows/ci.yml; do
+  if has "$f" 'schwung-manager.*\\|\\|[[:space:]]*echo'; then
+    bad "$f warns instead of failing when schwung-manager is missing from the tarball"
+  else
+    ok "$f does not soft-warn about a missing schwung-manager"
+  fi
+done
+
+# ----------------------------------- 6. CI actually looks inside the tarball
+# Without this the fix ships unpinned: cross-compile builds through Docker,
+# where build.sh's manager block is skipped by /.dockerenv, so the CI tarball
+# never carried a manager for anything to check.
+if has .github/workflows/ci.yml 'schwung/schwung-manager\\$'; then
+  ok "CI verifies schwung-manager reached the packaged tarball"
+else
+  bad "CI does not verify schwung-manager reached the tarball"
+fi
+
+exit $status

--- a/tests/host/test_old_entrypoint_payload_compat.sh
+++ b/tests/host/test_old_entrypoint_payload_compat.sh
@@ -48,7 +48,13 @@ done
 contains() {
     # $1 = file, $2 = literal substring (matched with index(), not a regex,
     # so a "." or "/" in a path is never accidentally a wildcard)
-    awk -v pat="$2" 'index($0, pat) { found = 1 } END { exit !found }' "$1" 2>/dev/null
+    #
+    # COMMENT LINES ARE SKIPPED. These scripts carry long comments naming the
+    # very paths this pin looks for, so without the skip a row is satisfiable
+    # by prose ABOUT the build step instead of the build step: deleting
+    # build.sh's call to scripts/build-manager.sh, leaving the comment above
+    # it, passed.
+    awk -v pat="$2" '/^[[:space:]]*#/ { next } index($0, pat) { found = 1 } END { exit !found }' "$1" 2>/dev/null
 }
 
 # ---- 1. the old entrypoint, vendored verbatim (git show e1bdf967:src/shim-entrypoint.sh) ----
@@ -300,13 +306,21 @@ esac
 #
 # path | build.sh substring | package.sh substring | build/ artifact (for the
 # local-only extra check; "-d" prefix means directory, else a plain file)
+#
+# schwung-manager is the one row whose build.sh substring is a CALL rather
+# than an output path: build.sh delegates to scripts/build-manager.sh, the
+# single builder (there were three, and the install.sh one was skipped in
+# silence on a Docker-only machine). The other half of that row -- that the
+# shared builder still writes build/schwung-manager, where package.sh looks
+# -- is asserted separately below, or this row would pass on a builder that
+# had quietly started emitting somewhere else.
 check_spec='
 schwung-shim.so|build/schwung-shim.so|./schwung-shim.so|build/schwung-shim.so
 shim-entrypoint.sh|shim-entrypoint.sh ./build/|./shim-entrypoint.sh|build/shim-entrypoint.sh
 bin/schwung-heal|build/bin/schwung-heal|./bin|build/bin/schwung-heal
 lib|./build/lib/|./lib|-dbuild/lib
 display-server|build/display-server|./display-server|build/display-server
-schwung-manager|build/schwung-manager|./schwung-manager|build/schwung-manager
+schwung-manager|build-manager.sh|./schwung-manager|build/schwung-manager
 bin/filebrowser|./build/bin/|./bin|build/bin/filebrowser
 '
 
@@ -346,6 +360,21 @@ while IFS='|' read -r dep build_pat pkg_pat artifact; do
 done <<EOF
 $check_spec
 EOF
+
+# ---- 6. the indirection's far end: the shared builder's default output ----
+# The schwung-manager row above proves build.sh still CALLS the builder. This
+# proves the builder still puts the binary where package.sh picks it up. Split
+# in two because a call that builds to the wrong path and a path built by
+# nobody are different regressions with the same symptom: a device whose web
+# update silently ships it no manager.
+BUILD_MANAGER_SH="${BUILD_MANAGER_SH:-scripts/build-manager.sh}"
+if [ ! -f "$BUILD_MANAGER_SH" ]; then
+    say_fail "schwung-manager -- $BUILD_MANAGER_SH is missing; nothing builds the manager"
+elif contains "$BUILD_MANAGER_SH" "build/schwung-manager"; then
+    say_pass "schwung-manager -- $BUILD_MANAGER_SH still writes build/schwung-manager"
+else
+    say_fail "schwung-manager -- $BUILD_MANAGER_SH no longer writes build/schwung-manager, which is where package.sh looks"
+fi
 
 if [ "$fails" -eq 0 ]; then
     say_pass "old pre-split entrypoint's payload dependencies (${hard_deps# } | guarded:${guarded_deps# }) are all still built and packaged -- a never-blessed device's next web update will not brick it"


### PR DESCRIPTION
Supersedes #489 (@rgeissen) — his two commits are the first two here, unchanged and with authorship intact. #489 cannot go green on its own: it trips `tests/host/test_old_entrypoint_payload_compat.sh`, which matched the literal `build/schwung-manager` in build.sh that the delegation removes. That pin is right to exist (the pre-split entrypoint still on never-blessed devices launches `$SCHWUNG_DIR/schwung-manager`), so it is taught the indirection rather than relaxed.

His diagnosis is correct and verified: `install.sh`'s manager rebuild was guarded on `command -v go`, so a machine with Docker and no local Go skipped the whole block **in silence** — the only warning sat on the build-FAILED branch inside an `if` that never ran — and `install.sh local` then shipped whatever manager was already in the tarball and reported success. A manager fix could be deployed, confirmed deployed, and still not be running. It cost him an afternoon on a Remote UI fix.

## What this adds

**The third builder was still there, and it is the one that ships.** `release.yml` carried its own `go build` for every tagged release, so "one builder" was still two — disagreeing precisely on the path users take. It goes through `scripts/build-manager.sh` now, and its Go pin moves 1.24 → 1.26 to match `go.mod` (it built only because the toolchain auto-downloads; `ci.yml`'s `go` job already says keep it ≥ 1.26).

**Its tarball check was a warning:** `grep schwung-manager || echo "WARNING: ..."` — the same non-check `ci.yml` already condemns for link-subscriber in its own words, *"A soft check on the one file that can rot invisibly is no check."* It fails the release now.

**CI could not have caught any of this, which is why nobody did.** The `cross-compile` job's comment says it reuses "the exact Docker build path that release.yml runs" — but release.yml builds the manager on the *runner* first and `package.sh` picks it up inside the container, and this job skipped that step. So the CI tarball never carried a manager, and the one shipped component with no CI cover at all is the one that quietly stopped being built. That job now builds it as release.yml does, checks it is aarch64 alongside the other artifacts, and verifies it reached the tarball.

**`install.sh`'s remaining `[ -d build ]` skip is kept but made loud.** `install.sh local` needs only `schwung.tar.gz`, so a tarball-only checkout genuinely has nothing to re-package from — but an unexplained skip there is this whole bug in miniature.

## Verification

- `scripts/build-manager.sh` exercised both ways on this machine: local `go` (1.3 s) and, with `go` masked off `PATH`, the `golang:1.26-bookworm` container. Both produce `ELF 64-bit LSB executable, ARM aarch64, statically linked`. The no-toolchain path exits 1 with a message.
- `tests/host`: 318/318 shell tests pass, `make -C tests/host test` green.
- `tests/host/test_manager_build_single_source.sh` is new and **mutation-tested — 11 mutations, all caught**: builder deleted / not executable; each of the three callers ceasing to call it; the `command -v go` guard returning; a second `go build` reappearing; and the tarball check softened in three different ways.
  Two of those mutations found real weaknesses in the pin's first draft, both fixed here: a `grep -q` closing a pipe under `pipefail` made it stop scanning after its first hit, and an assertion written against the historical one-liner passed when the same softening returned across two lines (it now asserts the workflow reaches `exit 1`, positively).
- `test_old_entrypoint_payload_compat.sh`'s `contains` now skips comment lines — deleting build.sh's call while leaving the comment above it used to pass.

Not deployed to hardware; this is build/CI plumbing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZpnGqV5Jxb8EuTddpeNJ1