### PR TITLE
manager: a stale catalog offered a host DOWNGRADE as an update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1467,6 +1467,25 @@ IP and a QR of `http://<ip>:7700`. The old on-device store module is retired
 
 Catalog: `https://raw.githubusercontent.com/charlesvestal/schwung/main/module-catalog.json`.
 
+**The catalog is served from an UNTIMED disk cache when the fetch fails, and
+the host check was not a version comparison.** `manager-cache/catalog.json` is
+last-known-good with no TTL — deliberately, so a device with no network can
+still repair and remove modules — but `/modules` rendered it with nothing
+saying so. Meanwhile both host checks were `offered != installed`, so a device
+that had cached the catalog before 2026-08-31, when host `latest_version` was
+still **1.0.0**, showed *"1.0.0 available"* against an installed 1.4.0 with an
+Upgrade button pointing at the v1.0.0 tarball: an offered DOWNGRADE, on
+month-old data, one click away. Modules never had it — they resolve through
+`updateAvailable()`, which dates the releases and falls back to
+`versionNewer`; `hostOfferIsUpdate` is the host arriving at the same rule. A
+stale render now says **Offline** and how old the copy is, because the silence
+is what made it read as a real release rather than as a device that cannot
+reach GitHub. `"unknown"` installed still gets offered (nothing to compare,
+and refusing strands a device that cannot name what it runs).
+`schwung-manager/host_update_test.go` renders the page against a backdated
+cache — the comparison alone passes either way, since the defect was in what
+the handler COMPOSED.
+
 **Shim mirror + stuck-shim repair (web update).** The manager runs as `ableton`
 and can't write `/usr/lib`, so a web update mirrors the new shim via the
 setuid-root `schwung-heal` helper (synchronously in `post-update.sh` + the

--- a/schwung-manager/host_update_test.go
+++ b/schwung-manager/host_update_test.go
@@ -1,0 +1,257 @@
+// The host update check, and the stale-catalog condition that made it lie.
+//
+// Field report: a device running 1.4.0 showed "1.0.0 available" with an
+// Upgrade button. Nothing was wrong with the published catalog — the
+// device could not reach it, so the manager served its untimed on-disk
+// cache, saved before 2026-08-31 when host latest_version WAS 1.0.0. The
+// check was `offered != installed`, which is not a version comparison, so
+// an offered downgrade rendered as an update.
+
+package main
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHostOfferIsUpdate(t *testing.T) {
+	cases := []struct {
+		name      string
+		offered   string
+		installed string
+		want      bool
+	}{
+		// The regression. Was true — an Upgrade button pointing at the
+		// v1.0.0 tarball, one click from downgrading a 1.4.0 device.
+		{"stale catalog offers an older host", "1.0.0", "1.4.0", false},
+		{"stale catalog offers an older patch", "1.3.3", "1.4.0", false},
+		{"up to date", "1.4.0", "1.4.0", false},
+		{"newer minor", "1.5.0", "1.4.0", true},
+		{"newer patch", "1.4.1", "1.4.0", true},
+		{"newer major", "2.0.0", "1.4.0", true},
+		{"v prefix on either side is not a difference", "v1.4.0", "1.4.0", false},
+		// Beta users: the resolver hands us the beta build, and the
+		// prerelease ordering is versionNewer's, not ours.
+		{"beta ahead of installed stable", "1.5.0-beta.1", "1.4.0", true},
+		{"beta behind installed stable", "1.4.0-beta.1", "1.4.0", false},
+		{"later beta over earlier beta", "1.5.0-beta.2", "1.5.0-beta.1", true},
+		{"earlier beta over later beta", "1.5.0-beta.1", "1.5.0-beta.2", false},
+		// An unreadable version.txt still gets offered the update: there
+		// is nothing to compare, and refusing would strand a device that
+		// cannot say what it runs.
+		{"unknown installed version still offers", "1.4.0", "unknown", true},
+		// Nothing to offer, or nothing to compare against.
+		{"no offer", "", "1.4.0", false},
+		{"no installed version", "1.4.0", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hostOfferIsUpdate(tc.offered, tc.installed); got != tc.want {
+				t.Errorf("hostOfferIsUpdate(%q, %q) = %v, want %v",
+					tc.offered, tc.installed, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHumanizeAge(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "just now"},
+		{time.Minute, "1 minute ago"},
+		{90 * time.Second, "1 minute ago"},
+		{45 * time.Minute, "45 minutes ago"},
+		{time.Hour, "1 hour ago"},
+		{5 * time.Hour, "5 hours ago"},
+		{24 * time.Hour, "1 day ago"},
+		{15 * 24 * time.Hour, "15 days ago"},
+	}
+	for _, tc := range cases {
+		if got := humanizeAge(tc.d); got != tc.want {
+			t.Errorf("humanizeAge(%v) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// writeCatalogCache plants a catalog in the on-disk cache, backdated, the
+// way a device that fetched successfully weeks ago would have it.
+func writeCatalogCache(t *testing.T, base, body string, age time.Duration) string {
+	t.Helper()
+	dir := filepath.Join(base, "manager-cache")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "catalog.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	when := time.Now().Add(-age)
+	if err := os.Chtimes(path, when, when); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+const catalogHost140 = `{"catalog_version":2,"host":{"name":"Schwung",` +
+	`"github_repo":"charlesvestal/schwung","latest_version":"1.4.0",` +
+	`"download_url":"https://example.invalid/v1.4.0/schwung.tar.gz"},"modules":[]}`
+
+// The host latest_version this catalog carried before 2026-08-31.
+const catalogHost100 = `{"catalog_version":2,"host":{"name":"Schwung",` +
+	`"github_repo":"charlesvestal/schwung","latest_version":"1.0.0",` +
+	`"download_url":"https://example.invalid/v1.0.0/schwung.tar.gz"},"modules":[]}`
+
+func TestCatalogStatusProvenance(t *testing.T) {
+	t.Run("served from disk when the fetch fails", func(t *testing.T) {
+		base := t.TempDir()
+		writeCatalogCache(t, base, catalogHost100, 14*24*time.Hour)
+		// A server that refuses, standing in for no network at all.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "nope", http.StatusServiceUnavailable)
+		}))
+		defer srv.Close()
+
+		cs := NewCatalogService(srv.URL, srv.URL, base)
+		cat, err := cs.Fetch()
+		if err == nil {
+			t.Fatal("want a fetch error")
+		}
+		if cat == nil {
+			t.Fatal("want the disk cache served despite the error")
+		}
+		st := cs.Status()
+		if st.Live {
+			t.Error("Status().Live is true after a failed fetch: a caller cannot " +
+				"tell it is rendering month-old data")
+		}
+		if got := time.Since(st.At); got < 13*24*time.Hour {
+			t.Errorf("Status().At is %v old, want ~14 days (the cache file's mtime)", got)
+		}
+	})
+
+	t.Run("live after a successful fetch", func(t *testing.T) {
+		base := t.TempDir()
+		writeCatalogCache(t, base, catalogHost100, 14*24*time.Hour)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(catalogHost140))
+		}))
+		defer srv.Close()
+
+		cs := NewCatalogService(srv.URL, srv.URL, base)
+		cat, err := cs.Fetch()
+		if err != nil {
+			t.Fatalf("Fetch: %v", err)
+		}
+		if cat.Host.LatestVersion != "1.4.0" {
+			t.Errorf("served %q, want the fetched 1.4.0 over the cached 1.0.0",
+				cat.Host.LatestVersion)
+		}
+		st := cs.Status()
+		if !st.Live {
+			t.Error("Status().Live is false after a successful fetch")
+		}
+		if time.Since(st.At) > time.Minute {
+			t.Errorf("Status().At is %v old after a live fetch, want ~now", time.Since(st.At))
+		}
+	})
+}
+
+// newModulesTestApp builds the App that handleModules actually needs.
+func newModulesTestApp(t *testing.T, catalogURL, base, hostVersion string) *App {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(base, "host"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "host", "version.txt"),
+		[]byte(hostVersion+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err := loadTemplates()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &App{
+		tmpl:        tmpl,
+		catalogSvc:  NewCatalogService(catalogURL, catalogURL, base),
+		channelPref: NewChannelPref(base),
+		basePath:    base,
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// The whole defect, rendered. Unit-testing the comparison alone would not
+// have caught it: the bug was in what the handler COMPOSED, and the page is
+// the only place the two halves meet.
+func TestModulesPageOnStaleCatalog(t *testing.T) {
+	base := t.TempDir()
+	writeCatalogCache(t, base, catalogHost100, 14*24*time.Hour)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	app := newModulesTestApp(t, srv.URL, base, "1.4.0")
+	rec := httptest.NewRecorder()
+	app.handleModules(rec, httptest.NewRequest(http.MethodGet, "/modules", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	if strings.Contains(body, "1.0.0 available") {
+		t.Error("page offers v1.0.0 as an update over an installed 1.4.0 — " +
+			"the stale-catalog downgrade this fix exists to prevent")
+	}
+	if strings.Contains(body, "Upgrade to v1.0.0") {
+		t.Error("page renders an Upgrade button for an older host version")
+	}
+	if !strings.Contains(body, "Offline") {
+		t.Error("page renders disk-cached data with no indication it is offline; " +
+			"that silence is what made a month-old version read as a real release")
+	}
+	if !strings.Contains(body, "14 days ago") {
+		t.Error("offline notice does not say how old the cached catalog is")
+	}
+	// The page must still WORK offline — the disk cache exists so users can
+	// repair and remove modules with no network.
+	if !strings.Contains(body, "Schwung Host") {
+		t.Error("page did not render its host summary at all")
+	}
+	if !strings.Contains(body, "1.4.0") {
+		t.Error("page does not report the installed version")
+	}
+}
+
+// The live case, same handler: a genuinely newer host still gets offered,
+// and the offline notice stays off.
+func TestModulesPageOffersNewerHost(t *testing.T) {
+	base := t.TempDir()
+	catalog := strings.Replace(catalogHost140, `"latest_version":"1.4.0"`,
+		`"latest_version":"1.5.0"`, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(catalog))
+	}))
+	defer srv.Close()
+
+	app := newModulesTestApp(t, srv.URL, base, "1.4.0")
+	rec := httptest.NewRecorder()
+	app.handleModules(rec, httptest.NewRequest(http.MethodGet, "/modules", nil))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "v1.5.0 available") {
+		t.Error("a newer host version is not offered as an update")
+	}
+	if strings.Contains(body, "Offline") {
+		t.Error("offline notice shown for a live catalog fetch")
+	}
+}

--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -396,6 +396,24 @@ type CatalogService struct {
 	releaseMeta map[string]ReleaseMeta
 	fetched     time.Time
 	client      *http.Client
+
+	// Provenance of the catalog currently held, reported by Status().
+	// servedAt is when the held copy was OBTAINED -- the fetch time for a
+	// network copy, the cache file's mtime for a disk one -- and live says
+	// whether the last fetch ATTEMPT reached the network. A caller cannot
+	// derive either from the (catalog, error) pair: a served disk cache
+	// comes back with a non-nil catalog, and every page that renders it
+	// without saying so presents month-old data as today's.
+	servedAt time.Time
+	live     bool
+}
+
+// CatalogStatus describes where the catalog a caller was just handed came
+// from. Live=false with a non-zero At is the offline case: we are serving
+// the last-known-good copy from disk and it is At old.
+type CatalogStatus struct {
+	Live bool
+	At   time.Time
 }
 
 // defaultReleaseMetaURL is where the catalog site publishes the release
@@ -437,6 +455,11 @@ func (cs *CatalogService) loadFromDisk() {
 			var cat Catalog
 			if json.Unmarshal(data, &cat) == nil {
 				cs.catalog = &cat
+				// The file's mtime is the only record of when this copy
+				// was current; the catalog itself carries no timestamp.
+				if fi, err := os.Stat(p); err == nil {
+					cs.servedAt = fi.ModTime()
+				}
 			}
 		}
 	}
@@ -474,18 +497,23 @@ func (cs *CatalogService) Fetch() (*Catalog, error) {
 	}
 	resp, err := cs.client.Get(cs.URL)
 	if err != nil {
+		cs.live = false
 		return cs.catalog, fmt.Errorf("fetching catalog: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		cs.live = false
 		return cs.catalog, fmt.Errorf("catalog returned %d", resp.StatusCode)
 	}
 	var cat Catalog
 	if err := json.NewDecoder(resp.Body).Decode(&cat); err != nil {
+		cs.live = false
 		return cs.catalog, fmt.Errorf("decoding catalog: %w", err)
 	}
 	cs.catalog = &cat
 	cs.fetched = time.Now()
+	cs.servedAt = cs.fetched
+	cs.live = true
 	cs.saveToDisk(cs.catalogCachePath(), &cat)
 
 	// Fetch release metadata (best-effort, don't fail if unavailable).
@@ -505,6 +533,14 @@ func (cs *CatalogService) Fetch() (*Catalog, error) {
 	}
 
 	return cs.catalog, nil
+}
+
+// Status reports the provenance of the catalog Fetch last returned.
+//
+// Fetch's TTL early-return does not touch either field, so a status
+// reflects the last real ATTEMPT rather than the last call.
+func (cs *CatalogService) Status() CatalogStatus {
+	return CatalogStatus{Live: cs.live, At: cs.servedAt}
 }
 
 // GetReleaseMeta returns cached release metadata.
@@ -899,6 +935,56 @@ func isNewerSemver(latest, current string) bool {
 	return len(lp) > len(cp)
 }
 
+// hostOfferIsUpdate answers whether the catalog's offered host version is
+// worth showing as an update over what is installed.
+//
+// This was a bare `offered != installed` at both call sites, which is not a
+// version comparison: the catalog is served from an untimed on-disk cache
+// whenever the network fetch fails, so a device that had cached the catalog
+// before 2026-08-31 -- when host latest_version was still 1.0.0 -- rendered
+// "1.0.0 available" against an installed 1.4.0, with an Upgrade button
+// pointing at the v1.0.0 tarball. An offered DOWNGRADE presented as an
+// update, on stale data, with one click between the user and it.
+//
+// Modules never had this: they resolve through updateAvailable(), which
+// dates the releases and falls back to versionNewer. This is the host
+// arriving at the same rule.
+//
+// An installed version we cannot parse ("unknown", from a missing or
+// unreadable version.txt) still offers the update -- versionNewer reads its
+// components as 0, so anything beats it. That preserves the old behaviour
+// for the one case where refusing to offer would strand a device with no
+// way to name what it is running.
+// humanizeAge renders a catalog cache age for the offline notice. Coarse
+// on purpose: the reader's question is "is this data from today or from
+// weeks ago", and a stale cache is only ever wrong about a release.
+func humanizeAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return pluralAge(int(d.Minutes()), "minute")
+	case d < 24*time.Hour:
+		return pluralAge(int(d.Hours()), "hour")
+	default:
+		return pluralAge(int(d.Hours())/24, "day")
+	}
+}
+
+func pluralAge(n int, unit string) string {
+	if n == 1 {
+		return "1 " + unit + " ago"
+	}
+	return fmt.Sprintf("%d %ss ago", n, unit)
+}
+
+func hostOfferIsUpdate(offered, installed string) bool {
+	if offered == "" || installed == "" {
+		return false
+	}
+	return versionNewer(offered, installed)
+}
+
 type templateMap map[string]*template.Template
 
 func loadTemplates() (templateMap, error) {
@@ -1137,7 +1223,7 @@ func (app *App) handleModules(w http.ResponseWriter, r *http.Request) {
 	if cat != nil {
 		hostRepo = cat.Host.GithubRepo
 		hostLatestVersion, _, hostServedChannel = hostResolveForChannel(cat.Host, currentChannel)
-		hostUpdateAvailable = hostLatestVersion != "" && hostLatestVersion != hostVersion
+		hostUpdateAvailable = hostOfferIsUpdate(hostLatestVersion, hostVersion)
 		hostOfferedIsBeta = hostServedChannel == ChannelBeta
 		// Stable users get the same "beta X.Y.Z available" nudge that
 		// modules do, when the host publishes a beta ahead of stable.
@@ -1151,6 +1237,19 @@ func (app *App) handleModules(w http.ResponseWriter, r *http.Request) {
 				hostBetaTeaser = beta
 			}
 		}
+	}
+
+	// Say so when the catalog on screen came off disk because the fetch
+	// failed. Every version on this page -- the host's and all 130-odd
+	// modules' -- is then as old as the cache, and nothing else about the
+	// render distinguishes it from a live one. That silence is what made a
+	// month-old "1.0.0 available" read as a real release rather than as a
+	// device that cannot reach GitHub.
+	catStatus := app.catalogSvc.Status()
+	catalogStale := cat != nil && !catStatus.Live
+	catalogAge := ""
+	if catalogStale && !catStatus.At.IsZero() {
+		catalogAge = humanizeAge(time.Since(catStatus.At))
 	}
 
 	// A nil catalog (offline, or first boot before the first fetch) yields the
@@ -1177,6 +1276,8 @@ func (app *App) handleModules(w http.ResponseWriter, r *http.Request) {
 		"HostUpdateAvailable": hostUpdateAvailable,
 		"HostOfferedIsBeta":   hostOfferedIsBeta,
 		"HostBetaTeaser":      hostBetaTeaser,
+		"CatalogStale":        catalogStale,
+		"CatalogAge":          catalogAge,
 		"Flash":               r.URL.Query().Get("flash"),
 	}
 	app.render(w, r, "modules.html", data)
@@ -2944,7 +3045,7 @@ func (app *App) handleSystem(w http.ResponseWriter, r *http.Request) {
 		hostRepo = cat.Host.GithubRepo
 		var served string
 		latestVersion, _, served = hostResolveForChannel(cat.Host, currentChannel)
-		updateAvailable = latestVersion != "" && latestVersion != version
+		updateAvailable = hostOfferIsUpdate(latestVersion, version)
 		offeredIsBeta = served == ChannelBeta
 		if currentChannel == ChannelStable && cat.Host.Channels != nil && cat.Host.Channels.Beta != nil {
 			beta := cat.Host.Channels.Beta.Version

--- a/schwung-manager/static/style.css
+++ b/schwung-manager/static/style.css
@@ -1098,6 +1098,27 @@ h2.section-header + .module-list {
     color: #ffffff;
 }
 
+/* The catalog can be served from an untimed on-disk cache when the fetch
+   fails, and then EVERY version on the page is as old as that file. A
+   render that says nothing presents month-old data as today's, which is
+   how a stale "1.0.0 available" read as a real release. Muted rather than
+   alarming: nothing is broken, the data is just old. */
+.catalog-stale {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    margin-bottom: var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+}
+
+.catalog-stale strong {
+    color: var(--text);
+}
+
 /* Teaser is a hint, not a badge — one line of muted italic text next
    to the version. Clicking it isn't a link (channel change requires
    a POST); a title tooltip explains what to do. */

--- a/schwung-manager/templates/modules.html
+++ b/schwung-manager/templates/modules.html
@@ -24,6 +24,13 @@
     </form>
 </section>
 
+{{if .CatalogStale}}
+<section class="catalog-stale" role="status">
+    <strong>Offline &mdash; showing saved catalog data{{if .CatalogAge}} from {{.CatalogAge}}{{end}}.</strong>
+    Every version on this page is as old as that. Check the Move's network connection and reload.
+</section>
+{{end}}
+
 <section class="host-summary {{if .HostUpdateAvailable}}host-summary-update{{end}}" aria-label="Schwung Host">
     <div class="host-summary-info">
         <h2 class="host-summary-title">Schwung Host</h2>


### PR DESCRIPTION
A user on **1.4.0** sent a screenshot reading **"1.0.0 available"**, with an Upgrade button beside it.

The published catalog is correct (`latest_version: 1.4.0`). That device could not reach it, so the manager served its on-disk last-known-good copy — saved before 2026-08-31, when the catalog's host `latest_version` **was** `1.0.0`.

## Two halves

**1. The host check was not a version comparison.** Both call sites read `offered != installed` (`handleModules`, `handleSystem`), so any disagreement with the catalog rendered as an update — including an *older* one, whose cached `download_url` points at the v1.0.0 tarball. One click from downgrading a 1.4.0 device, and `install.sh`'s post-extraction payload check is what turns that into a confusing device state.

Modules never had this bug: they resolve through `updateAvailable()`, which dates the releases and falls back to `versionNewer`. `hostOfferIsUpdate` is the host arriving at the same rule.

`"unknown"` installed (missing/unreadable `version.txt`) still gets offered the update — there is nothing to compare, and refusing would strand a device that cannot name what it runs.

**2. A disk-cache render said nothing about being one.** The cache is untimed deliberately — a device with no network must still be able to repair and remove modules — but then *every* version on the page is as old as that file, and the render was indistinguishable from a live one. That silence is what made a month-old version read as a real release rather than as a device that cannot reach GitHub.

`CatalogService.Status()` now reports provenance (`Live` = the last fetch *attempt* reached the network; `At` = the cache file's mtime, the only record of when that copy was current), and `/modules` draws an Offline notice with the age:

> **Offline — showing saved catalog data from 14 days ago.** Every version on this page is as old as that. Check the Move's network connection and reload.

## Testing

`schwung-manager/host_update_test.go` renders `/modules` against a backdated cache plus a refusing server — **the comparison alone passes either way**, because the defect was in what the handler composed. Mutating either half back reproduces the field report verbatim:

```
--- FAIL: TestModulesPageOnStaleCatalog
    page offers v1.0.0 as an update over an installed 1.4.0 — the stale-catalog downgrade this fix exists to prevent
    page renders an Upgrade button for an older host version
```
```
--- FAIL: TestModulesPageOnStaleCatalog   (notice removed)
    page renders disk-cached data with no indication it is offline
    offline notice does not say how old the cached catalog is
```

Plus a `hostOfferIsUpdate` table (stale-older, equal, newer, `v` prefix, four beta-ordering cases, `unknown`, empties), `Status()` provenance both ways, and `humanizeAge`. `go vet` and `go test ./...` green; the live-catalog case asserts a genuinely newer host is still offered and the notice stays off.

Unrelated to the user's report, so **not** fixed here:
- `handleSystemCheckUpdate` shares `Fetch`'s 5-minute TTL, so "Check for Update" can report a cached answer as if it had checked.
- `CatalogService`'s fields are read and written from concurrent handlers with no mutex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqnnfzPhFbKKiooge4WTLd