### PR TITLE
manager: "Check for Update" shared the cache TTL, and the cache had no lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1486,6 +1486,19 @@ and refusing strands a device that cannot name what it runs).
 cache — the comparison alone passes either way, since the defect was in what
 the handler COMPOSED.
 
+Two things found while reading that, fixed after: **`Check for Update` shared
+the 5-minute TTL**, so within five minutes of any page's fetch it reported the
+cached answer as though it had looked — including the "up to date" a user who
+had just fixed their network was pressing it to disprove (`Refresh()` forces
+past the TTL; `Fetch()` still honours it, since a page render must not hit the
+network every time). And **`CatalogService` had no lock** while every handler
+runs on its own goroutine — `mu` is held across the fetch, not just the
+assignment, so concurrent misses collapse into one request. `loadFromDisk`
+deliberately takes no lock (it runs before publication, and `fetch` holds `mu`
+across its whole body, so a reload from there would deadlock), and
+`GetReleaseMeta` hands out the map by reference, which is safe only while a
+refresh REPLACES it rather than writing into the copy a caller holds.
+
 **Shim mirror + stuck-shim repair (web update).** The manager runs as `ableton`
 and can't write `/usr/lib`, so a web update mirrors the new shim via the
 setuid-root `schwung-heal` helper (synchronously in `post-update.sh` + the

--- a/schwung-manager/catalog_refresh_test.go
+++ b/schwung-manager/catalog_refresh_test.go
@@ -1,0 +1,159 @@
+// "Check for Update" must actually check, and the cache must survive being
+// read by one request while another writes it.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// countingCatalog serves the catalog and counts how many times it is asked.
+//
+// The catalog and the release metadata are separate paths, and only the
+// catalog is counted: a successful fetch pulls BOTH, so pointing the two
+// URLs at one counting handler doubles every number and the test reads as
+// a TTL failure that is really an arithmetic one.
+func countingCatalog(t *testing.T, body string) (catalogURL, metaURL string, hits *atomic.Int32) {
+	t.Helper()
+	var n atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/catalog.json", func(w http.ResponseWriter, r *http.Request) {
+		n.Add(1)
+		w.Write([]byte(body))
+	})
+	mux.HandleFunc("/meta.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL + "/catalog.json", srv.URL + "/meta.json", &n
+}
+
+func TestFetchHonoursTTLAndRefreshBypassesIt(t *testing.T) {
+	catURL, metaURL, hits := countingCatalog(t, catalogHost140)
+	cs := NewCatalogService(catURL, metaURL, t.TempDir())
+
+	if _, err := cs.Fetch(); err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+	if _, err := cs.Fetch(); err != nil {
+		t.Fatalf("second Fetch: %v", err)
+	}
+	// The TTL is the point of the cache — a page render must not hit the
+	// network every time.
+	if got := hits.Load(); got != 1 {
+		t.Errorf("two Fetch calls made %d requests, want 1 (TTL not honoured)", got)
+	}
+
+	// Refresh is the user pressing a button that says it checks.
+	if _, err := cs.Refresh(); err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if got := hits.Load(); got != 2 {
+		t.Errorf("Refresh made no new request (%d total): "+
+			"\"Check for Update\" reports a cached answer as though it looked", got)
+	}
+}
+
+// A failed Refresh must leave the last-known-good catalog in place — the
+// button reports the failure, it does not blank the pages that follow.
+func TestRefreshFailureKeepsCacheAndMarksStale(t *testing.T) {
+	base := t.TempDir()
+	var fail atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if fail.Load() {
+			http.Error(w, "nope", http.StatusServiceUnavailable)
+			return
+		}
+		w.Write([]byte(catalogHost140))
+	}))
+	defer srv.Close()
+
+	cs := NewCatalogService(srv.URL, srv.URL, base)
+	if _, err := cs.Fetch(); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if !cs.Status().Live {
+		t.Fatal("not live after a successful fetch")
+	}
+
+	fail.Store(true)
+	cat, err := cs.Refresh()
+	if err == nil {
+		t.Error("Refresh past a failing server returned no error")
+	}
+	if cat == nil || cat.Host.LatestVersion != "1.4.0" {
+		t.Error("a failed Refresh dropped the last-known-good catalog")
+	}
+	if cs.Status().Live {
+		t.Error("Status().Live still true after a failed Refresh")
+	}
+}
+
+// The button, not the service. Swapping the handler back to Fetch leaves
+// every service-level test above green -- the TTL behaviour it depends on
+// is correct, and the defect is which method the handler CALLS.
+func TestCheckUpdateButtonActuallyChecks(t *testing.T) {
+	base := t.TempDir()
+	catURL, metaURL, hits := countingCatalog(t, catalogHost140)
+	app := newModulesTestApp(t, catURL, base, "1.4.0")
+	app.catalogSvc = NewCatalogService(catURL, metaURL, base)
+
+	// Some other page rendered first, seeding the 5-minute TTL. This is
+	// the ordinary case: the user browses, THEN presses the button.
+	if _, err := app.catalogSvc.Fetch(); err != nil {
+		t.Fatalf("priming Fetch: %v", err)
+	}
+	before := hits.Load()
+
+	rec := httptest.NewRecorder()
+	app.handleSystemCheckUpdate(rec, httptest.NewRequest(http.MethodPost, "/system/check-update", nil))
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status %d, want a redirect", rec.Code)
+	}
+	if got := hits.Load(); got == before {
+		t.Errorf("Check for Update made no request (%d before, %d after): it "+
+			"reported a cached answer as though it had looked", before, got)
+	}
+	if loc := rec.Header().Get("Location"); !strings.Contains(loc, "1.4.0") {
+		t.Errorf("redirect %q does not name the version it found", loc)
+	}
+}
+
+// Run with -race. Before the mutex, every mutable field of CatalogService
+// was written by one request's fetch while another request read it —
+// net/http gives each request its own goroutine, and any handler may reach
+// for the catalog.
+func TestCatalogServiceConcurrentAccess(t *testing.T) {
+	catURL, metaURL, _ := countingCatalog(t, catalogHost140)
+	cs := NewCatalogService(catURL, metaURL, t.TempDir())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for n := 0; n < 20; n++ {
+				switch (i + n) % 4 {
+				case 0:
+					cs.Fetch()
+				case 1:
+					cs.Refresh() // forces the write path to overlap the reads
+				case 2:
+					cs.Status()
+				case 3:
+					for id := range cs.GetReleaseMeta() {
+						_ = id
+					}
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}

--- a/schwung-manager/main.go
+++ b/schwung-manager/main.go
@@ -391,7 +391,17 @@ type CatalogService struct {
 	URL     string
 	MetaURL string // release-metadata.json; overridable so the update
 	//        // logic can be exercised against a fixture
-	CacheDir    string // root directory for persisted cache files
+	CacheDir string // root directory for persisted cache files
+
+	// mu guards every mutable field below. net/http serves each request on
+	// its own goroutine and any handler may reach for the catalog, so the
+	// cache was being written by one request while another read it.
+	//
+	// It is held across the network fetch rather than only around the
+	// assignment. That serialises concurrent misses, which is the point:
+	// the second caller wants the answer the first is already fetching,
+	// not a second request for it.
+	mu          sync.Mutex
 	catalog     *Catalog
 	releaseMeta map[string]ReleaseMeta
 	fetched     time.Time
@@ -449,6 +459,10 @@ func (cs *CatalogService) metaCachePath() string {
 	return filepath.Join(cs.CacheDir, "manager-cache", "release-metadata.json")
 }
 
+// loadFromDisk seeds the cache from the last-known-good files. It takes no
+// lock because NewCatalogService calls it before the service is published
+// to any handler -- and it must stay that way: fetch() holds mu across its
+// whole body, so a reload called from there would deadlock.
 func (cs *CatalogService) loadFromDisk() {
 	if p := cs.catalogCachePath(); p != "" {
 		if data, err := os.ReadFile(p); err == nil {
@@ -492,7 +506,26 @@ func (cs *CatalogService) saveToDisk(path string, v any) {
 // disk) along with the error, so callers can render a usable page when the
 // network is unavailable.
 func (cs *CatalogService) Fetch() (*Catalog, error) {
-	if cs.catalog != nil && time.Since(cs.fetched) < 5*time.Minute {
+	return cs.fetch(false)
+}
+
+// Refresh fetches past the in-memory TTL, for a user who ASKED whether
+// there is an update.
+//
+// "Check for Update" went through Fetch, so within five minutes of any
+// other page's fetch it reported the cached answer as though it had just
+// looked -- including the "up to date" that a user who had been told to
+// fix their network was pressing the button to disprove. The button is the
+// one place in the manager where the TTL is exactly wrong: its whole
+// purpose is to go and ask.
+func (cs *CatalogService) Refresh() (*Catalog, error) {
+	return cs.fetch(true)
+}
+
+func (cs *CatalogService) fetch(force bool) (*Catalog, error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	if !force && cs.catalog != nil && time.Since(cs.fetched) < 5*time.Minute {
 		return cs.catalog, nil
 	}
 	resp, err := cs.client.Get(cs.URL)
@@ -540,11 +573,20 @@ func (cs *CatalogService) Fetch() (*Catalog, error) {
 // Fetch's TTL early-return does not touch either field, so a status
 // reflects the last real ATTEMPT rather than the last call.
 func (cs *CatalogService) Status() CatalogStatus {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
 	return CatalogStatus{Live: cs.live, At: cs.servedAt}
 }
 
 // GetReleaseMeta returns cached release metadata.
+//
+// The map is returned by reference, which is safe only because a refresh
+// REPLACES it with a freshly decoded one rather than writing into the map
+// a caller is holding. Keep it that way: mutating in place would race a
+// handler mid-iteration.
 func (cs *CatalogService) GetReleaseMeta() map[string]ReleaseMeta {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
 	if cs.releaseMeta == nil {
 		return map[string]ReleaseMeta{}
 	}
@@ -3168,7 +3210,8 @@ func (app *App) handleSystemRepairRecheck(w http.ResponseWriter, r *http.Request
 }
 
 func (app *App) handleSystemCheckUpdate(w http.ResponseWriter, r *http.Request) {
-	cat, err := app.catalogSvc.Fetch()
+	// Refresh, not Fetch: the user pressed a button that says it checks.
+	cat, err := app.catalogSvc.Refresh()
 	if err != nil {
 		http.Redirect(w, r, "/system?flash=Failed+to+check:+"+err.Error(), http.StatusSeeOther)
 		return


### PR DESCRIPTION
The two follow-ups I noted while fixing the stale-catalog downgrade in #505.

## 1. The button did not necessarily check

`handleSystemCheckUpdate` went through `Fetch`, which serves any catalog fetched in the last five minutes. So within five minutes of rendering `/modules` or `/system`, **"Check for Update" reported a cached answer as though it had just looked.**

Worst exactly where it matters: a user told *"your Move can't reach GitHub — fix the network and check again"* presses the button and is shown the same stale verdict, with nothing distinguishing it from a real one.

`Refresh()` forces past the TTL. `Fetch()` keeps honouring it — a page render must not hit the network every time.

## 2. Every mutable field of CatalogService was unguarded

net/http serves each request on its own goroutine and any handler may reach for the catalog, so one request's fetch wrote `catalog`, `releaseMeta`, `fetched`, `servedAt` and `live` while another read them.

`mu` is held **across the network fetch**, not just around the assignment. That serialises concurrent misses, which is the intent: the second caller wants the answer the first is already fetching, not a second request for it.

Two constraints the comments record, since both are easy to undo later:
- `loadFromDisk` takes no lock — it runs before the service is published, and `fetch` holds `mu` across its whole body, so a reload called from there would **deadlock**.
- `GetReleaseMeta` returns the map by reference, safe only while a refresh **replaces** it instead of writing into the map a handler is iterating.

## Testing

Each half is pinned by a test that fails without it, verified by mutation:

```
--- FAIL: TestCheckUpdateButtonActuallyChecks    (handler back to Fetch)
    Check for Update made no request (1 before, 1 after): it reported a
    cached answer as though it had looked
```
```
WARNING: DATA RACE                               (locks removed, -race)
Previous write at 0x00c000142398 by goroutine 17   ... ×3 (fetched, servedAt, live)
```

**The handler test is separate on purpose.** Swapping `Refresh` back to `Fetch` leaves every service-level test green — the TTL behaviour they check is correct, and the defect is which method the handler *calls*. Same shape as #505, where the comparison alone passed either way.

Also covered: `Fetch` twice makes one request (the TTL still earns its keep), and a failed `Refresh` keeps the last-known-good catalog while flipping `Status().Live` — the button reports the failure, it doesn't blank the pages after it.

One test bug worth recording: pointing the catalog and release-metadata URLs at a single counting handler doubles every count, because a successful fetch pulls both — which reads as a TTL failure that is really an arithmetic one. Separate paths now, only the catalog counted.

`go vet` clean, `go test -race ./...` green with a cleared test cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqnnfzPhFbKKiooge4WTLd