### PR TITLE
release: three files name the host version, and one stopped being bumped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,3 +85,9 @@ jobs:
       # that bumps module-catalog.json `host.latest_version` (which is what
       # schwung-manager actually reads to offer the update) also updates
       # release.json to the same version. See the release checklist in CLAUDE.md.
+      #
+      # That delegation is only as good as the checklist, and for fourteen
+      # releases it was not in it: release.json sat at 0.12.1 from v1.0.0 to
+      # v1.4.0. `tests/host/test_release_version_agreement.sh` gates the three
+      # files against each other now, so the next drift fails a PR instead of
+      # shipping.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1655,7 +1655,19 @@ inline is how this file got to 151 KB.
 
 1. **Build**: `./scripts/build.sh` succeeds
 2. **Deploy + test**: `./scripts/install.sh local --skip-modules --skip-confirmation`, verify on hardware
-3. **Version**: bump `src/host/version.txt` and `module-catalog.json` (host `latest_version` + download URL)
+3. **Version**: bump **all three** in the release PR — `src/host/version.txt`,
+   `module-catalog.json` (host `latest_version` + download URL, and
+   `channels.stable` if present) and **`release.json`**. `release.yml`
+   deliberately commits none of them: `main` is branch-protected, so a
+   `github-actions[bot]` push is rejected (GH006) and would fail the workflow
+   *after* the release and its asset had published. That note delegated to
+   "the release PR" and this step did not name `release.json`, so it sat at
+   **0.12.1 from v1.0.0 through v1.4.0** — fourteen releases — undetected,
+   because nothing shipped reads it any more (the manager takes both the offer
+   and the download URL from the catalog's host block). The enforcement is
+   `tests/host/test_release_version_agreement.sh`, which also fails on a
+   bumped version beside a stale URL — that downloads the old tarball while
+   reporting the new number.
 4. **Docs**: update the subsystem file (`docs/PARAM_PAGES.md`, `docs/SHADOW_UI.md`,
    `docs/CHAIN.md`, `docs/DIAGNOSTICS.md`) and add a bullet to `CLAUDE.md`'s hook
    for it — **not** the prose itself. Then `docs/API.md`, `docs/MODULES.md`, `src/shared/help_content.json`, and `../schwung-catalog-site/manual.html` for new features / changed behavior. If a knob-grid widget changed, regenerate the sheet with `node tools/param-pages/widget_sheet.mjs --manual` — `tests/host/test_widget_sheet.sh` fails until the `docs/` half is current, and `--manual` also rewrites the manual's generated widget section and its images (skipped silently when the sibling repo is not checked out, so it is safe on any machine).

--- a/release.json
+++ b/release.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.12.1",
-  "download_url": "https://github.com/charlesvestal/schwung/releases/download/v0.12.1/schwung.tar.gz"
+  "version": "1.4.0",
+  "download_url": "https://github.com/charlesvestal/schwung/releases/download/v1.4.0/schwung.tar.gz"
 }

--- a/tests/host/test_release_version_agreement.sh
+++ b/tests/host/test_release_version_agreement.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# THREE files name the current host release, and nothing in the repo made
+# them agree.
+#
+#   src/host/version.txt              what the device reports it is running
+#   module-catalog.json host.*        what the manager OFFERS and downloads
+#   release.json                      the repo-level manifest
+#
+# They agreed at every release tag up to v0.12.1 and then stopped: from
+# v1.0.0 onward release.json was left at 0.12.1 while the other two moved
+# through fourteen releases. Nothing caught it because nothing reads
+# release.json today -- the manager takes both the offer and the download
+# URL from the catalog's host block, install.sh uses the releases API, and
+# the catalog site builds its own snapshot from `gh api releases/latest`.
+# The one reader is the retired on-device store's store_utils.mjs, which
+# OVERWRITES catalog.host.latest_version with it; that path compares with
+# isNewerVersion, so a 1.4.0 device saw "up to date" rather than an offered
+# downgrade, and the drift stayed invisible.
+#
+# It drifted because release.yml deliberately does not commit it (main is
+# branch-protected; a bot push is rejected GH006 and would fail the whole
+# workflow after a successful publish), delegating instead to "the release
+# PR" -- and the release checklist did not mention the file. A checklist
+# line is what already failed here, so this is the enforcement.
+#
+# Sibling: test_host_channels_mirror_stable.sh pins agreement WITHIN the
+# catalog (host.channels.stable vs the top-level fields). This one pins
+# agreement ACROSS the three files.
+
+node - <<'NODE'
+const fs = require("fs");
+
+let failures = 0;
+const fail = (msg) => { console.error("FAIL: " + msg); failures++; };
+
+const readJSON = (path) => {
+  try {
+    return JSON.parse(fs.readFileSync(path, "utf8"));
+  } catch (e) {
+    fail(`${path} is missing or not valid JSON: ${e.message}`);
+    return null;
+  }
+};
+
+const versionTxt = (() => {
+  try {
+    return fs.readFileSync("src/host/version.txt", "utf8").trim();
+  } catch (e) {
+    fail(`src/host/version.txt is unreadable: ${e.message}`);
+    return null;
+  }
+})();
+
+const catalog = readJSON("module-catalog.json");
+const release = readJSON("release.json");
+const host = catalog && catalog.host;
+if (catalog && !host) fail("module-catalog.json has no host block");
+
+if (versionTxt !== null && host) {
+  if (host.latest_version !== versionTxt) {
+    fail(`module-catalog.json host.latest_version (${host.latest_version}) != ` +
+         `src/host/version.txt (${versionTxt}).\n` +
+         `      The manager offers what the catalog names, so these disagreeing ` +
+         `means every device is\n` +
+         `      offered an "update" to, or told it is behind, a version that is not ` +
+         `the one that shipped.`);
+  }
+}
+
+if (versionTxt !== null && release) {
+  if (release.version !== versionTxt) {
+    fail(`release.json version (${release.version}) != src/host/version.txt ` +
+         `(${versionTxt}).\n` +
+         `      Bump release.json in the release PR -- release.yml cannot commit it ` +
+         `(branch protection),\n` +
+         `      which is exactly why it sat at 0.12.1 through fourteen releases.`);
+  }
+}
+
+// A bumped version beside a stale URL downloads the OLD tarball while
+// reporting the new number -- the same shape as the stale-catalog
+// downgrade, from the other direction.
+const urlNamesVersion = (url, version, where) => {
+  if (!url) {
+    fail(`${where} has no download_url; an upgrade resolves to an empty URL and dies`);
+    return;
+  }
+  if (!url.includes(`/v${version}/`)) {
+    fail(`${where} download_url does not name v${version}:\n      ${url}\n` +
+         `      A bumped version with a stale URL downloads the old tarball and ` +
+         `reports the new one.`);
+  }
+};
+
+if (host && host.latest_version) {
+  urlNamesVersion(host.download_url, host.latest_version, "module-catalog.json host");
+}
+if (release && release.version) {
+  urlNamesVersion(release.download_url, release.version, "release.json");
+}
+
+if (failures === 0) {
+  console.log(`version.txt, module-catalog.json host and release.json all name ` +
+              `${versionTxt}, with matching URLs, OK`);
+}
+process.exit(failures === 0 ? 0 : 1);
+NODE


### PR DESCRIPTION
Follow-up to #505. `release.json` sat at **0.12.1 from v1.0.0 through v1.4.0** — fourteen releases — while `src/host/version.txt` and `module-catalog.json` moved together:

| tag | version.txt | catalog | release.json |
|---|---|---|---|
| v1.4.0 | 1.4.0 | 1.4.0 | **0.12.1** |
| v1.3.3 | 1.3.3 | 1.3.3 | **0.12.1** |
| … | | | |
| v1.0.0 | 1.0.0 | 1.0.0 | **0.12.1** |
| v0.12.1 | 0.12.1 | 0.12.1 | 0.12.1 ✓ |

They agreed at every tag up to v0.12.1 — a habit that lapsed, not one that never existed.

## The workflow is not the place to fix it, and already says why

`release.yml` cannot commit the bump: `main` is branch-protected, so a `github-actions[bot]` push is rejected (GH006) and would fail the workflow *after* the release and asset had published. It delegates to "the release PR … see the release checklist in CLAUDE.md" — and **step 3 of that checklist named `version.txt` and the catalog, and never named `release.json`.** The note pointed at a step that did not exist.

## Why fourteen releases went by

Nothing shipped reads the file:

| Reader | Source it actually uses |
|---|---|
| Manager: the update offer | catalog `host.latest_version` |
| Manager: the upgrade download | catalog `host.download_url` |
| Manager: `resolveDownloadURL` (repo `release.json`) | modules/platforms only — no catalog entry points at `charlesvestal/schwung` |
| `install.sh` (non-local) | GitHub releases API |
| Catalog site | its own snapshot from `gh api releases/latest` |
| Retired on-device store (`store_utils.mjs:277`) | **the host's `release.json`** — overwrites `catalog.host.latest_version` |

That last one is the only consumer, and it compares with `isNewerVersion`, so a 1.4.0 device saw "up to date" rather than an offered downgrade — the old store was already doing what the manager only learned in #505.

## Three changes, and the third is the one that matters

1. `release.json` → 1.4.0.
2. Checklist step 3 names all three, with the GH006 reason inline.
3. `tests/host/test_release_version_agreement.sh` gates them. **A checklist line is exactly what failed here.**

Each of the four drifts is verified by mutation:

```
release.json left behind       FAIL: release.json version (0.12.1) != src/host/version.txt (1.4.0)
catalog ahead of version.txt   FAIL: host.latest_version (1.5.0) != src/host/version.txt (1.4.0)
catalog URL stale              FAIL: module-catalog.json host download_url does not name v1.4.0
release.json URL stale         FAIL: release.json download_url does not name v1.4.0
```

The URL half isn't padding: a bumped version beside a stale URL downloads the **old** tarball while reporting the new number — #505's downgrade arriving from the other direction.

Sibling to `test_host_channels_mirror_stable.sh`, which pins agreement *within* the catalog; this pins it *across* the three files. Whole `tests/host` suite green, `make -C tests/host test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqnnfzPhFbKKiooge4WTLd