### PR TITLE
catalog: overtake's fifth subcategory is Utility, not Kit Building

### DIFF
--- a/module-catalog.json
+++ b/module-catalog.json
@@ -187,12 +187,12 @@
           "label": "Sampler & Looper"
         },
         {
-          "id": "kit-building",
-          "label": "Kit Building"
-        },
-        {
           "id": "performance-fx",
           "label": "Performance FX"
+        },
+        {
+          "id": "utility",
+          "label": "Utility"
         }
       ]
     },
@@ -2172,7 +2172,7 @@
       "description": "Randomly builds, auditions and exports 16-pad drum kits from your Move sample library, with loudness matching and an audition step sequencer",
       "author": "sd88me",
       "component_type": "overtake",
-      "subcategory": "kit-building",
+      "subcategory": "utility",
       "tags": [
         "drums",
         "generative",

--- a/taxonomy.json
+++ b/taxonomy.json
@@ -172,12 +172,12 @@
         "label": "Sampler & Looper"
       },
       {
-        "id": "kit-building",
-        "label": "Kit Building"
-      },
-      {
         "id": "performance-fx",
         "label": "Performance FX"
+      },
+      {
+        "id": "utility",
+        "label": "Utility"
       }
     ]
   },


### PR DESCRIPTION
Follow-up to #501, which gave `kit-builder` a `kit-building` subcategory. That is a label with one member, not a category — the next overtake module that is neither a controller, a sequencer, a sampler nor an FX unit would have needed a second one-member id beside it.

`utility` is the generic bucket, and it already exists as `audio_fx`'s last entry, so the vocabulary gains no new concept and the chip reads the same way in both lists. Placed last, matching `audio_fx`, where the specific subcategories come first and the catch-all closes the list.

`kit-builder`'s reason for leaving `sampler-looper` is unchanged: it records nothing and loops nothing — it reads an existing library, randomizes pad assignments, auditions them, evens the levels, and exports a drum-rack preset.

## Change
- `taxonomy.json`: `kit-building` out, `{"id": "utility", "label": "Utility"}` in, after `performance-fx`.
- `module-catalog.json`: same in the embedded taxonomy block; `kit-builder` → `"subcategory": "utility"`. No other module moves.

## Test plan
- [x] `node tools/catalog/sync_taxonomy.mjs --check` → `taxonomy ok` (fails if the two copies drift)
- [x] `bash tests/host/test_taxonomy.sh` → `PASS: taxonomy`
- [x] `kit-building` appears nowhere in the tree after the change
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W9yyscvx4tac1UTju9ghbB